### PR TITLE
#870 breach modal

### DIFF
--- a/src/utilities/formatters.js
+++ b/src/utilities/formatters.js
@@ -17,3 +17,22 @@ export const formatExposureRange = ({ minTemperature, maxTemperature } = {}) => 
   const degree = String.fromCharCode(176);
   return `${minTemperature}${degree}C to ${maxTemperature}${degree}C`;
 };
+
+export const formattedDifferenceBetweenDates = (dateA, dateB) => {
+  const differenceInMs = new Date(dateB.getTime() - dateA.getTime()).getTime();
+
+  const msPerMinute = 1000 * 60;
+  const msPerHour = msPerMinute * 60;
+  const msPerDay = msPerHour * 24;
+
+  const numberOfDays = Math.floor(differenceInMs / msPerDay);
+  const numberOfHours = Math.floor((differenceInMs - numberOfDays * msPerDay) / msPerHour);
+  const numberOfMinutes = Math.floor((differenceInMs - numberOfHours * msPerHour) / msPerMinute);
+
+  let formattedDifference = '';
+  if (numberOfDays) formattedDifference += `${numberOfDays} Days `;
+  if (numberOfHours) formattedDifference += `${numberOfHours} Hours `;
+  if (numberOfMinutes) formattedDifference += `${numberOfMinutes} Minutes `;
+
+  return formattedDifference;
+};

--- a/src/utilities/formatters.js
+++ b/src/utilities/formatters.js
@@ -18,8 +18,9 @@ export const formatExposureRange = ({ minTemperature, maxTemperature } = {}) => 
   return `${minTemperature}${degree}C to ${maxTemperature}${degree}C`;
 };
 
-export const formattedDifferenceBetweenDates = (dateA, dateB) => {
-  const differenceInMs = new Date(dateB.getTime() - dateA.getTime()).getTime();
+export const formattedDifferenceBetweenDates = ({ startDate, endDate }) => {
+  if (!(startDate || endDate)) return 'Unavailable';
+  const differenceInMs = new Date(endDate.getTime() - startDate.getTime()).getTime();
 
   const msPerMinute = 1000 * 60;
   const msPerHour = msPerMinute * 60;

--- a/src/utilities/modules/vaccines.js
+++ b/src/utilities/modules/vaccines.js
@@ -1,5 +1,3 @@
-import { formattedDifferenceBetweenDates, formatExposureRange } from '../formatters';
-
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
@@ -85,6 +83,70 @@ export const extractBreaches = ({ sensorLogs = [], database }) => {
 };
 
 /**
+ * Helper method for sensorLogExtractBreaches. Extracts
+ * statistics for a set of sensorlogs and itembatches.
+ * @param {Realm.results<ItemBatch>} itemBatches
+ * @param {Realm.results<SensorLog>} sensorLogs
+ */
+const extractBreachStatistics = (itemBatches, sensorLogs) => ({
+  location: sensorLogs.location,
+  numberOfAffectedBatches: itemBatches.length,
+  affectedQuantity: itemBatches.sum('numberOfPacks'),
+  exposureRange: {
+    minTemperature: itemBatches.min('temperature') || Infinity,
+    maxTemperature: itemBatches.max('temperautre') || -Infinity,
+  },
+  breachDuration: {
+    startDate: itemBatches.max('timestamp') || null,
+    endDate: itemBatches.min('timestamp') || null,
+  },
+});
+
+/**
+ * Helper method for sensorLogExtractBreaches
+ * @param {Realm.Results<SensorLog>} sensorLogs
+ * @return {Object} example below
+ * groupedBatches = { itemId: { item, batches: { id: { duration, id, code.. }, .. }}, .. }
+ */
+const extractItemBatches = sensorLogs => {
+  const groupedBatches = {};
+  sensorLogs.forEach(({ itemBatches, isInBreach }) => {
+    // Premature exit if log has no batches, or is not a breached sensorLog
+    if (itemBatches.length === 0 || !isInBreach) return;
+    // For each batch, store it's details:
+    // { duration, id, code, enteredDate, totalQuantity, expiryDate }
+    // If already stored, skip.
+    itemBatches.forEach(({ id: batchId, code, enteredDate, totalQuantity, expiryDate, item }) => {
+      // Ensure each batch has stock and an associated Item.
+      if (!(item || totalQuantity > 0)) return;
+      const { id: itemId } = item;
+      // If this batches item hasn't been encountered yet, create
+      // a grouping object. groupedBatches = { itemId: { item, batches: {}  }}
+      if (!groupedBatches[itemId]) groupedBatches[itemId] = { item, batches: {} };
+      // If this batch has been encountered before, skip it.
+      const itemBatchGroup = groupedBatches[itemId].batches;
+      if (itemBatchGroup[batchId]) return;
+      // Calculate the duration this ItemBatch has been counted in this group of sensorLogs.
+      const duration = new Date(
+        sensorLogs.filtered('ItemBatches.id = $0', batchId).max('temperature') -
+          sensorLogs.filtered('ItemBatches.id = $0', batchId).min('temperature')
+      );
+      // Finally store the batches details:
+      // groupedBatches = { itemId: { item, batches: { id: { duration, id, code.. }, .. }}, .. }
+      itemBatchGroup[batchId] = {
+        duration,
+        id: batchId,
+        code,
+        enteredDate,
+        totalQuantity,
+        expiryDate,
+      };
+    });
+  });
+  return groupedBatches;
+};
+
+/**
  * Extracts all ItemBatches which are related to the passed sensorLogs.
  * Groups all ItemBatch objects by Item and calculates the duration of
  * time each ItemBatch was present during these logs.
@@ -110,48 +172,13 @@ export const extractBreaches = ({ sensorLogs = [], database }) => {
  *  ...
  * ]
  */
-export const sensorLogsExtractBatches = ({ sensorLogs = [], itemBatch, item } = {}) => {
-  const groupedBatches = {};
-  let filteredLogs;
+export const sensorLogsExtractBatches = ({ sensorLogs = [], itemBatch, item, database } = {}) => {
+  let filteredLogs = sensorLogs;
   // If an Item has been passed, only find batches for this item.
   if (item) filteredLogs = sensorLogs.filtered('ItemBatches.item.id = $0', item.id);
   // If an ItemBatch has been passed, only find batches for this item.
   else if (itemBatch) filteredLogs = sensorLogs.filtered('ItemBatches.id = $0', itemBatch.id);
-  filteredLogs.forEach(({ itemBatches, isInBreach }) => {
-    // Premature exit if log has no batches, or is not a breached sensorLog
-    if (itemBatches.length === 0 || !isInBreach) return;
-    // For each batch, store it's details:
-    // { duration, id, code, enteredDate, totalQuantity, expiryDate }
-    // If already stored, skip.
-    itemBatches.forEach(
-      ({ id: batchId, code, enteredDate, totalQuantity, expiryDate, item: batchItem }) => {
-        // Ensure each batch has stock and an associated Item.
-        if (!(batchItem || totalQuantity > 0)) return;
-        const { id: itemId } = batchItem;
-        // If this batches item hasn't been encountered yet, create
-        // a grouping object. groupedBatches = { itemId: { item, batches: {}  }}
-        if (!groupedBatches[itemId]) groupedBatches[itemId] = { item: batchItem, batches: {} };
-        // If this batch has been encountered before, skip it.
-        const itemBatchGroup = groupedBatches[itemId].batches;
-        if (itemBatchGroup[batchId]) return;
-        // Calculate the duration this ItemBatch has been counted in this group of sensorLogs.
-        const duration = new Date(
-          filteredLogs.filtered('ItemBatches.id = $0', itemBatch.id).max('temperature') -
-            filteredLogs.filtered('ItemBatches.id = $0', itemBatch.id).min('temperature')
-        );
-        // Finally store the batches details:
-        // groupedBatches = { itemId: { item, batches: { id: { duration, id, code.. }, .. }}, .. }
-        itemBatchGroup[batchId] = {
-          duration,
-          id: batchId,
-          code,
-          enteredDate,
-          totalQuantity,
-          expiryDate,
-        };
-      }
-    );
-  });
+  const groupedBatches = extractItemBatches(filteredLogs);
   // Create the return object. [ {item, batches: [ as above ] }, .. ]
   const allItemsForLogs = Object.values(groupedBatches).map(itemObject => {
     const { item: itemForGroup, batches } = itemObject;
@@ -160,50 +187,16 @@ export const sensorLogsExtractBatches = ({ sensorLogs = [], itemBatch, item } = 
       batches: Object.values(batches).map(batchObject => batchObject),
     };
   });
+  // Get all ItemBatch objects associated with these sensorLogs, used in
+  // calculating statistics of this breach.
+  const allItemBatches = database
+    .objects('ItemBatch')
+    .filtered(sensorLogs.map(({ id }) => `sensorLogs.id = "${id}"`).join(' OR '));
   // Also return the sensorLogs for these items and batches.
   // If no items or batches have been found, items: [] is returned
   return {
     sensorLogs,
     items: allItemsForLogs,
+    ...extractBreachStatistics(allItemBatches, sensorLogs),
   };
 };
-
-/**
- * Method for creating data for BreachTable rows.
- * Accepts an array (Example below) of objects,
- * each having a breach property which contains
- * a realm results of sensorLog objects.
- * @param {Array} data Example below
- * [ {
- *     breach: [ sensorLogs ],
- *     ...
- *   },
- *    ...
- * ]
- */
-export const setBreachData = (data = []) => {
-  const dataCopy = [];
-  data.forEach(dataSet => {
-    const { breach } = dataSet;
-    // A breach must have a minimum of 3 sensorlogs to be considered
-    // a breach.
-    if (!breach || breach.length < 4) return;
-    const [firstSensorLog = null, , { timestamp: lastTimestamp } = {}] = breach;
-    // If there is no first or last sensor logs, or if either does not have a timestamp,
-    // don't create data for this breach.
-    if (!(firstSensorLog && firstSensorLog.timestamp && lastTimestamp)) return;
-    dataCopy.push({
-      ...dataSet,
-      breachData: {
-        affectedQuantity: firstSensorLog.sum('itemBatches.numberOfPacks'),
-        location: (firstSensorLog.location && firstSensorLog.location.description) || 'Unavailable',
-        duration: formattedDifferenceBetweenDates(firstSensorLog.timestamp, lastTimestamp),
-        exposureRange: formatExposureRange(breach.min('temperature'), breach.max('temperature')),
-        numberOfAffectedBatches: firstSensorLog.itemBatches.length,
-      },
-    });
-  });
-  return dataCopy;
-};
-
-export default setBreachData;

--- a/src/utilities/modules/vaccines.js
+++ b/src/utilities/modules/vaccines.js
@@ -1,0 +1,41 @@
+import { formattedDifferenceBetweenDates, formatExposureRange } from '../formatters';
+
+/**
+ * Method for creating data for BreachTable rows.
+ * Accepts an array (Example below) of objects,
+ * each having a breach property which contains
+ * a realm results of sensorLog objects.
+ * @param {Array} data Example below
+ * [ {
+ *     breach: [ sensorLogs ],
+ *     ...
+ *   },
+ *    ...
+ * ]
+ */
+export const setBreachData = (data = []) => {
+  const dataCopy = [];
+  data.forEach(dataSet => {
+    const { breach } = dataSet;
+    // A breach must have a minimum of 3 sensorlogs to be considered
+    // a breach.
+    if (!breach || breach.length < 4) return;
+    const [firstSensorLog = null, , { timestamp: lastTimestamp } = {}] = breach;
+    // If there is no first or last sensor logs, or if either does not have a timestamp,
+    // don't create data for this breach.
+    if (!(firstSensorLog && firstSensorLog.timestamp && lastTimestamp)) return;
+    dataCopy.push({
+      ...dataSet,
+      breachData: {
+        affectedQuantity: firstSensorLog.sum('itemBatches.numberOfPacks'),
+        location: (firstSensorLog.location && firstSensorLog.location.description) || 'Unavailable',
+        duration: formattedDifferenceBetweenDates(firstSensorLog.timestamp, lastTimestamp),
+        exposureRange: formatExposureRange(breach.min('temperature'), breach.max('temperature')),
+        numberOfAffectedBatches: firstSensorLog.itemBatches.length,
+      },
+    });
+  });
+  return dataCopy;
+};
+
+export default setBreachData;

--- a/src/widgets/BreachTable.js
+++ b/src/widgets/BreachTable.js
@@ -14,6 +14,7 @@ import { StyleSheet, View } from 'react-native';
 import { VaccineChart, StackedTables } from '.';
 
 import { SHADOW_BORDER } from '../globalStyles/index';
+import { formattedDifferenceBetweenDates, formatExposureRange } from '../utilities/formatters';
 
 /**
  * CONSTANTS
@@ -126,11 +127,24 @@ export class BreachTable extends React.PureComponent {
 
   // Simple cell renderer to display non-editable data
   // for the main table.
-  renderCell = (key, value) => ({
-    type: 'text',
-    cellContents: value.breachData[key],
-    textAlign: 'right',
-  });
+  renderCell = (key, value) => {
+    switch (key) {
+      case 'location':
+        return { type: 'text', cellContents: (value && value.description) || 'Not available' };
+      case 'temperatureExposure':
+        return {
+          type: 'text',
+          cellContents: formatExposureRange(value),
+        };
+      case 'duration':
+        return {
+          type: 'text',
+          cellContents: formattedDifferenceBetweenDates(value),
+        };
+      default:
+        return { type: 'text', cellContents: value[key] };
+    }
+  };
 
   render() {
     const { database, genericTablePageStyles, data } = this.props;

--- a/src/widgets/BreachTable.js
+++ b/src/widgets/BreachTable.js
@@ -1,0 +1,185 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { GenericTablePage } from 'react-native-generic-table-page';
+
+import { StyleSheet, View } from 'react-native';
+
+import { VaccineChart, StackedTables } from '.';
+
+import { SHADOW_BORDER } from '../globalStyles/index';
+
+/**
+ * CONSTANTS
+ */
+
+// TODO: Localization
+const LOCALIZATION = {
+  columns: {
+    breach: {
+      date: 'DATE',
+      location: 'LOCATION',
+      duration: 'DURATION',
+      exposureRange: 'EXPOSURE RANGE',
+      affectedQuantity: 'AFFECTED QUANTITY',
+      numberOfAffectedBatches: 'NO. OF AFFECTED BATCHES',
+    },
+    batch: {
+      code: 'CODE',
+      expiry: 'EXPIRY',
+      quantity: 'QUANTITY',
+      duration: 'DURATION',
+    },
+  },
+};
+
+const BREACH_COLUMNS = [
+  { key: 'date', title: LOCALIZATION.columns.breach.date, width: 0.8, alignText: 'center' },
+  { key: 'location', title: LOCALIZATION.columns.breach.location, width: 0.8, alignText: 'center' },
+  { key: 'duration', title: LOCALIZATION.columns.breach.duration, width: 0.8, alignText: 'center' },
+  {
+    key: 'exposureRange',
+    title: LOCALIZATION.columns.breach.exposureRange,
+    width: 0.8,
+    alignText: 'center',
+  },
+  {
+    key: 'affectedQuantity',
+    title: LOCALIZATION.columns.breach.affectedQuantity,
+    width: 0.8,
+    alignText: 'center',
+  },
+  {
+    key: 'numberOfAffectedBatches',
+    title: LOCALIZATION.columns.breach.numberOfAffectedBatches,
+    width: 1,
+    alignText: 'center',
+  },
+];
+
+const BATCH_COLUMNS = [
+  { key: 'code', title: LOCALIZATION.columns.batch.code, width: 0.8 },
+  { key: 'expiry', title: LOCALIZATION.columns.batch.expiry, width: 0.8 },
+  { key: 'quantity', title: LOCALIZATION.columns.batch.quantity, width: 0.8 },
+  { key: 'duration', title: LOCALIZATION.columns.batch.duration, width: 1 },
+];
+
+/**
+ * Component to be used within a PageContentModal
+ *
+ * Renders a table of breaches with expandable rows which display
+ * sub tables of item batches grouped by item, as well as a table
+ * of temperatures for that breach.
+ *
+ *
+ * Props are intended to be made by calling methods in utilities/modules/vaccines
+ * -- extractBreaches : Getting the sensorLogs/breaches for a location, item or batch.
+ * -- sensorLogsExtractBatches : Called on each breach to extract item data for sub tables.
+ * -- getBreachData : Creates the data needed for the main table.
+ * -- aggregateLogs : Creates the data needed for the chart component.
+ * @prop {Array}  data     Array of data for both breach table and sub tables - example below
+ * @prop {Object} database Realm database **Not used, required for main table**
+ * @prop {Object} genericTablePageStyles Main table styles
+ *
+ * [
+ *    {
+ *      breach: [ array of sensorLogs ]
+ *      items: [ { item, batches: [ { code, expiry, totalQuantity, duration }, ... ] }, .. ]
+ *      chartData: [ {temp, date}, .. ]
+ *    },
+ *    .....
+ * ]
+ */
+export class BreachTable extends React.PureComponent {
+  /**
+   * RENDER HELPERS
+   */
+  // Returns an expansion for a row.
+  // Creates the required array for the StackTables component. See
+  // that component for an example.
+  renderExpansion = rowData => {
+    const { expansionContainer, chartContainer, tablesContainer } = localStyles;
+    const { chartData, items } = rowData;
+    const tableProps = items.map(itemGroup => ({
+      data: itemGroup.batches,
+      title: itemGroup.item.name,
+      columns: BATCH_COLUMNS,
+    }));
+    return (
+      <View style={expansionContainer}>
+        <View style={chartContainer}>
+          <VaccineChart {...chartData} />
+        </View>
+
+        <View style={tablesContainer}>
+          <StackedTables data={tableProps} />
+        </View>
+      </View>
+    );
+  };
+
+  // Simple cell renderer to display non-editable data
+  // for the main table.
+  renderCell = (key, value) => ({
+    type: 'text',
+    cellContents: value.breachData[key],
+    textAlign: 'right',
+  });
+
+  render() {
+    const { database, genericTablePageStyles, data } = this.props;
+    return (
+      <GenericTablePage
+        {...genericTablePageStyles}
+        database={database}
+        data={data}
+        columns={BREACH_COLUMNS}
+        renderExpansion={this.renderExpansion}
+        renderCell={this.renderCell}
+      />
+    );
+  }
+}
+
+const localStyles = StyleSheet.create({
+  tablesContainer: { width: '47%', margin: 30 },
+  chartContainer: {
+    width: '47%',
+    justifyContent: 'center',
+    height: 300,
+    backgroundColor: 'white',
+    margin: 20,
+  },
+  expansionContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    backgroundColor: '#ecf3fc',
+    margin: 10,
+    borderWidth: 1,
+    borderRadius: 2,
+    borderColor: SHADOW_BORDER,
+    borderBottomWidth: 0,
+    shadowColor: 'white',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.8,
+    shadowRadius: 2,
+    elevation: 1,
+    marginHorizontal: 5,
+    marginTop: 10,
+  },
+});
+
+BreachTable.defaultProps = {};
+BreachTable.propTypes = {
+  database: PropTypes.object.isRequired,
+  genericTablePageStyles: PropTypes.object.isRequired,
+  data: PropTypes.array.isRequired,
+};
+
+export default BreachTable;

--- a/src/widgets/SimpleTable.js
+++ b/src/widgets/SimpleTable.js
@@ -102,11 +102,12 @@ const localStyles = ({
   titleBackgroundColor,
   containerBackground,
   columnSeperatorColor,
+  data,
 } = {}) =>
   StyleSheet.create({
     container: {
       backgroundColor: containerBackground,
-      height: '100%',
+      height: rowHeight * data.length + headerHeight + titleHeight + 21,
       width: '100%',
     },
     titleContainer: {

--- a/src/widgets/StackedTables.js
+++ b/src/widgets/StackedTables.js
@@ -22,7 +22,6 @@ import { SimpleTable } from './SimpleTable';
  * between each table.
  * @prop    {array}  data  2D array, of data for each table. Example below.
  * @prop    {object} additionalTableProps additional props for each simple table
- * @prop    {number} tablesHeight The % of height all tables should utilize
  *
  * data should be in the form:
  * [
@@ -32,14 +31,14 @@ import { SimpleTable } from './SimpleTable';
  */
 export class StackedTables extends React.PureComponent {
   render() {
-    const { data, additionalTableProps, tablesHeight } = this.props;
+    const { data, additionalTableProps } = this.props;
     const { containerStyle } = localStyles(this.props);
     return (
       <View style={containerStyle}>
         {data.map((datum, index) => {
           const { title = 'default' } = datum;
           return (
-            <View key={`${title + index}`} style={{ height: `${tablesHeight / data.length}%` }}>
+            <View key={`${title + index}`} style={{ backgroundColor: 'transparent' }}>
               <SimpleTable {...datum} {...additionalTableProps} />
             </View>
           );
@@ -63,13 +62,11 @@ const localStyles = ({ containerStyle }) =>
 
 StackedTables.defaultProps = {
   additionalTableProps: {},
-  tablesHeight: 95,
 };
 
 StackedTables.propTypes = {
   data: PropTypes.array.isRequired,
   additionalTableProps: PropTypes.object,
-  tablesHeight: PropTypes.number,
 };
 
 export default StackedTables;

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -35,3 +35,5 @@ export { MiniToggleBar } from './MiniToggleBar';
 export { GenericChoiceList } from './GenericChoiceList';
 export { SimpleTable } from './SimpleTable';
 export { StackedTables } from './StackedTables';
+export { VaccineChart } from './VaccineChart';
+export { BreachTable } from './BreachTable';


### PR DESCRIPTION
Fixes #870 

[messy dev branch](https://github.com/openmsupply/mobile/tree/breach-modal)


<img width="1121" alt="image" src="https://user-images.githubusercontent.com/35858975/56408642-802ea580-62c9-11e9-95cf-e3df6e707b76.png">

#### Ignore the actual data

Ended up making this very dumb.

Expectation is that data will just be passed. Data will be fetched inside of a `runWithLoadingIndicator`. (Could cache it to save time if needed?)

Title is set in the `PageContentModal` this will be wrapped in

- I really hate the `formattedDifferenceBetweenDates` method
- Could change this to fetch some data when expanding a row quite easily
- To fetch the data:
    - `extractBreaches()` - passing `sensorLogs` from a `Location`, `ItemBatch` or `Item`
    - `sensorLogsExtractBreaches()` passing each `breach` from `extractBreaches`
    - `extractBreach()` - on return value from above
    -  `aggregateLogs` - will return the chartData needed