### PR TITLE
Fix finalise modal not showing

### DIFF
--- a/src/widgets/modals/ConfirmModal.js
+++ b/src/widgets/modals/ConfirmModal.js
@@ -25,7 +25,6 @@ import globalStyles, { DARK_GREY } from '../../globalStyles';
 
 export function ConfirmModal(props) {
   const {
-    isOpen,
     questionText,
     confirmText,
     cancelText,
@@ -40,10 +39,10 @@ export function ConfirmModal(props) {
     noCancel,
     ...modalProps
   } = props;
-
+  
   // On opening, dismiss the keyboard to ensure editable cells lose their focus
   // and their values become fixed (so that they save correctly)
-  if (isOpen) Keyboard.dismiss();
+  if (modalProps.isOpen) Keyboard.dismiss();
 
   return (
     <Modal {...modalProps} style={style}>


### PR DESCRIPTION
- Fix #806
- Modal needs `isOpen` as one of the props, since the lint code extracted it into a constant it was no longer available in `modalProps` object, hence the modal was not opening because it never got `isOpen` prop as true.
