### PR TITLE
#1011 fix reason saving to wrong row

### DIFF
--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -159,11 +159,15 @@ export class StocktakeEditPage extends React.Component {
    */
   onEndEditing = (key, stocktakeItem, newValue) => {
     const { database } = this.props;
-    const { reasons } = this.state;
+    const { reasons, isReasonsModalOpen } = this.state;
 
     if (key !== 'countedTotalQuantity' || newValue === '') return;
     const quantity = parsePositiveInteger(newValue);
     if (quantity === null) return;
+    // If the reason modal is open just ignore any change to the current line
+    // This a hack to solve https://github.com/openmsupply/mobile/issues/1011
+    // Underlying issue requires data table rewrite
+    if (isReasonsModalOpen) return;
 
     stocktakeItem.setCountedTotalQuantity(database, quantity);
     if (reasons.length > 0) this.assignReason(stocktakeItem);

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -97,7 +97,6 @@ export class StocktakeEditPage extends React.Component {
       modalKey: null,
       isModalOpen: false,
       isResetModalOpen: false,
-      stocktakeItem: null,
       isStocktakeEditModalOpen: false,
       reasons: [],
       isReasonsModalOpen: false,
@@ -297,7 +296,10 @@ export class StocktakeEditPage extends React.Component {
         return (
           <TouchableOpacity
             onPress={() => {
-              this.openBatchModal(stocktakeItem);
+              this.setState({
+                isStocktakeEditModalOpen: true,
+                currentStocktakeItem: stocktakeItem,
+              });
             }}
           >
             <View style={localStyles.modalControl}>
@@ -417,10 +419,6 @@ export class StocktakeEditPage extends React.Component {
     this.setState({ isStocktakeEditModalOpen: false });
   };
 
-  openBatchModal = item => {
-    this.setState({ stocktakeItem: item, isStocktakeEditModalOpen: true });
-  };
-
   renderReasonModal = () => {
     const { currentStocktakeItem, isReasonsModalOpen, reasons } = this.state;
     // The below findIndex would fail if title was changed on central server!
@@ -502,7 +500,7 @@ export class StocktakeEditPage extends React.Component {
       data,
       isResetModalOpen,
       isModalOpen,
-      stocktakeItem,
+      currentStocktakeItem,
       isStocktakeEditModalOpen,
       isReasonsModalOpen,
     } = this.state;
@@ -546,7 +544,7 @@ export class StocktakeEditPage extends React.Component {
 
         <StocktakeBatchModal
           isOpen={isStocktakeEditModalOpen}
-          stocktakeItem={stocktakeItem}
+          stocktakeItem={currentStocktakeItem}
           database={database}
           genericTablePageStyles={genericTablePageStyles}
           onConfirm={this.onConfirmBatchModal}

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -141,7 +141,7 @@ export class StocktakeEditPage extends React.Component {
   assignReason = stocktakeItem => {
     const { database } = this.props;
     if (stocktakeItem.shouldApplyReason) {
-      this.onOpenReasonModal();
+      this.setState({ isReasonsModalOpen: true, currentStocktakeItem: stocktakeItem });
     } else {
       stocktakeItem.applyReasonToBatches(database);
     }
@@ -171,7 +171,6 @@ export class StocktakeEditPage extends React.Component {
 
     stocktakeItem.setCountedTotalQuantity(database, quantity);
     if (reasons.length > 0) this.assignReason(stocktakeItem);
-    this.setState({ currentStocktakeItem: stocktakeItem });
   };
 
   /**
@@ -245,10 +244,6 @@ export class StocktakeEditPage extends React.Component {
     });
   };
 
-  onOpenReasonModal = () => {
-    this.setState({ isReasonsModalOpen: true });
-  };
-
   renderCell = (key, stocktakeItem) => {
     const { stocktake } = this.props;
     const isEditable = !stocktake.isFinalised;
@@ -282,7 +277,7 @@ export class StocktakeEditPage extends React.Component {
             key={stocktakeItem.id}
             onPress={() =>
               hasAnyReason && isEditable
-                ? this.setState({ currentStocktakeItem: stocktakeItem }, this.onOpenReasonModal)
+                ? this.setState({ currentStocktakeItem: stocktakeItem, isReasonsModalOpen: true })
                 : null
             }
             style={localStyles.reasonCell}
@@ -428,6 +423,7 @@ export class StocktakeEditPage extends React.Component {
 
   renderReasonModal = () => {
     const { currentStocktakeItem, isReasonsModalOpen, reasons } = this.state;
+    // The below findIndex would fail if title was changed on central server!
     const currentReasonIndex = reasons.findIndex(
       reason => reason.title === currentStocktakeItem.mostUsedReasonTitle
     );

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -160,15 +160,16 @@ export class StocktakeEditPage extends React.Component {
     const { database } = this.props;
     const { reasons, isReasonsModalOpen } = this.state;
 
-    if (key !== 'countedTotalQuantity' || newValue === '') return;
-    const quantity = parsePositiveInteger(newValue);
-    if (quantity === null) return;
     // If the reason modal is open just ignore any change to the current line
     // This a hack to solve https://github.com/openmsupply/mobile/issues/1011
     // Underlying issue requires data table rewrite
     if (isReasonsModalOpen) return;
 
+    if (key !== 'countedTotalQuantity' || newValue === '') return;
+    const quantity = parsePositiveInteger(newValue);
+    if (quantity === null) return;
     stocktakeItem.setCountedTotalQuantity(database, quantity);
+
     if (reasons.length > 0) this.assignReason(stocktakeItem);
   };
 

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -67,16 +67,17 @@ export default class StocktakeBatchModal extends React.Component {
   };
 
   onEndEditing = (key, stocktakeBatch, newValue) => {
-    const { database } = this.props;
-    const { reasons, reasonModalOpen } = this.state;
-    const { id } = stocktakeBatch;
-
     if (!newValue || newValue === '') return;
+
+    const { reasons, reasonModalOpen } = this.state;
+    const { database } = this.props;
+
     // If the reason modal is open just ignore any change to the current line
     // This a hack to solve similar issue https://github.com/openmsupply/mobile/issues/1011
     // Underlying issue requires data table rewrite
     if (reasonModalOpen) return;
 
+    const { id } = stocktakeBatch;
     switch (key) {
       case 'countedTotalQuantity': {
         if (parsePositiveInteger(newValue) === null) return;

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -228,7 +228,8 @@ export default class StocktakeBatchModal extends React.Component {
   renderReasonModal = () => {
     const { database } = this.props;
     const { reasonModalOpen, currentBatch, reasons } = this.state;
-    const currentReasonIndex = reasons.findIndex(reason => reason.id === currentBatch.option.id);
+    const { option } = currentBatch;
+    const currentReasonIndex = option && reasons.findIndex(reason => reason.id === option.id);
 
     return (
       <GenericChooseModal

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -226,7 +226,6 @@ export default class StocktakeBatchModal extends React.Component {
   };
 
   renderReasonModal = () => {
-    const { database } = this.props;
     const { reasonModalOpen, currentBatch, reasons } = this.state;
     const { option } = currentBatch;
     const currentReasonIndex = option && reasons.findIndex(reason => reason.id === option.id);
@@ -234,7 +233,7 @@ export default class StocktakeBatchModal extends React.Component {
     return (
       <GenericChooseModal
         isOpen={reasonModalOpen}
-        data={database.objects('Options')}
+        data={reasons}
         highlightIndex={currentReasonIndex}
         onPress={this.reasonModalConfirm}
         keyToDisplay="title"

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -51,15 +51,18 @@ export default class StocktakeBatchModal extends React.Component {
   };
 
   /**
-   * Opens the reason modal for applying a reason to a stocktakeItem
+   * Opens the reason modal for applying a reason to a stocktakeBatch
    * if the snapshot quantity and counted total quantity differ.
    * Otherwise, removes the reason from the stocktake items batches.
    * @param {Object} stocktakeItem
    */
   assignReason = stocktakeBatch => {
-    const { stocktakeItem } = this.props;
-    if (stocktakeItem.shouldApplyReason) {
+    if (stocktakeBatch.shouldApplyReason) {
       this.setState({ reasonModalOpen: true, currentBatch: stocktakeBatch });
+    } else {
+      const { database } = this.props;
+      const { id } = stocktakeBatch;
+      database.write(() => database.update('StocktakeBatch', { id, option: null }));
     }
   };
 

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -54,7 +54,7 @@ export default class StocktakeBatchModal extends React.Component {
    * Opens the reason modal for applying a reason to a stocktakeBatch
    * if the snapshot quantity and counted total quantity differ.
    * Otherwise, removes the reason from the stocktake items batches.
-   * @param {Object} stocktakeItem
+   * @param {Object} stocktakeBatch
    */
   assignReason = stocktakeBatch => {
     if (stocktakeBatch.shouldApplyReason) {


### PR DESCRIPTION
Fixes #1011

## Change summary
TL;DR: Small tweak. Basically stops the the `currentStocktakeItem` from changing when the reason modal is already up.

After editing a row to have a diff, hitting next or selecting the next row changes focus from the edited row and triggers endEditing. This will show the reason modal. Pressing anywhere on modal to change focus from _next row_ would trigger endEditing on next row. Modal is already up but the currentStocktakeItem would update to be the next row. Selecting a reason therefore updates that row erroneously.

## Testing
Steps to reproduce or otherwise test the changes of this PR:
- [ ] Make a new stocktake and go from top to bottom replacing "Not counted" values with counts and adding reasons, all is well.
![Screen Shot 2019-05-28 at 17 13 00](https://user-images.githubusercontent.com/7684221/58452826-e0d4bc00-816c-11e9-82d5-1a1b0e7bd309.png)
![Screen Shot 2019-05-28 at 17 13 42](https://user-images.githubusercontent.com/7684221/58452833-e7fbca00-816c-11e9-8aa5-d65f6fe92d56.png)
- [ ] Edit line 1 to have no diff. Reason will be reset to Not applicable.
![Screen Shot 2019-05-28 at 17 14 05](https://user-images.githubusercontent.com/7684221/58452834-eb8f5100-816c-11e9-885b-7063dd33d79e.png)
- [ ] Edit line 1 again to have a diff, hitting next or selecting the next line manually. Selecting reason saves correctly
- [ ] Do above, but click on search bar instead to change focus. Selecting reason saves correctly

### Related areas to think about
- There is also a state variable `stocktakeItem`. Seems a bit redundant. Bunch of the logic around reason modal and `assignReason()` seems a bit more spaghetti than needed but not refactoring today.
