### PR TITLE
#925 disable on finalized

### DIFF
--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -413,18 +413,15 @@ export class CustomerInvoicePage extends GenericPage {
   );
 
   getDataTableColumns = () => {
+    const { transaction } = this.props;
+    const { isFinalised } = transaction;
     const { hasVaccine } = this.state;
-    const normal = ['itemCode', 'itemName', 'availableQuantity', 'totalQuantity', 'remove'];
-    const withVaccines = [
-      'itemCode',
-      'itemName',
-      'availableQuantity',
-      'totalQuantity',
-      'doses',
-      'breach',
-      'remove',
-    ];
+    const normal = ['itemCode', 'itemName', 'availableQuantity', 'totalQuantity'];
+    const withVaccines = [...normal, 'doses'];
+
+    if (!isFinalised) withVaccines.push('breach');
     const columnsToUse = hasVaccine ? withVaccines : normal;
+    columnsToUse.push('remove');
     return columnsToUse.map(columnKey => DATA_TABLE_COLUMNS[columnKey]);
   };
 

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -327,6 +327,7 @@ export class CustomerInvoicePage extends GenericPage {
             color={SUSSOL_ORANGE}
             size={20}
             onPress={this.openModal({ currentItem: item, modalKey: MODAL_KEYS.BREACH_MODAL })}
+            disabled={isFinalised}
           />
         );
       }

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -308,7 +308,7 @@ export class CustomerInvoicePage extends GenericPage {
         // editable if doses > 1.
         const { item } = transactionItem;
         const { isVaccine, doses } = item;
-        const shouldDisable = doses === 1;
+        const shouldDisable = doses === 1 || isFinalised;
         if (!isVaccine || !doses) return emptyCell;
         return {
           type: shouldDisable ? 'text' : 'editable',

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -385,6 +385,7 @@ export class SupplierInvoicePage extends React.Component {
             rightText="FAIL"
             currentState={isVVMPassed}
             onPress={this.onVvmToggle(transactionBatch)}
+            disabled={!isEditable}
           />
         );
       }

--- a/src/widgets/MiniToggleBar.js
+++ b/src/widgets/MiniToggleBar.js
@@ -55,23 +55,54 @@ export class MiniToggleBar extends React.PureComponent {
     onPress({ newState: !currentState, key });
   };
 
+  wrapInOnPress = ({ onPress, containerStyle, children, disabled }) => {
+    if (!disabled) {
+      return (
+        <TouchableOpacity style={containerStyle} onPress={onPress}>
+          {children}
+        </TouchableOpacity>
+      );
+    }
+    return <View style={containerStyle}>{children}</View>;
+  };
+
+  getTextComponent = ({ text, additionalStyle }) => {
+    const { textStyle } = localStyles;
+    return (
+      <Text numberOfLines={1} ellipsizeMode="tail" style={[textStyle, additionalStyle]}>
+        {text}
+      </Text>
+    );
+  };
+
   render() {
-    const { leftText, rightText, leftKey, rightKey } = this.props;
-    const { main, touchable, text } = localStyles;
+    const { leftText, rightText, leftKey, rightKey, disabled } = this.props;
+    const { main, container } = localStyles;
     const { mainStyle, leftStyle, leftTextStyle, rightTextStyle, rightStyle } = this.styles();
+
+    const leftComponent = this.wrapInOnPress({
+      onPress: this.onPress(leftKey),
+      containerStyle: [container, leftStyle],
+      children: this.getTextComponent({
+        text: leftText,
+        additionalStyle: leftTextStyle,
+      }),
+      disabled,
+    });
+    const rightComponent = this.wrapInOnPress({
+      onPress: this.onPress(rightKey),
+      containerStyle: [container, rightStyle],
+      children: this.getTextComponent({
+        text: rightText,
+        additionalStyle: rightTextStyle,
+      }),
+      disabled,
+    });
+
     return (
       <View style={[main, mainStyle]}>
-        <TouchableOpacity style={[touchable, leftStyle]} onPress={this.onPress(leftKey)}>
-          <Text numberOfLines={1} ellipsizeMode="tail" style={[text, leftTextStyle]}>
-            {leftText}
-          </Text>
-        </TouchableOpacity>
-
-        <TouchableOpacity style={[touchable, rightStyle]} onPress={this.onPress(rightKey)}>
-          <Text numberOfLines={1} ellipsizeMode="tail" style={[text, rightTextStyle]}>
-            {rightText}
-          </Text>
-        </TouchableOpacity>
+        {leftComponent}
+        {rightComponent}
       </View>
     );
   }
@@ -87,12 +118,12 @@ const localStyles = StyleSheet.create({
     height: '85%',
     width: '85%',
   },
-  touchable: {
+  container: {
     width: '50%',
     justifyContent: 'center',
     alignItems: 'center',
   },
-  text: {
+  textStyle: {
     color: DARK_GREY,
     fontFamily: APP_FONT_FAMILY,
   },
@@ -101,6 +132,7 @@ const localStyles = StyleSheet.create({
 MiniToggleBar.defaultProps = {
   leftKey: null,
   rightKey: null,
+  disabled: false,
 };
 
 MiniToggleBar.propTypes = {
@@ -110,6 +142,7 @@ MiniToggleBar.propTypes = {
   rightKey: PropTypes.string,
   currentState: PropTypes.bool.isRequired,
   onPress: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
 };
 
 export default MiniToggleBar;

--- a/src/widgets/MiniToggleBar.js
+++ b/src/widgets/MiniToggleBar.js
@@ -21,12 +21,13 @@ import {
  * states - True: LHS toggled, False: RHS Toggled, Null: Nothing toggled.
  * Can be controlled by pressing any part of the component to switch the toggle,
  * or use the returned key to control dependent on which toggle was pressed.
- * @prop {String} leftText     Text for the LHS toggle
- * @prop {String} leftText    Text for the RHS toggle
+ * @prop {String} leftText      Text for the LHS toggle
+ * @prop {String} leftText      Text for the RHS toggle
  * @prop {String} firstKey      Key returned when the LHS toggle is pressed
- * @prop {String} rightKey     Key returned when the RHS toggle is pressed
+ * @prop {String} rightKey      Key returned when the RHS toggle is pressed
  * @prop {Bool}   currentState  Current state of the toggle. True = left, False = right, null = none
  * @prop {Func}   onPress       onPress function - returns {key, nextState}
+ * @prop {Bool}   disabled      Indicator if toggle should be wrapped in a Touchable or View
  */
 export class MiniToggleBar extends React.PureComponent {
   styles = () => {


### PR DESCRIPTION
#925 

#### Note: Branched from #932 

- Disables the doses column if the `CustomerInvoice` is finalized
- Disables the VVM Status column on `SupplierInvoice` finalized
- Refactors `MiniToggleBar` Slightly to wrap in either an Opacity or View container when disabled


#### Note: Not sure what to do about breaches for `CustomerInvoicePage`. Currently has a conditional check for finalized transaction to not open modals. Not sure if viewing the breach should be enabled or not on a finalized `CustomerInvoice`