### PR TITLE
#1018 #1017 #996 Remove realm copy and coerce threshold mos

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,6 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import Realm from 'realm';
 import React from 'react';
 import { AppRegistry } from 'react-native';
 import { Provider } from 'react-redux';
@@ -17,7 +16,6 @@ import MSupplyMobileApp from './mSupplyMobileApp';
 const bugsnagClient = new BugsnagClient();
 
 function App() {
-  Realm.copyBundledRealmFiles();
   return (
     <ErrorHandler persistedStore={persistedStore}>
       <Provider store={store}>

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -567,7 +567,7 @@ export class SupplierRequisitionPage extends React.Component {
             <UseSuggestedQuantitiesButton />
             {hasRegimenData && <ViewRegimenDataButton />}
           </View>
-          {program && thresholdMOS && <ThresholdMOSToggle />}
+          {program && !!thresholdMOS && <ThresholdMOSToggle />}
           {!program && <CreateAutomaticOrderButton />}
         </View>
 


### PR DESCRIPTION
Fixes things maybe.
Fixes #1018
Fixes #1017 
Fixes #996 

## Change summary
**For the memory leaks** the bugsnag trace isn't too useful and we haven't found out how to reproduce the bug yet. There are hints https://github.com/realm/realm-js/issues/1669 and https://github.com/realm/realm-js/issues/630

Could be excessively large write transactions, or some ability to continue using the app and starting new writes while old writes are still going. Or maybe a write within a write (if that's possible?).
One variable that changed was `Realm.copyBundledRealmFiles();`. Just an idea, a stab in the dark, to remove it and see if the next patch continues getting errors #1018 and #1017. If it does, bugsnag will reopen. 

@andreievg do FYI I've pulled this out for now. I wonder if we can have an env variable file or something that makes it run conditionally if it is a problem. Or it could check if there is a realm file to import before running copy. There aren't any docs on that realm method lol.

**ThresholdMOS** is definitely **_a_** cause of the render error in #996, but it isn't clear if that's the only cause. So closing for now, bugsnag will reopen if there are other similar cases.

## Testing
For memory leaks no idea at this point
ThresholdMOS, setup the situation where it's 0 on a requisition and see if viewing that requisition crashes the app.

### Related areas to think about

