### PR TITLE
#989 Fix supplier sort crash by using standard JS sort

### DIFF
--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -120,6 +120,9 @@ export class SupplierInvoicesPage extends React.Component {
       case 'serialNumber':
         sortDataType = 'number';
         break;
+      case 'otherPartyName':
+        sortDataType = 'string';
+        break;
       default:
         sortDataType = 'realm';
     }


### PR DESCRIPTION
Fixes #989?

## Change summary
Realm crashes when using realm sorting by getters on a schema. Use JS sort instead (same way customer invoices table sorts "CUSTOMER").

## Testing
Steps to reproduce or otherwise test the changes of this PR:
- [ ] Sorting by "SUPPLIER" in supplier invoices table doesn't crash the app

### Related areas to think about
Should be clean here