### PR TITLE
#921 regimen data bug

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -140,11 +140,13 @@ const createItemBatch = (database, item, batchString) => {
 const createRequisition = (
   database,
   user,
-  { otherStoreName, program, period, orderType, monthsLeadTime }
+  { otherStoreName, program, period, orderType = {}, monthsLeadTime = 0 }
 ) => {
   const { name: orderTypeName, maxMOS, thresholdMOS } = orderType;
-  const { regimenData } = program.parsedProgramSettings;
-  const daysToSupply = (monthsLeadTime + maxMOS) * 30;
+  const regimenData =
+    program && program.parsedProgramSettings ? program.parsedProgramSettings.regimenData : null;
+  const daysToSupply = monthsLeadTime ? (monthsLeadTime + maxMOS) * 30 : 30;
+
   const requisition = database.create('Requisition', {
     id: generateUUID(),
     serialNumber: getNextNumber(database, REQUISITION_SERIAL_NUMBER),
@@ -161,10 +163,12 @@ const createRequisition = (
     period,
     customData: regimenData && JSON.stringify({ regimenData }),
   });
+
   if (period) {
     period.addRequisitionIfUnique(requisition);
     database.save('Period', period);
   }
+
   return requisition;
 };
 

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -363,8 +363,9 @@ export class SupplierRequisitionPage extends React.Component {
 
   renderButtons = () => {
     const { requisition } = this.props;
-    const { program, thresholdMOS } = requisition;
-
+    const { program, thresholdMOS, parsedCustomData } = requisition;
+    const hasRegimenData =
+      parsedCustomData && parsedCustomData.regimenData && parsedCustomData.regimenData.length !== 0;
     const UseSuggestedQuantitiesButton = () => (
       <PageButton
         style={{
@@ -437,7 +438,7 @@ export class SupplierRequisitionPage extends React.Component {
         <View style={globalStyles.verticalContainer}>
           <View style={globalStyles.horizontalContainer}>
             <UseSuggestedQuantitiesButton />
-            {program && <ViewRegimenDataButton />}
+            {hasRegimenData && <ViewRegimenDataButton />}
           </View>
           {program && thresholdMOS && <ThresholdMOSToggle />}
           {!program && <CreateAutomaticOrderButton />}

--- a/src/pages/expansions/RequisitionRegimenModalTable.js
+++ b/src/pages/expansions/RequisitionRegimenModalTable.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-unused-state */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
@@ -19,40 +20,23 @@ import { expansionPageStyles } from '../../globalStyles';
 export class RequisitionRegimenModalTable extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      customData: [],
-    };
-  }
-
-  componentDidMount() {
-    const { requisition } = this.props;
-    this.setState({
-      customData: requisition.parsedCustomData,
-    });
+    this.state = { forceUpdate: [] };
   }
 
   onEndEditing = (key, rowData, newValue) => {
-    const { customData } = this.state;
     const { database, requisition } = this.props;
-    const { regimenData, otherData } = customData;
+    const { parsedCustomData } = requisition;
+    const { regimenData } = parsedCustomData;
 
-    const newRegimenData = [...regimenData];
-    const rowIndex = newRegimenData.findIndex(row => row.code === rowData.code);
-
-    newRegimenData[rowIndex][key] = newValue;
-    const newData = { ...otherData, regimenData: newRegimenData };
+    const rowIndex = regimenData.findIndex(row => row.code === rowData.code);
+    regimenData[rowIndex][key] = newValue;
 
     database.write(() => {
-      requisition.saveCustomData(newData);
+      requisition.saveCustomData(parsedCustomData);
       database.save('Requisition', requisition);
     });
 
-    this.setState({ customData: newData });
-  };
-
-  refreshData = () => {
-    const { customData } = this.state;
-    this.setState({ ...customData });
+    this.setState({ forceUpdate: [...regimenData] });
   };
 
   renderCell = (key, regimenRow) => {
@@ -81,20 +65,27 @@ export class RequisitionRegimenModalTable extends React.Component {
     }
   };
 
+  getData = () => {
+    const { requisition } = this.props;
+    const { parsedCustomData } = requisition;
+    const { regimenData } = parsedCustomData;
+    return regimenData;
+  };
+
   render() {
     const { database, genericTablePageStyles } = this.props;
-    const { customData } = this.state;
-    const { regimenData } = customData;
 
     return (
       <GenericPage
-        data={regimenData}
+        data={this.getData()}
         renderCell={this.renderCell}
-        refreshData={this.refreshData}
         hideSearchBar={true}
-        renderDataTableFooter={null} // Overrides default generic pages footer.
         dontRenderSearchBar={true}
+        renderDataTableFooter={null} // Overrides default generic pages footer.
         onEndEditing={this.onEndEditing}
+        database={database}
+        pageStyles={expansionPageStyles}
+        {...genericTablePageStyles}
         columns={[
           {
             key: 'name',
@@ -115,10 +106,6 @@ export class RequisitionRegimenModalTable extends React.Component {
             alignText: 'right',
           },
         ]}
-        dataTypesLinked={['Requisition']}
-        database={database}
-        pageStyles={expansionPageStyles}
-        {...genericTablePageStyles}
       />
     );
   }


### PR DESCRIPTION
Fixes #921 .. kind of

- On editing a cell in `GenericTablePage`, `refreshData()` is called. 
- This will clear `cellsRefMap`
- `cellsRefMap` is populated when a cell is rendered
- On re-rendering the `ListView`, only objects (or rows) which have changed will be re-rendered [ using a shallow compare ]
- As we only change the reference to one object currently, all others will return true on a shallow comparison and will not re-render, not populating `cellRefsMap`
- After editing a cell `onEndEditing()` is called, which will call `focusNextCell`, attempting to access the `cellRefsMap` and throwing a runtime error.


To enable the use of `JS Objects` rather than `Realm entities`, All objects within the `regimenData` array should return false on a shallow compare, ensuring that `cellRefsMap` is repopulated.

This PR does a hack solution: `JSON.stringify` and then `JSON.parse` on an object essentially creates an infinitely deep clone. So on every re-render, re-parse `Requisition.customData`.

I removed `refreshData` as it wasn't used anymore - `dataTypesLinked` was then causing errors, didn't look into it, just removed it.

Also hides the regimen data button and fixes a couple undefined things.

Not happy with this PR, more of a placeholder/informative to find a better solution
