### PR TITLE
#865 class helper methods

### DIFF
--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -223,9 +223,9 @@ export class Item extends Realm.Object {
    * are returned.
    * @param {Location} location
    */
-  getBatchesInLocation({ id } = {}) {
-    if (!id) return this.batches;
-    return this.batches.filtered('location.id = $0', id);
+  getBatchesInLocation({ id: locationId } = {}) {
+    if (!locationId) return this.batches;
+    return this.batches.filtered('location.id = $0', locationId);
   }
 
   /**
@@ -257,10 +257,10 @@ export class Item extends Realm.Object {
    * in breaches are returned.
    * @param {Location} location
    */
-  getBreachedBatches({ id } = {}) {
+  getBreachedBatches({ id: locationId } = {}) {
     const breachedBatches = this.batches.filter(({ hasBreached } = {}) => hasBreached);
-    if (!id) return breachedBatches;
-    return breachedBatches.filter(({ location } = {}) => location && location.id === id);
+    if (!locationId) return breachedBatches;
+    return breachedBatches.filter(({ location } = {}) => location && location.id === locationId);
   }
 
   /**

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -245,10 +245,7 @@ export class Item extends Realm.Object {
    * @param {Location} location
    */
   getQuantityInLocation(location) {
-    return this.getBatchesInLocation(location).reduce(
-      (sum, { numberOfPacks = 0, packSize = 1 } = {}) => sum + numberOfPacks * packSize,
-      0
-    );
+    return getTotal(this.getBatchesInLocation(location), 'totalQuantity');
   }
 
   /**
@@ -280,10 +277,7 @@ export class Item extends Realm.Object {
    * @param {Location} location
    */
   getQuantityInBreach(location) {
-    return this.getBreachedBatches(location).reduce(
-      (sum, { numberOfPacks = 0, packSize = 1 } = {}) => sum + numberOfPacks * packSize,
-      0
-    );
+    return getTotal(this.getBreachedBatches(location), 'totalQuantity');
   }
 
   /**

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -287,16 +287,18 @@ export class Item extends Realm.Object {
   getTemperatureExposure(location) {
     let { batches } = this;
     if (location) batches = this.getBatchesInLocation(location);
+
     const temperatures = batches.map(({ temperatureExposure } = {}) => temperatureExposure);
-    const maxTemperatures = temperatures.reduce(
-      (maxTemp, { max = 0 } = {}) => Math.max(maxTemp, max),
+
+    const maxTemperature = temperatures.reduce(
+      (maxTemp, { maxTemperature: max = -Infinity } = {}) => Math.max(maxTemp, max),
       0
     );
-    const minTemperatures = temperatures.reduce(
-      (minTemp, { min = Infinity } = {}) => Math.min(minTemp, min),
+    const minTemperature = temperatures.reduce(
+      (minTemp, { minTemperature: min = Infinity } = {}) => Math.min(minTemp, min),
       Infinity
     );
-    return { minTemperatures, maxTemperatures };
+    return { minTemperature, maxTemperature };
   }
 }
 

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -254,10 +254,8 @@ export class Item extends Realm.Object {
    * in breaches are returned.
    * @param {Location} location
    */
-  getBreachedBatches({ id: locationId } = {}) {
-    const breachedBatches = this.batches.filter(({ hasBreached } = {}) => hasBreached);
-    if (!locationId) return breachedBatches;
-    return breachedBatches.filter(({ location } = {}) => location && location.id === locationId);
+  getBreachedBatches(location) {
+    return this.getBatchesInLocation(location).filter(hasBreached => hasBreached);
   }
 
   /**

--- a/src/database/DataTypes/ItemBatch.js
+++ b/src/database/DataTypes/ItemBatch.js
@@ -125,6 +125,31 @@ export class ItemBatch extends Realm.Object {
   toString() {
     return `${this.itemName} - Batch ${this.batch}`;
   }
+
+  /**
+   * Returns all SensorLog objects related to this ItemBatch
+   * which has recorded a breach.
+   */
+  get breaches() {
+    return this.sensorLogs.filtered('isInBreach = $0', true);
+  }
+
+  /**
+   * Returns if this ItemBatch has been in a breach.
+   */
+  get hasBreached() {
+    return this.breaches.length > 0;
+  }
+
+  /**
+   * Returns an object {maxTemperature, minTemperature} for all
+   * recorded temperatures for this ItemBatch.
+   */
+  get temperatureExposure() {
+    const maxTemperature = this.sensorLogs.max('temperature');
+    const minTemperature = this.sensorLogs.min('temperature');
+    return { maxTemperature, minTemperature };
+  }
 }
 
 ItemBatch.schema = {

--- a/src/database/DataTypes/ItemBatch.js
+++ b/src/database/DataTypes/ItemBatch.js
@@ -146,8 +146,8 @@ export class ItemBatch extends Realm.Object {
    * recorded temperatures for this ItemBatch.
    */
   get temperatureExposure() {
-    const maxTemperature = this.sensorLogs.max('temperature');
-    const minTemperature = this.sensorLogs.min('temperature');
+    const maxTemperature = this.sensorLogs.max('temperature') || -Infinity;
+    const minTemperature = this.sensorLogs.min('temperature') || Infinity;
     return { maxTemperature, minTemperature };
   }
 }

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -212,14 +212,6 @@ export class Transaction extends Realm.Object {
   }
 
   /**
-   * Gets if this transaction has an item that is a vaccine
-   * @return {boolean}
-   */
-  get hasVaccine() {
-    return !!this.items.find(({ item }) => item.isVaccine);
-  }
-
-  /**
    * Get if this transaction includes a given item.
    *
    * @param   {Item}  item


### PR DESCRIPTION
Fixes #865 

- Some of these could be slightly more efficient (e.g. `getBreachedBatches` could filter on location before breach status) for uglier code
- Some may be unnecessary e.g just getting the length. Personally I like them as they are used a bit, but I can see the argument for them not being useful.
- Not sure about the names
- The two removed getters were duplicates