### PR TITLE
#1110 New CustomerInvoicePage sorting feature

### DIFF
--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -307,7 +307,7 @@ const deselectAll = () => ({
 });
 
 const sortData = (sortBy, isAscending) => ({
-  type: 'sortData',
+  type: 'sortBy',
   sortBy,
   isAscending,
 });

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -264,8 +264,13 @@ const reducer = (state, action) => {
       // that was set by the last sortBy action. Otherwise, default to true.
       const newIsAscending = newSortBy === sortBy ? !isAscending : true;
 
-      const newData = newSortDataBy(data, sortBy, columnKeyToDataType[sortBy], newIsAscending);
-      return { ...state, data: newData, sortBy, isAscending: newIsAscending };
+      const newData = newSortDataBy(
+        data,
+        newSortBy,
+        columnKeyToDataType[newSortBy],
+        newIsAscending
+      );
+      return { ...state, data: newData, sortBy: newSortBy, isAscending: newIsAscending };
     }
     default:
       return state;

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -251,8 +251,8 @@ const reducer = (state, action) => {
       return { ...state, dataState: newDataState };
     }
     case 'sortBy': {
-      const { data, isAscending } = state;
-      const { sortBy } = action;
+      const { data, isAscending, sortBy } = state;
+      const { sortBy: newSortBy } = action;
       const columnKeyToDataType = {
         itemCode: 'string',
         itemName: 'string',
@@ -260,8 +260,12 @@ const reducer = (state, action) => {
         totalQuantity: 'number',
       };
 
-      const newData = newSortDataBy(data, sortBy, columnKeyToDataType[sortBy], isAscending);
-      return { ...state, data: newData, sortBy, isAscending: !isAscending };
+      // If the new sortBy is the same as the sortBy in state, then invert isAscending
+      // that was set by the last sortBy action. Otherwise, default to true.
+      const newIsAscending = newSortBy === sortBy ? !isAscending : true;
+
+      const newData = newSortDataBy(data, sortBy, columnKeyToDataType[sortBy], newIsAscending);
+      return { ...state, data: newData, sortBy, isAscending: newIsAscending };
     }
     default:
       return state;

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -648,7 +648,6 @@ CustomerInvoicePage.propTypes = {
   database: PropTypes.object.isRequired,
   genericTablePageStyles: PropTypes.object.isRequired,
   runWithLoadingIndicator: PropTypes.func.isRequired,
-
   transaction: PropTypes.object.isRequired,
 };
 

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -328,7 +328,7 @@ export const CustomerInvoicePage = ({
   runWithLoadingIndicator,
 }) => {
   const [tableState, dispatch] = useReducer(reducer, {
-    data: transaction.items.slice(),
+    data: transaction.items.sorted('item.name').slice(),
     database,
     dataState: new Map(),
     currentFocusedRowKey: null,

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -11,7 +11,7 @@ import Icon from 'react-native-vector-icons/Ionicons';
 import FAIcon from 'react-native-vector-icons/FontAwesome';
 
 import { createRecord } from '../database';
-import { formatDate, parsePositiveInteger, debounce } from '../utilities';
+import { formatDate, parsePositiveInteger, debounce, newSortDataBy } from '../utilities';
 import { buttonStrings, modalStrings, pageInfoStrings, tableStrings } from '../localization';
 import { AutocompleteSelector, PageButton, PageInfo, TextEditor } from '../widgets';
 import { BottomConfirmModal, PageContentModal } from '../widgets/modals';
@@ -249,6 +249,19 @@ const reducer = (state, action) => {
         }
       }
       return { ...state, dataState: newDataState };
+    }
+    case 'sortBy': {
+      const { data, isAscending } = state;
+      const { sortBy } = action;
+      const columnKeyToDataType = {
+        itemCode: 'string',
+        itemName: 'string',
+        availableQuantity: 'number',
+        totalQuantity: 'number',
+      };
+
+      const newData = newSortDataBy(data, sortBy, columnKeyToDataType[sortBy], isAscending);
+      return { ...state, data: newData, sortBy, isAscending: !isAscending };
     }
     default:
       return state;

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -9,7 +9,7 @@ export {
   formatPlural,
 } from 'sussol-utilities';
 export { formatStatus } from './formatStatus';
-export { sortDataBy } from './sortDataBy';
+export { sortDataBy, newSortDataBy } from './sortDataBy';
 export { compareVersions } from './compareVersions';
 export { createReducer, REHYDRATE } from './createReducer';
 export { getAllPeriodsForProgram, getAllPrograms } from './byProgram';

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -15,3 +15,4 @@ export { createReducer, REHYDRATE } from './createReducer';
 export { getAllPeriodsForProgram, getAllPrograms } from './byProgram';
 export { requestPermission } from './requestPermission';
 export { backupValidation } from './fileSystem';
+export { debounce } from './underscoreMethods';

--- a/src/utilities/sortDataBy.js
+++ b/src/utilities/sortDataBy.js
@@ -63,7 +63,7 @@ export const newSortDataBy = (data, sortBy, sortDataType, isAscending = true) =>
       if (isAscending) return [...data.sort((a, b) => b[sortBy] - a[sortBy])];
       return [...data.sort((a, b) => a[sortBy] - b[sortBy])];
     default:
-      return [...data];
+      throw new Error('Invalid sortDataType');
   }
 };
 

--- a/src/utilities/sortDataBy.js
+++ b/src/utilities/sortDataBy.js
@@ -38,4 +38,33 @@ export const sortDataBy = (data, sortBy, sortDataType, isAscending = true) => {
   return sortedData;
 };
 
+/**
+ * Sorts an array of objects, returning a new array.
+ * Sorts strings, numbers, dates or booleans.
+ * Types: 'string', 'number', 'date', 'boolean'.
+ * @param {Array}   data          Array of objects to sort
+ * @param {String}  sortBy        Key for the field to sort by
+ * @param {String}  sortDataType  The type of data to sort
+ * @param {Boolean} isAscending   True if ascending, false otherwise.
+ */
+export const newSortDataBy = (data, sortBy, sortDataType, isAscending = true) => {
+  switch (sortDataType) {
+    case 'string':
+      if (isAscending) return [...data.sort((a, b) => b[sortBy].localeCompare(a[sortBy]))];
+      return [...data.sort((a, b) => a[sortBy].localeCompare(b[sortBy]))];
+    case 'number':
+      // Casts to number to cover cases where the property is a string (e.g. |serialNumber|).
+      if (isAscending) return [...data.sort((a, b) => Number(a[sortBy]) - Number(b[sortBy]))];
+      return [...data.sort((a, b) => Number(b[sortBy]) - Number(a[sortBy]))];
+    case 'date':
+      if (isAscending) return [...data.sort((a, b) => new Date(b[sortBy]) - new Date(a[sortBy]))];
+      return [...data.sort((a, b) => new Date(a[sortBy]) - new Date(b[sortBy]))];
+    case 'boolean':
+      if (isAscending) return [...data.sort((a, b) => b[sortBy] - a[sortBy])];
+      return [...data.sort((a, b) => a[sortBy] - b[sortBy])];
+    default:
+      return [...data];
+  }
+};
+
 export default sortDataBy;

--- a/src/utilities/sortDataBy.js
+++ b/src/utilities/sortDataBy.js
@@ -51,8 +51,8 @@ export const sortDataBy = (data, sortBy, sortDataType, isAscending = true) => {
 export const newSortDataBy = (data, sortBy, sortDataType, isAscending = true) => {
   switch (sortDataType) {
     case 'string':
-      if (isAscending) return [...data.sort((a, b) => b[sortBy].localeCompare(a[sortBy]))];
-      return [...data.sort((a, b) => a[sortBy].localeCompare(b[sortBy]))];
+      if (isAscending) return [...data.sort((a, b) => a[sortBy].localeCompare(b[sortBy]))];
+      return [...data.sort((a, b) => b[sortBy].localeCompare(a[sortBy]))];
     case 'number':
       // Casts to number to cover cases where the property is a string (e.g. |serialNumber|).
       if (isAscending) return [...data.sort((a, b) => Number(a[sortBy]) - Number(b[sortBy]))];

--- a/src/utilities/sortDataBy.js
+++ b/src/utilities/sortDataBy.js
@@ -42,10 +42,11 @@ export const sortDataBy = (data, sortBy, sortDataType, isAscending = true) => {
  * Sorts an array of objects, returning a new array.
  * Sorts strings, numbers, dates or booleans.
  * Types: 'string', 'number', 'date', 'boolean'.
- * @param {Array}   data          Array of objects to sort
- * @param {String}  sortBy        Key for the field to sort by
- * @param {String}  sortDataType  The type of data to sort
- * @param {Boolean} isAscending   True if ascending, false otherwise.
+ * @param  {Array}   data          Array of objects to sort
+ * @param  {String}  sortBy        Key for the field to sort by
+ * @param  {String}  sortDataType  The type of data to sort
+ * @param  {Boolean} isAscending   True if ascending, false otherwise.
+ * @return {Array}   A new array of sorted data
  */
 export const newSortDataBy = (data, sortBy, sortDataType, isAscending = true) => {
   switch (sortDataType) {

--- a/src/utilities/underscoreMethods.js
+++ b/src/utilities/underscoreMethods.js
@@ -1,0 +1,28 @@
+/* eslint-disable import/prefer-default-export */
+
+// Credit David Walsh (https://davidwalsh.name/javascript-debounce-function)
+// Slightly editted for linter to accept.
+// Returns a function, that, as long as it continues to be invoked, will not
+// be triggered. The function will be called after it stops being called for
+// N milliseconds. If `immediate` is passed, trigger the function on the
+// leading edge, instead of the trailing.
+export function debounce(func, wait, immediate) {
+  let timeout;
+
+  return function executedFunction(...args) {
+    const context = this;
+
+    const later = () => {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    };
+
+    const callNow = immediate && !timeout;
+
+    clearTimeout(timeout);
+
+    timeout = setTimeout(later, wait);
+
+    if (callNow) func.apply(context, args);
+  };
+}

--- a/src/widgets/DataTable/HeaderCell.js
+++ b/src/widgets/DataTable/HeaderCell.js
@@ -35,7 +35,7 @@ const HeaderCell = React.memo(
       }
     };
 
-    const Container = onPressAction ? View : TouchableOpacity;
+    const Container = onPressAction ? TouchableOpacity : View;
 
     return (
       <Container style={defaultStyles.headerCell} onPress={onPress} {...otherProps}>


### PR DESCRIPTION
Fixes #1110 

#### EPIC: #1043
~~#### BRANCHED FROM #1090 - Should be merged before this~~ done

## Change summary

- Adds a debounce method stolen from `underscore.js`
- Adds sorting functionality
    - I found layouts were a fraction faster/the same as using realm for up to 100 records, with realm starting to pull slightly ahead after that, for non-getter fields. The same for getter fields. Didn't think the performance gain of a few miliseconds was worth the complexity increase. However, very easy to refactor if we do think it is worth it.

## Testing
- [ ] Customer invoice page can be sorted be column

### Related areas to think about

- Rename sorting method when integrating this feature into develop
- Different way to steal `underscore.js` methods?


#### Branches:

- [ ] #1115 - Data table filtering 
- [ ] #1116 - Data table data type synchronization
- [ ] #1117 - Data table refactor
