### PR TITLE
#859 transaction batch missing getter

### DIFF
--- a/src/database/DataTypes/TransactionBatch.js
+++ b/src/database/DataTypes/TransactionBatch.js
@@ -169,6 +169,14 @@ export class TransactionBatch extends Realm.Object {
     return `${this.itemBatch} in a ${this.transaction.type}`;
   }
 
+  get transactionItem() {
+    const { transaction } = this;
+    return transaction.items.find(transactionItem => {
+      const { batches } = transactionItem;
+      return batches.some(batch => batch.id === this.id);
+    });
+  }
+
   /**
    * Splits a transactionBatch into two - (TB1, TB2). TB2 is a clone
    * of TB1 except for numberOfPacks and doses fields.

--- a/src/database/DataTypes/TransactionBatch.js
+++ b/src/database/DataTypes/TransactionBatch.js
@@ -171,10 +171,7 @@ export class TransactionBatch extends Realm.Object {
 
   get transactionItem() {
     const { transaction } = this;
-    return transaction.items.find(transactionItem => {
-      const { batches } = transactionItem;
-      return batches.some(batch => batch.id === this.id);
-    });
+    return transaction.items.find(({ batches }) => batches.some(batch => batch.id === this.id));
   }
 
   /**


### PR DESCRIPTION
Fixes #859 

Just adding a getter back that I removed.

Note on safeness:
- Realm list properties are always defined
- Every object must have an id
- array method is safe to run on empty lists

