### PR TITLE
Ic cmm calculation

### DIFF
--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -179,7 +179,7 @@ export class Item extends Realm.Object {
     let fromDate = startDate;
     if (!enforceEndDate) {
       const { addedDate } = this;
-      fromDate = addedDate < startDate ? addedDate : fromDate;
+      fromDate = addedDate > startDate ? addedDate : fromDate;
     }
     const periodInDays = millisecondsToDays(endDate - fromDate);
     const usage = this.totalUsageForPeriod(fromDate, endDate);

--- a/src/settings/MobileAppSettings.js
+++ b/src/settings/MobileAppSettings.js
@@ -6,7 +6,6 @@ import { SETTINGS_KEYS } from './index';
 import { MILLISECONDS_PER_DAY } from '../database/utilities';
 import { setCurrentLanguage, DEFAULT_LANGUAGE } from '../localization';
 
-const { THIS_STORE_CUSTOM_DATA } = SETTINGS_KEYS;
 const DEFAULT_AMC_MONTHS_LOOKBAK = 3; // three months
 
 export class MobileAppSettings extends Settings {
@@ -32,7 +31,7 @@ export class MobileAppSettings extends Settings {
     let customData = {};
 
     try {
-      customData = JSON.parse(this.get(THIS_STORE_CUSTOM_DATA));
+      customData = JSON.parse(this.get(SETTINGS_KEYS.THIS_STORE_CUSTOM_DATA));
     } catch (e) {
       //
     }

--- a/src/settings/MobileAppSettings.js
+++ b/src/settings/MobileAppSettings.js
@@ -3,13 +3,18 @@ import { Settings } from 'react-native-database';
 import DeviceInfo from 'react-native-device-info';
 
 import { SETTINGS_KEYS } from './index';
+import { MILLISECONDS_PER_DAY } from '../database/utilities';
 import { setCurrentLanguage, DEFAULT_LANGUAGE } from '../localization';
+
+const { THIS_STORE_CUSTOM_DATA } = SETTINGS_KEYS;
+const DEFAULT_AMC_MONTHS_LOOKBAK = 3; // three months
 
 export class MobileAppSettings extends Settings {
   constructor(database) {
     super(database);
     this.load();
     this.set(SETTINGS_KEYS.HARDWARE_UUID, DeviceInfo.getUniqueID());
+    this.refreshGlobals();
   }
 
   set(key, value) {
@@ -21,6 +26,30 @@ export class MobileAppSettings extends Settings {
       default:
         break;
     }
+  }
+
+  refreshGlobals() {
+    let customData = {};
+
+    try {
+      customData = JSON.parse(this.get(THIS_STORE_CUSTOM_DATA));
+    } catch (e) {
+      //
+    }
+
+    const {
+      monthlyConsumptionLookBackPeriod: { data: AMCLookBackMonthsString } = {},
+      monthlyConsumptionEnforceLookBackPeriod: { data: AMCenforceLookBackString } = {},
+    } = customData;
+
+    let AMCLookBackMonth = parseInt(AMCLookBackMonthsString, 10);
+    // eslint-disable-next-line no-restricted-globals
+    if (isNaN(AMCLookBackMonth) || AMCLookBackMonth <= 0) {
+      AMCLookBackMonth = DEFAULT_AMC_MONTHS_LOOKBAK;
+    }
+
+    global.AMCmillisecondsLookBack = AMCLookBackMonth * 30 * MILLISECONDS_PER_DAY;
+    global.AMCenforceLookBack = AMCenforceLookBackString === 'true';
   }
 
   // Call functions for initialising the app on start. Checks database for any

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -577,6 +577,8 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
           key: THIS_STORE_CUSTOM_DATA,
           value: custom_data && custom_data.replace(/\\/g, ''),
         });
+
+        settings.refreshGlobals();
       }
       break;
     }


### PR DESCRIPTION
Can now set:

`monthlyConsumptionLookBackPeriod` (string number), defaults to 3 month as per before
and
`monthlyConsumptionEnforceLookBackPeriod` (string boolean), defaults to false

PR is into 921-regimen-data-bug, as this seems to be the most stable branch 

using globals because dailyUsage is a getter and it is used by other methods which are used by other methods and it would be large amount of changes (easy to introduce bugs) to pass through `settings`