### PR TITLE
#882 refactor item getters

### DIFF
--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -225,7 +225,7 @@ export class Item extends Realm.Object {
    */
   getBatchesInLocation({ id: locationId } = {}) {
     if (!locationId) return this.batches;
-    return this.batches.filtered('location.id = $0', locationId);
+    return this.batches.filtered('location.id = $0 & numberOfPacks > 0', locationId);
   }
 
   /**
@@ -255,7 +255,7 @@ export class Item extends Realm.Object {
    * @param {Location} location
    */
   getBreachedBatches(location) {
-    return this.getBatchesInLocation(location).filter(hasBreached => hasBreached);
+    return this.getBatchesInLocation(location).filter(({ hasBreached }) => hasBreached);
   }
 
   /**
@@ -287,18 +287,10 @@ export class Item extends Realm.Object {
   getTemperatureExposure(location) {
     let { batches } = this;
     if (location) batches = this.getBatchesInLocation(location);
-
-    const temperatures = batches.map(({ temperatureExposure } = {}) => temperatureExposure);
-
-    const maxTemperature = temperatures.reduce(
-      (maxTemp, { maxTemperature: max = -Infinity } = {}) => Math.max(maxTemp, max),
-      -Infinity
-    );
-    const minTemperature = temperatures.reduce(
-      (minTemp, { minTemperature: min = Infinity } = {}) => Math.min(minTemp, min),
-      Infinity
-    );
-    return { minTemperature, maxTemperature };
+    return {
+      maxTemperature: batches.max('sensorLog.temperature') || -Infinity,
+      minTemperature: batches.min('sensorLog.temperature') || Infinity,
+    };
   }
 }
 

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -224,8 +224,8 @@ export class Item extends Realm.Object {
    * @param {Location} location
    */
   getBatchesInLocation({ id: locationId } = {}) {
-    if (!locationId) return this.batches;
-    return this.batches.filtered('location.id = $0 & numberOfPacks > 0', locationId);
+    if (!locationId) return this.batchesWithStock;
+    return this.batchesWithStock.filtered('location.id = $0', locationId);
   }
 
   /**

--- a/src/database/DataTypes/ItemBatch.js
+++ b/src/database/DataTypes/ItemBatch.js
@@ -142,13 +142,30 @@ export class ItemBatch extends Realm.Object {
   }
 
   /**
-   * Returns an object {maxTemperature, minTemperature} for all
-   * recorded temperatures for this ItemBatch.
+   * Returns an object { maxTemperature, minTemperature } for all
+   * temperatures recorded for this item batch
    */
   get temperatureExposure() {
-    const maxTemperature = this.sensorLogs.max('temperature') || -Infinity;
-    const minTemperature = this.sensorLogs.min('temperature') || Infinity;
-    return { maxTemperature, minTemperature };
+    return {
+      minTemperature: this.sensorLogs.min('temperature') || Infinity,
+      maxTemperature: this.sensorLogs.max('temperature') || -Infinity,
+    };
+  }
+
+  /**
+   * Returns an object { maxTemperature, minTemperature } for all
+   * temperatures recorded for this item batch in a given
+   * location.
+   * @param {Location} location
+   * @param {Location.id} LocationId
+   */
+  getTemperatureExposureInLocation({ id: locationId } = {}) {
+    return {
+      minTemperature:
+        this.sensorLogs.filtered('location.id = $0', locationId).min('temperature') || Infinity,
+      maxTemperature:
+        this.sensorLogs.filtered('location.id = $0', locationId).max('temperature') || -Infinity,
+    };
   }
 }
 


### PR DESCRIPTION
Fixes #882 

Still some methods that could be removed, but think I should leave them till later.

The `Item.getTemperatureExposure` example in issue gives the temperature exposure for an Item while it was in a certain location. I don't think we should not count the exposure for certain batches while they were in different locations? Happy to change this but it doesn't seem correct to throw away that a batch has potentially been in a lower or higher temperature, just in a different location?