### PR TITLE
#1017 Stocktake/login page leaking

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,37 +1,18 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.msupplymobile">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.msupplymobile">
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <supports-screens
-        android:smallScreens="false"
-        android:normalScreens="false"
-        android:largeScreens="false"
-        android:requiresSmallestWidthDp="720"
-    />
-    <application
-      android:name=".MainApplication"
-      android:allowBackup="true"
-      android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher"
-      android:roundIcon="@mipmap/ic_launcher_round"
-      android:theme="@style/AppTheme">
-      <activity
-        android:name=".MainActivity"
-        android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-        android:screenOrientation="landscape"
-        android:launchMode="singleTop"
-        android:windowSoftInputMode="adjustResize">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-      </activity>
-      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
-      <meta-data android:name="com.bugsnag.android.API_KEY"
-                 android:value="16a680e189b1e5f03f28665870f1401f"/>
-    </application>
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <supports-screens android:smallScreens="false" android:normalScreens="false" android:largeScreens="false" android:requiresSmallestWidthDp="720" />
+  <application android:name=".MainApplication" android:allowBackup="true" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/AppTheme" android:largeHeap="true">
+    <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize" android:screenOrientation="landscape" android:launchMode="singleTop" android:windowSoftInputMode="adjustResize">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    <meta-data android:name="com.bugsnag.android.API_KEY" android:value="16a680e189b1e5f03f28665870f1401f"/>
+  </application>
 
 </manifest>

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -172,11 +172,12 @@ export class StocktakeEditPage extends React.Component {
    */
   onResetItemsConfirm = () => {
     const { database, stocktake, runWithLoadingIndicator } = this.props;
-    this.setState({ isResetModalOpen: false });
-    runWithLoadingIndicator(() => {
-      stocktake.resetStocktakeItems(database, this.itemsOutdated);
-      this.refreshData();
-    });
+    const { itemsOutdated } = stocktake;
+    this.setState({ isResetModalOpen: false }, () =>
+      runWithLoadingIndicator(() => {
+        stocktake.resetStocktakeItems(database, itemsOutdated);
+      })
+    );
   };
 
   getModalTitle = () => {

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -103,19 +103,19 @@ export class StocktakeEditPage extends React.Component {
       sortBy: 'itemName',
       isAscending: true,
     };
-
-    // Validate the current state of the stocktake, use modal to warn user about any issues.
-    this.itemsOutdated = stocktake.itemsOutdated;
-    if (!stocktake.isFinalised && this.itemsOutdated.length > 0) {
-      this.state.isResetModalOpen = true;
-    }
   }
 
   componentDidMount = () => {
-    const { database } = this.props;
+    const { database, stocktake } = this.props;
+    const { itemsOutdated } = stocktake;
     const queryString = 'type == $0 && isActive == true';
     const reasons = database.objects('Options').filtered(queryString, 'stocktakeLineAdjustment');
-    this.setState({ reasons });
+
+    // Validate the current state of the stocktake, use modal to warn user about any issues.
+    this.setState({
+      reasons,
+      isResetModalOpen: !stocktake.isFinalised && itemsOutdated.length > 0,
+    });
   };
 
   reasonModalConfirm = ({ item: option }) => {

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -470,6 +470,12 @@ export class StocktakeEditPage extends React.Component {
     return columns;
   };
 
+  getModalText = () => {
+    const { stocktake } = this.props;
+    const { itemsOutdated } = stocktake;
+    return modalStrings.stocktake_invalid_stock + formatErrorItemNames(itemsOutdated);
+  };
+
   render() {
     const { database, genericTablePageStyles, stocktake, topRoute } = this.props;
     const {
@@ -481,9 +487,6 @@ export class StocktakeEditPage extends React.Component {
       modalKey,
     } = this.state;
     const { REASON_EDIT } = MODAL_KEYS;
-    const resetModalText = isResetModalOpen // Small optimisation.
-      ? modalStrings.stocktake_invalid_stock + formatErrorItemNames(this.itemsOutdated)
-      : '';
 
     return (
       <GenericPage
@@ -516,13 +519,15 @@ export class StocktakeEditPage extends React.Component {
           </PageContentModal>
         )}
 
-        <ConfirmModal
-          coverScreen
-          noCancel
-          isOpen={isResetModalOpen}
-          questionText={resetModalText}
-          onConfirm={this.onResetItemsConfirm}
-        />
+        {isResetModalOpen && (
+          <ConfirmModal
+            coverScreen
+            noCancel
+            isOpen={isResetModalOpen}
+            questionText={this.getModalText()}
+            onConfirm={this.onResetItemsConfirm}
+          />
+        )}
 
         <StocktakeBatchModal
           isOpen={isStocktakeEditModalOpen}

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -110,7 +110,7 @@ export class LoginModal extends React.Component {
       // Annoying reason, so this a crude hack around it.
       !isAuthenticated && (
         <Modal
-          isOpen={true}
+          isOpen={!isAuthenticated}
           style={[globalStyles.modal, globalStyles.authFormModal]}
           backdropPressToClose={false}
           swipeToClose={false}


### PR DESCRIPTION
Fixes #1017 

## Change summary

Not sure if this will fix the problem entirely. I checked the updating of state no-op through creating snapshots of the heap before and after a simple task (logging in, viewing a stock take, others but they were fine) to see if the heap was memory neutral or not. It wasn't, it was increasing, by small amounts. i.e. Login was causing about a 50kb increase to memory usage each time, if not less and viewing a StocktakePage with outdated items was causing ~300kb increase to memory usage.

- `StocktakeEditPage` was have state updates when it was not mounted, through `refreshData` when clicking OK on the `ConfirmModal` when a `Stocktake` had outdated items. Removed the unneeded `refreshData` call and moved logic out of the constructor into `componentDidMount`
- `LoginModal` was updating the underlying `Modal` component after logging in. Removed this
- Increased the heap size - probably not needed

## Testing

- [ ] Login, should not see a yellowbox warning about no-ops on unmounted components
- [ ] Create a stocktake with outdated items, don't see a yellowbox warning about no ops

*BONUS* - Use react-dev-tools
- [ ] Create a snapshot at the login page, login, logout, create a new snapshot. Repeat, should be memory neutral when comparing snapshots
- [ ] Create a snapshot at the menu page, create a stocktake, go back. Create a supplier invoice and adjust stock for an item in the stocktake, view the stocktake. Go back to the menu page and take another snapshot. Repeat. All snapshots should be memory neutral

### Related areas to think about

Few things came up during this which could be made into issues

- use of `componentWillMount` in the app - deprecated method
- Logic in constructors, all over the show, should be in `componentDidMount`, most likely
- `LoginModal` component is pretty crazy and should be rewritten, I think - no real need for state? Pretty heavy use of lifecycle methods for something so simple
