### PR TITLE
#987 handle incorrectly formatted transact entry dates

### DIFF
--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -446,7 +446,7 @@ Transaction.schema = {
     serialNumber: { type: 'string', default: 'placeholderSerialNumber' },
     otherParty: { type: 'Name', optional: true },
     comment: { type: 'string', optional: true },
-    entryDate: { type: 'date', default: new Date() },
+    entryDate: { type: 'date', optional: true },
     type: { type: 'string', default: 'placeholderType' },
     status: { type: 'string', default: 'new' },
     confirmDate: { type: 'date', optional: true },

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -152,7 +152,7 @@ export const schema = {
     User,
     Unit,
   ],
-  schemaVersion: 8,
+  schemaVersion: 9,
 };
 
 export default schema;

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -161,43 +161,42 @@ export class CustomerInvoicePage extends GenericPage {
   };
 
   renderPageInfo = () => {
+    const { transaction } = this.props;
     const infoColumns = [
       [
         {
           title: `${pageInfoStrings.entry_date}:`,
-          info: formatDate(this.props.transaction.entryDate) || 'N/A',
+          info: formatDate(transaction.entryDate) || 'N/A',
         },
         {
           title: `${pageInfoStrings.confirm_date}:`,
-          info: formatDate(this.props.transaction.confirmDate),
+          info: formatDate(transaction.confirmDate),
         },
         {
           title: `${pageInfoStrings.entered_by}:`,
-          info: this.props.transaction.enteredBy && this.props.transaction.enteredBy.username,
+          info: transaction.enteredBy && transaction.enteredBy.username,
         },
       ],
       [
         {
           title: `${pageInfoStrings.customer}:`,
-          info: this.props.transaction.otherParty && this.props.transaction.otherParty.name,
+          info: transaction.otherParty && transaction.otherParty.name,
         },
         {
           title: `${pageInfoStrings.their_ref}:`,
-          info: this.props.transaction.theirRef,
+          info: transaction.theirRef,
           onPress: this.openTheirRefEditor,
           editableType: 'text',
         },
         {
           title: `${pageInfoStrings.comment}:`,
-          info: this.props.transaction.comment,
+          info: transaction.comment,
           onPress: this.openCommentEditor,
           editableType: 'text',
         },
       ],
     ];
-    return (
-      <PageInfo columns={infoColumns} isEditingDisabled={this.props.transaction.isFinalised} />
-    );
+    return <PageInfo columns={infoColumns} isEditingDisabled={transaction.isFinalised} />;
   };
 
   renderCell = (key, transactionItem) => {

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -165,7 +165,7 @@ export class CustomerInvoicePage extends GenericPage {
       [
         {
           title: `${pageInfoStrings.entry_date}:`,
-          info: formatDate(this.props.transaction.entryDate),
+          info: formatDate(this.props.transaction.entryDate) || 'N/A',
         },
         {
           title: `${pageInfoStrings.confirm_date}:`,

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -140,7 +140,7 @@ export class CustomerInvoicesPage extends React.Component {
       case 'status':
         return formatStatus(invoice.status);
       case 'entryDate':
-        return invoice.entryDate.toDateString();
+        return (invoice.entryDate && invoice.entryDate.toDateString()) || 'N/A';
       case 'delete':
         return {
           type: 'checkable',

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -162,7 +162,7 @@ export class SupplierInvoicePage extends React.Component {
       [
         {
           title: `${pageInfoStrings.entry_date}:`,
-          info: formatDate(transaction.entryDate),
+          info: formatDate(transaction.entryDate) || 'N/A',
         },
         {
           title: `${pageInfoStrings.confirm_date}:`,

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -138,7 +138,7 @@ export class SupplierInvoicesPage extends React.Component {
       case 'status':
         return formatStatus(invoice.status);
       case 'entryDate':
-        return invoice.entryDate.toDateString();
+        return (invoice.entryDate && invoice.entryDate.toDateString()) || 'N/A';
       case 'remove':
         return {
           type: 'checkable',


### PR DESCRIPTION
Fixes #987.

Hotfix for transact sync bug. 

Not the most elegant, but at this stage just designed to handle buggy transaction records. Could be made a bit more tidy by incorporating similar logic into existing date conversion methods (but only when/if we want this logic to extend to other records).

Sync to desktop is handled by existing date conversion logic (already maps `null` values to ISO date `0000-00-00T00:00:00`).

## Change summary

Update realm schema to make `transact.entry_date` optional. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Incoming sync handles default transaction entry date (`00-00-0000`).
- [ ] Outgoing sync handles `null` transaction entry dates.
- [ ] Supplier invoice page correctly displays transactions with `null` entry dates.
- [ ] Supplier invoice page correctly displays transactions with `null` entry dates.
- [ ] Customer invoice page correctly displays transactions with `null` entry dates.
- [ ] Customer invoice page correctly displays transactions with `null` entry dates.

### Related areas to think about

N/A.
