### PR TITLE
#952 sync touchups

### DIFF
--- a/src/database/DataTypes/SensorLog.js
+++ b/src/database/DataTypes/SensorLog.js
@@ -18,7 +18,7 @@ SensorLog.schema = {
     sensor: 'Sensor',
     location: { type: 'Location', optional: true },
     pointer: 'int',
-    timestamp: 'date',
+    timestamp: { type: 'date', optional: true },
     temperature: 'double',
     logInterval: 'int',
     isInBreach: { type: 'bool', default: false },

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -73,6 +73,7 @@ const parseDate = (ISODate, ISOTime) => {
  * @return {boolean}               The boolean representation of the string
  */
 const parseBoolean = booleanString => {
+  if (!booleanString && booleanString !== false) return null;
   const trueStrings = ['true', 'True', 'TRUE'];
   return booleanString && trueStrings.indexOf(booleanString) >= 0;
 };


### PR DESCRIPTION
Fixes #952 


- 4D can send an empty string as `isVVMPassed`, accounting for that
- While testing sync I had a `sensorLog` with no timestamp - Not sure how this happened, but it stopped sync completely. Maybe this shouldn't be a change?