### PR TITLE
#911 - Breach modal integration

### DIFF
--- a/src/pages/ManageVaccineItemPage.js
+++ b/src/pages/ManageVaccineItemPage.js
@@ -322,7 +322,9 @@ export class ManageVaccineItemPage extends React.Component {
           <BreachTable
             {...this.props}
             breaches={this.getBreaches()}
-            itemBatchFilter={currentBatch && currentBatch.parentBatch}
+            itemBatchFilter={
+              currentBatch && currentBatch.parentBatch ? currentBatch.parentBatch : currentBatch
+            }
           />
         );
       }

--- a/src/pages/ManageVaccineItemPage.js
+++ b/src/pages/ManageVaccineItemPage.js
@@ -159,7 +159,6 @@ export class ManageVaccineItemPage extends React.Component {
   onSplitBatch = (splitValue = 0) => {
     const { currentBatch, data } = this.state;
     const { totalQuantity } = currentBatch;
-
     const parsedSplitValue = parseInt(splitValue, 10);
     let newObjectValues = {};
 
@@ -171,13 +170,15 @@ export class ManageVaccineItemPage extends React.Component {
       };
       // Account for 0 & NaN (From entering a non-numeric character)
     } else if (parsedSplitValue) {
+      let parentBatch = currentBatch;
+      if (currentBatch.parentBatch) parentBatch = currentBatch.parentBatch;
       const newBatchValues = {
         id: generateUUID(),
         totalQuantity: parsedSplitValue,
         vvmStatus: false,
         reason: this.VVMREASON || null,
         hasBreached: currentBatch.hasBreached,
-        parentBatch: currentBatch,
+        parentBatch,
       };
       data.push(createRowObject(currentBatch, newBatchValues));
       newObjectValues = { vvmStatus: true, totalQuantity: totalQuantity - parsedSplitValue };

--- a/src/pages/ManageVaccineStockPage.js
+++ b/src/pages/ManageVaccineStockPage.js
@@ -229,7 +229,9 @@ export class ManageVaccineStockPage extends React.Component {
 
     switch (modalKey) {
       case BREACH:
-        return <BreachTable {...this.props} breaches={this.getBreaches()} item={currentItem} />;
+        return (
+          <BreachTable {...this.props} breaches={this.getBreaches()} itemFilter={currentItem} />
+        );
       case FRIDGE_SELECT:
         return (
           <GenericChoiceList


### PR DESCRIPTION
Fixes #911 

#### NOTE: Branched from #904 

- Adds `BreachTable` as a modal to each page
    - `VaccineItemManagePage`
    - `VaccineStockManagePage`
    - `VaccineModulePage`
- Also alters the `BreachTable` modal logic on `CustomerInvoicePage`
- Alters slightly `BreachTable`

PR makes `BreachTable` accept an array of `Breaches`, which will then call the required methods to gather data needed to render in `runWithLoadingIndicator` within `componentDidMount`.

I think this is the best solution as, for example fridge hazards will have a breach already, making it unnecessary to call `extractBreaches`. By passing `BreachTable` a 2D array of `sensorLogs` (the breaches), this makes it more generic for all use cases, rather than having to pass a 'type' or use logic to work out who is passing the data.

The `runWithLoadingIndicator` is a little unneccesary for small amounts of data. For some `Item` or `ItemBatch`, it only shows for a split second and can be a little jarring which isn't great. Need `React Suspense` :(