### PR TITLE
#1111 New CustomerInvoicePage filtering feature

### DIFF
--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -148,12 +148,26 @@ const reducer = (state, action) => {
 
   switch (action.type) {
     case 'filterData': {
-      const { backingData, filterDataKeys } = state;
+      const { backingData, filterDataKeys, sortBy, isAscending } = state;
       const { searchTerm } = action;
+
+      const columnKeyToDataType = {
+        itemCode: 'string',
+        itemName: 'string',
+        availableQuantity: 'number',
+        totalQuantity: 'number',
+      };
+
       const queryString = filterDataKeys
         .map(filterTerm => `${filterTerm} BEGINSWITH[c]  $0`)
         .join(' OR ');
-      const newData = backingData.filtered(queryString, searchTerm).slice();
+
+      const newData = newSortDataBy(
+        backingData.filtered(queryString, searchTerm).slice(),
+        sortBy,
+        columnKeyToDataType[sortBy],
+        isAscending
+      );
       return { ...state, data: newData };
     }
     case 'editCell': {


### PR DESCRIPTION
Fixes #1111

**Forgot to rename this branch before publishing, oopsies**
#### EPIC: #1043
#### BRANCHED FROM #1110 - should be merged before this

## Change summary

- Adds a simple filtering mechanism
- Went with the simple approach, using realm to query a `backingData` in state, returning a filtered version of that.
- Could add realm sorting on top, but would also have to determine if the field is a getter/setter etc etc - just doing it simple

## Testing
- [ ] `CustomerInvoicePage` filtering functionality works

### Related areas to think about

As above - dealing with sorting while filtering. I think keeping this simple for now is a good option, personally - just removing the sorting. Hard to know if the added complexity is really actually worth it. I don't see adding a filter then pushing a sort button to be odd
