### PR TITLE
#896 refactor vaccine chart

### DIFF
--- a/src/globalStyles/colors.js
+++ b/src/globalStyles/colors.js
@@ -18,3 +18,4 @@ export const FINALISE_GREEN = '#219d1b';
 export const FINALISED_RED = '#f63b30';
 export const SOFT_RED = '#f63b3022';
 export const TRANSPARENT = 'rgba(0, 0, 0, 0)';
+export const WARM_BLUE = '#70b4f0';

--- a/src/globalStyles/index.js
+++ b/src/globalStyles/index.js
@@ -39,6 +39,7 @@ export {
   FINALISE_GREEN,
   FINALISED_RED,
   SOFT_RED,
+  WARM_BLUE,
 } from './colors';
 
 export { APP_FONT_FAMILY } from './fonts';

--- a/src/widgets/HazardPoint.js
+++ b/src/widgets/HazardPoint.js
@@ -12,17 +12,20 @@ const hazardPath = `M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.0
  46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982
  11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z`;
 
+/**
+ * Custom component for rendering clickable hazard icons.
+ */
 export const HazardPoint = props => {
-  const { x, y, datum } = props;
-
+  const { x, y, onPress, breach } = props;
   const { xOffset, yOffset, scale, fill } = hazardPointStyles;
 
-  const { onPress, data } = datum;
-  const onPressFunction = () => onPress && onPress(data);
+  // console.log(breach);
+
+  const onPressWrapper = () => onPress && onPress(breach);
 
   return (
     <Svg>
-      <G onPress={onPressFunction}>
+      <G onPress={onPressWrapper}>
         <Path x={x + xOffset} y={y + yOffset} scale={scale} d={hazardPath} fill={fill} />
       </G>
     </Svg>
@@ -36,14 +39,17 @@ const hazardPointStyles = {
   fill: 'red',
 };
 
-// Bug in Victory charts causes required props to be undefined on first render.
+// Bug in Victory charts causes required props to be undefined on first render,
+// do not set as required.
 HazardPoint.propTypes = {
   // eslint-disable-next-line react/require-default-props
   x: PropTypes.number,
   // eslint-disable-next-line react/require-default-props
   y: PropTypes.number,
-  // eslint-disable-next-line react/require-default-props, react/forbid-prop-types
-  datum: PropTypes.object,
+  // eslint-disable-next-line react/require-default-props
+  onPress: PropTypes.func,
+  // eslint-disable-next-line react/require-default-props
+  breach: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default HazardPoint;

--- a/src/widgets/HazardPoint.js
+++ b/src/widgets/HazardPoint.js
@@ -33,8 +33,8 @@ export const HazardPoint = props => {
 };
 
 const hazardPointStyles = {
-  xOffset: -15,
-  yOffset: -40,
+  xOffset: -14,
+  yOffset: -33,
   scale: 0.05,
   fill: SUSSOL_ORANGE,
 };

--- a/src/widgets/HazardPoint.js
+++ b/src/widgets/HazardPoint.js
@@ -18,10 +18,10 @@ const hazardPath = `M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.0
  * Custom component for rendering clickable hazard icons.
  */
 export const HazardPoint = props => {
-  const { x, y, onPress, breach } = props;
+  const { x, y, onPress, datum } = props;
   const { xOffset, yOffset, scale, fill } = hazardPointStyles;
 
-  const onPressWrapper = () => onPress && onPress(breach);
+  const onPressWrapper = () => onPress && onPress(datum);
 
   return (
     <Svg>
@@ -49,7 +49,8 @@ HazardPoint.propTypes = {
   x: PropTypes.number,
   y: PropTypes.number,
   onPress: PropTypes.func,
-  breach: PropTypes.arrayOf(PropTypes.object),
+  // eslint-disable-next-line react/require-default-props, react/forbid-prop-types
+  datum: PropTypes.object,
 };
 
 export default HazardPoint;

--- a/src/widgets/HazardPoint.js
+++ b/src/widgets/HazardPoint.js
@@ -32,6 +32,8 @@ export const HazardPoint = props => {
   );
 };
 
+// Offsets to position hazard point relative to top-left (x,y) coordinates to render above each
+// scatter point.
 const hazardPointStyles = {
   xOffset: -14,
   yOffset: -33,
@@ -41,14 +43,12 @@ const hazardPointStyles = {
 
 // Bug in Victory charts causes required props to be undefined on first render,
 // do not set as required.
+
+/* eslint-disable react/require-default-props */
 HazardPoint.propTypes = {
-  // eslint-disable-next-line react/require-default-props
   x: PropTypes.number,
-  // eslint-disable-next-line react/require-default-props
   y: PropTypes.number,
-  // eslint-disable-next-line react/require-default-props
   onPress: PropTypes.func,
-  // eslint-disable-next-line react/require-default-props
   breach: PropTypes.arrayOf(PropTypes.object),
 };
 

--- a/src/widgets/HazardPoint.js
+++ b/src/widgets/HazardPoint.js
@@ -7,6 +7,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Svg, { Path, G } from 'react-native-svg';
 
+import { SUSSOL_ORANGE } from '../globalStyles/colors';
+
 const hazardPath = `M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423
  23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595
  46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982
@@ -18,8 +20,6 @@ const hazardPath = `M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.0
 export const HazardPoint = props => {
   const { x, y, onPress, breach } = props;
   const { xOffset, yOffset, scale, fill } = hazardPointStyles;
-
-  // console.log(breach);
 
   const onPressWrapper = () => onPress && onPress(breach);
 
@@ -36,7 +36,7 @@ const hazardPointStyles = {
   xOffset: -15,
   yOffset: -40,
   scale: 0.05,
-  fill: 'red',
+  fill: SUSSOL_ORANGE,
 };
 
 // Bug in Victory charts causes required props to be undefined on first render,

--- a/src/widgets/VaccineChart.js
+++ b/src/widgets/VaccineChart.js
@@ -40,18 +40,22 @@ export class VaccineChart extends React.Component {
   };
 
   getDomain() {
-    const { minLine, maxLine, minTemperature, maxTemperature } = this.props;
+    const { minLine, maxLine, minTemperature, maxTemperature, dataKeys } = this.props;
     const lines = [...minLine, ...maxLine];
+
+    const { y: temperatureKey } = dataKeys;
 
     const minDomain =
       lines.reduce(
-        (reducedTemperature, { temperature }) => Math.min(reducedTemperature, temperature),
+        (currentMinTemperature, sensorLog) =>
+          Math.min(currentMinTemperature, sensorLog[temperatureKey]),
         minTemperature
       ) - 1;
 
     const maxDomain =
       lines.reduce(
-        (reducedTemperature, { temperature }) => Math.max(reducedTemperature, temperature),
+        (currentMaxTemperature, sensorLog) =>
+          Math.max(currentMaxTemperature, sensorLog[temperatureKey]),
         maxTemperature
       ) + 1;
 
@@ -86,47 +90,53 @@ export class VaccineChart extends React.Component {
     ) : null;
   }
 
-  renderMinLogTemperatures() {
+  renderMinLogTemperatureLine() {
     const { minLine, dataKeys } = this.props;
 
     if (!(minLine.length > 0)) return null;
 
     return (
-      <View>
-        <VictoryLine
-          data={minLine}
-          interpolation={minLineStyles.interpolation}
-          style={{ data: { stroke: minLineStyles.stroke } }}
-          {...dataKeys}
-        />
-        <VictoryScatter
-          data={minLine}
-          style={{ data: { fill: minLineStyles.fill } }}
-          {...dataKeys}
-        />
-      </View>
+      <VictoryLine
+        data={minLine}
+        interpolation={minLineStyles.interpolation}
+        style={{ data: { stroke: minLineStyles.stroke } }}
+        {...dataKeys}
+      />
     );
   }
 
-  renderMaxLogTemperatures() {
+  renderMinLogTemperatureScatter() {
+    const { minLine, dataKeys } = this.props;
+
+    if (!(minLine.length > 0)) return null;
+
+    return (
+      <VictoryScatter data={minLine} style={{ data: { fill: minLineStyles.fill } }} {...dataKeys} />
+    );
+  }
+
+  renderMaxLogTemperatureLine() {
     const { maxLine, dataKeys } = this.props;
 
     if (!(maxLine.length > 0)) return null;
 
     return (
-      <View>
-        <VictoryLine
-          data={maxLine}
-          interpolation={maxLineStyles.interpolation}
-          style={{ data: { stroke: maxLineStyles.stroke } }}
-          {...dataKeys}
-        />
-        <VictoryScatter
-          data={maxLine}
-          style={{ data: { fill: maxLineStyles.fill } }}
-          {...dataKeys}
-        />
-      </View>
+      <VictoryLine
+        data={maxLine}
+        interpolation={maxLineStyles.interpolation}
+        style={{ data: { stroke: maxLineStyles.stroke } }}
+        {...dataKeys}
+      />
+    );
+  }
+
+  renderMaxLogTemperatureScatter() {
+    const { maxLine, dataKeys } = this.props;
+
+    if (!(maxLine.length > 0)) return null;
+
+    return (
+      <VictoryScatter data={maxLine} style={{ data: { fill: maxLineStyles.fill } }} {...dataKeys} />
     );
   }
 
@@ -162,10 +172,12 @@ export class VaccineChart extends React.Component {
         >
           <VictoryAxis offsetY={50} />
           <VictoryAxis dependentAxis offsetX={50} crossAxis={false} />
+          {this.renderMinLogTemperatureLine()}
+          {this.renderMinLogTemperatureScatter()}
+          {this.renderMaxLogTemperatureLine()}
+          {this.renderMaxLogTemperatureScatter()}
           {this.renderMinTemperatureBoundary()}
           {this.renderMaxTemperatureBoundary()}
-          {this.renderMinLogTemperatures()}
-          {this.renderMaxLogTemperatures()}
           {this.renderHazardPoints()}
         </VictoryChart>
       </Svg>
@@ -208,7 +220,7 @@ VaccineChart.propTypes = {
   hazards: PropTypes.arrayOf(PropTypes.object),
   minTemperature: PropTypes.number,
   maxTemperature: PropTypes.number,
-  dataKeys: PropTypes.objectOf(),
+  dataKeys: PropTypes.objectOf(PropTypes.string),
 };
 
 VaccineChart.defaultProps = {

--- a/src/widgets/VaccineChart.js
+++ b/src/widgets/VaccineChart.js
@@ -120,18 +120,17 @@ export class VaccineChart extends React.Component {
 
   // Render hazard icons for sensor breaches.
   renderHazardPoints() {
-    const { breaches, onPress, dataKeys } = this.props;
+    const { breaches, onHazardPress, dataKeys } = this.props;
 
     if (!(breaches.length > 0)) return null;
 
-    return breaches.map(breach => (
+    return (
       <VictoryScatter
-        key={breach[0].id}
-        dataComponent={<HazardPoint onPress={onPress} breach={breach} />}
-        data={breach}
+        dataComponent={<HazardPoint onPress={onHazardPress} />}
+        data={breaches}
         {...dataKeys}
       />
-    ));
+    );
   }
 
   // Helper method for rendering vaccine chart.
@@ -279,7 +278,7 @@ VaccineChart.propTypes = {
   breaches: PropTypes.arrayOf(PropTypes.array),
   minTemperature: PropTypes.number,
   maxTemperature: PropTypes.number,
-  onPress: PropTypes.func,
+  onHazardPress: PropTypes.func,
   dataKeys: PropTypes.objectOf(PropTypes.string),
 };
 
@@ -289,7 +288,7 @@ VaccineChart.defaultProps = {
   breaches: [],
   minTemperature: Infinity,
   maxTemperature: -Infinity,
-  onPress: null,
+  onHazardPress: null,
   dataKeys: { x: 'timestamp', y: 'temperature' },
 };
 

--- a/src/widgets/VaccineChart.js
+++ b/src/widgets/VaccineChart.js
@@ -19,6 +19,7 @@ import {
 import Svg from 'react-native-svg';
 
 import { HazardPoint } from './HazardPoint';
+import { APP_FONT_FAMILY } from '../globalStyles/fonts';
 
 /**
  * Plots a line graph of temperature over time for vaccines.
@@ -37,8 +38,8 @@ export class VaccineChart extends React.Component {
   // calculate relative values for width and height for each chart.
   onLayout = event => {
     this.setState({
-      width: event.nativeEvent.layout.width,
-      height: event.nativeEvent.layout.height,
+      width: event.nativeEvent.layout.width * chartSize.width,
+      height: event.nativeEvent.layout.height * chartSize.height,
     });
   };
 
@@ -73,7 +74,7 @@ export class VaccineChart extends React.Component {
       <VictoryLine
         y={() => minTemperature}
         style={{
-          data: { strokeDasharray: minLineStyles.strokeDasharray, stroke: minLineStyles.stroke },
+          data: { stroke: minBoundaryStyles.stroke, opacity: minBoundaryStyles.opacity },
         }}
       />
     ) : null;
@@ -87,7 +88,7 @@ export class VaccineChart extends React.Component {
       <VictoryLine
         y={() => maxTemperature}
         style={{
-          data: { strokeDasharray: maxLineStyles.strokeDasharray, stroke: maxLineStyles.stroke },
+          data: { stroke: maxBoundaryStyles.stroke, opacity: maxBoundaryStyles.opacity },
         }}
       />
     ) : null;
@@ -114,7 +115,18 @@ export class VaccineChart extends React.Component {
     if (!(minLine.length > 0)) return null;
 
     return (
-      <VictoryScatter data={minLine} style={{ data: { fill: minLineStyles.fill } }} {...dataKeys} />
+      <VictoryScatter
+        data={minLine}
+        size={minScatterStyles.size}
+        style={{
+          data: {
+            fill: minScatterStyles.fill,
+            stroke: minScatterStyles.stroke,
+            strokeWidth: minScatterStyles.strokeWidth,
+          },
+        }}
+        {...dataKeys}
+      />
     );
   }
 
@@ -127,7 +139,11 @@ export class VaccineChart extends React.Component {
       <VictoryLine
         data={maxLine}
         interpolation={maxLineStyles.interpolation}
-        style={{ data: { stroke: maxLineStyles.stroke } }}
+        style={{
+          data: {
+            stroke: maxLineStyles.stroke,
+          },
+        }}
         {...dataKeys}
       />
     );
@@ -139,7 +155,18 @@ export class VaccineChart extends React.Component {
     if (!(maxLine.length > 0)) return null;
 
     return (
-      <VictoryScatter data={maxLine} style={{ data: { fill: maxLineStyles.fill } }} {...dataKeys} />
+      <VictoryScatter
+        data={maxLine}
+        size={maxScatterStyles.size}
+        style={{
+          data: {
+            fill: maxScatterStyles.fill,
+            stroke: maxScatterStyles.stroke,
+            strokeWidth: maxScatterStyles.strokeWidth,
+          },
+        }}
+        {...dataKeys}
+      />
     );
   }
 
@@ -174,15 +201,41 @@ export class VaccineChart extends React.Component {
         <VictoryChart
           width={width}
           height={height}
+          padding={{ top: 20, left: 50, right: 50, bottom: 50 }}
           style={chartStyles}
           theme={VictoryTheme.material}
           maxDomain={{ y: maxDomain }}
           minDomain={{ y: minDomain }}
         >
-          <VictoryAxis offsetY={50} /> <VictoryAxis dependentAxis offsetX={50} crossAxis={false} />
-          {this.renderMinLogTemperatureLine()} {this.renderMinLogTemperatureScatter()}
-          {this.renderMaxLogTemperatureLine()} {this.renderMaxLogTemperatureScatter()}
-          {this.renderMinTemperatureBoundary()} {this.renderMaxTemperatureBoundary()}
+          <VictoryAxis
+            offsetY={50}
+            style={{
+              tickLabels: {
+                fontSize: axisStyles.fontSize,
+                fontFamily: axisStyles.fontFamily,
+                fill: axisStyles.fill,
+              },
+            }}
+          />
+          <VictoryAxis
+            dependentAxis
+            offsetX={50}
+            crossAxis={false}
+            tickFormat={t => `${t}℃`}
+            style={{
+              tickLabels: {
+                fontSize: axisStyles.fontSize,
+                fontFamily: axisStyles.fontFamily,
+                fill: axisStyles.fill,
+              },
+            }}
+          />
+          {this.renderMinLogTemperatureLine()}
+          {this.renderMinLogTemperatureScatter()}
+          {this.renderMaxLogTemperatureLine()}
+          {this.renderMaxLogTemperatureScatter()}
+          {this.renderMinTemperatureBoundary()}
+          {this.renderMaxTemperatureBoundary()}
           {this.renderHazardPoints()}
         </VictoryChart>
       </Svg>
@@ -199,24 +252,57 @@ export class VaccineChart extends React.Component {
   }
 }
 
+const chartSize = {
+  width: 1,
+  height: 1.025,
+};
+
 const chartStyles = {
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'center',
 };
 
+const axisStyles = {
+  fontSize: 15,
+  fontFamily: APP_FONT_FAMILY,
+  fill: '#909192',
+};
+
+const minBoundaryStyles = {
+  stroke: '#70b4f0',
+  opacity: 0.3,
+};
+
+const maxBoundaryStyles = {
+  stroke: '#e95c30',
+  opacity: 0.3,
+};
+
 const minLineStyles = {
-  fill: 'blue',
+  fill: '#70b4f0',
+  stroke: '#70b4f0',
   interpolation: 'natural',
-  strokeDasharray: '1',
-  stroke: 'blue',
 };
 
 const maxLineStyles = {
-  fill: 'red',
+  fill: '#e95c30',
+  stroke: '#e95c30',
   interpolation: 'natural',
-  strokeDasharray: '1',
-  stroke: 'red',
+};
+
+const minScatterStyles = {
+  fill: 'white',
+  stroke: '#70b4f0',
+  strokeWidth: 2,
+  size: 3,
+};
+
+const maxScatterStyles = {
+  fill: 'white',
+  stroke: '#e95c30',
+  strokeWidth: 2,
+  size: 3,
 };
 
 VaccineChart.propTypes = {

--- a/src/widgets/VaccineChart.js
+++ b/src/widgets/VaccineChart.js
@@ -169,6 +169,7 @@ export class VaccineChart extends React.Component {
 
     return breaches.map(breach => (
       <VictoryScatter
+        key={breach[0].id}
         dataComponent={<HazardPoint onPress={onPress} breach={breach} />}
         data={breach}
         {...dataKeys}

--- a/src/widgets/VaccineChart.js
+++ b/src/widgets/VaccineChart.js
@@ -81,7 +81,7 @@ export class VaccineChart extends React.Component {
       <VictoryLine
         y={() => minTemperature}
         style={{
-          data: { stroke: minBoundaryStyles.stroke, opacity: minBoundaryStyles.opacity },
+          data: { ...minBoundaryStyles },
         }}
       />
     ) : null;
@@ -96,7 +96,7 @@ export class VaccineChart extends React.Component {
       <VictoryLine
         y={() => maxTemperature}
         style={{
-          data: { stroke: maxBoundaryStyles.stroke, opacity: maxBoundaryStyles.opacity },
+          data: { ...maxBoundaryStyles },
         }}
       />
     ) : null;
@@ -125,18 +125,7 @@ export class VaccineChart extends React.Component {
     if (!(minLine.length > 0)) return null;
 
     return (
-      <VictoryScatter
-        data={minLine}
-        size={minScatterStyles.size}
-        style={{
-          data: {
-            fill: minScatterStyles.fill,
-            stroke: minScatterStyles.stroke,
-            strokeWidth: minScatterStyles.strokeWidth,
-          },
-        }}
-        {...dataKeys}
-      />
+      <VictoryScatter data={minLine} style={{ data: { ...minScatterStyles } }} {...dataKeys} />
     );
   }
 
@@ -150,11 +139,7 @@ export class VaccineChart extends React.Component {
       <VictoryLine
         data={maxLine}
         interpolation={maxLineStyles.interpolation}
-        style={{
-          data: {
-            stroke: maxLineStyles.stroke,
-          },
-        }}
+        style={{ data: { stroke: maxLineStyles.stroke } }}
         {...dataKeys}
       />
     );
@@ -170,13 +155,7 @@ export class VaccineChart extends React.Component {
       <VictoryScatter
         data={maxLine}
         size={maxScatterStyles.size}
-        style={{
-          data: {
-            fill: maxScatterStyles.fill,
-            stroke: maxScatterStyles.stroke,
-            strokeWidth: maxScatterStyles.strokeWidth,
-          },
-        }}
+        style={{ data: { ...maxScatterStyles } }}
         {...dataKeys}
       />
     );

--- a/src/widgets/VaccineChart.js
+++ b/src/widgets/VaccineChart.js
@@ -20,6 +20,7 @@ import Svg from 'react-native-svg';
 
 import { HazardPoint } from './HazardPoint';
 import { APP_FONT_FAMILY } from '../globalStyles/fonts';
+import { GREY, SUSSOL_ORANGE, WARM_BLUE } from '../globalStyles/colors';
 
 /**
  * A chart component for plotting vaccine sensor log data.
@@ -214,34 +215,18 @@ export class VaccineChart extends React.Component {
         <VictoryChart
           width={width}
           height={height}
-          padding={{ top: 20, left: 50, right: 50, bottom: 50 }}
           style={chartStyles}
           theme={VictoryTheme.material}
           maxDomain={{ y: maxDomain }}
           minDomain={{ y: minDomain }}
         >
-          <VictoryAxis
-            offsetY={50}
-            style={{
-              tickLabels: {
-                fontSize: axisStyles.fontSize,
-                fontFamily: axisStyles.fontFamily,
-                fill: axisStyles.fill,
-              },
-            }}
-          />
+          <VictoryAxis offsetY={50} style={{ tickLabels: axisStyles }} />
           <VictoryAxis
             dependentAxis
             offsetX={50}
             crossAxis={false}
             tickFormat={t => `${t}℃`}
-            style={{
-              tickLabels: {
-                fontSize: axisStyles.fontSize,
-                fontFamily: axisStyles.fontFamily,
-                fill: axisStyles.fill,
-              },
-            }}
+            style={{ tickLabels: axisStyles }}
           />
           {this.renderMinLogTemperatureLine()}
           {this.renderMinLogTemperatureScatter()}
@@ -274,46 +259,47 @@ const chartStyles = {
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'center',
+  padding: { top: 20, left: 50, right: 50, bottom: 50 },
 };
 
 const axisStyles = {
   fontSize: 15,
   fontFamily: APP_FONT_FAMILY,
-  fill: '#909192',
+  fill: GREY,
 };
 
 const minBoundaryStyles = {
-  stroke: '#70b4f0',
+  stroke: WARM_BLUE,
   opacity: 0.3,
 };
 
 const maxBoundaryStyles = {
-  stroke: '#e95c30',
+  stroke: SUSSOL_ORANGE,
   opacity: 0.3,
 };
 
 const minLineStyles = {
-  fill: '#70b4f0',
-  stroke: '#70b4f0',
+  fill: WARM_BLUE,
+  stroke: WARM_BLUE,
   interpolation: 'natural',
 };
 
 const maxLineStyles = {
-  fill: '#e95c30',
-  stroke: '#e95c30',
+  fill: SUSSOL_ORANGE,
+  stroke: SUSSOL_ORANGE,
   interpolation: 'natural',
 };
 
 const minScatterStyles = {
   fill: 'white',
-  stroke: '#70b4f0',
+  stroke: WARM_BLUE,
   strokeWidth: 2,
   size: 3,
 };
 
 const maxScatterStyles = {
   fill: 'white',
-  stroke: '#e95c30',
+  stroke: SUSSOL_ORANGE,
   strokeWidth: 2,
   size: 3,
 };

--- a/src/widgets/VaccineChart.js
+++ b/src/widgets/VaccineChart.js
@@ -22,7 +22,11 @@ import { HazardPoint } from './HazardPoint';
 import { APP_FONT_FAMILY } from '../globalStyles/fonts';
 
 /**
- * Plots a line graph of temperature over time for vaccines.
+ * A chart component for plotting vaccine sensor log data.
+ *
+ * Plots maximum and/or minimum vaccine temperatures. Optionally
+ * displays temperature breaches using hazard icons which can be
+ * used to trigger onPress events passed as props.
  */
 export class VaccineChart extends React.Component {
   constructor(props) {
@@ -43,6 +47,7 @@ export class VaccineChart extends React.Component {
     });
   };
 
+  // Calculates maximum and minimum temperatures for chart y-axis.
   getDomain() {
     const { minLine, maxLine, minTemperature, maxTemperature, dataKeys } = this.props;
     const lines = [...minLine, ...maxLine];
@@ -66,6 +71,7 @@ export class VaccineChart extends React.Component {
     return { minDomain, maxDomain };
   }
 
+  // Plots line marking minimum temperature boundary for breaches.
   renderMinTemperatureBoundary() {
     const { minTemperature } = this.props;
 
@@ -80,6 +86,7 @@ export class VaccineChart extends React.Component {
     ) : null;
   }
 
+  // Render line plot of maximum temperature boundary for breaches.
   renderMaxTemperatureBoundary() {
     const { maxTemperature } = this.props;
 
@@ -94,6 +101,7 @@ export class VaccineChart extends React.Component {
     ) : null;
   }
 
+  // Render line plot of minimum log temperatures.
   renderMinLogTemperatureLine() {
     const { minLine, dataKeys } = this.props;
 
@@ -109,6 +117,7 @@ export class VaccineChart extends React.Component {
     );
   }
 
+  // Render data points of minimum log temperature line plot.
   renderMinLogTemperatureScatter() {
     const { minLine, dataKeys } = this.props;
 
@@ -130,6 +139,7 @@ export class VaccineChart extends React.Component {
     );
   }
 
+  // Render line plot of maximum log temperatures.
   renderMaxLogTemperatureLine() {
     const { maxLine, dataKeys } = this.props;
 
@@ -149,6 +159,7 @@ export class VaccineChart extends React.Component {
     );
   }
 
+  // Render data points of maximum log temperature line plot.
   renderMaxLogTemperatureScatter() {
     const { maxLine, dataKeys } = this.props;
 
@@ -170,6 +181,7 @@ export class VaccineChart extends React.Component {
     );
   }
 
+  // Render hazard icons for sensor breaches.
   renderHazardPoints() {
     const { breaches, onPress, dataKeys } = this.props;
 
@@ -184,6 +196,7 @@ export class VaccineChart extends React.Component {
     ));
   }
 
+  // Helper method for rendering vaccine chart.
   renderPlot() {
     const { minLine, maxLine } = this.props;
 

--- a/src/widgets/VaccineChart.js
+++ b/src/widgets/VaccineChart.js
@@ -55,17 +55,12 @@ export class VaccineChart extends React.Component {
     const { y: temperatureKey } = dataKeys;
 
     const minDomain =
-      lines.reduce(
-        (currentMinTemperature, sensorLog) =>
-          Math.min(currentMinTemperature, sensorLog[temperatureKey]),
-        minTemperature
+      Math.min(
+        ...lines.map(({ [temperatureKey]: temperature }) => temperature).append(minTemperature)
       ) - 1;
-
     const maxDomain =
-      lines.reduce(
-        (currentMaxTemperature, sensorLog) =>
-          Math.max(currentMaxTemperature, sensorLog[temperatureKey]),
-        maxTemperature
+      Math.max(
+        ...lines.map(({ [temperatureKey]: temperature }) => temperature).append(maxTemperature)
       ) + 1;
 
     return { minDomain, maxDomain };

--- a/src/widgets/VaccineChart.js
+++ b/src/widgets/VaccineChart.js
@@ -55,13 +55,9 @@ export class VaccineChart extends React.Component {
     const { y: temperatureKey } = dataKeys;
 
     const minDomain =
-      Math.min(
-        ...lines.map(({ [temperatureKey]: temperature }) => temperature).append(minTemperature)
-      ) - 1;
+      Math.min(minTemperature, ...lines.map(({ [temperatureKey]: temp }) => temp)) - 1;
     const maxDomain =
-      Math.max(
-        ...lines.map(({ [temperatureKey]: temperature }) => temperature).append(maxTemperature)
-      ) + 1;
+      Math.max(maxTemperature, ...lines.map(({ [temperatureKey]: temp }) => temp)) + 1;
 
     return { minDomain, maxDomain };
   }

--- a/src/widgets/VaccineChart.js
+++ b/src/widgets/VaccineChart.js
@@ -20,6 +20,9 @@ import Svg from 'react-native-svg';
 
 import { HazardPoint } from './HazardPoint';
 
+/**
+ * Plots a line graph of temperature over time for vaccines.
+ */
 export class VaccineChart extends React.Component {
   constructor(props) {
     super(props);
@@ -141,11 +144,17 @@ export class VaccineChart extends React.Component {
   }
 
   renderHazardPoints() {
-    const { hazards, dataKeys } = this.props;
+    const { breaches, onPress, dataKeys } = this.props;
 
-    return hazards.length > 0 ? (
-      <VictoryScatter dataComponent={<HazardPoint />} data={hazards} {...dataKeys} />
-    ) : null;
+    if (!(breaches.length > 0)) return null;
+
+    return breaches.map(breach => (
+      <VictoryScatter
+        dataComponent={<HazardPoint onPress={onPress} breach={breach} />}
+        data={breach}
+        {...dataKeys}
+      />
+    ));
   }
 
   renderPlot() {
@@ -170,14 +179,10 @@ export class VaccineChart extends React.Component {
           maxDomain={{ y: maxDomain }}
           minDomain={{ y: minDomain }}
         >
-          <VictoryAxis offsetY={50} />
-          <VictoryAxis dependentAxis offsetX={50} crossAxis={false} />
-          {this.renderMinLogTemperatureLine()}
-          {this.renderMinLogTemperatureScatter()}
-          {this.renderMaxLogTemperatureLine()}
-          {this.renderMaxLogTemperatureScatter()}
-          {this.renderMinTemperatureBoundary()}
-          {this.renderMaxTemperatureBoundary()}
+          <VictoryAxis offsetY={50} /> <VictoryAxis dependentAxis offsetX={50} crossAxis={false} />
+          {this.renderMinLogTemperatureLine()} {this.renderMinLogTemperatureScatter()}
+          {this.renderMaxLogTemperatureLine()} {this.renderMaxLogTemperatureScatter()}
+          {this.renderMinTemperatureBoundary()} {this.renderMaxTemperatureBoundary()}
           {this.renderHazardPoints()}
         </VictoryChart>
       </Svg>
@@ -217,18 +222,20 @@ const maxLineStyles = {
 VaccineChart.propTypes = {
   minLine: PropTypes.arrayOf(PropTypes.object),
   maxLine: PropTypes.arrayOf(PropTypes.object),
-  hazards: PropTypes.arrayOf(PropTypes.object),
+  breaches: PropTypes.arrayOf(PropTypes.array),
   minTemperature: PropTypes.number,
   maxTemperature: PropTypes.number,
+  onPress: PropTypes.func,
   dataKeys: PropTypes.objectOf(PropTypes.string),
 };
 
 VaccineChart.defaultProps = {
   minLine: [],
   maxLine: [],
-  hazards: [],
+  breaches: [],
   minTemperature: Infinity,
   maxTemperature: -Infinity,
+  onPress: () => null,
   dataKeys: { x: 'timestamp', y: 'temperature' },
 };
 

--- a/src/widgets/VaccineChart.js
+++ b/src/widgets/VaccineChart.js
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { View } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 
 import {
   VictoryLine,
@@ -19,8 +19,7 @@ import {
 import Svg from 'react-native-svg';
 
 import { HazardPoint } from './HazardPoint';
-import { APP_FONT_FAMILY } from '../globalStyles/fonts';
-import { GREY, SUSSOL_ORANGE, WARM_BLUE } from '../globalStyles/colors';
+import { APP_FONT_FAMILY, GREY, SUSSOL_ORANGE, WARM_BLUE } from '../globalStyles';
 
 /**
  * A chart component for plotting vaccine sensor log data.
@@ -78,12 +77,7 @@ export class VaccineChart extends React.Component {
 
     // minTemp default prop is Infinity.
     return minTemperature !== Infinity ? (
-      <VictoryLine
-        y={() => minTemperature}
-        style={{
-          data: { ...minBoundaryStyles },
-        }}
-      />
+      <VictoryLine y={() => minTemperature} {...minBoundaryStyles} />
     ) : null;
   }
 
@@ -93,12 +87,7 @@ export class VaccineChart extends React.Component {
 
     // maxTemp default prop is -Infinity.
     return maxTemperature !== -Infinity ? (
-      <VictoryLine
-        y={() => maxTemperature}
-        style={{
-          data: { ...maxBoundaryStyles },
-        }}
-      />
+      <VictoryLine y={() => maxTemperature} {...maxBoundaryStyles} />
     ) : null;
   }
 
@@ -108,14 +97,7 @@ export class VaccineChart extends React.Component {
 
     if (!(minLine.length > 0)) return null;
 
-    return (
-      <VictoryLine
-        data={minLine}
-        interpolation={minLineStyles.interpolation}
-        style={{ data: { stroke: minLineStyles.stroke } }}
-        {...dataKeys}
-      />
-    );
+    return <VictoryLine data={minLine} {...minLineStyles} {...dataKeys} />;
   }
 
   // Render data points of minimum log temperature line plot.
@@ -124,9 +106,7 @@ export class VaccineChart extends React.Component {
 
     if (!(minLine.length > 0)) return null;
 
-    return (
-      <VictoryScatter data={minLine} style={{ data: { ...minScatterStyles } }} {...dataKeys} />
-    );
+    return <VictoryScatter data={minLine} {...minScatterStyles} {...dataKeys} />;
   }
 
   // Render line plot of maximum log temperatures.
@@ -135,14 +115,7 @@ export class VaccineChart extends React.Component {
 
     if (!(maxLine.length > 0)) return null;
 
-    return (
-      <VictoryLine
-        data={maxLine}
-        interpolation={maxLineStyles.interpolation}
-        style={{ data: { stroke: maxLineStyles.stroke } }}
-        {...dataKeys}
-      />
-    );
+    return <VictoryLine data={maxLine} {...maxLineStyles} {...dataKeys} />;
   }
 
   // Render data points of maximum log temperature line plot.
@@ -151,14 +124,7 @@ export class VaccineChart extends React.Component {
 
     if (!(maxLine.length > 0)) return null;
 
-    return (
-      <VictoryScatter
-        data={maxLine}
-        size={maxScatterStyles.size}
-        style={{ data: { ...maxScatterStyles } }}
-        {...dataKeys}
-      />
-    );
+    return <VictoryScatter data={maxLine} {...maxScatterStyles} {...dataKeys} />;
   }
 
   // Render hazard icons for sensor breaches.
@@ -195,19 +161,13 @@ export class VaccineChart extends React.Component {
         <VictoryChart
           width={width}
           height={height}
-          style={chartStyles}
           theme={VictoryTheme.material}
           maxDomain={{ y: maxDomain }}
           minDomain={{ y: minDomain }}
+          {...chartStyles}
         >
-          <VictoryAxis offsetY={50} style={{ tickLabels: axisStyles }} />
-          <VictoryAxis
-            dependentAxis
-            offsetX={50}
-            crossAxis={false}
-            tickFormat={t => `${t}℃`}
-            style={{ tickLabels: axisStyles }}
-          />
+          <VictoryAxis {...dateAxisStyles} />
+          <VictoryAxis dependentAxis crossAxis={false} {...tempAxisStyles} />
           {this.renderMinLogTemperatureLine()}
           {this.renderMinLogTemperatureScatter()}
           {this.renderMaxLogTemperatureLine()}
@@ -235,53 +195,91 @@ const chartSize = {
   height: 1.025,
 };
 
-const chartStyles = {
-  display: 'flex',
-  flexDirection: 'row',
-  justifyContent: 'center',
-  padding: { top: 20, left: 50, right: 50, bottom: 50 },
+const chartStyles = StyleSheet.create({
+  style: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  padding: { top: 20, left: 50, bottom: 50, right: 50 },
+});
+
+const tempAxisStyles = {
+  style: {
+    fontSize: 15,
+    fontFamily: APP_FONT_FAMILY,
+    fill: GREY,
+  },
+  offsetX: 50,
+  // Unicode for degrees celcius.
+  tickFormat: t => `${t}\u2103`,
 };
 
-const axisStyles = {
-  fontSize: 15,
-  fontFamily: APP_FONT_FAMILY,
-  fill: GREY,
+const dateAxisStyles = {
+  style: {
+    fontSize: 15,
+    fontFamily: APP_FONT_FAMILY,
+    fill: GREY,
+  },
+  offsetY: 50,
 };
 
 const minBoundaryStyles = {
-  stroke: WARM_BLUE,
-  opacity: 0.3,
+  style: {
+    data: {
+      stroke: WARM_BLUE,
+      opacity: 0.3,
+    },
+  },
 };
 
 const maxBoundaryStyles = {
-  stroke: SUSSOL_ORANGE,
-  opacity: 0.3,
+  style: {
+    data: {
+      stroke: SUSSOL_ORANGE,
+      opacity: 0.3,
+    },
+  },
 };
 
 const minLineStyles = {
-  fill: WARM_BLUE,
-  stroke: WARM_BLUE,
+  style: {
+    data: {
+      stroke: WARM_BLUE,
+    },
+  },
   interpolation: 'natural',
 };
 
 const maxLineStyles = {
-  fill: SUSSOL_ORANGE,
-  stroke: SUSSOL_ORANGE,
+  style: {
+    data: {
+      stroke: SUSSOL_ORANGE,
+    },
+  },
   interpolation: 'natural',
 };
 
 const minScatterStyles = {
-  fill: 'white',
-  stroke: WARM_BLUE,
-  strokeWidth: 2,
-  size: 3,
+  style: {
+    data: {
+      fill: 'white',
+      stroke: WARM_BLUE,
+      strokeWidth: 2,
+      size: 3,
+    },
+  },
 };
 
 const maxScatterStyles = {
-  fill: 'white',
-  stroke: SUSSOL_ORANGE,
-  strokeWidth: 2,
-  size: 3,
+  style: {
+    data: {
+      fill: 'white',
+      stroke: SUSSOL_ORANGE,
+      strokeWidth: 2,
+      size: 3,
+    },
+  },
 };
 
 VaccineChart.propTypes = {
@@ -300,7 +298,7 @@ VaccineChart.defaultProps = {
   breaches: [],
   minTemperature: Infinity,
   maxTemperature: -Infinity,
-  onPress: () => null,
+  onPress: null,
   dataKeys: { x: 'timestamp', y: 'temperature' },
 };
 


### PR DESCRIPTION
Fixes #896.

Test branch `#896-refactor-vaccine-chart`.

Changelog:

- `VaccineChart` graph components refactored into smaller methods.
- `VaccineChart` props updated for consistency with `aggregateLogs`.
- `VaccineChart` return value updated.
- `VaccineChart` and `HazardPoint` styles updated and tidied up