### PR TITLE
#1004 Require cycle warnings

### DIFF
--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -27,14 +27,8 @@ import { NavigationActions } from 'react-navigation';
 import { FirstUsePage, FINALISABLE_PAGES } from './pages';
 import { MobileAppSettings } from './settings';
 import { Synchroniser, PostSyncProcessor, SyncModal } from './sync';
-import {
-  FinaliseButton,
-  FinaliseModal,
-  LoginModal,
-  NavigationBar,
-  SyncState,
-  Spinner,
-} from './widgets';
+import { FinaliseButton, NavigationBar, SyncState, Spinner } from './widgets';
+import { FinaliseModal, LoginModal } from './widgets/modals';
 
 import { getCurrentParams, getCurrentRouteName, ReduxNavigator } from './navigation';
 import { migrateDataToVersion } from './dataMigration';

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -13,14 +13,8 @@ import { GenericPage } from './GenericPage';
 import { createRecord } from '../database';
 import { formatDate, parsePositiveInteger, sortDataBy } from '../utilities';
 import { buttonStrings, modalStrings, pageInfoStrings, tableStrings } from '../localization';
-import {
-  AutocompleteSelector,
-  BottomConfirmModal,
-  PageButton,
-  PageContentModal,
-  PageInfo,
-  TextEditor,
-} from '../widgets';
+import { AutocompleteSelector, PageButton, PageInfo, TextEditor } from '../widgets';
+import { BottomConfirmModal, PageContentModal } from '../widgets/modals';
 
 import globalStyles from '../globalStyles';
 

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -7,11 +7,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { GenericPage } from './GenericPage';
+import { PageButton } from '../widgets';
+import { BottomConfirmModal, SelectModal } from '../widgets/modals';
 
 import { createRecord } from '../database';
-import { buttonStrings, modalStrings, navStrings, tableStrings } from '../localization';
 import { formatStatus, sortDataBy } from '../utilities';
-import { BottomConfirmModal, PageButton, SelectModal } from '../widgets';
+import { buttonStrings, modalStrings, navStrings, tableStrings } from '../localization';
 
 const DATA_TYPES_SYNCHRONISED = ['Transaction'];
 

--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -9,10 +9,11 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
 import { GenericPage } from './GenericPage';
+import { PageContentModal } from '../widgets/modals';
+import { PageButton, PageInfo, TextEditor } from '../widgets';
 
-import { buttonStrings, modalStrings, pageInfoStrings, tableStrings } from '../localization';
 import { formatDate, sortDataBy } from '../utilities';
-import { PageButton, PageInfo, PageContentModal, TextEditor } from '../widgets';
+import { buttonStrings, modalStrings, pageInfoStrings, tableStrings } from '../localization';
 
 import globalStyles from '../globalStyles';
 

--- a/src/pages/FirstUsePage.js
+++ b/src/pages/FirstUsePage.js
@@ -9,8 +9,9 @@ import PropTypes from 'prop-types';
 import { Image, StyleSheet, Text, TextInput, View } from 'react-native';
 import { Button } from 'react-native-ui-components';
 
+import { SyncState } from '../widgets';
 import { getAppVersion } from '../settings';
-import { SyncState, DemoUserModal } from '../widgets';
+import { DemoUserModal } from '../widgets/modals';
 
 import globalStyles, { SUSSOL_ORANGE, WARM_GREY } from '../globalStyles';
 

--- a/src/pages/PageContainer.js
+++ b/src/pages/PageContainer.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 
 import { Keyboard } from 'react-native';
 
-import { getCurrentRouteName } from '../navigation';
+import { getCurrentRouteName } from '../navigation/selectors';
 
 const mapStateToProps = ({ nav }) => ({ currentRouteName: getCurrentRouteName(nav) });
 

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -9,11 +9,15 @@ import { TouchableOpacity, Text, StyleSheet, View } from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
 import { GenericPage } from './GenericPage';
-import { PageButton, PageInfo, TextEditor, PageContentModal, ConfirmModal } from '../widgets';
-import StocktakeBatchModal from '../widgets/modals/StocktakeBatchModal';
-import GenericChooseModal from '../widgets/modals/GenericChooseModal';
+import { PageButton, PageInfo, TextEditor } from '../widgets';
+import {
+  PageContentModal,
+  ConfirmModal,
+  StocktakeBatchModal,
+  GenericChooseModal,
+} from '../widgets/modals';
+
 import { parsePositiveInteger, truncateString, sortDataBy } from '../utilities';
-import { SUSSOL_ORANGE } from '../globalStyles';
 import {
   buttonStrings,
   modalStrings,
@@ -22,6 +26,8 @@ import {
   pageInfoStrings,
   programStrings,
 } from '../localization';
+
+import { SUSSOL_ORANGE } from '../globalStyles';
 
 const DATA_TYPES_SYNCHRONISED = ['StocktakeItem', 'StocktakeBatch', 'ItemBatch', 'Item'];
 

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -9,11 +9,13 @@ import PropTypes from 'prop-types';
 import { StyleSheet } from 'react-native';
 
 import { GenericPage } from './GenericPage';
-import { BottomModal, OnePressButton, TextInput, ToggleBar } from '../widgets';
+import { OnePressButton, TextInput, ToggleBar } from '../widgets';
+import { BottomModal } from '../widgets/modals';
 
 import { createRecord } from '../database';
 
 import { buttonStrings, modalStrings, tableStrings, navStrings } from '../localization';
+
 import globalStyles from '../globalStyles';
 
 const DATA_TYPES_SYNCHRONISED = ['Item', 'ItemBatch'];

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -8,13 +8,14 @@ import PropTypes from 'prop-types';
 
 import { GenericPage } from './GenericPage';
 
-import { buttonStrings, modalStrings, navStrings, tableStrings } from '../localization';
+import { PageButton, ToggleBar } from '../widgets';
+import { ByProgramModal, BottomConfirmModal } from '../widgets/modals';
+
+import { createRecord } from '../database/utilities/index';
 import { formatStatus, getAllPrograms } from '../utilities';
-import { PageButton, BottomConfirmModal, ToggleBar } from '../widgets';
-import { ByProgramModal } from '../widgets/modals/index';
+import { buttonStrings, modalStrings, navStrings, tableStrings } from '../localization';
 
 import globalStyles from '../globalStyles';
-import { createRecord } from '../database/utilities/index';
 
 const DATA_TYPES_SYNCHRONISED = ['Stocktake'];
 

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -6,20 +6,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { GenericPage } from './GenericPage';
-
-import { createRecord } from '../database';
-import { buttonStrings, modalStrings, pageInfoStrings, tableStrings } from '../localization';
-import { formatDate, parsePositiveInteger, sortDataBy } from '../utilities';
 import {
   AutocompleteSelector,
-  BottomConfirmModal,
   PageButton,
-  PageContentModal,
   PageInfo,
   TextEditor,
   ExpiryTextInput,
 } from '../widgets';
+import { GenericPage } from './GenericPage';
+import { BottomConfirmModal, PageContentModal } from '../widgets/modals';
+
+import { createRecord } from '../database';
+import { formatDate, parsePositiveInteger, sortDataBy } from '../utilities';
+import { buttonStrings, modalStrings, pageInfoStrings, tableStrings } from '../localization';
 
 import globalStyles, { dataTableStyles } from '../globalStyles';
 

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -6,12 +6,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { PageButton } from '../widgets';
 import { GenericPage } from './GenericPage';
+import { SelectModal, BottomConfirmModal } from '../widgets/modals';
 
 import { createRecord } from '../database';
-import { buttonStrings, modalStrings, navStrings, tableStrings } from '../localization';
 import { formatStatus, sortDataBy } from '../utilities';
-import { SelectModal, PageButton, BottomConfirmModal } from '../widgets';
+import { buttonStrings, modalStrings, navStrings, tableStrings } from '../localization';
 
 const DATA_TYPES_SYNCHRONISED = ['Transaction'];
 

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -6,14 +6,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { PageButton } from '../widgets';
 import { GenericPage } from './GenericPage';
-import { BottomConfirmModal, PageButton, SelectModal, ByProgramModal } from '../widgets';
+import { BottomConfirmModal, ByProgramModal, SelectModal } from '../widgets/modals';
 
 import { createRecord } from '../database';
-import { buttonStrings, modalStrings, navStrings, tableStrings } from '../localization';
-import { formatStatus, sortDataBy, getAllPrograms } from '../utilities';
-
 import { SETTINGS_KEYS } from '../settings';
+import { formatStatus, sortDataBy, getAllPrograms } from '../utilities';
+import { buttonStrings, modalStrings, navStrings, tableStrings } from '../localization';
 
 const { THIS_STORE_CUSTOM_DATA } = SETTINGS_KEYS;
 

--- a/src/widgets/SequentialSteps.js
+++ b/src/widgets/SequentialSteps.js
@@ -29,7 +29,7 @@ import { WARM_GREY, SUSSOL_ORANGE } from '../globalStyles';
  * @
  *
  */
-export default class SequentialSteps extends React.PureComponent {
+export class SequentialSteps extends React.PureComponent {
   renderStepIcon = ({ isCurrentStep, isLessThanCurrentStep, step, complete }) => {
     const { error } = step;
     return (
@@ -143,6 +143,8 @@ SequentialSteps.propTypes = {
   steps: PropTypes.array.isRequired,
   currentStepKey: PropTypes.string.isRequired,
 };
+
+export default SequentialSteps;
 
 /**
  * Steps array example

--- a/src/widgets/TextEditor.js
+++ b/src/widgets/TextEditor.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { View, StyleSheet } from 'react-native';
 import { Button } from 'react-native-ui-components';
 
-import { TextInput } from './index';
+import { TextInput } from './TextInput';
 
 import { buttonStrings } from '../localization';
 import globalStyles from '../globalStyles';

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -5,19 +5,6 @@
 
 export { Button, ProgressBar } from 'react-native-ui-components';
 
-export {
-  BottomConfirmModal,
-  BottomModal,
-  ConfirmModal,
-  FinaliseModal,
-  LanguageModal,
-  LoginModal,
-  DemoUserModal,
-  PageContentModal,
-  SelectModal,
-  ByProgramModal,
-} from './modals';
-
 export { AutocompleteSelector } from './AutocompleteSelector';
 export { FinaliseButton } from './FinaliseButton';
 export { NavigationBar } from './NavigationBar';
@@ -31,3 +18,4 @@ export { ToggleBar } from './ToggleBar';
 export { ToggleSelector } from './ToggleSelector';
 export { ExpiryTextInput } from './ExpiryTextInput';
 export { OnePressButton } from './OnePressButton';
+export { SequentialSteps } from './SequentialSteps';

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -11,14 +11,13 @@ import PropTypes from 'prop-types';
 import { StyleSheet, View } from 'react-native';
 
 import { PageContentModal } from './PageContentModal';
-
-import globalStyles, { DARK_GREY, WARM_GREY, SUSSOL_ORANGE } from '../../globalStyles';
-import { AutocompleteSelector, ToggleBar, PageButton, TextEditor } from '..';
+import { SequentialSteps, AutocompleteSelector, ToggleBar, PageButton, TextEditor } from '..';
 
 import { SETTINGS_KEYS } from '../../settings';
 import { getAllPrograms, getAllPeriodsForProgram } from '../../utilities';
-import SequentialSteps from '../SequentialSteps';
 import { programStrings, modalStrings, generalStrings, navStrings } from '../../localization';
+
+import globalStyles, { DARK_GREY, WARM_GREY, SUSSOL_ORANGE } from '../../globalStyles';
 
 // TODO: Proper localization
 const localization = {

--- a/src/widgets/modals/DemoUserModal.js
+++ b/src/widgets/modals/DemoUserModal.js
@@ -11,9 +11,10 @@ import { Button } from 'react-native-ui-components';
 import Modal from 'react-native-modalbox';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
+import { ConfirmModal } from './ConfirmModal';
+
 import { DemoSiteRequest } from '../../authentication';
 import { authStrings, generalStrings, demoUserModalStrings } from '../../localization';
-import { ConfirmModal } from '..';
 
 import globalStyles, { SUSSOL_ORANGE, GREY, WARM_GREY } from '../../globalStyles';
 

--- a/src/widgets/modals/FinaliseModal.js
+++ b/src/widgets/modals/FinaliseModal.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import { Client as BugsnagClient } from 'bugsnag-react-native';
 
 import { ConfirmModal } from './ConfirmModal';
+
 import { modalStrings } from '../../localization';
 
 const bugsnagClient = new BugsnagClient();

--- a/src/widgets/modals/GenericChooseModal.js
+++ b/src/widgets/modals/GenericChooseModal.js
@@ -29,7 +29,7 @@ import { COMPONENT_HEIGHT } from '../../globalStyles';
  * NOTE: If there are multiple, equal values used in highlightValue within the data array,
  * multiple values will be highlighted.
  */
-export default class GenericChooseModal extends React.PureComponent {
+export class GenericChooseModal extends React.PureComponent {
   keyExtractor = (item, index) => {
     const { keyToDisplay } = this.props;
     const content = keyToDisplay && item ? item[keyToDisplay] : item;
@@ -104,3 +104,5 @@ GenericChooseModal.propTypes = {
   highlightIndex: PropTypes.number,
   highlightValue: PropTypes.string,
 };
+
+export default GenericChooseModal;

--- a/src/widgets/modals/LanguageModal.js
+++ b/src/widgets/modals/LanguageModal.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import { Image, ListView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 import { PageContentModal } from './PageContentModal';
+
 import { SETTINGS_KEYS } from '../../settings';
 import { COUNTRY_FLAGS, LANGUAGE_KEYS, modalStrings } from '../../localization';
 

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -12,8 +12,10 @@ import Icon from 'react-native-vector-icons/FontAwesome';
 import { Image, StyleSheet, Text, TextInput, View } from 'react-native';
 
 import { LanguageModal } from './LanguageModal';
+
 import { SETTINGS_KEYS, getAppVersion } from '../../settings';
 import { authStrings, navStrings } from '../../localization';
+
 import globalStyles, { SUSSOL_ORANGE, GREY, WARM_GREY } from '../../globalStyles';
 
 export class LoginModal extends React.Component {

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -9,11 +9,14 @@ import PropTypes from 'prop-types';
 import Modal from 'react-native-modalbox';
 import { TouchableOpacity, StyleSheet, View, Text } from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
+
 import { GenericPage } from '../../pages/GenericPage';
+import { Button, PageButton, ExpiryTextInput, PageInfo } from '..';
+import { GenericChooseModal } from './GenericChooseModal';
 
 import { tableStrings, buttonStrings, modalStrings, pageInfoStrings } from '../../localization';
 import { parsePositiveInteger } from '../../utilities';
-import { Button, PageButton, ExpiryTextInput, PageInfo } from '..';
+
 import globalStyles, {
   WARM_GREY,
   SUSSOL_ORANGE,
@@ -21,9 +24,8 @@ import globalStyles, {
   dataTableStyles,
   expansionPageStyles,
 } from '../../globalStyles';
-import GenericChooseModal from './GenericChooseModal';
 
-export default class StocktakeBatchModal extends React.Component {
+export class StocktakeBatchModal extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -368,3 +370,5 @@ const localStyles = StyleSheet.create({
     paddingRight: 10,
   },
 });
+
+export default StocktakeBatchModal;

--- a/src/widgets/modals/index.js
+++ b/src/widgets/modals/index.js
@@ -13,3 +13,5 @@ export { PageContentModal } from './PageContentModal';
 export { SelectModal } from './SelectModal';
 export { DemoUserModal } from './DemoUserModal';
 export { ByProgramModal } from './ByProgramModal';
+export { StocktakeBatchModal } from './StocktakeBatchModal';
+export { GenericChooseModal } from './GenericChooseModal';


### PR DESCRIPTION
Fixes #1004 

## Change summary
- Fixes the TextEditor require cycle through a simple import change
- Fixes the modal require cycles through having each modal be imported through the index in `widgets/modals` and each modal importing a secondary modal it may use directly from the modal file

## Testing
Steps to reproduce or otherwise test the changes of this PR:
- [ ] Building is possible (Catching incorrect import/exporting)
- [ ] In development mode, there are no require cycle warnings

### Related areas to think about
Could have gotten rid of the `widgets/modals` index and have everything import from the `widgets` index. Felt this was better
