### PR TITLE
#1000 Fix stocktake reason sort crash

### DIFF
--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -166,7 +166,7 @@ export class StocktakeItem extends Realm.Object {
     // Sort (ASC) the options by count, return the first option
     const sortedOptions = Object.values(options).sort((a, b) => b.count - a.count);
 
-    return sortedOptions[0] ? sortedOptions[0].option : '';
+    return sortedOptions[0] ? sortedOptions[0].option.title : '';
   }
 
   /**

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -142,8 +142,8 @@ export class StocktakeItem extends Realm.Object {
    * Finds the mode option within this stocktake items batches
    * @return {string} The title of the reason with the highest frequency
    */
-  get mostUsedReason() {
-    if (!this.batches.length) return false;
+  get mostUsedReasonTitle() {
+    if (!this.batches.length) return '';
 
     // Mapping table for ranking reasons by usage
     // {option.id: {option: OptionObject, count: X}, ... }
@@ -164,11 +164,9 @@ export class StocktakeItem extends Realm.Object {
     });
 
     // Sort (ASC) the options by count, return the first option
-    const sortedOptions = Object.values(options).sort(
-      ({ count: valueA }, { count: valueB }) => parseInt(valueB, 10) - parseInt(valueA, 10)
-    );
+    const sortedOptions = Object.values(options).sort((a, b) => b.count - a.count);
 
-    return sortedOptions[0] && sortedOptions[0].option;
+    return sortedOptions[0] ? sortedOptions[0].option : '';
   }
 
   /**

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -139,7 +139,7 @@ export class StocktakeItem extends Realm.Object {
   }
 
   /**
-   * Finds the mode option within this stocktake items batches
+   * Returns the title of the most common option within this stocktakeItem's batches
    * @return {string} The title of the reason with the highest frequency
    */
   get mostUsedReasonTitle() {

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -165,7 +165,7 @@ export class StocktakeItem extends Realm.Object {
 
     // Sort (ASC) the options by count
     const sortedOptions = Object.values(options).sort((a, b) => b.count - a.count);
-    // Return the first option or empty string if there aren't any options
+    // Return the first option title or empty string if there aren't any options
     return sortedOptions[0] ? sortedOptions[0].option.title : '';
   }
 

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -163,9 +163,9 @@ export class StocktakeItem extends Realm.Object {
       }
     });
 
-    // Sort (ASC) the options by count, return the first option
+    // Sort (ASC) the options by count
     const sortedOptions = Object.values(options).sort((a, b) => b.count - a.count);
-
+    // Return the first option or empty string if there aren't any options
     return sortedOptions[0] ? sortedOptions[0].option.title : '';
   }
 

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -223,7 +223,7 @@ export class StocktakeEditPage extends React.Component {
     );
     let sortDataType;
     switch (sortBy) {
-      case 'reason':
+      case 'mostUsedReasonTitle':
       case 'itemCode':
       case 'itemName':
         sortDataType = 'string';
@@ -272,7 +272,7 @@ export class StocktakeEditPage extends React.Component {
         const prefix = difference > 0 ? '+' : '';
         return { cellContents: `${prefix}${difference}` };
       }
-      case 'reason': {
+      case 'mostUsedReasonTitle': {
         return (
           <TouchableOpacity
             key={stocktakeItem.id}
@@ -287,8 +287,8 @@ export class StocktakeEditPage extends React.Component {
               <Icon name="external-link" size={14} color={SUSSOL_ORANGE} />
             )}
             <Text style={{ width: '80%' }} numberOfLines={1} ellipsizeMode="tail">
-              {stocktakeItem.mostUsedReason
-                ? stocktakeItem.mostUsedReason.title
+              {stocktakeItem.mostUsedReasonTitle
+                ? stocktakeItem.mostUsedReasonTitle
                 : programStrings.not_applicable}
             </Text>
           </TouchableOpacity>
@@ -462,7 +462,7 @@ export class StocktakeEditPage extends React.Component {
     ];
     if (usesReasons) {
       columns.push({
-        key: 'reason',
+        key: 'mostUsedReasonTitle',
         width: 1.2,
         title: tableStrings.reason,
         sortable: true,


### PR DESCRIPTION
Fixes #1000

## Change summary
Change stocktakeItem `mostUsedReason` to return `option.title` rather than `option` itself. This allows string based sorting to work on the getter. Changed code using `mostUsedReason` to use `mostUsedReasonTitle`. 

A bit of rework on the choosing modal to make sure the right reason is highlighted, but should be a bit better using the realm result of reasons saved in state rather than querying the db for them every time the modal was rendered. I think in the old implementation the modal choices wouldn't have been filtered by just stocktakeReason either.

## Testing
Steps to reproduce or otherwise test the changes of this PR:
- [ ] Sort the reasons column in a stocktake and not crash the app
- [ ] Sort sorts alphabetically
- [ ] Sort handles "Not applicable" (`''`/empty string) values
- [ ] Select reason modal highlights none if the current row didn't have one prior
- [ ] Select reason modal highlights correct option if the row did have one prior

### Related areas to think about
Pretty sure I covered them all. If you're really keen, test stocktakes without reasons too.
