### PR TITLE
#977 full aggregation rewrite

### DIFF
--- a/src/database/DataTypes/ItemBatch.js
+++ b/src/database/DataTypes/ItemBatch.js
@@ -107,6 +107,14 @@ export class ItemBatch extends Realm.Object {
   }
 
   /**
+   * Add a sensor log to be associated with this batch.
+   * @param {SensorLog} sensorLog
+   */
+  addSensorLog(sensorLog) {
+    this.sensorLogs.push(sensorLog);
+  }
+
+  /**
    * Add a transaction batch to be associated with this batch, if not
    * already added.
    *

--- a/src/utilities/modules/temperatureSensorHelpers.js
+++ b/src/utilities/modules/temperatureSensorHelpers.js
@@ -12,7 +12,6 @@ const ONE_HOUR_MILLISECONDS = ONE_MINUTE_MILLISECONDS * 60;
 const EIGHT_HOURS_MILLISECONDS = ONE_HOUR_MILLISECONDS * 8;
 const FIVE_MINUTES_MILLISECONDS = ONE_MINUTE_MILLISECONDS * 5;
 const NO_FULL_AGGREGATE_PERIOD = EIGHT_HOURS_MILLISECONDS * 4 + FIVE_MINUTES_MILLISECONDS;
-const SENSOR_LOG_NO_DELETION_INTERVAL = ONE_HOUR_MILLISECONDS * 24 * 3;
 // Include a small offset on the interval to account for each timestamp being
 // small amounts of time off.
 const FULL_AGGREGATION_INTERVAL = EIGHT_HOURS_MILLISECONDS + FIVE_MINUTES_MILLISECONDS;
@@ -475,7 +474,6 @@ function doFullAggregation({ result, sensor, database }) {
   const mostRecentPreAggregateTimestamp = sensorLogs
     .filtered('aggregation == $0', SENSOR_LOG_PRE_AGGREGATE_TYPE)
     .max('timestamp');
-  const maxTimestampForDeletion = new Date().getTime() - SENSOR_LOG_NO_DELETION_INTERVAL;
   // Starting timestamp is either from the first fullAggregate timestamp, or beginning of time
   const aggregationIntervalStart = (mostRecentFullAggregateTimestamp || -Infinity) + 1;
   // Ending timestamp is either from the most recent preAggregate or from now, less the

--- a/src/utilities/modules/temperatureSensorHelpers.js
+++ b/src/utilities/modules/temperatureSensorHelpers.js
@@ -448,7 +448,7 @@ function doFullAggregation({ result, sensor, database }) {
     sensorLogs.filtered('aggregate == $0', 'preAggregate').max('timestamp') -
     TWO_HOURS_MILLISECONDS;
   const sortedSensorLogs = sensorLogs
-    .filtered('aggregate == $0 && timestamp < $1', 'preAggregate', maxTimeToAggregate)
+    .filtered('aggregation == $0 && timestamp < $1', 'preAggregate', maxTimeToAggregate)
     .sorted('timestamp');
   // Initialized for creating a timestamp of the first sensor log for
   // a sequential group of logs, which are delimited by a sensorlog

--- a/src/utilities/modules/temperatureSensorHelpers.js
+++ b/src/utilities/modules/temperatureSensorHelpers.js
@@ -470,10 +470,10 @@ function doFullAggregation({ result, sensor, database }) {
   // aggregate the most recently added preAggregate logs, from the most
   // most recent fullAggregation log.
   const mostRecentFullAggregateTimestamp = sensorLogs
-    .filtered('aggregate == $0', SENSOR_LOG_FULL_AGGREGATE_TYPE)
+    .filtered('aggregation == $0', SENSOR_LOG_FULL_AGGREGATE_TYPE)
     .max('timestamp');
   const mostRecentPreAggregateTimestamp = sensorLogs
-    .filtered('aggregate == $0', SENSOR_LOG_PRE_AGGREGATE_TYPE)
+    .filtered('aggregation == $0', SENSOR_LOG_PRE_AGGREGATE_TYPE)
     .max('timestamp');
   const maxTimestampForDeletion = new Date().getTime() - SENSOR_LOG_NO_DELETION_INTERVAL;
   // Starting timestamp is either from the first fullAggregate timestamp, or beginning of time

--- a/src/utilities/modules/temperatureSensorHelpers.js
+++ b/src/utilities/modules/temperatureSensorHelpers.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable no-continue */
 import { generateUUID } from 'react-native-database';
 import { NativeModules } from 'react-native';

--- a/src/utilities/modules/temperatureSensorHelpers.js
+++ b/src/utilities/modules/temperatureSensorHelpers.js
@@ -447,11 +447,9 @@ function doFullAggregation({ result, sensor, database }) {
   const maxTimeToAggregate =
     sensorLogs.filtered('aggregate == $0', 'preAggregate').max('timestamp') -
     TWO_HOURS_MILLISECONDS;
-  const sortedSensorLogs = sensorLogs.filtered(
-    'aggregate == $0 && timestamp < $1',
-    'preAggregate',
-    maxTimeToAggregate
-  );
+  const sortedSensorLogs = sensorLogs
+    .filtered('aggregate == $0 && timestamp < $1', 'preAggregate', maxTimeToAggregate)
+    .sorted('timestamp');
   // Initialized for creating a timestamp of the first sensor log for
   // a sequential group of logs, which are delimited by a sensorlog
   // outside of the 8 hour window this group is aggregated for.

--- a/src/utilities/modules/temperatureSensorHelpers.js
+++ b/src/utilities/modules/temperatureSensorHelpers.js
@@ -453,7 +453,7 @@ function doFullAggregation({ result, sensor, database }) {
   // Initialized for creating a timestamp of the first sensor log for
   // a sequential group of logs, which are delimited by a sensorlog
   // outside of the 8 hour window this group is aggregated for.
-  let logGroupStartTimestamp = null;
+  let logGroupStartTimestamp = Infinity;
   // 2D array for all groups of to-be-aggregated sensor logs.
   const sensorLogGroups = [];
   // A collection of sensor logs, grouped for the currently being operated on,
@@ -463,7 +463,8 @@ function doFullAggregation({ result, sensor, database }) {
     const { timestamp } = sensorLog;
     // Premature return if this sensorlog is malformed
     if (!timestamp) return;
-    // Check if this sensorLog is in the current interval.
+    // Check if this sensorLog is in the current interval. The first iteration
+    // will never be in the same interval, as there isn't one yet.
     const isInSameInterval = logGroupStartTimestamp - timestamp < FULL_AGGREGATION_INTERVAL;
     // If so, simply add it to the current group of logs.
     if (isInSameInterval) sensorLogGroup.push(sensorLog);

--- a/src/utilities/modules/temperatureSensorHelpers.js
+++ b/src/utilities/modules/temperatureSensorHelpers.js
@@ -481,9 +481,11 @@ function doFullAggregation({ result, sensor, database }) {
     .map(group => createFullAggregateSensorLogs(group))
     .flat();
   // Store each aggregated sensorlog in the database.
-  aggregatedSensorLogs.forEach(aggregatedLog => database.update('SensorLog', aggregatedLog));
-  // Delete each pre-aggregated sensorlog.
-  sortedSensorLogs.forEach(preAggregatedLog => database.delete(preAggregatedLog));
+  database.write(() => {
+    aggregatedSensorLogs.forEach(aggregatedLog => database.update('SensorLog', aggregatedLog));
+    // Delete each pre-aggregated sensorlog.
+    sortedSensorLogs.forEach(preAggregatedLog => database.delete(preAggregatedLog));
+  });
   return {
     ...result,
     fullAggregateAdditions: aggregatedSensorLogs.length,


### PR DESCRIPTION
Fixes #977 

- Adds a new full aggregation method
- Does not use the most recent 2 hours of sensor logs.
- Deletes all other pre-aggregated logs


- I think the time constants should be in their own file
- Could use the generic sensorlog create method in other methods when theyre cleaned up

- think I need to take another go over to make sure it's as defensive as possible
