### PR TITLE
#851 manage vaccine item page

### DIFF
--- a/src/pages/ItemManagePage.js
+++ b/src/pages/ItemManagePage.js
@@ -1,0 +1,284 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { generateUUID } from 'react-native-database';
+
+import { GenericPage } from './GenericPage';
+import { FinaliseButton, MiniToggleBar, AutocompleteSelector, TextEditor } from '../widgets/index';
+import { PageContentModal } from '../widgets/modals/index';
+import { IconCell } from '../widgets/IconCell';
+import { DARK_GREY, FINALISED_RED, SUSSOL_ORANGE, SOFT_RED } from '../globalStyles/index';
+
+/**
+ * CONSTANTS
+ */
+
+// Titles for each modal
+const MODAL_TITLES = {
+  location: 'Place this batch of vaccines in a fridge',
+  vvmStatus: 'How many vials have a failed VVM status?',
+};
+
+// Columns available for this component
+const COLUMNS = {
+  batch: { key: 'batch', title: 'BATCH', sortable: false, width: 2 },
+  expiry: { key: 'expiryDate', title: 'EXPIRY', sortable: false, width: 1.5 },
+  arrived: { key: 'arrived', title: 'ARRIVED', sortable: false, width: 1 },
+  fridge: { key: 'location', title: 'FRIDGE', sortable: false, width: 2 },
+  breach: { key: 'breach', title: 'BREACH', sortable: false, width: 1 },
+  vvm: { key: 'vvmStatus', title: 'VVM STATUS', sortable: false, width: 2 },
+  dispose: { key: 'dispose', title: 'DISPOSE', sortable: false, width: 1 },
+  quantity: {
+    key: 'totalQuantity',
+    title: 'QUANTITY',
+    sortable: false,
+    width: 1.2,
+    alignText: 'right',
+  },
+};
+
+// Columns usable for a certain module or item
+const VACCINE_COLUMN_KEYS = ['batch', 'expiry', 'quantity', 'fridge', 'breach', 'vvm', 'dispose'];
+
+/**
+ * HELPER METHODS
+ */
+
+const getColumns = columnKeys => columnKeys.map(columnKey => COLUMNS[columnKey]);
+
+// Creates a row object for use within this component.
+const createRowObject = (itemBatch, extraData) => {
+  const { id, batch, totalQuantity, location, expiryDate } = itemBatch;
+  return {
+    id: id || generateUUID(),
+    batch,
+    totalQuantity,
+    location: location || { description: 'Unassigned' },
+    expiryDate: typeof expiryDate === 'object' ? expiryDate.toDateString() : expiryDate,
+    vvmStatus: null,
+    ...extraData,
+  };
+};
+
+/**
+ * Component used for displaying all ItemBatches for a particular
+ * item. No changes are made internally until the apply changes
+ * button is pressed.
+ */
+export class ItemManagePage extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.FRIDGES = null;
+
+    this.state = {
+      data: null,
+      isModalOpen: false,
+      modalKey: null,
+      currentBatch: null,
+    };
+  }
+
+  /**
+   * COMPONENT METHODS
+   */
+  componentDidMount = () => {
+    const { database, item } = this.props;
+    // Will normally be passed item from props;
+    this.FRIDGES = database.objects('Location');
+    this.setState({ data: item.batches.map(itemBatch => createRowObject(itemBatch)) });
+  };
+
+  /**
+   * HELPER METHODS
+   */
+  getModalTitle = () => {
+    const { modalKey } = this.state;
+    return MODAL_TITLES[modalKey];
+  };
+
+  // Updates the currentBatch object held within state with new
+  // values. Optional second parameter of fields to be used within
+  // the setState call.
+  updateObject = (extraObjectValues = {}, extraStateValues = {}) => {
+    const { data, currentBatch } = this.state;
+    const batchIndex = data.findIndex(({ id = 0 }) => currentBatch.id === id);
+    // If something has gone wrong finding the batch, don't try to update
+    if (batchIndex >= 0) data[batchIndex] = { ...currentBatch, ...extraObjectValues };
+    this.setState({ data: [...data], ...extraStateValues });
+  };
+
+  /**
+   * EVENT HANDLERS
+   */
+
+  // Called after entering the doses after toggling the VVM status to FAIL.
+  // Will create a new row in the table with a quantity equal to the amount
+  // entered and a VVM status of FAIL. Also updates the currentBatch objects
+  // quantity.
+  onSplitBatch = (splitValue = 0) => {
+    const { currentBatch, data } = this.state;
+    const { totalQuantity } = currentBatch;
+
+    const parsedSplitValue = parseInt(splitValue, 10);
+    let newObjectValues = {};
+
+    if (parsedSplitValue > totalQuantity) {
+      newObjectValues = { vvmStatus: false };
+      // Account for 0 & NaN (From entering a non-numeric character)
+    } else if (parsedSplitValue) {
+      const newBatchValues = { totalQuantity: parsedSplitValue, vvmStatus: false };
+      data.push(createRowObject(currentBatch, newBatchValues));
+      newObjectValues = { vvmStatus: true, totalQuantity: totalQuantity - parsedSplitValue };
+    }
+    this.updateObject(newObjectValues, { isModalOpen: false });
+  };
+
+  onApplyChanges = () => {
+    // TODO:
+    // Create inventory adjustments for any failed vvm status'.
+    // Create repacks for any location changes
+    // Pop this page off the navigation stack.
+  };
+
+  onDispose = () => {
+    // TODO:
+    // Open a modal to select the doses?
+    // Set the row to have some distinctive marker to show it
+    // is being disposed of.
+    // Set the dispose icon to one which will 'undelete' this row.
+  };
+
+  // Called on selecting a fridge in the fridge selection modal,
+  // just update the location of the currentBatch and close the modal.
+  onFridgeSelection = location => {
+    this.updateObject({ location }, { isModalOpen: false });
+  };
+
+  // Called on toggle the vvm toggle bar. If being set to PASS, will just update
+  // the object held in the closure to a PASS VVM status. Otherwise, opens a
+  // modal for a user to enter the doses affected and set the currentBatch.
+  onVvmToggle = currentBatch => ({ newState }) => {
+    if (!newState) return this.setState({ modalKey: 'vvmStatus', isModalOpen: true, currentBatch });
+    return this.setState({ currentBatch }, () => this.updateObject({ vvmStatus: true }));
+  };
+
+  // Method which controls all modals. Will open a modal corresponding to the
+  // modal key in renderModal and set the passed itemBatch as the current
+  // itemBatch. If called with no parameters, will clear the currentBatch
+  // and close the modal.
+  onModalUpdate = ({ modalKey, itemBatch } = {}) => () => {
+    if (modalKey) this.setState({ modalKey, isModalOpen: true, currentBatch: itemBatch });
+    else this.setState({ isModalOpen: false, currentBatch: null });
+  };
+
+  /**
+   * RENDER HELPERS
+   */
+  renderCell = (key, itemBatch) => {
+    const { location, vvmStatus } = itemBatch;
+    const modalUpdateProps = { modalKey: key, itemBatch };
+    const hasFridges = this.FRIDGES && this.FRIDGES.length > 0;
+    const usingFridge = vvmStatus !== false && hasFridges;
+    switch (key) {
+      default:
+        return itemBatch[key];
+      case 'location':
+        return (
+          <IconCell
+            text={
+              (hasFridges && 'No Fridges') ||
+              (vvmStatus !== false ? location.description : 'Discarded')
+            }
+            disabled={!usingFridge}
+            icon={usingFridge ? 'caret-up' : 'times'}
+            iconColour={usingFridge ? SUSSOL_ORANGE : SOFT_RED}
+            onPress={this.onModalUpdate(modalUpdateProps)}
+          />
+        );
+      case 'breach':
+        return (
+          <IconCell icon="warning" iconSize={30} onPress={() => {}} iconColour={FINALISED_RED} />
+        );
+      case 'dispose':
+        return <IconCell icon="trash" iconSize={30} onPress={() => {}} iconColour={DARK_GREY} />;
+      case 'vvmStatus':
+        return (
+          <MiniToggleBar
+            leftText="PASS"
+            rightText="FAIL"
+            currentState={itemBatch.vvmStatus}
+            onPress={this.onVvmToggle(itemBatch)}
+          />
+        );
+    }
+  };
+
+  renderModal = () => {
+    const { modalKey } = this.state;
+    let splitValue;
+    const modals = {
+      location: (
+        <AutocompleteSelector
+          options={this.FRIDGES}
+          queryString="description BEGINSWITH[c] $0"
+          sortByString="description"
+          onSelect={this.onFridgeSelection}
+          renderLeftText={({ description } = { description: 'Unnamed Fridge' }) => description}
+        />
+      ),
+      vvmStatus: <TextEditor text={splitValue} onEndEditing={this.onSplitBatch} />,
+    };
+    return modals[modalKey];
+  };
+
+  renderTopRightComponent = () => (
+    <FinaliseButton
+      text="Apply Changes"
+      onPress={() => {}}
+      isFinalised={false}
+      fontStyle={{ fontSize: 18 }}
+    />
+  );
+
+  render() {
+    const { database, genericTablePageStyles, topRoute } = this.props;
+    const { data, isModalOpen } = this.state;
+    return (
+      <GenericPage
+        data={data || []}
+        renderCell={this.renderCell}
+        renderTopRightComponent={this.renderTopRightComponent}
+        onEndEditing={this.onEndEditing}
+        columns={getColumns(VACCINE_COLUMN_KEYS)}
+        database={database}
+        topRoute={topRoute}
+        isDataCircular={true}
+        {...genericTablePageStyles}
+      >
+        <PageContentModal
+          isOpen={isModalOpen}
+          onClose={this.onModalUpdate()}
+          title={this.getModalTitle()}
+        >
+          {this.renderModal()}
+        </PageContentModal>
+      </GenericPage>
+    );
+  }
+}
+
+ItemManagePage.propTypes = {
+  database: PropTypes.object.isRequired,
+  genericTablePageStyles: PropTypes.object.isRequired,
+  topRoute: PropTypes.object.isRequired,
+  item: PropTypes.object.isRequired,
+};
+
+export default ItemManagePage;

--- a/src/pages/ItemManagePage.js
+++ b/src/pages/ItemManagePage.js
@@ -164,8 +164,8 @@ export class ItemManagePage extends React.Component {
   // Called on toggle the vvm toggle bar. If being set to PASS, will just update
   // the object held in the closure to a PASS VVM status. Otherwise, opens a
   // modal for a user to enter the doses affected and set the currentBatch.
-  onVvmToggle = currentBatch => ({ newState }) => {
-    if (!newState) return this.setState({ modalKey: 'vvmStatus', isModalOpen: true, currentBatch });
+  onVvmToggle = ({ modalKey, currentBatch }) => ({ newState }) => {
+    if (!newState) return this.onModalUpdate({ modalKey, currentBatch });
     return this.setState({ currentBatch }, () => this.updateObject({ vvmStatus: true }));
   };
 
@@ -214,7 +214,7 @@ export class ItemManagePage extends React.Component {
             leftText="PASS"
             rightText="FAIL"
             currentState={itemBatch.vvmStatus}
-            onPress={this.onVvmToggle(itemBatch)}
+            onPress={this.onVvmToggle(modalUpdateProps)}
           />
         );
     }

--- a/src/pages/ItemManagePage.js
+++ b/src/pages/ItemManagePage.js
@@ -53,18 +53,10 @@ const VACCINE_COLUMN_KEYS = ['batch', 'expiry', 'quantity', 'fridge', 'breach', 
 const getColumns = columnKeys => columnKeys.map(columnKey => COLUMNS[columnKey]);
 
 // Creates a row object for use within this component.
-const createRowObject = (itemBatch, extraData) => {
-  const { id, batch, totalQuantity, location, expiryDate } = itemBatch;
-  return {
-    id: id || generateUUID(),
-    batch,
-    totalQuantity,
-    location: location || { description: 'Unassigned' },
-    expiryDate: typeof expiryDate === 'object' ? expiryDate.toDateString() : expiryDate,
-    vvmStatus: null,
-    ...extraData,
-  };
-};
+const createRowObject = (itemBatch, extraData) => ({
+  ...itemBatch,
+  ...extraData,
+});
 
 /**
  * Component used for displaying all ItemBatches for a particular
@@ -132,7 +124,11 @@ export class ItemManagePage extends React.Component {
       newObjectValues = { vvmStatus: false };
       // Account for 0 & NaN (From entering a non-numeric character)
     } else if (parsedSplitValue) {
-      const newBatchValues = { totalQuantity: parsedSplitValue, vvmStatus: false };
+      const newBatchValues = {
+        id: generateUUID(),
+        totalQuantity: parsedSplitValue,
+        vvmStatus: false,
+      };
       data.push(createRowObject(currentBatch, newBatchValues));
       newObjectValues = { vvmStatus: true, totalQuantity: totalQuantity - parsedSplitValue };
     }

--- a/src/pages/ItemManagePage.js
+++ b/src/pages/ItemManagePage.js
@@ -194,7 +194,7 @@ export class ItemManagePage extends React.Component {
           <IconCell
             text={
               (hasFridges && 'No Fridges') ||
-              (vvmStatus !== false ? location.description : 'Discarded')
+              (vvmStatus !== false ? location.description || 'Unnamed Fridge' : 'Discarded')
             }
             disabled={!usingFridge}
             icon={usingFridge ? 'caret-up' : 'times'}

--- a/src/pages/ItemManagePage.js
+++ b/src/pages/ItemManagePage.js
@@ -90,7 +90,6 @@ export class ItemManagePage extends React.Component {
    */
   componentDidMount = () => {
     const { database, item } = this.props;
-    // Will normally be passed item from props;
     this.FRIDGES = database.objects('Location');
     this.setState({ data: item.batches.map(itemBatch => createRowObject(itemBatch)) });
   };
@@ -142,9 +141,14 @@ export class ItemManagePage extends React.Component {
 
   onApplyChanges = () => {
     // TODO:
-    // Create inventory adjustments for any failed vvm status'.
+    // Confirmation dialog
+    // Create inventory adjustments for any failed vvm status'
     // Create repacks for any location changes
     // Pop this page off the navigation stack.
+    // If more data is needed to create these repacks and inventory
+    // adjustments, they can easily be added to the row object with
+    // no side-effects. e.g. the ItemBatch itself or just
+    // some extra fields.
   };
 
   onDispose = () => {

--- a/src/pages/ItemManagePage.js
+++ b/src/pages/ItemManagePage.js
@@ -173,8 +173,8 @@ export class ItemManagePage extends React.Component {
   // modal key in renderModal and set the passed itemBatch as the current
   // itemBatch. If called with no parameters, will clear the currentBatch
   // and close the modal.
-  onModalUpdate = ({ modalKey, itemBatch } = {}) => () => {
-    if (modalKey) this.setState({ modalKey, isModalOpen: true, currentBatch: itemBatch });
+  onModalUpdate = ({ modalKey, currentBatch } = {}) => () => {
+    if (modalKey) this.setState({ modalKey, isModalOpen: true, currentBatch });
     else this.setState({ isModalOpen: false, currentBatch: null });
   };
 
@@ -183,7 +183,7 @@ export class ItemManagePage extends React.Component {
    */
   renderCell = (key, itemBatch) => {
     const { location, vvmStatus } = itemBatch;
-    const modalUpdateProps = { modalKey: key, itemBatch };
+    const modalUpdateProps = { modalKey: key, currentBatch: itemBatch };
     const hasFridges = this.FRIDGES && this.FRIDGES.length > 0;
     const usingFridge = vvmStatus !== false && hasFridges;
     switch (key) {

--- a/src/pages/ItemManagePage.js
+++ b/src/pages/ItemManagePage.js
@@ -90,7 +90,7 @@ export class ItemManagePage extends React.Component {
    */
   componentDidMount = () => {
     const { database, item } = this.props;
-    this.FRIDGES = database.objects('Location');
+    this.FRIDGES = database.objects('Location').filter(({ isFridge }) => isFridge);
     this.setState({ data: item.batches.map(itemBatch => createRowObject(itemBatch)) });
   };
 

--- a/src/pages/ItemManagePage.js
+++ b/src/pages/ItemManagePage.js
@@ -10,7 +10,13 @@ import PropTypes from 'prop-types';
 import { generateUUID } from 'react-native-database';
 
 import { GenericPage } from './GenericPage';
-import { FinaliseButton, MiniToggleBar, AutocompleteSelector, TextEditor } from '../widgets/index';
+import {
+  FinaliseButton,
+  MiniToggleBar,
+  AutocompleteSelector,
+  TextEditor,
+  ExpiryTextInput,
+} from '../widgets/index';
 import { PageContentModal } from '../widgets/modals/index';
 import { IconCell } from '../widgets/IconCell';
 import { DARK_GREY, FINALISED_RED, SUSSOL_ORANGE, SOFT_RED } from '../globalStyles/index';
@@ -189,6 +195,8 @@ export class ItemManagePage extends React.Component {
     switch (key) {
       default:
         return itemBatch[key];
+      case 'expiryDate':
+        return <ExpiryTextInput text={itemBatch[key]} />;
       case 'location':
         return (
           <IconCell

--- a/src/widgets/ExpiryTextInput.js
+++ b/src/widgets/ExpiryTextInput.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/forbid-prop-types */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
@@ -7,6 +8,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { TextInput, StyleSheet } from 'react-native';
 import { formatExpiryDate, parseExpiryDate } from '../utilities';
+
+import { dataTableStyles } from '../globalStyles';
 
 /* Component that allows masking of TextInput for date in format MM/YY[YY] */
 export class ExpiryTextInput extends React.Component {
@@ -93,9 +96,14 @@ export class ExpiryTextInput extends React.Component {
 
 export default ExpiryTextInput;
 
-/* eslint-disable react/forbid-prop-types, react/require-default-props */
+ExpiryTextInput.defaultProps = {
+  style: dataTableStyles.text,
+  onEndEditing: null,
+  isEditable: false,
+};
+
 ExpiryTextInput.propTypes = {
-  text: PropTypes.object,
+  text: PropTypes.object.isRequired,
   style: PropTypes.object,
   onEndEditing: PropTypes.func,
   isEditable: PropTypes.bool,

--- a/src/widgets/FinaliseButton.js
+++ b/src/widgets/FinaliseButton.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/forbid-prop-types */
+
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
@@ -14,13 +16,12 @@ import globalStyles from '../globalStyles';
 import { navStrings } from '../localization';
 
 export const FinaliseButton = props => {
-  const { isFinalised, onPress } = props;
-
+  const { isFinalised, onPress, text, fontStyle } = props;
   if (isFinalised) {
     return (
       <View style={[globalStyles.navBarRightContainer, localStyles.outerContainer]}>
-        <Text style={[globalStyles.navBarText, localStyles.text]}>
-          {navStrings.finalised_cannot_be_edited}
+        <Text style={[globalStyles.navBarText, localStyles.text, fontStyle]}>
+          {text || navStrings.finalised_cannot_be_edited}
         </Text>
         <Icon name="lock" style={globalStyles.finalisedLock} />
       </View>
@@ -28,10 +29,10 @@ export const FinaliseButton = props => {
   }
   return (
     <TouchableOpacity
-      style={[globalStyles.navBarRightContainer, localStyles.outerContainer]}
+      style={[globalStyles.navBarRightContainer, localStyles.outerContainer, fontStyle]}
       onPress={onPress}
     >
-      <Text style={[globalStyles.navBarText, localStyles.text]}>{navStrings.finalise}</Text>
+      <Text style={[globalStyles.navBarText, localStyles.text]}>{text || navStrings.finalise}</Text>
       <Icon name="check-circle" style={globalStyles.finaliseButton} />
     </TouchableOpacity>
   );
@@ -39,14 +40,17 @@ export const FinaliseButton = props => {
 
 export default FinaliseButton;
 
-/* eslint-disable react/require-default-props, react/default-props-match-prop-types */
 FinaliseButton.propTypes = {
   isFinalised: PropTypes.bool.isRequired,
   onPress: PropTypes.func,
+  fontStyle: PropTypes.object,
+  text: PropTypes.string,
 };
 
 FinaliseButton.defaultProps = {
-  isFinalised: false,
+  onPress: null,
+  fontStyle: {},
+  text: '',
 };
 
 const APPBAR_HEIGHT = Platform.OS === 'ios' ? 44 : 56; // Taken from NavigationExperimental

--- a/src/widgets/IconCell.js
+++ b/src/widgets/IconCell.js
@@ -11,15 +11,17 @@ import Icon from 'react-native-vector-icons/FontAwesome';
 import { SUSSOL_ORANGE, APP_FONT_FAMILY, DARK_GREY, SOFT_RED } from '../globalStyles/index';
 
 /**
- * Simple stateless component which renders some text and and an
- * icon in a cell with an optional onPress. Setitng disabled to
- * true changes the colour scheme.
- *
+ * Simple stateless component which renders either:
+ * some text, left aligned and ellipsis overflow and a rightaligned icon
+ * or, a centered icon with optional colours.
+ * Default styles are dark grey text, soft red when disabled with an
+ * orange up-caret icon.
  */
 export class IconCell extends React.PureComponent {
   getComponent = () => {
-    const { text, icon, disabled } = this.props;
-    const { mainContainer, textContainer, iconContainer, font } = getLocalStyles(disabled);
+    const { text, icon, disabled, iconSize, iconColour } = this.props;
+    const styleParameters = { disabled, text };
+    const { mainContainer, textContainer, iconContainer, font } = getLocalStyles(styleParameters);
     return (
       <View style={mainContainer}>
         <View style={textContainer}>
@@ -29,7 +31,7 @@ export class IconCell extends React.PureComponent {
         </View>
 
         <View style={iconContainer}>
-          <Icon name={icon} size={20} color={disabled ? SOFT_RED : SUSSOL_ORANGE} />
+          <Icon name={icon} size={iconSize} color={iconColour} />
         </View>
       </View>
     );
@@ -43,7 +45,7 @@ export class IconCell extends React.PureComponent {
   }
 }
 
-const getLocalStyles = disabled =>
+const getLocalStyles = ({ disabled, text }) =>
   StyleSheet.create({
     mainContainer: {
       display: 'flex',
@@ -51,14 +53,14 @@ const getLocalStyles = disabled =>
       marginHorizontal: 10,
     },
     textContainer: {
-      width: '75%',
+      width: text ? '75%' : '0%',
       fontFamily: APP_FONT_FAMILY,
     },
     iconContainer: {
-      width: '20%',
+      width: text ? '20%' : '100%',
       display: 'flex',
       flexDirection: 'row',
-      justifyContent: 'flex-end',
+      justifyContent: text ? 'flex-end' : 'center',
     },
     font: { fontFamily: APP_FONT_FAMILY, color: disabled ? SOFT_RED : DARK_GREY },
   });
@@ -68,6 +70,8 @@ IconCell.defaultProps = {
   icon: 'caret-up',
   disabled: false,
   onPress: null,
+  iconColour: SUSSOL_ORANGE,
+  iconSize: 20,
 };
 
 IconCell.propTypes = {
@@ -75,6 +79,8 @@ IconCell.propTypes = {
   onPress: PropTypes.func,
   icon: PropTypes.string,
   disabled: PropTypes.bool,
+  iconColour: PropTypes.string,
+  iconSize: PropTypes.number,
 };
 
 export default IconCell;


### PR DESCRIPTION
Fixes #851

#### Note: Possibly should close this and do a new PR when I make the page before this one, and other features are in so it can be properly finished, although it's a reasonable size now?

Branch I developed on mainly: [#851-manage-vaccine-page-test](https://github.com/openmsupply/mobile/tree/%23851-manage-vaccine-page-test) (I need a better way to do this .. )

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/35858975/56073040-22461d80-5df2-11e9-87e2-0cfcc7c5abcf.png">


Just the skeleton really. Still a few things to do:
- on apply changes (the biggest part, really)
- opening breach modal.
- Navigation, but really is from the parent/prior page component

Other than just creating this component, 
- have updated `IconCell` to also be able to render *just* an icon, rather than *text+icon*. 
- `FinaliseButton` to be able to pass in some text and some font styles.

