### PR TITLE
#969 incorrect reason conditions

### DIFF
--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -114,6 +114,15 @@ export class StocktakeBatch extends Realm.Object {
   }
 
   /**
+   * Returns whether or not a reason should be applied to this
+   * stocktake batch.
+   * @return {bool}
+   */
+  get shouldApplyReason() {
+    return this.countedTotalQuantity !== this.snapshotTotalQuantity && !this.option;
+  }
+
+  /**
    * Set counted total quantity.
    *
    * @param  {number}  quantity

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -118,7 +118,9 @@ export class StocktakeEditPage extends React.Component {
 
   componentDidMount = () => {
     const { database } = this.props;
-    this.setState({ usesReasons: database.objects('Options').length !== 0 });
+    const queryString = 'type == $0 && isActive == true';
+    const reasons = database.objects('Options').filtered(queryString, 'stocktakeLineAdjustment');
+    this.setState({ usesReasons: reasons.length !== 0 });
   };
 
   reasonModalConfirm = ({ item: option }) => {
@@ -138,7 +140,7 @@ export class StocktakeEditPage extends React.Component {
    */
   assignReason = stocktakeItem => {
     const { database } = this.props;
-    if (stocktakeItem.shouldHaveReason) {
+    if (stocktakeItem.shouldApplyReason) {
       this.onOpenReasonModal();
     } else {
       stocktakeItem.applyReasonToBatches(database);
@@ -432,7 +434,7 @@ export class StocktakeEditPage extends React.Component {
       },
       {
         key: 'itemName',
-        width: 3.2,
+        width: 2.8,
         title: tableStrings.item_name,
         sortable: true,
       },
@@ -469,7 +471,7 @@ export class StocktakeEditPage extends React.Component {
     }
     columns.push({
       key: 'modalControl',
-      width: 0.6,
+      width: 0.8,
       title: tableStrings.batches,
       sortable: false,
     });


### PR DESCRIPTION
Fixes #969 (?)

I'm not 100% sure this issue is really fixed. I could not replicate the behavior of the reason modal opening after editing the expiry date.

The `StocktakeBatchModal` behaviour however was incorrect and opening a reason modal whenever the quantity cell `OnEndEditing` event fired, however, rather than checking if there was already an option. There would be no reason for the modal to open when `OnEndEditing` was fired for the expiry column. I deduced that this may be due to a little lag on the data table, and leaving the expiry after leaving the last quantity cell, or leaving a quantity cell just after leaving the expiry cell was opening the modal.

Have fixed/cleaned slightly this logic. I will be making another issue to clean up more around stocktakes, didn't want to clutter this.

I can't find an issue with the keyboard and batch number a part from the regular, the keyboard takes up a lot of space