### PR TITLE
#920 fix gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -115,7 +115,7 @@ android {
         versionCode appVersionCode
         versionName getAppVersion()
         ndk {
-            abiFilters "armeabi-v7a", "x86", "arm64-v8a"
+            abiFilters "armeabi-v7a", "x86"
         }
     }
     signingConfigs {
@@ -131,7 +131,7 @@ android {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
             universalApk false  // If true, also generate a universal APK
-            include "armeabi-v7a", "x86", "arm64-v8a"
+            include "armeabi-v7a", "x86"
         }
     }
     buildTypes {
@@ -146,7 +146,7 @@ android {
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
             // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits
-            def versionCodes = ["armeabi-v7a":1, "x86":2, "arm64-v8a": 3]
+            def versionCodes = ["armeabi-v7a":1, "x86":2]
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =


### PR DESCRIPTION
Fixes #920 

#### NOTE: This should probably be merged into IC branch also

- Ensures only a 32bit build is compiled

Without this, the app fails to load on certain tablets, e.g. Lenovo. I haven't had a look yet at the Lenovo architecture so I am not sure exactly why the builds were working on other 64 bit tablets.

As per the issue, our dependencies do not currently support compiling for 64bit architectures regardless