### PR TITLE
#1112 New CustomerInvoicePage data types shnychronizationh feature

### DIFF
--- a/src/hooks/useDatabaseListener.js
+++ b/src/hooks/useDatabaseListener.js
@@ -1,0 +1,59 @@
+/* eslint-disable import/prefer-default-export */
+import { useEffect, useRef } from 'react';
+import { debounce } from '../utilities';
+
+/**
+ * Custom hook for subscribing to database changes from sync.
+ * Takes a callback to call when a notified of a particular
+ * subscribed event. An array of data types to subscribe to
+ * and the database to listen to changes.
+ * When a component calling this method unmounts, changes will
+ * be unsubscribed.
+ * Callback is debounced, only being called after 10seconds of the
+ * last sync notification.
+ * Filtering is done in this hook, only notifying of sync changes
+ * for record types passed in dataTypes
+ * @param {Func}   callback  A function to call when notified of changes.
+ * @param {Array}  dataTypes Record types to listen to changes for.
+ * @param {Object} database  Database to subscribe to.
+ * Example dataTypes: ['Item', 'ItemBatch'] - must be in realm schema.
+ * @return {Array}
+ * isSubscribed - boolean indicating if currently subscribed
+ * subscribe - function to subscribe, if not already
+ * unSubscribe - function to unSubscribe, if already subscribed
+ */
+export const useDatabaseListener = ({ callback, dataTypes, database }) => {
+  // Reference for being subscribed
+  const isSubscribed = useRef(false);
+  // Debounced callback, only calling 10 seconds after the last invocation
+  const debouncedCallback = debounce(callback, 10000);
+
+  const subscribe = () => {
+    if (isSubscribed.current) return null;
+    isSubscribed.current = true;
+    return database.addListener(filterResults);
+  };
+
+  const unSubscribe = callbackId => {
+    if (!isSubscribed.current) return;
+    database.removeListener(callbackId);
+    isSubscribed.current = false;
+  };
+
+  // Subscribing to the database notifies of all changes made. Filter
+  // notifications by sync causation and by the record types provided.
+  const filterResults = (changeType, recordType, record, causedBy) => {
+    if (dataTypes.includes(recordType) && causedBy === 'sync') {
+      debouncedCallback(changeType, recordType, record, causedBy);
+    }
+  };
+
+  // Subscribe to the database on first invocation and when the
+  // calling component unmounts.
+  useEffect(() => {
+    const callbackId = subscribe();
+    return () => unSubscribe(callbackId);
+  }, []);
+
+  return [isSubscribed, subscribe, unSubscribe];
+};


### PR DESCRIPTION
Fixes #1112

#### EPIC: #1043
#### BRANCHED FROM #1111  - should be merged before this

## Change summary

- Adds a simple database listener 

**NOTE:** Currently when sync occurs, `mSupplyMobileAppContainer` re-renders, re-rendering the entire app (and for some reason also unmounting like, everything). So, without actually plugging this into the page, the data table will refresh on syncing a synchronized data type .. or, all data types. So it is not actually hooked up. I think it is a reasonably large refactor to fix this problem, so I've not done it yet. I had already written this hook, though, so I figured I'd PR it in. 

Have tested and it was triggering the event on the correct data types. Quite simple to hook up - just need a `useDatabaseListener( .. )` and a `callback` which sends a `dispatch` ....... `refreshData` 🤣 - could use a better action, which finds the rows the sync changes are related to, but doing this rather than just re-rendering seems premature. 

## Testing
- [ ] Hooking this hook up to a component will trigger the callback passed on incoming sync change for a data type provided.

### Related areas to think about

Could add to this hook:
- Toast functionality
- Grouping the debounced calls, such that you can see '3 item names changed' etc.
