### PR TITLE
Add conditional around modals

### DIFF
--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -215,26 +215,30 @@ export class CustomerInvoicesPage extends React.Component {
         {...genericTablePageStyles}
         topRoute={topRoute}
       >
-        <BottomConfirmModal
-          isOpen={selection.length > 0}
-          questionText={modalStrings.delete_these_invoices}
-          onCancel={this.onDeleteCancel}
-          onConfirm={this.onDeleteConfirm}
-          confirmText={modalStrings.delete}
-        />
-        <SelectModal
-          isOpen={isCreatingInvoice}
-          options={database.objects('Customer')}
-          placeholderText={modalStrings.start_typing_to_select_customer}
-          queryString="name BEGINSWITH[c] $0"
-          sortByString="name"
-          onSelect={name => {
-            this.onNewInvoice(name);
-            this.setState({ isCreatingInvoice: false });
-          }}
-          onClose={() => this.setState({ isCreatingInvoice: false })}
-          title={modalStrings.search_for_the_customer}
-        />
+        {selection.length > 0 && (
+          <BottomConfirmModal
+            isOpen={selection.length > 0}
+            questionText={modalStrings.delete_these_invoices}
+            onCancel={this.onDeleteCancel}
+            onConfirm={this.onDeleteConfirm}
+            confirmText={modalStrings.delete}
+          />
+        )}
+        {isCreatingInvoice && (
+          <SelectModal
+            isOpen={isCreatingInvoice}
+            options={database.objects('Customer')}
+            placeholderText={modalStrings.start_typing_to_select_customer}
+            queryString="name BEGINSWITH[c] $0"
+            sortByString="name"
+            onSelect={name => {
+              this.onNewInvoice(name);
+              this.setState({ isCreatingInvoice: false });
+            }}
+            onClose={() => this.setState({ isCreatingInvoice: false })}
+            title={modalStrings.search_for_the_customer}
+          />
+        )}
       </GenericPage>
     );
   }

--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -326,13 +326,15 @@ export class CustomerRequisitionPage extends React.Component {
         {...genericTablePageStyles}
         topRoute={topRoute}
       >
-        <PageContentModal
-          isOpen={modalIsOpen && !requisition.isFinalised}
-          onClose={this.closeModal}
-          title={this.getModalTitle()}
-        >
-          {this.renderModalContent()}
-        </PageContentModal>
+        {modalIsOpen && !requisition.isFinalised && (
+          <PageContentModal
+            isOpen={modalIsOpen && !requisition.isFinalised}
+            onClose={this.closeModal}
+            title={this.getModalTitle()}
+          >
+            {this.renderModalContent()}
+          </PageContentModal>
+        )}
       </GenericPage>
     );
   }

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -375,13 +375,15 @@ export class StocktakeEditPage extends React.Component {
         {...genericTablePageStyles}
         topRoute={topRoute}
       >
-        <PageContentModal
-          isOpen={isModalOpen && !stocktake.isFinalised}
-          onClose={this.closeModal}
-          title={this.getModalTitle()}
-        >
-          {this.renderModalContent()}
-        </PageContentModal>
+        {isModalOpen && !stocktake.isFinalised && (
+          <PageContentModal
+            isOpen={isModalOpen && !stocktake.isFinalised}
+            onClose={this.closeModal}
+            title={this.getModalTitle()}
+          >
+            {this.renderModalContent()}
+          </PageContentModal>
+        )}
         <ConfirmModal
           coverScreen
           noCancel

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -249,26 +249,28 @@ export class StocktakeManagePage extends React.Component {
         {...genericTablePageStyles}
         topRoute={topRoute}
       >
-        <BottomModal
-          isOpen={!(stocktake && stocktake.isFinalised) && selection.length > 0}
-          style={localStyles.bottomModal}
-        >
-          <TextInput
-            style={globalStyles.modalTextInput}
-            textStyle={globalStyles.modalText}
-            underlineColorAndroid="transparent"
-            placeholderTextColor="white"
-            placeholder={modalStrings.give_your_stocktake_a_name}
-            value={stocktakeName}
-            onChangeText={text => this.setState({ stocktakeName: text })}
-          />
-          <OnePressButton
-            style={[globalStyles.button, globalStyles.modalOrangeButton]}
-            textStyle={[globalStyles.buttonText, globalStyles.modalButtonText]}
-            text={!stocktake ? modalStrings.create : modalStrings.confirm}
-            onPress={this.onConfirmPress}
-          />
-        </BottomModal>
+        {!(stocktake && stocktake.isFinalised) && selection.length > 0 && (
+          <BottomModal
+            isOpen={!(stocktake && stocktake.isFinalised) && selection.length > 0}
+            style={localStyles.bottomModal}
+          >
+            <TextInput
+              style={globalStyles.modalTextInput}
+              textStyle={globalStyles.modalText}
+              underlineColorAndroid="transparent"
+              placeholderTextColor="white"
+              placeholder={modalStrings.give_your_stocktake_a_name}
+              value={stocktakeName}
+              onChangeText={text => this.setState({ stocktakeName: text })}
+            />
+            <OnePressButton
+              style={[globalStyles.button, globalStyles.modalOrangeButton]}
+              textStyle={[globalStyles.buttonText, globalStyles.modalButtonText]}
+              text={!stocktake ? modalStrings.create : modalStrings.confirm}
+              onPress={this.onConfirmPress}
+            />
+          </BottomModal>
+        )}
       </GenericPage>
     );
   }

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -199,13 +199,15 @@ export class StocktakesPage extends React.Component {
         {...genericTablePageStyles}
         topRoute={topRoute}
       >
-        <BottomConfirmModal
-          isOpen={selection.length > 0 && showCurrent}
-          questionText={modalStrings.delete_these_stocktakes}
-          onCancel={() => this.clearSelection(true)}
-          onConfirm={() => this.onDeleteConfirm()}
-          confirmText={modalStrings.delete}
-        />
+        {selection.length > 0 && showCurrent && (
+          <BottomConfirmModal
+            isOpen={selection.length > 0 && showCurrent}
+            questionText={modalStrings.delete_these_stocktakes}
+            onCancel={() => this.clearSelection(true)}
+            onConfirm={() => this.onDeleteConfirm()}
+            confirmText={modalStrings.delete}
+          />
+        )}
       </GenericPage>
     );
   }

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -210,26 +210,30 @@ export class SupplierInvoicesPage extends React.Component {
         {...genericTablePageStyles}
         topRoute={topRoute}
       >
-        <BottomConfirmModal
-          isOpen={selection.length > 0}
-          questionText={modalStrings.remove_these_items}
-          onCancel={() => this.onDeleteCancel()}
-          onConfirm={() => this.onDeleteConfirm()}
-          confirmText={modalStrings.remove}
-        />
-        <SelectModal
-          isOpen={isCreatingInvoice}
-          options={database.objects('ExternalSupplier')}
-          placeholderText={modalStrings.start_typing_to_select_supplier}
-          queryString="name BEGINSWITH[c] $0"
-          sortByString="name"
-          onSelect={name => {
-            this.onNewSupplierInvoice(name);
-            this.setState({ isCreatingInvoice: false });
-          }}
-          onClose={() => this.setState({ isCreatingInvoice: false })}
-          title={modalStrings.search_for_the_supplier}
-        />
+        {selection.length > 0 && (
+          <BottomConfirmModal
+            isOpen={selection.length > 0}
+            questionText={modalStrings.remove_these_items}
+            onCancel={() => this.onDeleteCancel()}
+            onConfirm={() => this.onDeleteConfirm()}
+            confirmText={modalStrings.remove}
+          />
+        )}
+        {isCreatingInvoice && (
+          <SelectModal
+            isOpen={isCreatingInvoice}
+            options={database.objects('ExternalSupplier')}
+            placeholderText={modalStrings.start_typing_to_select_supplier}
+            queryString="name BEGINSWITH[c] $0"
+            sortByString="name"
+            onSelect={name => {
+              this.onNewSupplierInvoice(name);
+              this.setState({ isCreatingInvoice: false });
+            }}
+            onClose={() => this.setState({ isCreatingInvoice: false })}
+            title={modalStrings.search_for_the_supplier}
+          />
+        )}
       </GenericPage>
     );
   }

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -302,7 +302,7 @@ export class SupplierRequisitionPage extends React.Component {
             selected={requisition.monthsToSupply}
           />
         );
-      case COMMENT_EDIT:
+      case COMMENT_EDIT: {
         return (
           <TextEditor
             text={requisition.comment}
@@ -317,6 +317,7 @@ export class SupplierRequisitionPage extends React.Component {
             }}
           />
         );
+      }
     }
   };
 
@@ -426,20 +427,24 @@ export class SupplierRequisitionPage extends React.Component {
         {...genericTablePageStyles}
         topRoute={topRoute}
       >
-        <BottomConfirmModal
-          isOpen={selection.length > 0 && !requisition.isFinalised}
-          questionText={modalStrings.remove_these_items}
-          onCancel={this.onDeleteCancel}
-          onConfirm={this.onDeleteConfirm}
-          confirmText={modalStrings.remove}
-        />
-        <PageContentModal
-          isOpen={modalIsOpen && !requisition.isFinalised}
-          onClose={this.closeModal}
-          title={this.getModalTitle()}
-        >
-          {this.renderModalContent()}
-        </PageContentModal>
+        {selection.length > 0 && !requisition.isFinalised && (
+          <BottomConfirmModal
+            isOpen={selection.length > 0 && !requisition.isFinalised}
+            questionText={modalStrings.remove_these_items}
+            onCancel={this.onDeleteCancel}
+            onConfirm={this.onDeleteConfirm}
+            confirmText={modalStrings.remove}
+          />
+        )}
+        {modalIsOpen && !requisition.isFinalised && (
+          <PageContentModal
+            isOpen={modalIsOpen && !requisition.isFinalised}
+            onClose={this.closeModal}
+            title={this.getModalTitle()}
+          >
+            {this.renderModalContent()}
+          </PageContentModal>
+        )}
       </GenericPage>
     );
   }

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -199,25 +199,29 @@ export class SupplierRequisitionsPage extends React.Component {
         {...genericTablePageStyles}
         topRoute={topRoute}
       >
-        <BottomConfirmModal
-          isOpen={selection.length > 0}
-          questionText={modalStrings.delete_these_invoices}
-          onCancel={() => this.onDeleteCancel()}
-          onConfirm={() => this.onDeleteConfirm()}
-          confirmText={modalStrings.delete}
-        />
-        <SelectModal
-          isOpen={isCreatingRequisition}
-          options={database.objects('InternalSupplier')}
-          placeholderText={modalStrings.start_typing_to_select_supplier}
-          queryString="name BEGINSWITH[c] $0"
-          sortByString="name"
-          onSelect={name =>
-            this.setState({ isCreatingRequisition: false }, () => this.onNewRequisition(name))
-          }
-          onClose={() => this.setState({ isCreatingRequisition: false })}
-          title={modalStrings.search_for_the_supplier}
-        />
+        {selection.length > 0 && (
+          <BottomConfirmModal
+            isOpen={selection.length > 0}
+            questionText={modalStrings.delete_these_invoices}
+            onCancel={() => this.onDeleteCancel()}
+            onConfirm={() => this.onDeleteConfirm()}
+            confirmText={modalStrings.delete}
+          />
+        )}
+        {isCreatingRequisition && (
+          <SelectModal
+            isOpen={isCreatingRequisition}
+            options={database.objects('InternalSupplier')}
+            placeholderText={modalStrings.start_typing_to_select_supplier}
+            queryString="name BEGINSWITH[c] $0"
+            sortByString="name"
+            onSelect={name =>
+              this.setState({ isCreatingRequisition: false }, () => this.onNewRequisition(name))
+            }
+            onClose={() => this.setState({ isCreatingRequisition: false })}
+            title={modalStrings.search_for_the_supplier}
+          />
+        )}
       </GenericPage>
     );
   }


### PR DESCRIPTION
Fixes #898 Fixes #793 

Not an elegant solution - essentially removes the unmounting animation. I don't think there is a better solution though.

Problem is from the `react-native-modalbox` library, from what I can tell.

https://github.com/maxs15/react-native-modalbox/pull/175

I think this PR fixes it on their end, but is from 2017. Either have to fork or remove the dependency.

- Fixes modals staying open after navigating
- Fixes modal state freezing on pushing enter

