### PR TITLE
#994 Incorrect reasons being applied

### DIFF
--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -161,7 +161,7 @@ export class StocktakeEditPage extends React.Component {
     const { database } = this.props;
     const { usesReasons } = this.state;
 
-    if (key !== 'countedTotalQuantity' || newValue === '') return;
+    if (key !== 'countedTotalQuantity' || !newValue) return;
     const quantity = parsePositiveInteger(newValue);
     if (quantity === null) return;
 


### PR DESCRIPTION
#### NOTE: @Chris-Petty develop or master ?

Fixes #994 

## Change summary
- Reproduced by focusing a different row in the stocktakes data table between `onEndEditing` triggering and the reasons modal opening.

When the modal finally opens, focus is still on the cell which was last set by the user. When clicking on the modal to select a reason, focus then leaves the cell, triggering a new `onEndEditing`, which then updates the `currentStocktakeItem`. 

This still leaves a problem: If focusing a new row AND entering a value, the `currentStocktakeItem` will still update.

To resolve the second issue: Essentially required to force focus in the current cell after `onEndEditing` *if* it needs a reason. This requires a ref matrix, updated on each column sort (The react-native-data-table already creates one of these each `refreshData` I believe). I think this is really excessive for right now. This is only really possible on larger stock takes. It's pretty hard to reproduce on a emulator with keyboard and mouse on a smaller stocktake, let alone on a tablet. I think the more time consuming solution will just need to be a factor of consideration when we redesign the data table (enforcement of fields)

Unless anyone can think of a better solution!

## Testing
Steps to reproduce or otherwise test the changes of this PR:
Reproduction steps above and in issue
- [ ] When entering a quantity !== snapshot quantity in a stock take line and then focusing a different line, the stocktake line still has a reason applied [ If you don't enter a value into the line that is focused next ]

### Related areas to think about
Just adding another factor to think about for the data table (I imagine this type of thing may come up again one day), enforcing values for cells and triggering events from entering values in cells (i.e. if we use `onKeyPressed`, that might be weird for having to apply a reason!)
