### PR TITLE
#917 simple table formatting

### DIFF
--- a/src/utilities/modules/vaccines.js
+++ b/src/utilities/modules/vaccines.js
@@ -139,11 +139,16 @@ const extractItemBatches = ({ sensorLogs, itemBatch, item, database }) => {
         // If this batch has been encountered before, skip it.
         const itemBatchGroup = groupedBatches[itemId].batches;
         if (itemBatchGroup[batchId]) return;
+
         // Calculate the duration this ItemBatch has been counted in this group of sensorLogs.
-        const duration = new Date(
-          sensorLogs.filtered('itemBatches.id = $0', batchId).max('temperature') -
-            sensorLogs.filtered('itemBatches.id = $0', batchId).min('temperature')
-        );
+        const sensorLogsForThisBatch = sensorLogs
+          .filtered('itemBatches.id = $0', batchId)
+          .sorted('timestamp');
+        const duration = {
+          startDate: sensorLogsForThisBatch[0].timestamp,
+          endDate: sensorLogsForThisBatch[sensorLogsForThisBatch.length - 1].timestamp,
+        };
+
         // Finally store the batches details:
         // groupedBatches = { itemId: { item, batches: { id: { duration, id, code.. }, .. }}, .. }
         itemBatchGroup[batchId] = {

--- a/src/widgets/BreachTable.js
+++ b/src/widgets/BreachTable.js
@@ -20,7 +20,6 @@ import { SHADOW_BORDER } from '../globalStyles';
 /**
  * CONSTANTS
  */
-
 // TODO: Localization
 const LOCALIZATION = {
   columns: {
@@ -72,9 +71,19 @@ const BREACH_COLUMNS = [
 
 const BATCH_COLUMNS = [
   { key: 'code', title: LOCALIZATION.columns.batch.code, width: 0.8 },
-  { key: 'expiryDate', title: LOCALIZATION.columns.batch.expiry, width: 0.8 },
   { key: 'totalQuantity', title: LOCALIZATION.columns.batch.quantity, width: 0.8 },
-  { key: 'duration', title: LOCALIZATION.columns.batch.duration, width: 1 },
+  {
+    key: 'expiryDate',
+    title: LOCALIZATION.columns.batch.expiry,
+    width: 0.8,
+    formatMethod: content => content.toLocaleDateString(),
+  },
+  {
+    key: 'duration',
+    title: LOCALIZATION.columns.batch.duration,
+    width: 1,
+    formatMethod: content => formattedDifferenceBetweenDates(content),
+  },
 ];
 
 /**

--- a/src/widgets/SimpleTable.js
+++ b/src/widgets/SimpleTable.js
@@ -18,8 +18,19 @@ import { ROW_BLUE, APP_FONT_FAMILY, SUSSOL_ORANGE } from '../globalStyles/index'
  * @prop    {array}  data    Array of data. Example below.
  * @prop    {array}  columns Array of column objects. Example below.
  * @prop    {string} title   Title for this table.
+ *
  * data = [ { a: 1, b: 2}, {a: 3, b: 4}, .. ]
- * columns = [ { key: 'a', width: 1, title: 'A COLUMN' }, { key: 'b', width: 1, title: 'B COLUMN' }]
+ * Simple objects with key/values pairs corresponding to each column. Values
+ * must be simple scalar values, unless the corresponding column has a formatMethod
+ *
+ * columns = [ { key: 'a', width: 1, title: 'A COLUMN' },
+ *             { key: 'b', width: 1, title: 'B COLUMN', formatMethod: () => {} }
+ * ]
+ * formatMethod: e.g. (value) => value.toLocaleDateString()
+ *
+ * Objects using flex to scale width and a key to find the correct data for each
+ * row. If the value being passed in the data object is not a simple scalar value,
+ * a formatMethod can be passed to transform it to one.
  */
 export class SimpleTable extends React.PureComponent {
   keyExtractor = ({ index }) => index;
@@ -34,15 +45,11 @@ export class SimpleTable extends React.PureComponent {
     );
   };
 
-  renderCell = ({ content, rowIndex, header, width, cellIndex }) => {
+  renderCell = ({ content, rowIndex, header, width, cellIndex, formatMethod }) => {
     const { cell, cellFont } = localStyles({ ...this.props, rowIndex, header, width });
     return (
       <View style={cell} key={this.keyExtractor({ index: cellIndex })}>
-        <Text style={cellFont}>
-          {content && typeof content === 'object'
-            ? content.toLocaleDateString()
-            : content.toString()}
-        </Text>
+        <Text style={cellFont}>{formatMethod ? formatMethod(content) : content}</Text>
       </View>
     );
   };
@@ -66,9 +73,9 @@ export class SimpleTable extends React.PureComponent {
     return (
       <View style={row}>
         {columns.map((column, cellIndex) => {
-          const { key, width } = column;
+          const { key, width, formatMethod } = column;
           const content = item[key];
-          return this.renderCell({ content, column, width, cellIndex, rowIndex });
+          return this.renderCell({ content, column, width, cellIndex, rowIndex, formatMethod });
         })}
       </View>
     );


### PR DESCRIPTION
Fixes #917 

#### NOTE: Branched from #913 

- Adds the ability to pass a formatting method for a column in `SimpleTable` to return a scalar value to render in a cell
- Updates the return value of `sensorLogsExtractBatches` to return `{ startDate, endDate}` for the duration an `ItemBatch` was in a breach, rather than calculating the duration. Means we can use `formattedDifferenceBetweenDates` method to calculate the duration when rendering the cell, while also giving the ability to use the timestamps to potentially show on the chart the duration the batch was in the breach in the future