### PR TITLE
#1002 Supplier requisition sorting error

### DIFF
--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -307,6 +307,7 @@ export class SupplierRequisitionPage extends React.Component {
       case 'itemName':
         sortDataType = 'string';
         break;
+      case 'stockOnHand':
       case 'monthlyUsage':
       case 'suggestedQuantity':
       case 'requiredQuantity':


### PR DESCRIPTION
#### NOTE: PR Into develop

Fixes #1002

## Change summary
Simple fix that has been done before. I will check for anymore of these errors in other pages also.

## Testing

- [ ] Sorting by the stock on hand column does not crash the app!

### Related areas to think about
I need to also check all the other pages for this type of error. Would be good to double check that this is sufficient though, before I go looking
