### PR TITLE
#936 price and unit columns

### DIFF
--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -231,6 +231,7 @@ Item.schema = {
     defaultPrice: { type: 'double', optional: true },
     isVisible: { type: 'bool', default: false },
     crossReferenceItem: { type: 'Item', optional: true },
+    UnitId: { type: 'Unit', optional: true },
   },
 };
 

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -231,7 +231,7 @@ Item.schema = {
     defaultPrice: { type: 'double', optional: true },
     isVisible: { type: 'bool', default: false },
     crossReferenceItem: { type: 'Item', optional: true },
-    unitId: { type: 'Unit', optional: true },
+    unit: { type: 'Unit', optional: true },
   },
 };
 

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -231,7 +231,7 @@ Item.schema = {
     defaultPrice: { type: 'double', optional: true },
     isVisible: { type: 'bool', default: false },
     crossReferenceItem: { type: 'Item', optional: true },
-    UnitId: { type: 'Unit', optional: true },
+    unitId: { type: 'Unit', optional: true },
   },
 };
 

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -149,7 +149,7 @@ export class Item extends Realm.Object {
 
   /**
    * Returns a string representing the units for this item.
-   * @return {string} the unit for this item, or N/A if none has been assgined.
+   * @return {string} the unit for this item, or N/A if none has been assigned.
    */
   get unitString() {
     return (this.unit && this.unit.units) || 'N/A';

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -148,6 +148,14 @@ export class Item extends Realm.Object {
   }
 
   /**
+   * Returns a string representing the units for this item.
+   * @return {string} the unit for this item, or N/A if none has been assgined.
+   */
+  get unitString() {
+    return (this.unit && this.unit.units) || 'N/A';
+  }
+
+  /**
    * Get the sum of all transaction batch usage related to batches for this item within a start
    * and end date.
    *

--- a/src/database/DataTypes/MasterListItem.js
+++ b/src/database/DataTypes/MasterListItem.js
@@ -32,6 +32,7 @@ MasterListItem.schema = {
     masterList: { type: 'MasterList', optional: true },
     item: { type: 'Item', optional: true },
     imprestQuantity: { type: 'double', optional: true },
+    price: { type: 'double', default: 0 },
   },
 };
 

--- a/src/database/DataTypes/RequisitionItem.js
+++ b/src/database/DataTypes/RequisitionItem.js
@@ -120,6 +120,14 @@ export class RequisitionItem extends Realm.Object {
   }
 
   /**
+   * Gets the unit string for this requisition items related item.
+   * @return {string}
+   */
+  get itemUnit() {
+    return this.item.unitString;
+  }
+
+  /**
    * Set supplied quantity of this requisition item.
    *
    * @param  {Realm}   database

--- a/src/database/DataTypes/Unit.js
+++ b/src/database/DataTypes/Unit.js
@@ -1,0 +1,24 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import Realm from 'realm';
+
+/**
+ * TODO
+ */
+export class Unit extends Realm.Object {}
+
+Unit.schema = {
+  name: 'Unit',
+  primaryKey: 'id',
+  properties: {
+    id: 'string',
+    units: { type: 'string', default: 'Each' },
+    comment: { type: 'string', optional: true },
+    orderNumber: { type: 'double', default: 0 },
+  },
+};
+
+export default Unit;

--- a/src/database/DataTypes/Unit.js
+++ b/src/database/DataTypes/Unit.js
@@ -15,7 +15,7 @@ Unit.schema = {
   primaryKey: 'id',
   properties: {
     id: 'string',
-    units: { type: 'string', default: 'Each' },
+    units: { type: 'string', optional: true },
     comment: { type: 'string', optional: true },
     orderNumber: { type: 'double', default: 0 },
   },

--- a/src/database/DataTypes/index.js
+++ b/src/database/DataTypes/index.js
@@ -34,3 +34,4 @@ export { StocktakeItem } from './StocktakeItem';
 export { Transaction } from './Transaction';
 export { TransactionBatch } from './TransactionBatch';
 export { TransactionItem } from './TransactionItem';
+export { Unit } from './Unit';

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -32,6 +32,7 @@ import {
   TransactionCategory,
   TransactionItem,
   User,
+  Unit,
 } from './DataTypes';
 
 Address.schema = {
@@ -149,6 +150,7 @@ export const schema = {
     PeriodSchedule,
     StocktakeBatch,
     User,
+    Unit,
   ],
   schemaVersion: 7,
 };

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -408,12 +408,14 @@ export class SupplierRequisitionPage extends React.Component {
       case 'price':
         return {
           type: 'text',
-          cellContents: this.ITEM_PRICE_MAPPING[requisitionItem.item.id] || 'N/A',
+          cellContents: this.ITEM_PRICE_MAPPING[requisitionItem.item.id]
+            ? this.ITEM_PRICE_MAPPING[requisitionItem.item.id]
+            : 'N/A',
         };
       case 'unit': {
         return {
           type: 'text',
-          cellContents: requisitionItem.item.unitId.units || 'N/A',
+          cellContents: requisitionItem.item.unit ? requisitionItem.item.unit.units : 'N/A',
         };
       }
     }

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -37,9 +37,94 @@ const MODAL_KEYS = {
   VIEW_REGIMEN_DATA: 'viewRegimenData',
 };
 
+const NORMAL_COLUMNS = [
+  'itemCode',
+  'itemName',
+  'stockOnHand',
+  'monthlyUsage',
+  'suggestedQuantity',
+  'requiredQuantity',
+  'remove',
+];
+
+const PROGRAM_COLUMNS = [
+  'itemCode',
+  'itemName',
+  'price',
+  'unit',
+  'stockOnHand',
+  'monthlyUsage',
+  'suggestedQuantity',
+  'requiredQuantity',
+  'remove',
+];
+
+const COLUMNS = {
+  itemCode: {
+    key: 'itemCode',
+    width: 1.4,
+    title: tableStrings.code,
+    sortable: true,
+  },
+  itemName: {
+    key: 'itemName',
+    width: 3.5,
+    title: tableStrings.item_name,
+    sortable: true,
+  },
+  stockOnHand: {
+    key: 'stockOnHand',
+    width: 2,
+    title: tableStrings.current_stock,
+    sortable: true,
+    alignText: 'right',
+  },
+  monthlyUsage: {
+    key: 'monthlyUsage',
+    width: 1.5,
+    title: tableStrings.monthly_usage,
+    sortable: true,
+    alignText: 'right',
+  },
+  suggestedQuantity: {
+    key: 'suggestedQuantity',
+    width: 2,
+    title: tableStrings.suggested_quantity,
+    sortable: true,
+    alignText: 'right',
+  },
+  requiredQuantity: {
+    key: 'requiredQuantity',
+    width: 2,
+    title: tableStrings.required_quantity,
+    sortable: true,
+    alignText: 'right',
+  },
+  remove: {
+    key: 'remove',
+    width: 1,
+    title: tableStrings.remove,
+    alignText: 'center',
+  },
+  price: {
+    key: 'price',
+    width: 1,
+    title: 'PRICE',
+    alignText: 'center',
+  },
+  unit: {
+    key: 'unit',
+    width: 1,
+    title: 'UNIT',
+    alignText: 'center',
+  },
+};
+
 export class SupplierRequisitionPage extends React.Component {
   constructor(props) {
     super(props);
+
+    this.ITEM_PRICE_MAPPING = null;
 
     const { requisition } = props;
     const { program, thresholdMOS } = requisition;
@@ -58,6 +143,37 @@ export class SupplierRequisitionPage extends React.Component {
       isAscending: true,
     };
   }
+
+  // On mounting, creating an Item -> Price mapping table if
+  // this is a program requisition.
+  componentDidMount = () => {
+    const { database, requisition } = this.props;
+    const { program, otherStoreName } = requisition;
+    this.ITEM_PRICE_MAPPING = {};
+    // If not a program requisition, premature return
+    if (!(program && otherStoreName)) return;
+
+    // Get all MasterListNameJoins for the supplier.
+    const supplierMasterListNameJoins = database
+      .objects('MasterListNameJoin')
+      .filtered('name.id == $0', otherStoreName.id);
+
+    // If no MasterListNameJoins, premature return
+    if (supplierMasterListNameJoins.length === 0) return;
+
+    // Get all MasterListItems for the supplier
+    const queryString = supplierMasterListNameJoins
+      .map(({ masterList }) => `masterList.id == "${masterList.id}"`)
+      .join(' OR ');
+    const masterListItems = database.objects('MasterListItem').filtered(queryString);
+
+    // Create a lookup table for each item in all of the MasterLists, mapped to
+    // the highest price.
+    masterListItems.forEach(({ item, price }) => {
+      if (!this.ITEM_PRICE_MAPPING[item.id]) this.ITEM_PRICE_MAPPING[item.id] = price;
+      else this.ITEM_PRICE_MAPPING[item.id] = Math.max(this.ITEM_PRICE_MAPPING[item.id], price);
+    });
+  };
 
   onAddMasterItems = () => {
     const { database, requisition, runWithLoadingIndicator } = this.props;
@@ -289,6 +405,17 @@ export class SupplierRequisitionPage extends React.Component {
           icon: 'md-remove-circle',
           isDisabled: requisition.isFinalised,
         };
+      case 'price':
+        return {
+          type: 'text',
+          cellContents: this.ITEM_PRICE_MAPPING[requisitionItem.item.id] || 'N/A',
+        };
+      case 'unit': {
+        return {
+          type: 'text',
+          cellContents: requisitionItem.item.unitId.units || 'N/A',
+        };
+      }
     }
   };
 
@@ -454,6 +581,15 @@ export class SupplierRequisitionPage extends React.Component {
     );
   };
 
+  getColumns = () => {
+    const { requisition } = this.props;
+    const { program } = requisition;
+    let columnsToUse;
+    if (program) columnsToUse = PROGRAM_COLUMNS;
+    else columnsToUse = NORMAL_COLUMNS;
+    return columnsToUse.map(columnKey => COLUMNS[columnKey]);
+  };
+
   render() {
     const { database, genericTablePageStyles, requisition, topRoute } = this.props;
     const { data, modalIsOpen, selection } = this.state;
@@ -469,54 +605,7 @@ export class SupplierRequisitionPage extends React.Component {
         onSelectionChange={this.onSelectionChange}
         defaultSortKey={this.dataFilters.sortBy}
         defaultSortDirection={this.dataFilters.isAscending ? 'ascending' : 'descending'}
-        columns={[
-          {
-            key: 'itemCode',
-            width: 1.5,
-            title: tableStrings.code,
-            sortable: true,
-          },
-          {
-            key: 'itemName',
-            width: 4,
-            title: tableStrings.item_name,
-            sortable: true,
-          },
-          {
-            key: 'stockOnHand',
-            width: 2,
-            title: tableStrings.current_stock,
-            sortable: true,
-            alignText: 'right',
-          },
-          {
-            key: 'monthlyUsage',
-            width: 2,
-            title: tableStrings.monthly_usage,
-            sortable: true,
-            alignText: 'right',
-          },
-          {
-            key: 'suggestedQuantity',
-            width: 2,
-            title: tableStrings.suggested_quantity,
-            sortable: true,
-            alignText: 'right',
-          },
-          {
-            key: 'requiredQuantity',
-            width: 2,
-            title: tableStrings.required_quantity,
-            sortable: true,
-            alignText: 'right',
-          },
-          {
-            key: 'remove',
-            width: 1,
-            title: tableStrings.remove,
-            alignText: 'center',
-          },
-        ]}
+        columns={this.getColumns()}
         dataTypesSynchronised={DATA_TYPES_SYNCHRONISED}
         finalisableDataType="Requisition"
         database={database}

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -412,7 +412,7 @@ export class SupplierRequisitionPage extends React.Component {
       case 'unit': {
         return {
           type: 'text',
-          cellContents: requisitionItem.item.unit ? requisitionItem.item.unit.units : 'N/A',
+          cellContents: requisitionItem.itemUnit,
         };
       }
     }

--- a/src/sync/createInternalRecord.js
+++ b/src/sync/createInternalRecord.js
@@ -9,7 +9,7 @@
  * createOrUpdateRecord in incomingSyncUtils.
  */
 
-import { parseBoolean, parseDate } from './incomingSyncUtils';
+import { parseBoolean, parseDate, parseNumber } from './incomingSyncUtils';
 
 export const createPeriodInternalRecord = (record, database) => ({
   id: record.ID,
@@ -29,4 +29,11 @@ export const createOptionsInternalRecord = record => ({
 export const createPeriodScheduleInternalRecord = record => ({
   id: record.ID,
   name: record.name,
+});
+
+export const createUnitInternalRecord = record => ({
+  id: record.ID,
+  units: record.units,
+  orderNumber: parseNumber(record.order_number),
+  comment: record.comment,
 });

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -285,7 +285,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         description: record.description,
         name: record.item_name,
         crossReferenceItem: database.getOrCreate('Item', record.cross_ref_item_ID),
-        unitId: database.getOrCreate('Unit', record.unit_ID),
+        unit: database.getOrCreate('Unit', record.unit_ID),
       };
       database.update(recordType, internalRecord);
       break;

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -17,6 +17,7 @@ import {
   createOptionsInternalRecord,
   createPeriodInternalRecord,
   createPeriodScheduleInternalRecord,
+  createUnitInternalRecord,
 } from './createInternalRecord';
 
 const { THIS_STORE_ID, THIS_STORE_TAGS, THIS_STORE_CUSTOM_DATA } = SETTINGS_KEYS;
@@ -27,7 +28,7 @@ const { THIS_STORE_ID, THIS_STORE_TAGS, THIS_STORE_CUSTOM_DATA } = SETTINGS_KEYS
  * @param   {string}  numberString  The string to convert to a number.
  * @return  {float}                 The numeric representation of the string.
  */
-const parseNumber = numberString => {
+export const parseNumber = numberString => {
   if (!numberString) return null;
   const result = parseFloat(numberString);
   return Number.isNaN(result) ? null : result;
@@ -233,6 +234,10 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
       cannotBeBlank: ['name', 'startDate', 'endDate', 'periodScheduleID'],
       canBeBlank: [],
     },
+    Unit: {
+      cannotBeBlank: [],
+      canBeBlank: ['units', 'comment', 'order_number'],
+    },
   };
   if (!requiredFields[recordType]) return false; // Unsupported record type
   const hasAllNonBlankFields = requiredFields[recordType].cannotBeBlank.reduce(
@@ -280,6 +285,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         description: record.description,
         name: record.item_name,
         crossReferenceItem: database.getOrCreate('Item', record.cross_ref_item_ID),
+        unitId: database.getOrCreate('Unit', record.unit_ID),
       };
       database.update(recordType, internalRecord);
       break;
@@ -674,6 +680,11 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       }
       break;
     }
+    case 'Unit': {
+      database.update(recordType, createUnitInternalRecord(record));
+      break;
+    }
+
     default:
       break; // Silently ignore record types which are not used by mobile.
   }

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -395,6 +395,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         id: record.ID,
         item: database.getOrCreate('Item', record.item_ID),
         imprestQuantity: parseNumber(record.imprest_quan),
+        price: parseNumber(record.price),
         masterList,
       };
       const masterListItem = database.update(recordType, internalRecord);

--- a/src/sync/syncTranslators.js
+++ b/src/sync/syncTranslators.js
@@ -57,6 +57,7 @@ export const RECORD_TYPES = new SyncTranslator({
   TransactionCategory: 'transaction_category',
   TransactionBatch: 'trans_line',
   User: 'user',
+  Unit: 'unit',
 });
 
 export const REQUISITION_TYPES = new SyncTranslator({


### PR DESCRIPTION
Fixes #936 

### NOTE: This finds a price from the Supplier masterlist - the cost price. Should this be finding the price from the current stores masterlist?


- Add `Unit` table
- Add `Item.unit` field
- Add `MasterListItem.price` field
- Add Price column to a program requisition
- Add a unit column to a program requisition (?)

#### NOTE: Does NOT use `[item]default_price` - waiting for #821 ? Just assigns 'N/A' to any unit or price which has not been found.


Could maybe? be more performant. At the moment creates the`ITEM_PRICE_MAPPING` table for all `MasterListItems` (`n`). Could potentially be faster by iterating through items for the requisition (`m`) and performing a realm query for each, finding the max price within the `MasterListItems` related. Essentially trading `n` assignments for `m` queries. I dunno if it's worth it - I think the simpler logic is best.
