### PR TITLE
#1095 by program refactor 3

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -142,7 +142,7 @@ const createRequisition = (
   user,
   { otherStoreName, program, period, orderType = {}, monthsLeadTime = 0 }
 ) => {
-  const { name: orderTypeName, maxMOS, thresholdMOS } = orderType;
+  const { name: orderTypeName = '', maxMOS = 0, thresholdMOS = 0 } = orderType || {};
   const regimenData =
     program && program.parsedProgramSettings ? program.parsedProgramSettings.regimenData : null;
   const daysToSupply = ((monthsLeadTime || 0) + (maxMOS || 1)) * 30;

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -51,10 +51,8 @@ export class StocktakesPage extends React.Component {
 
   createNewStocktake = properties => {
     const { currentUser, database } = this.props;
-    const { steps, program } = properties;
-    const stocktakeName = steps[1].name;
+    const { program, name: stocktakeName } = properties;
     let stocktake;
-
     database.write(() => {
       stocktake = createRecord(database, 'Stocktake', currentUser, stocktakeName, program);
       stocktake.addItemsFromProgram(database);

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -72,14 +72,15 @@ export class SupplierRequisitionsPage extends React.Component {
     this.refreshData();
   };
 
+  onCancelNewRequisition = () => {
+    this.setState({ byProgramModalOpen: false, isCreatingRequisition: false });
+  };
+
   onNewRequisition = requisitionValues => {
     const { database, currentUser, settings } = this.props;
 
     let requisition;
-    if (!requisitionValues) {
-      this.setState({ byProgramModalOpen: false, isCreatingRequisition: false });
-      return;
-    }
+
     database.write(() => {
       let customData = {};
       try {
@@ -239,7 +240,7 @@ export class SupplierRequisitionsPage extends React.Component {
           queryString="name BEGINSWITH[c] $0"
           sortByString="name"
           onSelect={name => this.onNewRequisition({ otherStoreName: name })}
-          onClose={() => this.onNewRequisition()}
+          onClose={this.onCancelNewRequisition}
           title={modalStrings.search_for_the_supplier}
         />
 
@@ -247,7 +248,7 @@ export class SupplierRequisitionsPage extends React.Component {
           <ByProgramModal
             isOpen={byProgramModalOpen}
             onConfirm={this.onNewRequisition}
-            onCancel={this.onNewRequisition}
+            onCancel={this.onCancelNewRequisition}
             database={database}
             type="requisition"
             settings={settings}


### PR DESCRIPTION
Fixes #1095 

## Change summary

#### Branched from #1097 

Last PR for refactor

- Hooks up the new `ByPRogramModal` to `SupplierRequisitionsPage` and `StocktakesPage`
- Tried to make minimal changes as possible, even though the logic in these is pretty spaghetti, as it should be getting change in `DataTable` rewrite

## Testing
- [ ] When creating a requisition with a program defined, by program modal opens. If no program is defined, the modal does not open
- [ ] When creating a stocktake with a program defined, by program modal opens. If no program is defined, the modal does not open

**Creating a program requisition:**
- [ ]  must select steps in order - program, supplier, period, order type.
- [ ] Can back pedal steps, where the progress is adjusted correctly
- [ ] Only order types which are defined for a program are displayed
- [ ] Only periods for the order type defined are displayed
- [ ] Order types, when being selected show the correct details (MOS etc.)
- [ ] Periods, when being selected show the correct details (number of requisitions etc.)
- [ ] Switching between general and program orders adjusts the steps correctly
- [ ] OK is enabled when all steps are complete
- [ ] closing the modal, closes the modal
- [ ] programs items are added to the requisition

**Creating a stocktakes requisition:**
- [ ] must select steps in order - program, name or name if toggled
- [ ] Can back pedal steps, where the progress is adjusted correctly
- [ ] Name used is the name applied to the stock take
- [ ] programs items are added to the stocktake
### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
