### PR TITLE
#999 Uncaught NaN error in createRecord

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -145,7 +145,7 @@ const createRequisition = (
   const { name: orderTypeName, maxMOS, thresholdMOS } = orderType;
   const regimenData =
     program && program.parsedProgramSettings ? program.parsedProgramSettings.regimenData : null;
-  const daysToSupply = monthsLeadTime + (maxMOS || 1) * 30;
+  const daysToSupply = (monthsLeadTime || 0) + (maxMOS || 1) * 30;
 
   const requisition = database.create('Requisition', {
     id: generateUUID(),

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -142,10 +142,10 @@ const createRequisition = (
   user,
   { otherStoreName, program, period, orderType = {}, monthsLeadTime = 0 }
 ) => {
-  const { name: orderTypeName, maxMOS, thresholdMOS } = orderType;
+  const { name: orderTypeName, maxMOS = 1, thresholdMOS } = orderType;
   const regimenData =
     program && program.parsedProgramSettings ? program.parsedProgramSettings.regimenData : null;
-  const daysToSupply = monthsLeadTime ? (monthsLeadTime + maxMOS) * 30 : 30;
+  const daysToSupply = monthsLeadTime + maxMOS * 30;
 
   const requisition = database.create('Requisition', {
     id: generateUUID(),

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -142,10 +142,10 @@ const createRequisition = (
   user,
   { otherStoreName, program, period, orderType = {}, monthsLeadTime = 0 }
 ) => {
-  const { name: orderTypeName, maxMOS = 1, thresholdMOS } = orderType;
+  const { name: orderTypeName, maxMOS, thresholdMOS } = orderType;
   const regimenData =
     program && program.parsedProgramSettings ? program.parsedProgramSettings.regimenData : null;
-  const daysToSupply = monthsLeadTime + maxMOS * 30;
+  const daysToSupply = monthsLeadTime + (maxMOS || 1) * 30;
 
   const requisition = database.create('Requisition', {
     id: generateUUID(),

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -145,7 +145,7 @@ const createRequisition = (
   const { name: orderTypeName, maxMOS, thresholdMOS } = orderType;
   const regimenData =
     program && program.parsedProgramSettings ? program.parsedProgramSettings.regimenData : null;
-  const daysToSupply = (monthsLeadTime || 0) + (maxMOS || 1) * 30;
+  const daysToSupply = ((monthsLeadTime || 0) + (maxMOS || 1)) * 30;
 
   const requisition = database.create('Requisition', {
     id: generateUUID(),


### PR DESCRIPTION
#### NOTE: Merge into Develop - not sure if that should be master or not

Fixes #999

## Change summary
If `maxMOS` is undefined, doing arithmetic on it results in `NaN`. This is the only way that I can see a `NaN` result anywhere in this method. Please check to see if you can see one!

This solution is defensive against `maxMOS` being `undefined`, `null` or `0`.. I did use a default value in the destructuring, but that does not protect against `0` or `null`.

From what I can tell, if any other `orderType` fields are `undefined` then we are covered by default realm fields and optional fields.

## Testing
I could only reproduce this error by having `maxMOS` be undefined. So:
- [ ] No error is thrown when `maxMOS` is undefined

### Related areas to think about
Please do check if there is anyway, other than from `maxMOS` that a `NaN` error could be thrown in `createRequisition`
