### PR TITLE
Add bug fix for requisitions nto being cancelled

### DIFF
--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -239,7 +239,7 @@ export class SupplierRequisitionsPage extends React.Component {
           queryString="name BEGINSWITH[c] $0"
           sortByString="name"
           onSelect={name => this.onNewRequisition({ otherStoreName: name })}
-          onClose={this.onNewRequisition}
+          onClose={() => this.onNewRequisition()}
           title={modalStrings.search_for_the_supplier}
         />
 


### PR DESCRIPTION
Fixes #924 


- Event object was being passed, which caused the check for a parameter being passed return true, creating the requisition.