### PR TITLE
#945 Setting sync promise rejection

### DIFF
--- a/src/sync/PostSyncProcessor.js
+++ b/src/sync/PostSyncProcessor.js
@@ -92,6 +92,7 @@ export class PostSyncProcessor {
     this.recordQueue.forEach((recordType, recordId) => {
       // Use local database record, not what comes in sync. Ensures that records are
       // integrated information (definitely after sync is done).
+      if (recordType === 'Setting') return;
       const internalRecord = this.database.objects(recordType).filtered('id == $0', recordId)[0];
       this.enqueueFunctionsForRecordType(recordType, internalRecord);
     });


### PR DESCRIPTION
Fixes #945 #972 

## Change summary
- Just adds an early return for `Setting` record types in sync post processing.
- I think this is too hacky and I want a better solution. This mainly shows the source of the problem.

## Testing
Steps to reproduce or otherwise test the changes of this PR:
- [ ] Syncing any data which updates `Setting` records does not throw a rejected promise warning - i.e. changing a store tag for a store

### Related areas to think about

I'm not 100% on this post processing yet, but from what I can tell at a high-level:

- A `recordQueue` is created which holds all records from incoming sync
- For each of the records in the `recordQueue`, create another queue of functions to execute for the post processing.
- all the while taking care of crashes etc.

So from what I can tell at a high level, the `recordQueue` is probably to large, as only `Transaction` records and `Requisition` records have functions which are added to the `functionQueue`. So I think this should be changed to have a lookup table of records which should actually be added to the `recordQueue` - maybe better than defaulting to True for adding and having an exclusion table.
