### PR TITLE
#1025 Sync to have logging

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,18 +1,24 @@
 {
   "env": { "jest": true },
   "extends": "airbnb",
+  "globals": {
+    "fetch": false
+  },
   "parser": "babel-eslint",
   "plugins": ["prettier"],
   "rules": {
     "arrow-body-style": ["error", "as-needed"],
     "arrow-parens": ["error", "as-needed"],
-    "comma-dangle": ["error", {
-      "arrays": "always-multiline",
-      "exports": "always-multiline",
-      "functions": "never",
-      "imports": "always-multiline",
-      "objects": "always-multiline"
-    }],
+    "comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "never",
+        "imports": "always-multiline",
+        "objects": "always-multiline"
+      }
+    ],
     "function-paren-newline": "off",
     "implicit-arrow-linebreak": "off",
     "indent": ["error", 2, { "SwitchCase": 1 }],

--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -102,11 +102,11 @@ export class Synchroniser {
     try {
       responseJson = await response.json();
     } catch (error) {
-      bugsnagNotify('Failed parsing response form server', response);
+      bugsnagNotify('Failed parsing response from server', response);
       throw new Error('Unexpected response from sync server');
     }
 
-    if (responseJson.error && responseJson.error) {
+    if (responseJson.error) {
       if (responseJson.error.startsWith("Site registration doesn't match.")) {
         throw new Error(responseJson.error);
       } else {

--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -106,7 +106,7 @@ export class Synchroniser {
       throw new Error('Unexpected response from sync server');
     }
 
-    if (responseJson.error && responseJson.error !== '') {
+    if (responseJson.error && responseJson.error) {
       if (responseJson.error.startsWith("Site registration doesn't match.")) {
         throw new Error(responseJson.error);
       } else {

--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -87,8 +87,8 @@ export class Synchroniser {
   fetchWrapper = async (url, opts) => {
     const { body } = opts;
 
-    const bugsnagNotify = async (message, response) => {
-      const responseText = await response.text();
+    const bugsnagNotify = async message => {
+      const responseText = await responseClone.text();
       bugsnagClient.notify(new Error(message), report => {
         report.context = 'SYNC ERROR';
         report.metadata = { error: { url, body, responseText } };
@@ -96,6 +96,7 @@ export class Synchroniser {
     };
 
     const response = await fetch(url, opts);
+    const responseClone = response.clone();
 
     if (response.status < 200 || response.status >= 300) {
       throw new Error('Connection failure while attempting to sync.');

--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -93,7 +93,6 @@ export class Synchroniser {
         metaData: { url, body, responseText: await response.text() },
       });
     };
-    // eslint-disable-next-line no-undef
     const response = await fetch(url, opts);
     if (response.status < 200 || response.status >= 300) {
       throw new Error('Connection failure while attempting to sync.');

--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -87,10 +87,10 @@ export class Synchroniser {
   fetchWrapper = async (url, opts) => {
     const { body } = opts;
 
-    const bugsnagNotify = (message, response) => {
+    const bugsnagNotify = async (message, response) => {
       bugsnagClient.notify(new Error(message), {
         context: 'SYNC ERROR',
-        metaData: { url, body, responseText: response.text() },
+        metaData: { url, body, responseText: await response.text() },
       });
     };
     // eslint-disable-next-line no-undef

--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -5,6 +5,7 @@
 
 /* eslint-disable no-await-in-loop */
 
+import { Client as BugsnagClient } from 'bugsnag-react-native';
 import {
   incrementSyncProgress,
   setSyncProgress,
@@ -19,6 +20,8 @@ import { generateSyncJson } from './outgoingSyncUtils';
 import { SyncDatabase } from './SyncDatabase';
 import { SyncQueue } from './SyncQueue';
 import { SETTINGS_KEYS } from '../settings';
+
+const bugsnagClient = new BugsnagClient();
 
 const {
   SYNC_IS_INITIALISED,
@@ -81,6 +84,39 @@ export class Synchroniser {
     this.batchSize = MIN_SYNC_BATCH_SIZE;
   };
 
+  fetchWrapper = async (url, opts) => {
+    const { body } = opts;
+
+    const bugsnagNotify = (message, response) => {
+      bugsnagClient.notify(new Error(message), {
+        context: 'SYNC ERROR',
+        metaData: { url, body, responseText: response.text() },
+      });
+    };
+    // eslint-disable-next-line no-undef
+    const response = await fetch(url, opts);
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error('Connection failure while attempting to sync.');
+    }
+    let responseJson;
+    try {
+      responseJson = await response.json();
+    } catch (error) {
+      bugsnagNotify('Failed parsing response form server', response);
+      throw new Error('Unexpected response from sync server');
+    }
+
+    if (responseJson.error && responseJson.error !== '') {
+      if (responseJson.error.startsWith("Site registration doesn't match.")) {
+        throw new Error(responseJson.error);
+      } else {
+        bugsnagNotify(responseJson.error, response);
+        throw new Error('Server rejected pushed records');
+      }
+    }
+    return { responseJson };
+  };
+
   /**
    * Wipe the current database, check that the given URL can be synced against
    * using the given name and password, and if so populate the database by pulling
@@ -117,8 +153,7 @@ export class Synchroniser {
 
       if (isFresh) {
         // If a fresh initialisation, send request to server to prepare required sync records.
-        // eslint-disable-next-line no-undef
-        const response = await fetch(
+        await this.fetchWrapper(
           `${this.serverURL}/sync/v3/initial_dump/` +
             `?from_site=${this.thisSiteId}&to_site=${this.serverId}`,
           {
@@ -128,16 +163,6 @@ export class Synchroniser {
             },
           }
         );
-
-        if (response.status < 200 || response.status >= 300) {
-          throw new Error('Connection failure while attempting to sync.');
-        }
-
-        const responseJson = await response.json();
-        if (responseJson.error && responseJson.error.length > 0) {
-          throw new Error(responseJson.error);
-        }
-
         // If the initial_dump has been successful, serverURL is valid, and should now have all sync
         // records queued and ready to send. Safe to store as this.serverURL
         this.serverURL = serverURL;
@@ -257,8 +282,7 @@ export class Synchroniser {
    * @return  {Promise}          Resolves if successful, or passes up any error thrown.
    */
   pushRecords = async records => {
-    // eslint-disable-next-line no-undef
-    const response = await fetch(
+    await this.fetchWrapper(
       `${this.serverURL}/sync/v3/queued_records/` +
         `?from_site=${this.thisSiteId}&to_site=${this.serverId}`,
       {
@@ -270,19 +294,6 @@ export class Synchroniser {
         body: JSON.stringify(records),
       }
     );
-    let responseJson;
-    try {
-      responseJson = await response.json();
-    } catch (error) {
-      throw new Error('Unexpected response from sync server');
-    }
-    if (responseJson.error.length > 0) {
-      if (responseJson.error.startsWith("Site registration doesn't match.")) {
-        throw new Error(responseJson.error);
-      } else {
-        throw new Error('Server rejected pushed records');
-      }
-    }
   };
 
   /**
@@ -331,8 +342,7 @@ export class Synchroniser {
    * @return  {Promise}  Resolves with the record count, or bubbles up any errors thrown.
    */
   getWaitingRecordCount = async () => {
-    // eslint-disable-next-line no-undef
-    const response = await fetch(
+    const { responseJson } = await this.fetchWrapper(
       `${this.serverURL}/sync/v3/queued_records/count` +
         `?from_site=${this.thisSiteId}&to_site=${this.serverId}`,
       {
@@ -342,16 +352,6 @@ export class Synchroniser {
         },
       }
     );
-    if (response.status < 200 || response.status >= 300) {
-      throw new Error('Connection failure while attempting to sync.');
-    }
-    const responseJson = await response.json();
-    if (responseJson.error && responseJson.error.length > 0) {
-      throw new Error(responseJson.error);
-    }
-    if (typeof responseJson.NumRecords !== 'number') {
-      throw new Error('Unexpected response from server');
-    }
     return responseJson.NumRecords;
   };
 
@@ -361,8 +361,7 @@ export class Synchroniser {
    * @return  {Promise}  Resolves with the records, or bubbles up any errors thrown.
    */
   getIncomingRecords = async () => {
-    // eslint-disable-next-line no-undef
-    const response = await fetch(
+    const { responseJson } = await this.fetchWrapper(
       `${this.serverURL}/sync/v3/queued_records` +
         `?from_site=${this.thisSiteId}&to_site=${this.serverId}&limit=${this.batchSize}`,
       {
@@ -372,13 +371,6 @@ export class Synchroniser {
         },
       }
     );
-    if (response.status < 200 || response.status >= 300) {
-      throw new Error('Connection failure while pulling sync records.');
-    }
-    const responseJson = await response.json();
-    if (responseJson.error && responseJson.error.length > 0) {
-      throw new Error(responseJson.error);
-    }
     return responseJson;
   };
 
@@ -409,8 +401,7 @@ export class Synchroniser {
       SyncRecordIDs: syncIds,
     };
 
-    // eslint-disable-next-line no-undef
-    const response = await fetch(
+    await this.fetchWrapper(
       `${this.serverURL}/sync/v3/acknowledged_records` +
         `?from_site=${this.thisSiteId}&to_site=${this.serverId}`,
       {
@@ -422,15 +413,6 @@ export class Synchroniser {
         body: JSON.stringify(requestBody),
       }
     );
-    let responseJson;
-    try {
-      responseJson = await response.json();
-    } catch (error) {
-      throw new Error('Unexpected response from sync server');
-    }
-    if (responseJson.error.length > 0) {
-      throw new Error(responseJson.error);
-    }
   };
 
   /**

--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -88,12 +88,15 @@ export class Synchroniser {
     const { body } = opts;
 
     const bugsnagNotify = async (message, response) => {
-      bugsnagClient.notify(new Error(message), {
-        context: 'SYNC ERROR',
-        metaData: { url, body, responseText: await response.text() },
+      const responseText = await response.text();
+      bugsnagClient.notify(new Error(message), report => {
+        report.context = 'SYNC ERROR';
+        report.metadata = { error: { url, body, responseText } };
       });
     };
+
     const response = await fetch(url, opts);
+
     if (response.status < 200 || response.status >= 300) {
       throw new Error('Connection failure while attempting to sync.');
     }


### PR DESCRIPTION
Fixes #1025

## Change summary
https://github.com/openmsupply/mobile/issues/1025#issuecomment-504264134

- Adds a wrapper around `fetch` in `synchronizer.js`
    - consistent handling of common http status codes
    - Consistent handling of error handling and bugsnag notifying

## Additional Context
#### Note: Anyone know the versions missing?
This will need to be merged into all versions that are having sync issues:
* Loas - ??
* IC (2.3.4 .. should go to 2.3.5)
* Kiribati - ??
* Vanuatu - (vaccine-special)

## Testing
- [ ] When an error occurs during sync, a bugsnag report is sent [This should be sent in all cases where sync is being prevented]
    - [ ] Where there are invalid reports on the server
    - [ ] Where there are invalid reports on mobile
- [ ] The bugsnag report is detailed and useful


