### PR TITLE
#843 helper methods

### DIFF
--- a/src/utilities/modules/vaccines.js
+++ b/src/utilities/modules/vaccines.js
@@ -30,7 +30,7 @@
 export const extractBreaches = ({ sensorLogs = [], database }) => {
   if (!(database && sensorLogs.length > 0)) return [];
 
-  const sensorLogStack = [];
+  let sensorLogStack = [];
   const breaches = [];
   const sensorLogsByLocation = {};
 
@@ -66,8 +66,8 @@ export const extractBreaches = ({ sensorLogs = [], database }) => {
         // onto the stack as the new potential delimiter for the next breach.
       } else {
         sensorLogStack.push(sensorLog);
-        breaches.push([...sensorLogStack]);
-        sensorLogStack.length = 0;
+        breaches.push([sensorLogStack]);
+        sensorLogStack = [];
         sensorLogStack.push(sensorLog);
       }
     });

--- a/src/utilities/modules/vaccines.js
+++ b/src/utilities/modules/vaccines.js
@@ -78,11 +78,9 @@ export const extractBreaches = ({ sensorLogs = [], database }) => {
   if (sensorLogStack.length > 0) breaches.push(sensorLogStack);
 
   // Create Realm.result objects for each breach.
-  return breaches.map(breach => {
-    const sensorIds = breach.map(log => log.id);
-    const queryString = sensorIds.map((_, i) => `id = $${i}`).join(' OR ');
-    return database.objects('SensorLog').filtered(queryString, ...sensorIds);
-  });
+  return breaches.map(breach =>
+    database.objects('SensorLog').filtered(breach.map(({ id }) => `id = "${id}"`).join(' OR '))
+  );
 };
 
 /**

--- a/src/utilities/modules/vaccines.js
+++ b/src/utilities/modules/vaccines.js
@@ -85,7 +85,7 @@ export const extractBreaches = ({ sensorLogs = [], database }) => {
   breaches.map(breach => {
     const sensorIds = breach.map(log => log.id);
     const queryString = sensorIds.map((_, i) => `id = $${i}`).join(' OR ');
-    return database.objects('SensorLog').filtered(...queryString, ...sensorIds);
+    return database.objects('SensorLog').filtered(queryString, ...sensorIds);
   });
 
   return breaches;

--- a/src/utilities/modules/vaccines.js
+++ b/src/utilities/modules/vaccines.js
@@ -114,33 +114,32 @@ export const extractBreaches = ({ sensorLogs = [], database }) => {
 export const sensorLogsExtractBatches = ({ sensorLogs = [], itemBatch, item } = {}) => {
   const groupedBatches = {};
   sensorLogs.forEach(({ itemBatches, logInterval, isInBreach }) => {
-    // Premature exit if log has no batches.
-    if (itemBatches.length === 0) return;
-    if (!isInBreach) return;
-
-    let batchesToUse = [...itemBatches];
+    // Premature exit if log has no batches, or is not a breached sensorLog
+    if (itemBatches.length === 0 || !isInBreach) return;
+    // Ensure each batch has stock
+    let batchesToUse = itemBatches.filtered('totalQuantity > $0', 0);
     // If an Item has been passed, only find batches for this item.
-    if (item) batchesToUse = batchesToUse.filter(batch => batch.item && batch.item.id === item.id);
+    if (item) batchesToUse = batchesToUse.filtered('batch.id = $0', item.id);
     // If an ItemBatch has been passed, only find batches for this item.
-    else if (itemBatch) batchesToUse = batchesToUse.filter(({ id }) => id === itemBatch.id);
-    // For each batch, store it's details. If already stored, increment the
-    // duration in the breach by this logs interval.
+    else if (itemBatch) batchesToUse = batchesToUse.filtered('batch.id = $0', itemBatch.id);
+    // For each batch, store it's details:
+    // { duration, id, code, enteredDate, totalQuantity, expiryDate }
+    // If already stored, increment the duration in the breach by this logs interval.
     batchesToUse.forEach(
       ({ item: batchItem, id: batchId, code, enteredDate, expiryDate, totalQuantity }) => {
         // Premature return if this ItemBatch does not have an Item associated
-        // if it's totalQuantity is 0.
-        if (!(batchItem && totalQuantity)) return;
+        if (!batchItem) return;
         const { id: itemId } = batchItem;
         // If this batches item hasn't been encountered yet, create
-        // a grouping object.
+        // a grouping object. groupedBatches = { itemId: { item, batches: {}  }}
         if (!groupedBatches[itemId]) groupedBatches[itemId] = { item: batchItem, batches: {} };
         const itemBatchesGrouping = groupedBatches[itemId].batches;
-        // If this batch has been encountered before, just increment
-        // it's duration by the interval of this log.
+        // If this batch has been encountered before, just increment it's duration by the
+        // interval of this log.
         if (itemBatchesGrouping[batchId]) {
           itemBatchesGrouping[batchId].duration += logInterval;
           // If it has not been encountered yet, store the details
-          // for this batch
+          // for this batch: groupedBatches = { itemId: { item, batches: { id: {}, .. }}, .. }
         } else {
           itemBatchesGrouping[batchId] = {
             duration: logInterval,
@@ -154,12 +153,10 @@ export const sensorLogsExtractBatches = ({ sensorLogs = [], itemBatch, item } = 
       }
     );
   });
-  // Create the return object. If no items are found,
-  // [ {item, batches: [ as above ] }, .. ]
+  // Create the return object. [ {item, batches: [ as above ] }, .. ]
   const allItemsForLogs = Object.values(groupedBatches).map(itemObject => {
     const { item: itemForGroup, batches } = itemObject;
     return {
-      sensorLogs,
       item: itemForGroup,
       batches: Object.values(batches).map(batchObject => batchObject),
     };

--- a/src/utilities/modules/vaccines.js
+++ b/src/utilities/modules/vaccines.js
@@ -1,0 +1,172 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+/**
+ * Utility and helper methods for the vaccine
+ * module.
+ */
+
+/**
+ * Method used with Array.prototype.sort for sensorLogs
+ * Sorts from oldest to newest.
+ * @param  {SensorLog} sensorLogA
+ * @param  {SensorLog} sensorLogB
+ * @param  {Date}      sensorLogA.timestamp
+ * @param  {Date}      sensorLogB.timestamp
+ * @return {Number}    1 for A>B, -1 for A<B, 0 for A=B
+ */
+const sortSensorLogs = (
+  { timestamp: timestampA = new Date(-8640000000000000) },
+  { timestamp: timestampB = new Date(-8640000000000000) }
+) => {
+  if (timestampA > timestampB) return 1;
+  if (timestampA < timestampB) return -1;
+  return 0;
+};
+
+/**
+ * Extracts breaches from a set of sensor logs.
+ * Breach: Sequential sensorLog objects whose temperature is outside
+ * the lower or uppound limits, form a breach. Each array returned
+ * contains all sensorLogs which form a breach INCLUDING the sensorLog
+ * prior to the breach, and after the breach, if they exist. There may
+ * be duplicate non-breach sensorLogs as breach delimiters if there is
+ * only one sensorLog between breaches.
+ *
+ * Method sorts the sensorLogs by timestamp, iterates and pushes onto a
+ * stack. Only one unBreached sensorLog is kept at the tail of the stack.
+ * All breached sensorLogs are pushed, until a non breached log, where this
+ * marks a breach has been found. Store these sensorLogs and reset the stack.
+ *
+ * @param  {Realm.results/array} sensorLogs array of sensorLog objects
+ * @return {Array<Realm.results<SensorLog>} A 2D array of Realm.results. Example:
+ * [ [ sensorLog1, sensorLog2 .. ], [ sensorLog1, sensorLog2, sensorLog3, .. ]]
+ * where each element is a Realm.results<SensorLog>
+ */
+export const extractBreaches = ({ sensorLogs = [], database }) => {
+  if (!(database && sensorLogs.length > 0)) return [];
+
+  const sensorLogStack = [];
+  const breaches = [];
+
+  // Sort the sensor logs by timestamp.
+  sensorLogs.sort(sortSensorLogs);
+
+  sensorLogs.forEach(sensorLog => {
+    const { isInBreach } = sensorLog;
+    const { length: stackLength } = sensorLogStack;
+    // If the stack is empty, just push this sensorLog.
+    if (stackLength === 0) sensorLogStack.push(sensorLog);
+    // Any breached sensorLogs are always pushed onto the stack.
+    else if (isInBreach) sensorLogStack.push(sensorLog);
+    // If both head of the stack and this sensorLog are unbreached,
+    // replace the head. This can occurs when the length is 1. Two
+    // sequential unbreached logs are never pushed.
+    else if (!sensorLogStack[stackLength - 1].isInBreach && !isInBreach) {
+      sensorLogStack.pop();
+      sensorLogStack.push(sensorLog);
+      // In all other cases, a breach has been found. Push the last sensorlog,
+      // store the breach and reset the stack. Push this sensorLog back
+      // onto the stack as the new potential delimiter for the next breach.
+    } else {
+      sensorLogStack.push(sensorLog);
+      breaches.push(sensorLogStack);
+      sensorLogStack.length = 0;
+      sensorLogStack.push(sensorLog);
+    }
+  });
+  // Push any remaining sensorlogs. If any are left, they form a breach
+  // with no delimiting non-breached sensorlog.
+  if (sensorLogStack.length > 0) breaches.push(sensorLogStack);
+
+  // Create Realm.result objects for each breach.
+  breaches.map(breach => {
+    const sensorIds = breach.map(log => log.id);
+    const queryString = sensorIds.map((_, i) => `id = $${i}`).join(' OR ');
+    return database.objects('SensorLog').filtered(...queryString, ...sensorIds);
+  });
+
+  return breaches;
+};
+
+/**
+ * Extracts all ItemBatches which are related to the passed sensorLogs.
+ * Groups all ItemBatch objects by Item and calculates the duration of
+ * time each ItemBatch was present during these logs.
+ *
+ * Option parameters itemBatch and item are used to filter the ItemBatches
+ * for these sensorLogs to only search for ItemBatch records which are
+ * related to the Item xor the ItemBatch. Item takes priority over
+ * ItemBatch if both are passed.
+ *
+ * Method iterates through each batch, grouping batches by Item. Will store
+ * values on the first encounter of a batch, otherwise will just increment
+ * the duration.
+ *
+ * @param  {Realm.results/array} sensorLogs
+ * @param  {ItemBatch}           itemBatch
+ * @param  {Item}                item
+ * @return {Array<Object>} array of objects, see example below.
+ * [
+ *  {
+ *     itemId,
+ *     itemName,
+ *     batches: [ { id, code, expiryDate, enteredDate, duration, totalQuantity }]
+ *  }
+ *  ...
+ * ]
+ */
+export const sensorLogsExtractBatches = ({ sensorLogs = [], itemBatch, item } = {}) => {
+  const groupedBatches = {};
+  sensorLogs.forEach(({ itemBatches, interval }) => {
+    // Premature exit if log has no batches.
+    if (itemBatches.length === 0) return;
+
+    let batchesToUse = [...itemBatches];
+    // If an Item has been passed, only find batches for this item.
+    if (item) batchesToUse = batchesToUse.filter(batch => batch.item && batch.item.id === item.id);
+    // If an ItemBatch has been passed, only find batches for this item.
+    else if (itemBatch) batchesToUse = batchesToUse.filter(({ id }) => id === itemBatch.id);
+    // For each batch, store it's details. If already stored, increment the
+    // duration in the breach by this logs interval.
+    batchesToUse.forEach(
+      ({ item: batchItem, id: batchId, code, enteredDate, expiryDate, totalQuantity }) => {
+        // Premature return if this ItemBatch does not have an Item associated
+        if (!batchItem) return;
+        const { id: itemId, name: itemName } = batchItem;
+        // If this batches item hasn't been encountered yet, create
+        // a grouping object.
+        if (!groupedBatches[itemId]) groupedBatches[itemId] = { itemId, itemName, batches: {} };
+        const itemBatchesGrouping = groupedBatches[itemId].batches;
+        // If this batch has been encountered before, just increment
+        // it's duration by the interval of this log.
+        if (itemBatchesGrouping[batchId]) {
+          itemBatchesGrouping[batchId].duration += interval;
+          // If it has not been encountered yet, store the details
+          // for this batch
+        } else {
+          itemBatchesGrouping[batchId] = {
+            duration: interval,
+            id: batchId,
+            code,
+            enteredDate,
+            totalQuantity,
+            expiryDate,
+          };
+        }
+      }
+    );
+  });
+
+  // Create the return object
+  return Object.values(groupedBatches).map(itemObject => {
+    const { itemId, itemName, batches } = itemObject;
+    return {
+      itemId,
+      itemName,
+      batches: Object.values(batches).map(batchObject => batchObject),
+    };
+  });
+};


### PR DESCRIPTION
Fixes half of #843 

Other methods will be a part of #878 

`extractBreaches` : 
- Allows for either an array of `SensorLog` objects or a `Realm.results`. *Could* enforce that it must be a `Realm.results` so that we can use Realm sorting. Wanted to be safe for now, if it turns out we always are calling with a `Realm.Results`, I think change the method then. It is annoying to 'create' `Realm.Results` objects, imo.
- Potentially there is a different way to use `Results.filtered` by using the timestamps of the delimiter `SensorLog` objects, but this would be time consuming to find the surrounding `SensorLog` objects. Would require a similar method, but would use the timestamps of the delimiters to find all `SensorLog` between. Would then need to `find()` the first and last `SensorLog` in an array of all `SensorLog`'s, and use the index before and after. I don't think this offers any improvement to performance, as you would still not have a query which returns a `Realm.Results` of `SensorLog`'s.

`sensorLogExtractBreaches`
- Don't like this name
- Return object has a slightly different shape to what was described in the issue. Have added a couple of fields because of not having any negatives, but could come in handy.
- Using the object shape during the method to make searching for `Item` and `ItemBatch` objects are done in constant time, rather than having to search an array each time you want to update.
- Could not bother creating a different shape at the end of the method, but this means it can be passed straight to `BreachModal` after adding columns for the tables easily.