### PR TITLE
#1107 Separate CPU Architecture APKs

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -113,7 +113,7 @@ def appVersionCode = ((major.toInteger() * 10000000) + (minor.toInteger() * 1000
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
-    setProperty("archivesBaseName", getAppName() + "-" + getAppVersion())
+    setProperty("archivesBaseName", (getAppName() + "-" + getAppVersion()).replace(".","_"))
     defaultConfig {
         applicationId "com.msupplymobile"
         minSdkVersion rootProject.ext.minSdkVersion

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -145,7 +145,6 @@ android {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             signingConfig signingConfigs.release
-
         }
     }
     // applicationVariants are e.g. debug, release

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -100,6 +100,12 @@ def getAppVersion() {
     return packageJson["version"]
 }
 
+def getAppName() {
+    def inputFile = new File("../package.json")
+    def packageJson = new JsonSlurper().parseText(inputFile.text)
+    return packageJson["name"]
+}
+
 def (appVersion, provisional) = getAppVersion().tokenize('-rc')
 def (major, minor, patch) = appVersion.tokenize('.')
 def appVersionCode = ((major.toInteger() * 10000000) + (minor.toInteger() * 100000) + (patch.toInteger() * 100) + (provisional != null ? provisional.toInteger() : 99))
@@ -107,7 +113,7 @@ def appVersionCode = ((major.toInteger() * 10000000) + (minor.toInteger() * 1000
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
-
+    setProperty("archivesBaseName", getAppName() + "-" + getAppVersion())
     defaultConfig {
         applicationId "com.msupplymobile"
         minSdkVersion rootProject.ext.minSdkVersion
@@ -139,6 +145,7 @@ android {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             signingConfig signingConfigs.release
+
         }
     }
     // applicationVariants are e.g. debug, release
@@ -151,7 +158,7 @@ android {
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =
                         versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
-            }
+            }   
         }
     }
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -87,7 +87,7 @@ apply from: "../../node_modules/react-native/react.gradle"
  * Upload all the APKs to the Play Store and people will download
  * the correct one based on the CPU architecture of their device.
  */
-def enableSeparateBuildPerCPUArchitecture = false
+def enableSeparateBuildPerCPUArchitecture = true
 
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
@@ -130,7 +130,7 @@ android {
         abi {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
-            universalApk false  // If true, also generate a universal APK
+            universalApk true  // If true, also generate a universal APK
             include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }


### PR DESCRIPTION
Fixes #1107 

## Change summary

@Chris-Petty made a solid point that double the size of the APK is not an insignificant problem when dealing with users in remote locations. Solution is to build a separate APK for x86 and ARMv7a AND a universal APK.

- Currently develop is creating a single APK for both 32 and 64 bit as well as x86 and ARMv7a architectures. This has an APK size of around 33Mb. This was an increase over the previous APK size of aaround 15mb, which was only creating a 32bit APK.
- This PR edits our gradle config to build 5 APKs - one for 32/64bit x86 and ARMv7a architectures AND a universal APK.
- The universal APK:
![image](https://user-images.githubusercontent.com/35858975/63206294-f8856600-c105-11e9-8fea-210f241ac8e4.png)
- Individual architecture APKs:
![image](https://user-images.githubusercontent.com/35858975/63206303-105cea00-c106-11e9-9822-0a2242a5253e.png)


All APKs generated:
![image](https://user-images.githubusercontent.com/35858975/63206304-2074c980-c106-11e9-86bd-bb8d4c3968bf.png)


Build process output json: 

[output.json.zip](https://github.com/openmsupply/mobile/files/3511630/output.json.zip)

Figured may aswel have the best of both worlds - use the universal APK when network usage isn't a problem and a smaller one when it is.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] On this branch, `yarn build` (using java 11+ and node 10+). Should generate 5 APKs as above.
- [ ] Check each APK in android studio->debug APK to view contents
- [ ] Each APK tested on it's respective CPU architecture on a real tablet (hehe)
- [ ] Universal APK tested on each CPU architecture on real tablets

### Related areas to think about

I think this is the best solution. It is quite annoying having to know what the exact tablet is before being able to provide anyone with an APK, or providing several and telling anyone - users, consulants or anyone that they have to figure out their CPU architecture before they can install it. I think a universal APK is really needed. 

If we had our app on google play store, there are several other things we can do, not only will the playstore download for anyone the correct apk for their device, but building can also be done on the playstore also, I believe. One day?
