### PR TITLE
#815 integrate by program dialog into requisitions

### DIFF
--- a/src/database/DataTypes/MasterList.js
+++ b/src/database/DataTypes/MasterList.js
@@ -44,18 +44,22 @@ export class MasterList extends Realm.Object {
   }
 
   /**
-   * Find the current stores matching store tag object in this master lists program settings
+   * Find the current stores matching store tag object in this master lists program settings.
+   * Program settings is a JSON object from 4D, which requires two parses.
    * @param  {string}  tags   Current stores tags field
    * @return {object} The matching storeTag programsettings field for the current store
    */
   getStoreTagObject(tags) {
     const storeTags = tags.split(/[\s,]+/);
-    return Object.entries(JSON.parse(this.programSettings).storeTags).reduce(
+    const firstParse = JSON.parse(this.programSettings);
+    if (!firstParse) return null;
+
+    return Object.entries(JSON.parse(firstParse).storeTags).reduce(
       ([programStoreTag, storeTagObject]) => {
         if (!(storeTags.indexOf(programStoreTag) >= 0)) return null;
         return storeTagObject;
       }
-    );
+    )[1];
   }
 
   /**
@@ -74,10 +78,9 @@ export class MasterList extends Realm.Object {
    * @return {object} The matching orderType object
    */
   getOrderType(tags, orderTypeName) {
-    this.getStoreTagObject(tags).orderTypes.reduce(orderType => {
-      if (!(orderType.name === orderTypeName)) return null;
-      return orderType;
-    });
+    return this.getStoreTagObject(tags).orderTypes.filter(
+      orderType => !orderType.name === orderTypeName
+    )[0];
   }
 }
 

--- a/src/database/DataTypes/Period.js
+++ b/src/database/DataTypes/Period.js
@@ -10,6 +10,12 @@ export class Period extends Realm.Object {
     return this.requisitions.length;
   }
 
+  removeRequisition(requisition, database) {
+    const indexToRemove = this.requisitions.indexOf(requisition);
+    this.requisitions.splice(indexToRemove, 1);
+    database.save('Period', this);
+  }
+
   numberOfRequisitionsForProgram(program) {
     return this.requisitions.filtered('program.id = $0', program.id).length;
   }
@@ -17,6 +23,12 @@ export class Period extends Realm.Object {
   addRequisitionIfUnique(requisition) {
     if (this.requisitions.filtered('id == $0', requisition.id).length > 0) return;
     this.requisitions.push(requisition);
+  }
+
+  getFormattedPeriod() {
+    return `${this.startDate.toLocaleDateString('en-US')} - ${this.endDate.toLocaleDateString(
+      'en-US'
+    )} `;
   }
 }
 

--- a/src/database/DataTypes/PeriodSchedule.js
+++ b/src/database/DataTypes/PeriodSchedule.js
@@ -7,10 +7,9 @@ import Realm from 'realm';
 
 export class PeriodSchedule extends Realm.Object {
   getUseablePeriodsForProgram(program, maxOrdersPerPeriod) {
-    const periods = this.periods.reduce(period => {
-      if (period.numberOfRequisitionsForProgram(program) >= maxOrdersPerPeriod) return null;
-      return period;
-    });
+    const periods = this.periods.filter(
+      period => period.numberOfRequisitionsForProgram(program) < maxOrdersPerPeriod
+    );
     return periods;
   }
 

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -44,6 +44,7 @@ export class Requisition extends Realm.Object {
    * @param {Realm} database
    */
   destructor(database) {
+    this.period.removeRequisition(this, database);
     database.delete('RequisitionItem', this.items);
   }
 

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -150,7 +150,7 @@ export const schema = {
     StocktakeBatch,
     User,
   ],
-  schemaVersion: 14,
+  schemaVersion: 16,
 };
 
 export default schema;

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -341,6 +341,16 @@ const createTransactionItem = (database, transaction, item) => {
   return transactionItem;
 };
 
+const createProgramRequisition = (database, requisitionValues) => {
+  const requisition = database.create('Requisition', {
+    id: generateUUID(),
+    otherStoreName: requisitionValues.supplier,
+    ...requisitionValues,
+  });
+  database.save('Requisition', requisition);
+  return requisition;
+};
+
 /**
  * Create a record of the given type, taking care of linkages, generating IDs, serial
  * numbers, current dates, and inserting sensible defaults.
@@ -378,6 +388,8 @@ export const createRecord = (database, type, ...args) => {
       return createTransactionItem(database, ...args);
     case 'TransactionBatch':
       return createTransactionBatch(database, ...args);
+    case 'ProgramRequisition':
+      return createProgramRequisition(database, ...args);
     default:
       throw new Error(`Cannot create a record with unsupported type: ${type}`);
   }

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -342,12 +342,16 @@ const createTransactionItem = (database, transaction, item) => {
 };
 
 const createProgramRequisition = (database, requisitionValues) => {
+  const { period } = requisitionValues;
   const requisition = database.create('Requisition', {
     id: generateUUID(),
     otherStoreName: requisitionValues.supplier,
     ...requisitionValues,
+    orderType: requisitionValues.orderType.name,
   });
   database.save('Requisition', requisition);
+  period.addRequisitionIfUnique(requisition);
+  database.save('Period', period);
   return requisition;
 };
 

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -41,6 +41,7 @@ export class SupplierRequisitionPage extends React.Component {
       modalKey: null,
       modalIsOpen: false,
       selection: [],
+      isProgramOrder: false,
     };
     this.dataFilters = {
       searchTerm: '',
@@ -49,12 +50,24 @@ export class SupplierRequisitionPage extends React.Component {
     };
   }
 
+  componentDidMount() {
+    const { requisition, settings } = this.props;
+    if (requisition.program) {
+      const isProgramOrder = requisition.program.canUseProgram(
+        settings.get(SETTINGS_KEYS.THIS_STORE_TAGS)
+      );
+      this.setState({ isProgramOrder });
+      this.onAddMasterItems();
+    }
+  }
+
   onAddMasterItems = () => {
     const { database, requisition, runWithLoadingIndicator } = this.props;
-
+    const { isProgramOrder } = this.state;
     runWithLoadingIndicator(() => {
       database.write(() => {
-        requisition.addItemsFromMasterList(database, this.getThisStore());
+        if (isProgramOrder) requisition.addItemsFromProgram(database);
+        else requisition.addItemsFromMasterList(database, this.getThisStore());
         database.save('Requisition', requisition);
       });
       this.refreshData();

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -373,7 +373,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         name: record.description,
         note: record.note,
         isProgram: parseBoolean(record.isProgram),
-        programSettings: JSON.stringify(record.programSettings),
+        programSettings: record.programSettings ? JSON.stringify(record.programSettings) : '',
       };
       database.update(recordType, internalRecord);
       break;

--- a/src/widgets/AutocompleteSelector.js
+++ b/src/widgets/AutocompleteSelector.js
@@ -10,7 +10,7 @@ import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native
 import { complement } from 'set-manipulator';
 import { APP_FONT_FAMILY } from '../globalStyles';
 import { generalStrings } from '../localization';
-import withOnePress from './withOnePress';
+import { withOnePress } from './withOnePress';
 
 /**
  * A search bar that autocompletes from the options passed in, and allows any of
@@ -43,21 +43,23 @@ export class AutocompleteSelector extends React.PureComponent {
     } = this.props;
 
     const { queryText } = this.state;
+    let data;
+    if (options && options.filtered) {
+      data = options
+        .filtered(queryString, queryText)
+        .sorted(sortByString)
+        .slice();
+      if (queryStringSecondary) {
+        const secondQueryResult = options
+          .filtered(queryStringSecondary, queryText)
+          .sorted(sortByString);
+        // Remove duplicates from secondQueryResult
+        const secondaryData = complement(secondQueryResult, data);
 
-    let data = options
-      .filtered(queryString, queryText)
-      .sorted(sortByString)
-      .slice();
-    if (queryStringSecondary) {
-      const secondQueryResult = options
-        .filtered(queryStringSecondary, queryText)
-        .sorted(sortByString);
-      // Remove duplicates from secondQueryResult
-      const secondaryData = complement(secondQueryResult, data);
-
-      // Append secondary results to the first query results
-      data = data.concat(secondaryData);
-    }
+        // Append secondary results to the first query results
+        data = data.concat(secondaryData);
+      }
+    } else data = options;
 
     return (
       <View style={localStyles.container}>
@@ -74,7 +76,7 @@ export class AutocompleteSelector extends React.PureComponent {
         {data.length > 0 && (
           <FlatList
             data={data}
-            keyExtractor={item => item.id}
+            keyExtractor={item => item.id || item.name}
             renderItem={({ item }) => (
               <ResultRowWithOnePress
                 item={item}

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -17,7 +17,6 @@ import { SETTINGS_KEYS } from '../../settings';
 export class ByProgramModal extends React.Component {
   constructor(props) {
     super(props);
-
     this.state = {
       searchIsOpen: false,
       searchModalKey: 'supplier',


### PR DESCRIPTION
Fixes #815 with branch from #826

### NOTE: BRANCHES FROM THIS:
- #828 
- #829 

This PR integrates the `SupplierRequisitionPage` with the `byProgramDialog` introduced in #826. Adds additional information in `PageInfo` components (program, type period etc.). Also hides buttons such as `Add item`. Also adds a few more model helper methods/fixes

Issues:
- Further disorganises `byProgramModal` state.
- Adds methods instead of refactoring - `createRecord`

