### PR TITLE
#840 - VVN Component

### DIFF
--- a/src/widgets/MiniToggleBar.js
+++ b/src/widgets/MiniToggleBar.js
@@ -21,11 +21,11 @@ import {
  * states - True: LHS toggled, False: RHS Toggled, Null: Nothing toggled.
  * Can be controlled by pressing any part of the component to switch the toggle,
  * or use the returned key to control dependent on which toggle was pressed.
- * @prop {String} firstText     Text for the LHS toggle
- * @prop {String} secondText    Text for the RHS toggle
+ * @prop {String} leftText     Text for the LHS toggle
+ * @prop {String} leftText    Text for the RHS toggle
  * @prop {String} firstKey      Key returned when the LHS toggle is pressed
- * @prop {String} secondKey     Key returned when the RHS toggle is pressed
- * @prop {Bool}   currentState  Current state of the toggle. True = left, right = right, null = none
+ * @prop {String} rightKey     Key returned when the RHS toggle is pressed
+ * @prop {Bool}   currentState  Current state of the toggle. True = left, False = right, null = none
  * @prop {Func}   onPress       onPress function - returns {key, nextState}
  */
 export default class MiniToggleBar extends React.PureComponent {
@@ -34,7 +34,7 @@ export default class MiniToggleBar extends React.PureComponent {
     if (currentState === null) {
       return {
         // Set a middle divider when no toggles have been set.
-        firstStyle: { borderRightColor: '#CDCDCD', borderRightWidth: 1 },
+        leftStyle: { borderRightColor: '#CDCDCD', borderRightWidth: 1 },
       };
     }
 
@@ -42,11 +42,11 @@ export default class MiniToggleBar extends React.PureComponent {
       // Set the border color for the main container.
       mainStyle: currentState ? { borderColor: FINALISE_GREEN } : { borderColor: FINALISED_RED },
       // Set the background and font color for the left hand side.
-      firstStyle: currentState && { backgroundColor: FINALISE_GREEN },
-      firstTextStyle: currentState && { color: BLUE_WHITE },
+      leftStyle: currentState && { backgroundColor: FINALISE_GREEN },
+      leftTextStyle: currentState && { color: BLUE_WHITE },
       // Set the background color and font color for the right hand side.
-      secondTextStyle: !currentState && { color: BLUE_WHITE },
-      secondStyle: !currentState && { backgroundColor: FINALISED_RED, color: BLUE_WHITE },
+      rightTextStyle: !currentState && { color: BLUE_WHITE },
+      rightStyle: !currentState && { backgroundColor: FINALISED_RED, color: BLUE_WHITE },
     };
   };
 
@@ -56,20 +56,20 @@ export default class MiniToggleBar extends React.PureComponent {
   };
 
   render() {
-    const { firstText, secondText, firstKey, secondKey } = this.props;
+    const { leftText, rightText, leftKey, rightKey } = this.props;
     const { main, touchable, text } = localStyles;
-    const { mainStyle, firstStyle, firstTextStyle, secondTextStyle, secondStyle } = this.styles();
+    const { mainStyle, leftStyle, leftTextStyle, rightTextStyle, rightStyle } = this.styles();
     return (
       <View style={[main, mainStyle]}>
-        <TouchableOpacity style={[touchable, firstStyle]} onPress={this.onPress(firstKey)}>
-          <Text numberOfLines={1} ellipsizeMode="tail" style={[text, firstTextStyle]}>
-            {firstText}
+        <TouchableOpacity style={[touchable, leftStyle]} onPress={this.onPress(leftKey)}>
+          <Text numberOfLines={1} ellipsizeMode="tail" style={[text, leftTextStyle]}>
+            {leftText}
           </Text>
         </TouchableOpacity>
 
-        <TouchableOpacity style={[touchable, secondStyle]} onPress={this.onPress(secondKey)}>
-          <Text numberOfLines={1} ellipsizeMode="tail" style={[text, secondTextStyle]}>
-            {secondText}
+        <TouchableOpacity style={[touchable, rightStyle]} onPress={this.onPress(rightKey)}>
+          <Text numberOfLines={1} ellipsizeMode="tail" style={[text, rightTextStyle]}>
+            {rightText}
           </Text>
         </TouchableOpacity>
       </View>
@@ -99,15 +99,15 @@ const localStyles = StyleSheet.create({
 });
 
 MiniToggleBar.defaultProps = {
-  firstKey: null,
-  secondKey: null,
+  leftKey: null,
+  rightKey: null,
 };
 
 MiniToggleBar.propTypes = {
-  firstText: PropTypes.string.isRequired,
-  secondText: PropTypes.string.isRequired,
-  firstKey: PropTypes.string,
-  secondKey: PropTypes.string,
+  leftText: PropTypes.string.isRequired,
+  rightText: PropTypes.string.isRequired,
+  leftKey: PropTypes.string,
+  rightKey: PropTypes.string,
   currentState: PropTypes.bool.isRequired,
   onPress: PropTypes.func.isRequired,
 };

--- a/src/widgets/MiniToggleBar.js
+++ b/src/widgets/MiniToggleBar.js
@@ -1,0 +1,113 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+import {
+  APP_FONT_FAMILY,
+  FINALISED_RED,
+  FINALISE_GREEN,
+  BLUE_WHITE,
+  DARK_GREY,
+} from '../globalStyles';
+
+/**
+ * Two state toggle bar. Primary use for within a cell in a data table. Has three
+ * states - True: LHS toggled, False: RHS Toggled, Null: Nothing toggled.
+ * Can be controlled by pressing any part of the component to switch the toggle,
+ * or use the returned key to control dependent on which toggle was pressed.
+ * @prop {String} firstText     Text for the LHS toggle
+ * @prop {String} secondText    Text for the RHS toggle
+ * @prop {String} firstKey      Key returned when the LHS toggle is pressed
+ * @prop {String} secondKey     Key returned when the RHS toggle is pressed
+ * @prop {Bool}   currentState  Current state of the toggle. True = left, right = right, null = none
+ * @prop {Func}   onPress       onPress function - returns {key, nextState}
+ */
+export default class MiniToggleBar extends React.PureComponent {
+  styles = () => {
+    const { currentState } = this.props;
+    if (currentState === null) {
+      return {
+        // Set a middle divider when no toggles have been set.
+        firstStyle: { borderRightColor: '#CDCDCD', borderRightWidth: 1 },
+      };
+    }
+
+    return {
+      // Set the border color for the main container.
+      mainStyle: currentState ? { borderColor: FINALISE_GREEN } : { borderColor: FINALISED_RED },
+      // Set the background and font color for the left hand side.
+      firstStyle: currentState && { backgroundColor: FINALISE_GREEN },
+      firstTextStyle: currentState && { color: BLUE_WHITE },
+      // Set the background color and font color for the right hand side.
+      secondTextStyle: !currentState && { color: BLUE_WHITE },
+      secondStyle: !currentState && { backgroundColor: FINALISED_RED, color: BLUE_WHITE },
+    };
+  };
+
+  onPress = key => () => {
+    const { onPress, currentState } = this.props;
+    onPress({ newState: !currentState, key });
+  };
+
+  render() {
+    const { firstText, secondText, firstKey, secondKey } = this.props;
+    const { main, touchable, text } = localStyles;
+    const { mainStyle, firstStyle, firstTextStyle, secondTextStyle, secondStyle } = this.styles();
+    return (
+      <View style={[main, mainStyle]}>
+        <TouchableOpacity style={[touchable, firstStyle]} onPress={this.onPress(firstKey)}>
+          <Text numberOfLines={1} ellipsizeMode="tail" style={[text, firstTextStyle]}>
+            {firstText}
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity style={[touchable, secondStyle]} onPress={this.onPress(secondKey)}>
+          <Text numberOfLines={1} ellipsizeMode="tail" style={[text, secondTextStyle]}>
+            {secondText}
+          </Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+}
+
+const localStyles = StyleSheet.create({
+  main: {
+    borderRadius: 5,
+    borderWidth: 1,
+    borderColor: DARK_GREY,
+    alignSelf: 'center',
+    flexDirection: 'row',
+    height: '85%',
+    width: '85%',
+  },
+  touchable: {
+    width: '50%',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    color: DARK_GREY,
+    fontFamily: APP_FONT_FAMILY,
+  },
+});
+
+MiniToggleBar.defaultProps = {
+  firstKey: null,
+  secondKey: null,
+};
+
+MiniToggleBar.propTypes = {
+  firstText: PropTypes.string.isRequired,
+  secondText: PropTypes.string.isRequired,
+  firstKey: PropTypes.string,
+  secondKey: PropTypes.string,
+  currentState: PropTypes.bool.isRequired,
+  onPress: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
Fixes #840 

Adds a `MiniToggle` component.

'Neutral' state might be a little to bold? Can lighten - but also might need a better indicator that this should be pressed. Maybe appending a '?' to the text?

<img width="323" alt="image" src="https://user-images.githubusercontent.com/35858975/55674964-9b83d300-590f-11e9-8c89-ac6c35641e70.png">

- Controlled by one onPress. Can use a key to return to control depending on which button of the toggle was pressed.
- Responsive:

<img width="283" alt="image" src="https://user-images.githubusercontent.com/35858975/55674965-9e7ec380-590f-11e9-98e2-737954b90d71.png">
<img width="266" alt="image" src="https://user-images.githubusercontent.com/35858975/55674966-a0e11d80-590f-11e9-9c79-21bc3f333967.png">

Just noticed I did the on/off states opposite to what was in the example. I guess just natural that the truthy state be first? Easy to switch

Branch here to test: https://github.com/openmsupply/mobile/tree/%23840-vvn-component-example
