### PR TITLE
#1102 foreign item lines IC special

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "2.3.5",
+  "version": "2.3.6-IC1",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "2.3.6-IC1",
+  "version": "2.3.6-rc1",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/database/migration/v2.js
+++ b/src/database/migration/v2.js
@@ -251,6 +251,7 @@ const v2Migrations = [
           });
           // Add the transaction batch into the new item batch
           newItemBatch.addTransactionBatchIfUnique(transactionBatch);
+          item.addBatch(newItemBatch);
           database.save('ItemBatch', newItemBatch);
           // Update the TransactionBatch with the newly created ItemBatch
           database.update('TransactionBatch', {

--- a/src/database/migration/v2.js
+++ b/src/database/migration/v2.js
@@ -140,7 +140,7 @@ const v2Migrations = [
     migrate: database => {
       // *** PART ONE, find foreign item line and delete
 
-      const itemBatches = this.database.objects('ItemBatch').snapshot();
+      const itemBatches = database.objects('ItemBatch').snapshot();
       const itemBatcheIDsToDelete = [];
       // Assuming this exists everywhere
       const inventoryAdjustmentName = database
@@ -195,7 +195,7 @@ const v2Migrations = [
       // Delete foreign item lines
       database.write(() => {
         itemBatcheIDsToDelete.forEach(id => {
-          database.delete('ItemBatch', database.objects('ItemLine').filtered('id = $0', id));
+          database.delete('ItemBatch', database.objects('ItemBatch').filtered('id = $0', id));
         });
       });
 

--- a/src/database/migration/v2.js
+++ b/src/database/migration/v2.js
@@ -141,7 +141,7 @@ const v2Migrations = [
       // *** PART ONE, find foreign item line and delete
 
       const itemBatches = database.objects('ItemBatch').snapshot();
-      const itemBatcheIDsToDelete = [];
+      const itemBatchIDsToDelete = [];
       // Assuming this exists everywhere
       const inventoryAdjustmentName = database
         .objects('Name')
@@ -150,7 +150,7 @@ const v2Migrations = [
       itemBatches.forEach(({ id, transactionBatches }) => {
         // No transaction batches on item line should mean it's foreign
         if (transactionBatches.length === 0) {
-          itemBatcheIDsToDelete.push(id);
+          itemBatchIDsToDelete.push(id);
           return;
         }
         // supplier_invoice type transactions are all addition transactions
@@ -191,12 +191,12 @@ const v2Migrations = [
           const hasStockAddition = stocktakeBatches[0].countedNumberOfPacks > 0;
           if (snapShotIsZero && hasStockAddition) return;
         }
-        itemBatcheIDsToDelete.push(id);
+        itemBatchIDsToDelete.push(id);
       });
 
       // Delete foreign item lines
       database.write(() => {
-        itemBatcheIDsToDelete.forEach(id => {
+        itemBatchIDsToDelete.forEach(id => {
           database.delete('ItemBatch', database.objects('ItemBatch').filtered('id = $0', id));
         });
       });
@@ -204,7 +204,7 @@ const v2Migrations = [
       // *** PART TWO, delete sync outs for those Item Batches that were just deleted
 
       database.write(() => {
-        itemBatcheIDsToDelete.forEach(id => {
+        itemBatchIDsToDelete.forEach(id => {
           const syncOuts = database.objects('SyncOut').filtered('recordId = $0', id);
           if (syncOuts.length > 0) database.delete('SyncOut', syncOuts);
         });

--- a/src/database/migration/v2.js
+++ b/src/database/migration/v2.js
@@ -3,12 +3,12 @@ import { generateUUID } from 'react-native-database';
 import { SETTINGS_KEYS } from '../../settings';
 
 /**
- * 2.3.6-IC1: An unavoidable situation around the time 2.3.5 was released, delete records
+ * 2.3.6-rc1: An unavoidable situation around the time 2.3.5 was released, delete records
  *       for item lines were synced to mobile. This caused issues having TransactionBatch
  *       records with no related ItemBatch. Solution was to use migration code to
  *       create ItemBatch records for these TransactionBatches with a quantity of zero.
  *
- * 2.3.6-IC1: Also we want to find and delete all foreign batches. Then run migration as per
+ * 2.3.6-rc1: Also we want to find and delete all foreign batches. Then run migration as per
  *       above, then make sure to delete, deleted batches from sync out queue
  */
 
@@ -136,7 +136,7 @@ const v2Migrations = [
     },
   },
   {
-    version: '2.3.6-IC1',
+    version: '2.3.6-rc1',
     migrate: database => {
       // *** PART ONE, find foreign item line and delete
 

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -322,6 +322,8 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       break;
     }
     case 'ItemBatch': {
+      // Not for this store
+      if (record.store_ID !== settings.get(THIS_STORE_ID)) break;
       const item = database.getOrCreate('Item', record.item_ID);
       const packSize = parseNumber(record.pack_size);
       internalRecord = {


### PR DESCRIPTION
Fixes #1102 

## Change summary

It's hard to identify the 'first' transaction (since confirmDate lacks the time if tablet was reinitialised or created from desktop site)
So instead, look at all of the transactionBatches for an itemBatch:
* If we find one that belongs to supplier invoice, then don't delete
* Look at all of the addition inventory adjustments
  * If inventory adjustment doesn't have stock take, don't delete (Mobile site must have been created from a desktop site, and stock was increased with just inventory adjustments, take not that mobile does not integrate foreign transactions)
  * If inventory adjustment does have a stock take, find StocktakeBatch that references current itemBatch and see if it's an increasing record from 0 snapshot, if so then don't delete
* Delete every ItemBatch that wasn't skipped
* Delete from sync out the fresh deletions
* Make sure transaction batches have itemBatch (@joshxg PR that i'am branching from)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] - Sync a mobile store with version <= 2.3.5
- [ ] - Run this foot runner code:
```
QUERY([item_line];[item_line]store_ID={foreignStoreID})
REDUCE SELECTION([item_line];1)
sync_generate_sync_record (Table(->[item_line]);"I";12;"";{syncSiteID};{mobileStoreID})
```
- [ ] - Sync the tablet, you will see you have a foreign Item Line (check stock page in mobile)
- [ ] - Upgrade to this version
- [ ] - Item Line should be deleted

To fully test though, before the upgrade step, do the following
- [ ] - Create stock takes, with increasing and decreasing stock lines for this item line (finalise them)
- [ ] - Create a stock take but don't finalise (with this item line)
- [ ] - Create reducing customer invoices with this item line
- [ ] - Upgrade
- [ ] - Make sure the customer invoices you've entered can be opened, also make sure all of the stock takes created with item line can be opened, and in un finalised stock take can still edit counted quantities etc (and can finalise)

### Related areas to think about

The branch this PR is going into will be IC specific.

@mark-prins, this is the fix, we need to test it a little bit further (tonight) and make a release for you.
A few more conditions then i though (due to not being able to find the 'first' transaction for the itemLine and some mobile sites were created from desktop sites)
