### PR TITLE
#909 customer invoice breach column

### DIFF
--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -301,7 +301,9 @@ export class Item extends Realm.Object {
   }
 
   getAllSensorLogs(database) {
-    return database.objects('SensorLog').filtered('itemBatches.item.id = $0', this.id);
+    return database
+      .objects('SensorLog')
+      .filtered('itemBatches.item.id = $0 && itemBatches.numberOfPacks > 0', this.id);
   }
 }
 

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -299,6 +299,10 @@ export class Item extends Realm.Object {
       minTemperature: sensorLogs.min('temperature'),
     };
   }
+
+  getAllSensorLogs(database) {
+    return database.objects('SensorLog').filtered('itemBatches.item.id = $0', this.id);
+  }
 }
 
 Item.schema = {

--- a/src/pages/VaccineModulePage.js
+++ b/src/pages/VaccineModulePage.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable react/forbid-prop-types, global-require */
 /**
  * mSupply Mobile

--- a/src/widgets/BreachTable.js
+++ b/src/widgets/BreachTable.js
@@ -135,6 +135,11 @@ export class BreachTable extends React.PureComponent {
   // for the main table.
   renderCell = (key, value) => {
     switch (key) {
+      case 'date':
+        return {
+          type: 'text',
+          cellContents: value[key].toLocaleDateString(),
+        };
       case 'location':
         return {
           type: 'text',


### PR DESCRIPTION
Fixes #909 

- Adds a Breach column to `CustomerInvoicePage`
- Small update to `vaccines.js`
    - Was not filtering the `ItemBatches` by `Item` or `ItemBatch`
    - Added data for the date column for a breach
    - Double use of variable `Item` (Used as a parameter

I couldn't not trace it properly, but if I did not set `breachData` as state, and instead just used a `getBreachData()` method for the `BreachModal` to get it's data, on navigating back from `CustomerInvoicePage`, when the modal was open - some infinite recursion was happening? Not a fan of putting this in state, so will take another look most likely to make sure there isn't a way to not have this data in state.