### PR TITLE
#1136 New CustomerInvoicePage refactor two

### DIFF
--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -256,6 +256,7 @@ export class Transaction extends Realm.Object {
    * @param   {Array.<string>}  itemIds
    */
   removeItemsById(database, itemIds) {
+    if (!this.items.length) return;
     const itemsToDelete = [];
     for (let i = 0; i < itemIds.length; i += 1) {
       const transactionItem = this.items.find(testItem => testItem.id === itemIds[i]);

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -256,7 +256,6 @@ export class Transaction extends Realm.Object {
    * @param   {Array.<string>}  itemIds
    */
   removeItemsById(database, itemIds) {
-    if (!this.items.length) return;
     const itemsToDelete = [];
     for (let i = 0; i < itemIds.length; i += 1) {
       const transactionItem = this.items.find(testItem => testItem.id === itemIds[i]);

--- a/src/globalStyles/newPageStyles.js
+++ b/src/globalStyles/newPageStyles.js
@@ -35,7 +35,7 @@ const newPageStyles = {
     flexDirection: 'column',
     alignItems: 'flex-start',
     justifyContent: 'space-between',
-    width: 500,
+    flex: 2,
     paddingHorizontal: 10,
   },
   newPageTopRightSectionContainer: {

--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -6,6 +6,7 @@
 import { useReducer, useCallback } from 'react';
 import getReducer from '../pages/dataTableUtilities/reducer/getReducer';
 import getColumns from '../pages/dataTableUtilities/columns';
+import getPageInfo from '../pages/dataTableUtilities/pageInfo';
 import { debounce } from '../utilities/index';
 
 /**
@@ -31,7 +32,8 @@ const usePageReducer = (
   instantDebounceTimeout = 250
 ) => {
   const columns = getColumns(page);
-  const [state, dispatch] = useReducer(getReducer(page), { ...initialState, columns });
+  const pageInfo = getPageInfo(page);
+  const [state, dispatch] = useReducer(getReducer(page), { ...initialState, columns, pageInfo });
 
   const debouncedDispatch = useCallback(debounce(dispatch, debounceTimeout), []);
   const instantDebouncedDispatch = useCallback(

--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -41,13 +41,18 @@ const usePageReducer = (
     pageInfo,
   });
 
-  const debouncedDispatch = useCallback(debounce(dispatch, debounceTimeout), []);
+  const thunkDispatcher = action => {
+    if (typeof action === 'function') action(dispatch, state);
+    dispatch(action);
+  };
+
+  const debouncedDispatch = useCallback(debounce(thunkDispatcher, debounceTimeout), []);
   const instantDebouncedDispatch = useCallback(
-    debounce(dispatch, instantDebounceTimeout, true),
+    debounce(thunkDispatcher, instantDebounceTimeout, true),
     []
   );
 
-  return [state, dispatch, instantDebouncedDispatch, debouncedDispatch];
+  return [state, thunkDispatcher, instantDebouncedDispatch, debouncedDispatch];
 };
 
 export default usePageReducer;

--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -3,7 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import { useReducer, useCallback } from 'react';
+import { useReducer, useCallback, useMemo } from 'react';
 import getReducer from '../pages/dataTableUtilities/reducer/getReducer';
 import getColumns from '../pages/dataTableUtilities/columns';
 import getPageInfo from '../pages/dataTableUtilities/pageInfo';
@@ -12,8 +12,9 @@ import { debounce } from '../utilities/index';
 /**
  * useReducer wrapper for pages within the app. Creates a
  * composed reducer through getReducer for a particular
- * page as well as fetching the required columns and inserting
- * them into the initial state of the component.
+ * page as well as fetching the required data table columns
+ * and page info columns and inserting them into the initial
+ * state of the component.
  *
  * Returns the current state as well as three dispatchers for
  * actions to the reducer - a regular dispatch and two debounced
@@ -33,7 +34,7 @@ const usePageReducer = (
 ) => {
   const columns = getColumns(page);
   const pageInfo = getPageInfo(page);
-  const memoizedReducer = useCallback(getReducer(page), []);
+  const memoizedReducer = useMemo(() => getReducer(page), []);
   const [state, dispatch] = useReducer(memoizedReducer, {
     ...initialState,
     columns,

--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -48,7 +48,7 @@ const usePageReducer = (
 
   const thunkDispatcher = action => {
     if (typeof action === 'function') action(dispatch, state);
-    dispatch(action);
+    else dispatch(action);
   };
 
   const debouncedDispatch = useCallback(debounce(thunkDispatcher, debounceTimeout), []);

--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -16,6 +16,11 @@ import { debounce } from '../utilities/index';
  * and page info columns and inserting them into the initial
  * state of the component.
  *
+ * Dispatch returned from useReducer is wrapped allowing the use
+ * of thunks. Actions can return either a plain object or a function.
+ * If a function is returned, it is called, rather than dispatched,
+ * allowing actions to perform side-effects.
+ *
  * Returns the current state as well as three dispatchers for
  * actions to the reducer - a regular dispatch and two debounced
  * dispatchers - which group sequential calls within the timeout
@@ -32,8 +37,8 @@ const usePageReducer = (
   debounceTimeout = 250,
   instantDebounceTimeout = 250
 ) => {
-  const columns = getColumns(page);
-  const pageInfo = getPageInfo(page);
+  const columns = useMemo(() => getColumns(page), [page]);
+  const pageInfo = useMemo(() => getPageInfo(page), [page]);
   const memoizedReducer = useMemo(() => getReducer(page), []);
   const [state, dispatch] = useReducer(memoizedReducer, {
     ...initialState,

--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -33,7 +33,12 @@ const usePageReducer = (
 ) => {
   const columns = getColumns(page);
   const pageInfo = getPageInfo(page);
-  const [state, dispatch] = useReducer(getReducer(page), { ...initialState, columns, pageInfo });
+  const memoizedReducer = useCallback(getReducer(page), []);
+  const [state, dispatch] = useReducer(memoizedReducer, {
+    ...initialState,
+    columns,
+    pageInfo,
+  });
 
   const debouncedDispatch = useCallback(debounce(dispatch, debounceTimeout), []);
   const instantDebouncedDispatch = useCallback(

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
 
-import { createRecord } from '../database';
 import { debounce, MODAL_KEYS, getModalTitle } from '../utilities';
 import { buttonStrings, modalStrings } from '../localization';
 
@@ -48,6 +47,7 @@ import {
   openBasicModal,
   closeBasicModal,
   addMasterListItems,
+  addItem,
 } from './dataTableUtilities/actions';
 
 import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
@@ -227,14 +227,7 @@ export const CustomerInvoicePage = ({
             queryString="name BEGINSWITH[c] $0 OR code BEGINSWITH[c] $0"
             queryStringSecondary="name CONTAINS[c] $0"
             sortByString="name"
-            onSelect={item => {
-              database.write(() => {
-                if (!transaction.hasItem(item)) {
-                  createRecord(database, 'TransactionItem', transaction, item);
-                }
-              });
-              dispatch(closeBasicModal());
-            }}
+            onSelect={item => dispatch(addItem(item, 'TransactionItem'))}
             renderLeftText={item => `${item.name}`}
             renderRightText={item => `${item.totalQuantity}`}
           />

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -75,8 +75,8 @@ export const CustomerInvoicePage = ({
     routeName,
     {
       pageObject: transaction,
-      backingData: transaction.items,
-      data: transaction.items.sorted('item.name').slice(),
+      backingData: transaction.items.sorted('item.name'),
+      data: transaction.items.slice(),
       database,
       keyExtractor,
       dataState: new Map(),

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -46,6 +46,7 @@ import {
   sortData,
   filterData,
   openBasicModal,
+  closeBasicModal,
 } from './dataTableUtilities/actions';
 
 import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
@@ -102,8 +103,6 @@ export const CustomerInvoicePage = ({
       break;
     }
   }
-
-  const closeModal = () => setModalIsOpen(false);
 
   const getModalTitle = () => {
     switch (modalKey) {
@@ -277,7 +276,7 @@ export const CustomerInvoicePage = ({
                   createRecord(database, 'TransactionItem', transaction, item);
                 }
               });
-              closeModal();
+              dispatch(closeBasicModal());
             }}
             renderLeftText={item => `${item.name}`}
             renderRightText={item => `${item.totalQuantity}`}
@@ -294,7 +293,7 @@ export const CustomerInvoicePage = ({
                   database.save('Transaction', transaction);
                 });
               }
-              closeModal();
+              dispatch(closeBasicModal());
             }}
           />
         );
@@ -309,7 +308,7 @@ export const CustomerInvoicePage = ({
                   database.save('Transaction', transaction);
                 });
               }
-              closeModal();
+              dispatch(closeBasicModal());
             }}
           />
         );
@@ -408,7 +407,7 @@ export const CustomerInvoicePage = ({
       />
       <PageContentModal
         isOpen={modalIsOpen && !transaction.isFinalised}
-        onClose={closeModal}
+        onClose={() => dispatch(closeBasicModal())}
         title={getModalTitle()}
       >
         {renderModalContent()}

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -75,8 +75,8 @@ export const CustomerInvoicePage = ({
     routeName,
     {
       pageObject: transaction,
-      backingData: transaction.items.sorted('item.name'),
-      data: transaction.items.slice(),
+      backingData: transaction.items,
+      data: transaction.items.sorted('item.name').slice(),
       database,
       keyExtractor,
       dataState: new Map(),

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -85,7 +85,6 @@ export const CustomerInvoicePage = ({
       filterDataKeys: ['item.name'],
       sortBy: 'itemName',
       isAscending: true,
-      modalIsOpen: false,
       modalKey: '',
       hasSelection: false,
     }
@@ -98,7 +97,6 @@ export const CustomerInvoicePage = ({
     sortBy,
     isAscending,
     columns,
-    modalIsOpen,
     modalKey,
     pageInfo,
     pageObject,
@@ -294,7 +292,7 @@ export const CustomerInvoicePage = ({
         confirmText={modalStrings.remove}
       />
       <PageContentModal
-        isOpen={modalIsOpen && !transaction.isFinalised}
+        isOpen={!!modalKey && !transaction.isFinalised}
         onClose={() => dispatch(closeBasicModal())}
         title={getModalTitle(modalKey)}
       >

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -102,16 +102,16 @@ export const CustomerInvoicePage = ({
     backingData,
   } = state;
 
-  const { isFinalised } = transaction;
+  const { isFinalised, comment, theirRef } = pageObject;
 
   // Transaction is impure - finalization logic prunes items, deleting them from the transaction.
   // Since this does not manipulate the state through the reducer, data object does not get
   // updated.
-  if (transaction.isFinalised && data.length !== backingData.length) dispatch(refreshData());
+  if (isFinalised && data.length !== backingData.length) dispatch(refreshData());
 
   const renderPageInfo = useCallback(
     () => <PageInfo columns={pageInfo(pageObject, dispatch)} isEditingDisabled={isFinalised} />,
-    [modalKey]
+    [comment, theirRef]
   );
 
   const renderCells = useCallback((rowData, rowState = {}, rowKey) => {
@@ -200,7 +200,6 @@ export const CustomerInvoicePage = ({
   );
 
   const renderModalContent = () => {
-    const { comment, theirRef } = transaction;
     switch (modalKey) {
       default:
       case ITEM_SELECT:
@@ -238,12 +237,12 @@ export const CustomerInvoicePage = ({
         style={globalStyles.topButton}
         text={buttonStrings.new_item}
         onPress={() => dispatch(openBasicModal(ITEM_SELECT))}
-        isDisabled={transaction.isFinalised}
+        isDisabled={isFinalised}
       />
       <PageButton
         text={buttonStrings.add_master_list_items}
         onPress={() => runWithLoadingIndicator(() => dispatch(addMasterListItems('Transaction')))}
-        isDisabled={transaction.isFinalised}
+        isDisabled={isFinalised}
       />
     </View>
   );
@@ -286,14 +285,14 @@ export const CustomerInvoicePage = ({
         keyExtractor={keyExtractor}
       />
       <BottomConfirmModal
-        isOpen={hasSelection && !transaction.isFinalised}
+        isOpen={hasSelection}
         questionText={modalStrings.remove_these_items}
         onCancel={() => dispatch(deselectAll())}
         onConfirm={() => dispatch(deleteItemsById('Transaction'))}
         confirmText={modalStrings.remove}
       />
       <PageContentModal
-        isOpen={!!modalKey && !transaction.isFinalised}
+        isOpen={!!modalKey}
         onClose={() => dispatch(closeBasicModal())}
         title={getModalTitle(modalKey)}
       >

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -48,6 +48,7 @@ import {
   editTheirRef,
   deleteItemsById,
   openBasicModal,
+  refreshData,
 } from './dataTableUtilities/actions';
 
 import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
@@ -101,7 +102,13 @@ export const CustomerInvoicePage = ({
     pageInfo,
     pageObject,
     hasSelection,
+    backingData,
   } = tableState;
+
+  // Transaction is impure - finalization logic prunes items, deleting them from the transaction.
+  // Since this does not manipulate the state through the reducer, data object does not get
+  // updated.
+  if (transaction.isFinalised && data.length !== backingData.length) dispatch(refreshData());
 
   const renderPageInfo = useCallback(
     () => (

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -3,7 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useState, useCallback, useMemo, useLayoutEffect } from 'react';
+import React, { useCallback, useMemo, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
@@ -103,16 +103,6 @@ export const CustomerInvoicePage = ({
     }
   }
 
-  const openCommentEditor = () => {
-    setModalKey(COMMENT_EDIT);
-    setModalIsOpen(true);
-  };
-
-  const openTheirRefEditor = () => {
-    setModalKey(THEIR_REF_EDIT);
-    setModalIsOpen(true);
-  };
-
   const closeModal = () => setModalIsOpen(false);
 
   const getModalTitle = () => {
@@ -172,13 +162,13 @@ export const CustomerInvoicePage = ({
         {
           title: `${pageInfoStrings.their_ref}:`,
           info: transaction.theirRef,
-          onPress: openTheirRefEditor,
+          onPress: () => dispatch(openBasicModal(THEIR_REF_EDIT)),
           editableType: 'text',
         },
         {
           title: `${pageInfoStrings.comment}:`,
           info: transaction.comment,
-          onPress: openCommentEditor,
+          onPress: () => dispatch(openBasicModal(COMMENT_EDIT)),
           editableType: 'text',
         },
       ],

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -9,7 +9,7 @@ import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
 
 import { createRecord } from '../database';
-import { formatDate, debounce } from '../utilities';
+import { formatDate, debounce, MODAL_KEYS, getModalTitle } from '../utilities';
 import { buttonStrings, modalStrings, pageInfoStrings } from '../localization';
 
 import { BottomConfirmModal, PageContentModal } from '../widgets/modals';
@@ -52,12 +52,6 @@ import {
 import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
 import usePageReducer from '../hooks/usePageReducer';
 import DataTablePageView from './containers/DataTablePageView';
-
-const MODAL_KEYS = {
-  COMMENT_EDIT: 'commentEdit',
-  THEIR_REF_EDIT: 'theirRefEdit',
-  ITEM_SELECT: 'itemSelect',
-};
 
 const keyExtractor = item => item.id;
 
@@ -103,18 +97,6 @@ export const CustomerInvoicePage = ({
       break;
     }
   }
-
-  const getModalTitle = () => {
-    switch (modalKey) {
-      default:
-      case ITEM_SELECT:
-        return modalStrings.search_for_an_item_to_add;
-      case COMMENT_EDIT:
-        return modalStrings.edit_the_invoice_comment;
-      case THEIR_REF_EDIT:
-        return modalStrings.edit_their_reference;
-    }
-  };
 
   const onDeleteConfirm = () => {};
 

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -47,6 +47,7 @@ import {
   filterData,
   openBasicModal,
   closeBasicModal,
+  addMasterListItems,
 } from './dataTableUtilities/actions';
 
 import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
@@ -113,15 +114,6 @@ export const CustomerInvoicePage = ({
 
   const onDeleteCancel = () => {
     dispatch(deselectAll());
-  };
-
-  const onAddMasterItems = () => {
-    runWithLoadingIndicator(() => {
-      database.write(() => {
-        transaction.addItemsFromMasterList(database);
-        database.save('Transaction', transaction);
-      });
-    });
   };
 
   const onSearchChange = searchTerm => {
@@ -290,7 +282,7 @@ export const CustomerInvoicePage = ({
       />
       <PageButton
         text={buttonStrings.add_master_list_items}
-        onPress={onAddMasterItems}
+        onPress={() => runWithLoadingIndicator(() => dispatch(addMasterListItems('Transaction')))}
         isDisabled={transaction.isFinalised}
       />
     </View>
@@ -373,7 +365,7 @@ export const CustomerInvoicePage = ({
       <PageContentModal
         isOpen={modalIsOpen && !transaction.isFinalised}
         onClose={() => dispatch(closeBasicModal())}
-        title={getModalTitle()}
+        title={getModalTitle(modalKey)}
       >
         {renderModalContent()}
       </PageContentModal>

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -8,6 +8,8 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
 
+// eslint-disable-next-line no-unused-vars
+import { createRecord } from '../database';
 import { debounce, MODAL_KEYS, getModalTitle } from '../utilities';
 import { buttonStrings, modalStrings } from '../localization';
 
@@ -48,6 +50,7 @@ import {
   closeBasicModal,
   addMasterListItems,
   addItem,
+  editPageObject,
 } from './dataTableUtilities/actions';
 
 import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
@@ -218,6 +221,7 @@ export const CustomerInvoicePage = ({
   );
 
   const renderModalContent = () => {
+    const { comment, theirRef } = transaction;
     switch (modalKey) {
       default:
       case ITEM_SELECT:
@@ -235,31 +239,15 @@ export const CustomerInvoicePage = ({
       case COMMENT_EDIT:
         return (
           <TextEditor
-            text={transaction.comment}
-            onEndEditing={newComment => {
-              if (newComment !== transaction.comment) {
-                database.write(() => {
-                  transaction.comment = newComment;
-                  database.save('Transaction', transaction);
-                });
-              }
-              dispatch(closeBasicModal());
-            }}
+            text={comment}
+            onEndEditing={value => dispatch(editPageObject(value, 'Transaction', 'comment'))}
           />
         );
       case THEIR_REF_EDIT:
         return (
           <TextEditor
-            text={transaction.theirRef}
-            onEndEditing={newTheirRef => {
-              if (newTheirRef !== transaction.theirRef) {
-                database.write(() => {
-                  transaction.theirRef = newTheirRef;
-                  database.save('Transaction', transaction);
-                });
-              }
-              dispatch(closeBasicModal());
-            }}
+            text={theirRef}
+            onEndEditing={value => dispatch(editPageObject(value, 'Transaction', 'theirRef'))}
           />
         );
     }

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -3,7 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useLayoutEffect } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
@@ -45,6 +45,7 @@ import {
   deselectAll,
   sortData,
   filterData,
+  openBasicModal,
 } from './dataTableUtilities/actions';
 
 import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
@@ -74,6 +75,7 @@ export const CustomerInvoicePage = ({
   runWithLoadingIndicator,
   routeName,
 }) => {
+  const startTime = Date.now();
   const [tableState, dispatch, instantDebouncedDispatch] = usePageReducer(routeName, {
     backingData: transaction.items,
     data: transaction.items.sorted('item.name').slice(),
@@ -85,12 +87,12 @@ export const CustomerInvoicePage = ({
     filterDataKeys: ['item.name'],
     sortBy: 'itemName',
     isAscending: true,
+    modalIsOpen: false,
+    modalKey: '',
   });
 
-  const [modalKey, setModalKey] = useState(null);
-  const [modalIsOpen, setModalIsOpen] = useState(false);
   const { ITEM_SELECT, COMMENT_EDIT, THEIR_REF_EDIT } = MODAL_KEYS;
-  const { data, dataState, sortBy, isAscending, columns } = tableState;
+  const { data, dataState, sortBy, isAscending, columns, modalIsOpen, modalKey } = tableState;
   let isSelection = false;
 
   // eslint-disable-next-line no-restricted-syntax
@@ -100,11 +102,6 @@ export const CustomerInvoicePage = ({
       break;
     }
   }
-
-  const openItemSelector = () => {
-    setModalKey(ITEM_SELECT);
-    setModalIsOpen(true);
-  };
 
   const openCommentEditor = () => {
     setModalKey(COMMENT_EDIT);
@@ -334,7 +331,7 @@ export const CustomerInvoicePage = ({
       <PageButton
         style={globalStyles.topButton}
         text={buttonStrings.new_item}
-        onPress={openItemSelector}
+        onPress={() => dispatch(openBasicModal(ITEM_SELECT))}
         isDisabled={transaction.isFinalised}
       />
       <PageButton
@@ -378,6 +375,12 @@ export const CustomerInvoicePage = ({
     ),
     [sortBy, isAscending]
   );
+
+  useLayoutEffect(() => {
+    console.log('===============Layout time=====================');
+    console.log(Date.now() - startTime);
+    console.log('====================================');
+  });
 
   const {
     newPageTopSectionContainer,

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -3,7 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
@@ -110,13 +110,10 @@ export const CustomerInvoicePage = ({
   // updated.
   if (transaction.isFinalised && data.length !== backingData.length) dispatch(refreshData());
 
+  const pageInfoColumns = useMemo(() => pageInfo(pageObject, dispatch), []);
+
   const renderPageInfo = useCallback(
-    () => (
-      <PageInfo
-        columns={pageInfo(pageObject, dispatch)}
-        isEditingDisabled={transaction.isFinalised}
-      />
-    ),
+    () => <PageInfo columns={pageInfoColumns} isEditingDisabled={transaction.isFinalised} />,
     []
   );
 

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -3,7 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useCallback, useLayoutEffect } from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
@@ -75,7 +75,6 @@ export const CustomerInvoicePage = ({
   runWithLoadingIndicator,
   routeName,
 }) => {
-  const startTime = Date.now();
   const [tableState, dispatch, instantDebouncedDispatch, debouncedDispatch] = usePageReducer(
     routeName,
     {
@@ -287,12 +286,6 @@ export const CustomerInvoicePage = ({
     ),
     [sortBy, isAscending]
   );
-
-  useLayoutEffect(() => {
-    console.log('===============Layout time=====================');
-    console.log(Date.now() - startTime);
-    console.log('====================================');
-  });
 
   const {
     newPageTopSectionContainer,

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -3,7 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
@@ -105,16 +105,16 @@ export const CustomerInvoicePage = ({
     backingData,
   } = tableState;
 
+  const { isFinalised } = transaction;
+
   // Transaction is impure - finalization logic prunes items, deleting them from the transaction.
   // Since this does not manipulate the state through the reducer, data object does not get
   // updated.
   if (transaction.isFinalised && data.length !== backingData.length) dispatch(refreshData());
 
-  const pageInfoColumns = useMemo(() => pageInfo(pageObject, dispatch), []);
-
   const renderPageInfo = useCallback(
-    () => <PageInfo columns={pageInfoColumns} isEditingDisabled={transaction.isFinalised} />,
-    []
+    () => <PageInfo columns={pageInfo(pageObject, dispatch)} isEditingDisabled={isFinalised} />,
+    [modalKey]
   );
 
   const renderCells = useCallback((rowData, rowState = {}, rowKey) => {

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -19,9 +19,6 @@ import {
   PageButton,
   PageInfo,
   TextEditor,
-  SortAscIcon,
-  SortNeutralIcon,
-  SortDescIcon,
   CheckedComponent,
   UncheckedComponent,
   DisabledCheckedComponent,
@@ -33,8 +30,7 @@ import {
   Cell,
   EditableCell,
   CheckableCell,
-  HeaderCell,
-  HeaderRow,
+  DataTableHeaderRow,
 } from '../widgets/DataTable';
 
 import {
@@ -253,38 +249,14 @@ export const CustomerInvoicePage = ({
     </View>
   );
 
-  const renderHeader = useCallback(
-    () => (
-      <HeaderRow
-        renderCells={() =>
-          columns.map(({ key, title, sortable, width, alignText }, index) => {
-            const sortDirection = isAscending ? 'ASC' : 'DESC';
-            const directionForThisColumn = key === sortBy ? sortDirection : null;
-            const isLastCell = index === columns.length - 1;
-            const { headerCells, cellText } = newDataTableStyles;
-            return (
-              <HeaderCell
-                key={key}
-                title={title}
-                SortAscComponent={SortAscIcon}
-                SortDescComponent={SortDescIcon}
-                SortNeutralComponent={SortNeutralIcon}
-                columnKey={key}
-                onPressAction={sortable ? sortData : null}
-                dispatch={instantDebouncedDispatch}
-                sortDirection={directionForThisColumn}
-                sortable={sortable}
-                width={width}
-                containerStyle={headerCells[alignText || 'left']}
-                textStyle={cellText[alignText || 'left']}
-                isLastCell={isLastCell}
-              />
-            );
-          })
-        }
-      />
-    ),
-    [sortBy, isAscending]
+  const renderHeader = () => (
+    <DataTableHeaderRow
+      columns={columns}
+      dispatch={instantDebouncedDispatch}
+      sortAction={sortData}
+      isAscending={isAscending}
+      sortBy={sortBy}
+    />
   );
 
   const {

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -72,24 +72,21 @@ export const CustomerInvoicePage = ({
   runWithLoadingIndicator,
   routeName,
 }) => {
-  const [tableState, dispatch, instantDebouncedDispatch, debouncedDispatch] = usePageReducer(
-    routeName,
-    {
-      pageObject: transaction,
-      backingData: transaction.items,
-      data: transaction.items.sorted('item.name').slice(),
-      database,
-      keyExtractor,
-      dataState: new Map(),
-      currentFocusedRowKey: null,
-      searchTerm: '',
-      filterDataKeys: ['item.name'],
-      sortBy: 'itemName',
-      isAscending: true,
-      modalKey: '',
-      hasSelection: false,
-    }
-  );
+  const [state, dispatch, instantDebouncedDispatch, debouncedDispatch] = usePageReducer(routeName, {
+    pageObject: transaction,
+    backingData: transaction.items,
+    data: transaction.items.sorted('item.name').slice(),
+    database,
+    keyExtractor,
+    dataState: new Map(),
+    currentFocusedRowKey: null,
+    searchTerm: '',
+    filterDataKeys: ['item.name'],
+    sortBy: 'itemName',
+    isAscending: true,
+    modalKey: '',
+    hasSelection: false,
+  });
 
   const { ITEM_SELECT, COMMENT_EDIT, THEIR_REF_EDIT } = MODAL_KEYS;
   const {
@@ -103,7 +100,7 @@ export const CustomerInvoicePage = ({
     pageObject,
     hasSelection,
     backingData,
-  } = tableState;
+  } = state;
 
   const { isFinalised } = transaction;
 

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -32,7 +32,6 @@ import {
   CheckableCell,
   DataTableHeaderRow,
 } from '../widgets/DataTable';
-
 import {
   editTotalQuantity,
   focusCell,
@@ -45,7 +44,8 @@ import {
   closeBasicModal,
   addMasterListItems,
   addItem,
-  editPageObject,
+  editComment,
+  editTheirRef,
   deleteItemsById,
   openBasicModal,
 } from './dataTableUtilities/actions';
@@ -218,14 +218,14 @@ export const CustomerInvoicePage = ({
         return (
           <TextEditor
             text={comment}
-            onEndEditing={value => dispatch(editPageObject(value, 'Transaction', 'comment'))}
+            onEndEditing={value => dispatch(editComment(value, 'Transaction'))}
           />
         );
       case THEIR_REF_EDIT:
         return (
           <TextEditor
             text={theirRef}
-            onEndEditing={value => dispatch(editPageObject(value, 'Transaction', 'theirRef'))}
+            onEndEditing={value => dispatch(editTheirRef(value, 'Transaction'))}
           />
         );
     }

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -89,6 +89,7 @@ export const CustomerInvoicePage = ({
     isAscending: true,
     modalIsOpen: false,
     modalKey: '',
+    hasSelection: false,
   });
 
   const { ITEM_SELECT, COMMENT_EDIT, THEIR_REF_EDIT } = MODAL_KEYS;
@@ -102,16 +103,8 @@ export const CustomerInvoicePage = ({
     modalKey,
     pageInfo,
     pageObject,
+    hasSelection,
   } = tableState;
-  let isSelection = false;
-
-  // eslint-disable-next-line no-restricted-syntax
-  for (const row of dataState.values()) {
-    if (row.isSelected) {
-      isSelection = true;
-      break;
-    }
-  }
 
   const onDeleteConfirm = () => {};
 
@@ -337,7 +330,7 @@ export const CustomerInvoicePage = ({
         keyExtractor={keyExtractor}
       />
       <BottomConfirmModal
-        isOpen={isSelection && !transaction.isFinalised}
+        isOpen={hasSelection && !transaction.isFinalised}
         questionText={modalStrings.remove_these_items}
         onCancel={onDeleteCancel}
         onConfirm={onDeleteConfirm}

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -46,11 +46,12 @@ import {
   deselectAll,
   sortData,
   filterData,
-  openBasicModal,
   closeBasicModal,
   addMasterListItems,
   addItem,
   editPageObject,
+  deleteItemsById,
+  openBasicModal,
 } from './dataTableUtilities/actions';
 
 import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
@@ -105,8 +106,6 @@ export const CustomerInvoicePage = ({
     pageObject,
     hasSelection,
   } = tableState;
-
-  const onDeleteConfirm = () => {};
 
   const onDeleteCancel = () => {
     dispatch(deselectAll());
@@ -333,7 +332,7 @@ export const CustomerInvoicePage = ({
         isOpen={hasSelection && !transaction.isFinalised}
         questionText={modalStrings.remove_these_items}
         onCancel={onDeleteCancel}
-        onConfirm={onDeleteConfirm}
+        onConfirm={() => dispatch(deleteItemsById('Transaction'))}
         confirmText={modalStrings.remove}
       />
       <PageContentModal

--- a/src/pages/dataTableUtilities/actions.js
+++ b/src/pages/dataTableUtilities/actions.js
@@ -8,7 +8,7 @@
  */
 
 export const editTotalQuantity = (value, rowKey, columnKey) => ({
-  type: 'editCell',
+  type: 'editTotalQuantity',
   value,
   rowKey,
   columnKey,
@@ -76,4 +76,10 @@ export const editPageObject = (value, pageObjectType, field) => ({
   pageObjectType,
   value,
   field,
+});
+
+export const deleteItemsById = (pageObjectType, object) => ({
+  type: 'deleteItemsById',
+  pageObjectType,
+  object,
 });

--- a/src/pages/dataTableUtilities/actions.js
+++ b/src/pages/dataTableUtilities/actions.js
@@ -59,3 +59,8 @@ export const openBasicModal = modalKey => ({
 export const closeBasicModal = () => ({
   type: 'closeBasicModal',
 });
+
+export const addMasterListItems = objectType => ({
+  type: 'addMasterListItems',
+  objectType,
+});

--- a/src/pages/dataTableUtilities/actions.js
+++ b/src/pages/dataTableUtilities/actions.js
@@ -71,11 +71,16 @@ export const addItem = (item, addedItemType) => ({
   addedItemType,
 });
 
-export const editPageObject = (value, pageObjectType, field) => ({
-  type: 'editPageObject',
+export const editTheirRef = (value, pageObjectType) => ({
+  type: 'editTheirRef',
   pageObjectType,
   value,
-  field,
+});
+
+export const editComment = (value, pageObjectType) => ({
+  type: 'editComment',
+  pageObjectType,
+  value,
 });
 
 export const deleteItemsById = (pageObjectType, object) => ({

--- a/src/pages/dataTableUtilities/actions.js
+++ b/src/pages/dataTableUtilities/actions.js
@@ -88,3 +88,7 @@ export const deleteItemsById = (pageObjectType, object) => ({
   pageObjectType,
   object,
 });
+
+export const refreshData = () => ({
+  type: 'refreshData',
+});

--- a/src/pages/dataTableUtilities/actions.js
+++ b/src/pages/dataTableUtilities/actions.js
@@ -50,3 +50,8 @@ export const filterData = searchTerm => ({
   type: 'filterData',
   searchTerm,
 });
+
+export const openBasicModal = modalKey => ({
+  type: 'openBasicModal',
+  modalKey,
+});

--- a/src/pages/dataTableUtilities/actions.js
+++ b/src/pages/dataTableUtilities/actions.js
@@ -2,6 +2,7 @@
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
  */
+import { createRecord } from '../../database/utilities/index';
 
 /**
  * Actions for use with a data table reducer
@@ -70,11 +71,18 @@ export const addMasterListItems = objectType => (dispatch, state) => {
   dispatch({ type: 'addMasterListItems', objectType });
 };
 
-export const addItem = (item, addedItemType) => ({
-  type: 'addItem',
-  item,
-  addedItemType,
-});
+export const addItem = (item, addedItemType) => (dispatch, state) => {
+  const { database, pageObject } = state;
+  let addedItem;
+
+  database.write(() => {
+    if (pageObject.hasItem(item)) return;
+    addedItem = createRecord(database, addedItemType, pageObject, item);
+  });
+
+  if (addedItem) dispatch({ type: 'addItem', item: addedItem });
+  else dispatch(closeBasicModal());
+};
 
 export const editTheirRef = (value, pageObjectType) => (dispatch, state) => {
   const { database, pageObject } = state;

--- a/src/pages/dataTableUtilities/actions.js
+++ b/src/pages/dataTableUtilities/actions.js
@@ -70,3 +70,10 @@ export const addItem = (item, addedItemType) => ({
   item,
   addedItemType,
 });
+
+export const editPageObject = (value, pageObjectType, field) => ({
+  type: 'editPageObject',
+  pageObjectType,
+  value,
+  field,
+});

--- a/src/pages/dataTableUtilities/actions.js
+++ b/src/pages/dataTableUtilities/actions.js
@@ -64,3 +64,9 @@ export const addMasterListItems = objectType => ({
   type: 'addMasterListItems',
   objectType,
 });
+
+export const addItem = (item, addedItemType) => ({
+  type: 'addItem',
+  item,
+  addedItemType,
+});

--- a/src/pages/dataTableUtilities/actions.js
+++ b/src/pages/dataTableUtilities/actions.js
@@ -55,3 +55,7 @@ export const openBasicModal = modalKey => ({
   type: 'openBasicModal',
   modalKey,
 });
+
+export const closeBasicModal = () => ({
+  type: 'closeBasicModal',
+});

--- a/src/pages/dataTableUtilities/pageInfo.js
+++ b/src/pages/dataTableUtilities/pageInfo.js
@@ -1,0 +1,33 @@
+import { buttonStrings, modalStrings, pageInfoStrings } from '../../localization';
+import { formatDate } from '../../utilities';
+
+const PAGE_INFO_PARTS = pageObject => ({
+  entryDate: {
+    title: `${pageInfoStrings.entry_date}:`,
+    info: formatDate(pageObject.entryDate) || 'N/A',
+  },
+  confirmDate: {
+    title: `${pageInfoStrings.confirm_date}:`,
+    info: formatDate(pageObject.confirmDate),
+  },
+  enteredBy: {
+    title: `${pageInfoStrings.entered_by}:`,
+    info: pageObject.enteredBy && pageObject.enteredBy.username,
+  },
+  customer: {
+    title: `${pageInfoStrings.customer}:`,
+    info: pageObject.otherParty && pageObject.otherParty.name,
+  },
+  theifRef: {
+    title: `${pageInfoStrings.their_ref}:`,
+    info: pageObject.theirRef,
+    onPress: openTheirRefEditor,
+    editableType: 'text',
+  },
+  comment: {
+    title: `${pageInfoStrings.comment}:`,
+    info: transaction.comment,
+    onPress: openCommentEditor,
+    editableType: 'text',
+  },
+});

--- a/src/pages/dataTableUtilities/pageInfo.js
+++ b/src/pages/dataTableUtilities/pageInfo.js
@@ -1,7 +1,37 @@
-import { buttonStrings, modalStrings, pageInfoStrings } from '../../localization';
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2016
+ */
+import { pageInfoStrings } from '../../localization';
 import { formatDate } from '../../utilities';
 
-const PAGE_INFO_PARTS = pageObject => ({
+import { openBasicModal } from './actions';
+
+import { MODAL_KEYS } from '../../utilities/getModalTitle';
+
+/**
+ * PageInfo rows/columns for use with the PageInfo component.
+ *
+ *
+ * To add a page, add the pages routeName (see: pages/index.js)
+ * and a 2d array of page info rows to PER_PAGE_INFO_COLUMNS,
+ * of the desired pageinfo rows needed on the page.
+ *
+ * To use in the new page: use the usePageReducer hook.
+ * usePageReducer will inject a your pages reducer with a field
+ * pageInfo - a function returned by getPageInfo. Passing
+ * this function the particular pages base object - i.e,
+ * transaction, requisition or stock and it's dispatch will return the
+ * required pageInfo columns for the page.
+ */
+
+const { THEIR_REF_EDIT, COMMENT_EDIT } = MODAL_KEYS;
+
+const PER_PAGE_INFO_COLUMNS = {
+  customerInvoice: [['entryDate', 'confirmDate', 'enteredBy'], ['customer', 'theirRef', 'comment']],
+};
+
+const PAGE_INFO_ROWS = (pageObject, dispatch) => ({
   entryDate: {
     title: `${pageInfoStrings.entry_date}:`,
     info: formatDate(pageObject.entryDate) || 'N/A',
@@ -18,16 +48,29 @@ const PAGE_INFO_PARTS = pageObject => ({
     title: `${pageInfoStrings.customer}:`,
     info: pageObject.otherParty && pageObject.otherParty.name,
   },
-  theifRef: {
+  theirRef: {
     title: `${pageInfoStrings.their_ref}:`,
     info: pageObject.theirRef,
-    onPress: openTheirRefEditor,
+    onPress: () => dispatch(openBasicModal(THEIR_REF_EDIT)),
     editableType: 'text',
   },
   comment: {
     title: `${pageInfoStrings.comment}:`,
-    info: transaction.comment,
-    onPress: openCommentEditor,
+    info: pageObject.comment,
+    onPress: () => dispatch(openBasicModal(COMMENT_EDIT)),
     editableType: 'text',
   },
 });
+
+const getPageInfo = page => {
+  const pageInfoColumns = PER_PAGE_INFO_COLUMNS[page];
+  if (!pageInfoColumns) return null;
+  return (pageObject, dispatch) => {
+    const pageInfoRows = PAGE_INFO_ROWS(pageObject, dispatch);
+    return pageInfoColumns.map(pageInfoColumn =>
+      pageInfoColumn.map(pageInfoKey => pageInfoRows[pageInfoKey])
+    );
+  };
+};
+
+export default getPageInfo;

--- a/src/pages/dataTableUtilities/reducer/getReducer.js
+++ b/src/pages/dataTableUtilities/reducer/getReducer.js
@@ -26,6 +26,7 @@ import {
   focusCell,
   sortData,
   openBasicModal,
+  closeBasicModal,
 } from './reducerMethods';
 
 /**
@@ -45,6 +46,7 @@ const customerInvoice = {
   deselectRow,
   deselectAll,
   openBasicModal,
+  closeBasicModal,
 };
 
 const PAGE_REDUCERS = {

--- a/src/pages/dataTableUtilities/reducer/getReducer.js
+++ b/src/pages/dataTableUtilities/reducer/getReducer.js
@@ -29,6 +29,7 @@ import {
   closeBasicModal,
   addMasterListItems,
   addItem,
+  editPageObject,
 } from './reducerMethods';
 
 /**
@@ -51,6 +52,7 @@ const customerInvoice = {
   closeBasicModal,
   addMasterListItems,
   addItem,
+  editPageObject,
 };
 
 const PAGE_REDUCERS = {

--- a/src/pages/dataTableUtilities/reducer/getReducer.js
+++ b/src/pages/dataTableUtilities/reducer/getReducer.js
@@ -28,6 +28,7 @@ import {
   openBasicModal,
   closeBasicModal,
   addMasterListItems,
+  addItem,
 } from './reducerMethods';
 
 /**
@@ -49,6 +50,7 @@ const customerInvoice = {
   openBasicModal,
   closeBasicModal,
   addMasterListItems,
+  addItem,
 };
 
 const PAGE_REDUCERS = {

--- a/src/pages/dataTableUtilities/reducer/getReducer.js
+++ b/src/pages/dataTableUtilities/reducer/getReducer.js
@@ -30,6 +30,7 @@ import {
   addMasterListItems,
   addItem,
   editPageObject,
+  deleteItemsById,
 } from './reducerMethods';
 
 /**
@@ -53,6 +54,7 @@ const customerInvoice = {
   addMasterListItems,
   addItem,
   editPageObject,
+  deleteItemsById,
 };
 
 const PAGE_REDUCERS = {

--- a/src/pages/dataTableUtilities/reducer/getReducer.js
+++ b/src/pages/dataTableUtilities/reducer/getReducer.js
@@ -27,6 +27,7 @@ import {
   sortData,
   openBasicModal,
   closeBasicModal,
+  addMasterListItems,
 } from './reducerMethods';
 
 /**
@@ -47,6 +48,7 @@ const customerInvoice = {
   deselectAll,
   openBasicModal,
   closeBasicModal,
+  addMasterListItems,
 };
 
 const PAGE_REDUCERS = {

--- a/src/pages/dataTableUtilities/reducer/getReducer.js
+++ b/src/pages/dataTableUtilities/reducer/getReducer.js
@@ -29,7 +29,8 @@ import {
   closeBasicModal,
   addMasterListItems,
   addItem,
-  editPageObject,
+  editTheirRef,
+  editComment,
   deleteItemsById,
 } from './reducerMethods';
 
@@ -53,7 +54,8 @@ const customerInvoice = {
   closeBasicModal,
   addMasterListItems,
   addItem,
-  editPageObject,
+  editTheirRef,
+  editComment,
   deleteItemsById,
 };
 

--- a/src/pages/dataTableUtilities/reducer/getReducer.js
+++ b/src/pages/dataTableUtilities/reducer/getReducer.js
@@ -25,6 +25,7 @@ import {
   deselectAll,
   focusCell,
   sortData,
+  openBasicModal,
 } from './reducerMethods';
 
 /**
@@ -43,6 +44,7 @@ const customerInvoice = {
   selectRow,
   deselectRow,
   deselectAll,
+  openBasicModal,
 };
 
 const PAGE_REDUCERS = {

--- a/src/pages/dataTableUtilities/reducer/getReducer.js
+++ b/src/pages/dataTableUtilities/reducer/getReducer.js
@@ -32,6 +32,7 @@ import {
   editTheirRef,
   editComment,
   deleteItemsById,
+  refreshData,
 } from './reducerMethods';
 
 /**
@@ -57,6 +58,7 @@ const customerInvoice = {
   editTheirRef,
   editComment,
   deleteItemsById,
+  refreshData,
 };
 
 const PAGE_REDUCERS = {

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -365,10 +365,10 @@ export const deleteItemsById = (state, action) => {
 
   if (!hasSelection) return state;
 
-  const itemsById = Array.from(dataState.keys()).filter(rowKey => dataState.get(rowKey).isSelected);
+  const itemsIds = Array.from(dataState.keys()).filter(rowKey => dataState.get(rowKey).isSelected);
 
   database.write(() => {
-    pageObject.removeItemsById(database, itemsById);
+    pageObject.removeItemsById(database, itemsIds);
     database.save(pageObjectType, pageObject);
   });
 

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -396,7 +396,7 @@ export const editComment = (state, action) => {
  * @param {Object} action The action to act upon
  */
 export const deleteItemsById = (state, action) => {
-  const { database, pageObject, dataState, hasSelection, backingData } = state;
+  const { database, pageObject, data, dataState, hasSelection } = state;
   const { pageObjectType } = action;
 
   if (!hasSelection) return state;
@@ -409,7 +409,7 @@ export const deleteItemsById = (state, action) => {
   });
 
   const newDataState = new Map();
-  const newData = backingData.slice();
+  const newData = data.filter(item => item.isValid());
 
   return {
     ...state,

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -274,3 +274,27 @@ export const openBasicModal = (state, action) => {
  * Action: { type: 'closeBasicModal' }
  */
 export const closeBasicModal = state => ({ ...state, modalIsOpen: false, modalKey: '' });
+
+/**
+ * Adds all items from a master list to the pageObject held
+ * in state - either a Requisition or Transaction.
+ * @param {Object} state  The current state
+ * @param {Object} action The action to act upon
+ * Action: { type: 'addMasterListItems', objectType }
+ */
+export const addMasterListItems = (state, action) => {
+  const { pageObject, database, backingData } = state;
+  const { objectType } = action;
+
+  database.write(() => {
+    pageObject.addItemsFromMasterList(database);
+    database.save(objectType, pageObject);
+  });
+
+  const newData = backingData.slice();
+
+  return {
+    ...state,
+    data: newData,
+  };
+};

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -419,3 +419,17 @@ export const deleteItemsById = (state, action) => {
     modalKey: '',
   };
 };
+
+/**
+ * Simply refresh's the data object in state to
+ * correctly match the backingData when side effects
+ * such as finalizing manipulate the state of a page
+ * from outside the reducer. Should only be used when
+ * there are no other options.
+ *
+ * @param {Object} state  The current state
+ */
+export const refreshData = state => {
+  const { backingData } = state;
+  return { ...state, data: backingData.slice() };
+};

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -292,15 +292,8 @@ export const closeBasicModal = state => ({ ...state, modalKey: '' });
  * @param {Object} action The action to act upon
  * Action: { type: 'addMasterListItems', objectType }
  */
-export const addMasterListItems = (state, action) => {
-  const { pageObject, database, backingData } = state;
-  const { objectType } = action;
-
-  database.write(() => {
-    pageObject.addItemsFromMasterList(database);
-    database.save(objectType, pageObject);
-  });
-
+export const addMasterListItems = state => {
+  const { backingData } = state;
   const newData = backingData.slice();
 
   return { ...state, data: newData };
@@ -341,17 +334,7 @@ export const addItem = (state, action) => {
  * @param {Object} action The action to act upon
  * Action: { type: 'editPageObject', value, field, pageObjectType }
  */
-const editPageObject = (state, action) => {
-  const { database, pageObject } = state;
-  const { value, pageObjectType, field } = action;
-
-  database.write(() => {
-    pageObject[field] = value;
-    database.save(pageObjectType, pageObject);
-  });
-
-  return { ...state, modalKey: '' };
-};
+const editPageObject = state => ({ ...state, modalKey: '' });
 
 /**
  * Edits the passed pageObject 'theirRef' field with the value supplied.
@@ -395,18 +378,8 @@ export const editComment = (state, action) => {
  * @param {Object} state  The current state
  * @param {Object} action The action to act upon
  */
-export const deleteItemsById = (state, action) => {
-  const { database, pageObject, data, dataState, hasSelection } = state;
-  const { pageObjectType } = action;
-
-  if (!hasSelection) return state;
-
-  const itemsIds = Array.from(dataState.keys()).filter(rowKey => dataState.get(rowKey).isSelected);
-
-  database.write(() => {
-    pageObject.removeItemsById(database, itemsIds);
-    database.save(pageObjectType, pageObject);
-  });
+export const deleteItemsById = state => {
+  const { data } = state;
 
   const newDataState = new Map();
   const newData = data.filter(item => item.isValid());

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -5,6 +5,7 @@
 
 /* eslint-disable import/prefer-default-export */
 import { parsePositiveInteger, newSortDataBy } from '../../../utilities';
+import { createRecord } from '../../../database/utilities/index';
 
 /**
  * Immutably clears the current focus
@@ -293,8 +294,28 @@ export const addMasterListItems = (state, action) => {
 
   const newData = backingData.slice();
 
-  return {
-    ...state,
-    data: newData,
-  };
+  return { ...state, data: newData };
+};
+
+/**
+ * Creates an Item (Either Requisition or Transaction), and appends
+ * this item to the data array for a page.
+ *
+ * @param {Object} state  The current state
+ * @param {Object} action The action to act upon
+ * Action: { type: 'adadItem', item, addedItemType }
+ */
+export const addItem = (state, action) => {
+  const { database, pageObject, data } = state;
+  const { item, addedItemType } = action;
+  let addedItem;
+
+  database.write(() => {
+    if (pageObject.hasItem(item)) return;
+    addedItem = createRecord(database, addedItemType, pageObject, item);
+  });
+
+  if (addedItem) return { ...state, data: [addedItem, ...data], modalIsOpen: false };
+
+  return { ...state, modalIsOpen: false };
 };

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -265,3 +265,12 @@ export const openBasicModal = (state, action) => {
   const { modalKey } = action;
   return { ...state, modalIsOpen: true, modalKey };
 };
+
+/**
+ * Sets the modal open state to false, closing any
+ * modal that is open.
+ *
+ * @param {Object} state  The current state
+ * Action: { type: 'closeBasicModal' }
+ */
+export const closeBasicModal = state => ({ ...state, modalIsOpen: false, modalKey: '' });

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -319,3 +319,25 @@ export const addItem = (state, action) => {
 
   return { ...state, modalIsOpen: false };
 };
+
+/**
+ * Edits the passed pageObject field with the value supplied.
+ * Used for simple value setting i.e. comments.
+ *
+ * @param {Object} state  The current state
+ * @param {Object} action The action to act upon
+ * Action: { type: 'editPageObject', value, field, pageObjectType }
+ */
+export const editPageObject = (state, action) => {
+  const { database, pageObject } = state;
+  const { value, pageObjectType, field } = action;
+
+  if (pageObject[field] !== value) {
+    database.write(() => {
+      pageObject[field] = value;
+      database.save(pageObjectType, pageObject);
+    });
+  }
+
+  return { ...state, modalIsOpen: false };
+};

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -273,7 +273,7 @@ export const sortData = (state, action) => {
  */
 export const openBasicModal = (state, action) => {
   const { modalKey } = action;
-  return { ...state, modalIsOpen: true, modalKey };
+  return { ...state, modalKey };
 };
 
 /**
@@ -283,7 +283,7 @@ export const openBasicModal = (state, action) => {
  * @param {Object} state  The current state
  * Action: { type: 'closeBasicModal' }
  */
-export const closeBasicModal = state => ({ ...state, modalIsOpen: false, modalKey: '' });
+export const closeBasicModal = state => ({ ...state, modalKey: '' });
 
 /**
  * Adds all items from a master list to the pageObject held
@@ -324,9 +324,9 @@ export const addItem = (state, action) => {
     addedItem = createRecord(database, addedItemType, pageObject, item);
   });
 
-  if (addedItem) return { ...state, data: [addedItem, ...data], modalIsOpen: false };
+  if (addedItem) return { ...state, data: [addedItem, ...data], modalKey: '' };
 
-  return { ...state, modalIsOpen: false };
+  return { ...state, modalKey: '' };
 };
 
 /**
@@ -348,7 +348,7 @@ export const editPageObject = (state, action) => {
     });
   }
 
-  return { ...state, modalIsOpen: false };
+  return { ...state, modalKey: '' };
 };
 
 /**
@@ -380,6 +380,6 @@ export const deleteItemsById = (state, action) => {
     data: newData,
     dataState: newDataState,
     hasSelection: false,
-    modalIsOpen: false,
+    modalKey: '',
   };
 };

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -330,25 +330,61 @@ export const addItem = (state, action) => {
 };
 
 /**
- * Edits the passed pageObject field with the value supplied.
- * Used for simple value setting i.e. comments.
+ * Reducer helper method for editing a non-setter field on a
+ * realm object. Should be called by more explicit reducer
+ * methods and not exported to avoid misuse. To create a reducer
+ * method for setting a simple value for a realm object, create a
+ * more explicit reducer method with logic specific to that field
+ * contained, and call this method. See editTheirRef.
  *
  * @param {Object} state  The current state
  * @param {Object} action The action to act upon
  * Action: { type: 'editPageObject', value, field, pageObjectType }
  */
-export const editPageObject = (state, action) => {
+const editPageObject = (state, action) => {
   const { database, pageObject } = state;
   const { value, pageObjectType, field } = action;
 
-  if (pageObject[field] !== value) {
-    database.write(() => {
-      pageObject[field] = value;
-      database.save(pageObjectType, pageObject);
-    });
-  }
+  database.write(() => {
+    pageObject[field] = value;
+    database.save(pageObjectType, pageObject);
+  });
 
   return { ...state, modalKey: '' };
+};
+
+/**
+ * Edits the passed pageObject 'theirRef' field with the value supplied.
+ *
+ * @param {Object} state  The current state
+ * @param {Object} action The action to act upon
+ * Action: { type: 'editPageObject', value, pageObjectType }
+ */
+export const editTheirRef = (state, action) => {
+  const { pageObject } = state;
+  const { value } = action;
+
+  const { theirRef } = pageObject;
+
+  if (theirRef !== value) return { ...editPageObject(state, { ...action, field: 'theirRef' }) };
+  return state;
+};
+
+/**
+ * Edits the passed pageObject 'comment' field with the value supplied.
+ *
+ * @param {Object} state  The current state
+ * @param {Object} action The action to act upon
+ * Action: { type: 'editPageObject', value, pageObjectType }
+ */
+export const editComment = (state, action) => {
+  const { pageObject } = state;
+  const { value } = action;
+
+  const { comment } = pageObject;
+
+  if (comment !== value) return { ...editPageObject(state, { ...action, field: 'comment' }) };
+  return state;
 };
 
 /**

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -350,3 +350,36 @@ export const editPageObject = (state, action) => {
 
   return { ...state, modalIsOpen: false };
 };
+
+/**
+ * Deletes the selected RequisitionItems or
+ * TransactionItems held in state. Where each selected
+ * item is indicated by DataState[rowKey].isSelected.
+ *
+ * @param {Object} state  The current state
+ * @param {Object} action The action to act upon
+ */
+export const deleteItemsById = (state, action) => {
+  const { database, pageObject, dataState, hasSelection, backingData } = state;
+  const { pageObjectType } = action;
+
+  if (!hasSelection) return state;
+
+  const itemsById = Array.from(dataState.keys()).filter(rowKey => dataState.get(rowKey).isSelected);
+
+  database.write(() => {
+    pageObject.removeItemsById(database, itemsById);
+    database.save(pageObjectType, pageObject);
+  });
+
+  const newDataState = new Map();
+  const newData = backingData.slice();
+
+  return {
+    ...state,
+    data: newData,
+    dataState: newDataState,
+    hasSelection: false,
+    modalIsOpen: false,
+  };
+};

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -171,7 +171,7 @@ export const selectRow = (state, action) => {
     isSelected: true,
   });
 
-  return { ...state, dataState: newDataState };
+  return { ...state, dataState: newDataState, hasSelection: true };
 };
 
 /**
@@ -192,7 +192,16 @@ export const deselectRow = (state, action) => {
     isSelected: false,
   });
 
-  return { ...state, dataState: newDataState };
+  let hasSelection = false;
+  // eslint-disable-next-line no-restricted-syntax
+  for (const row of newDataState.values()) {
+    if (row.isSelected) {
+      hasSelection = true;
+      break;
+    }
+  }
+
+  return { ...state, dataState: newDataState, hasSelection };
 };
 
 /**
@@ -213,7 +222,7 @@ export const deselectAll = state => {
       });
     }
   }
-  return { ...state, dataState: newDataState };
+  return { ...state, dataState: newDataState, hasSelection: false };
 };
 
 /**

--- a/src/pages/dataTableUtilities/reducer/reducerMethods.js
+++ b/src/pages/dataTableUtilities/reducer/reducerMethods.js
@@ -5,7 +5,6 @@
 
 /* eslint-disable import/prefer-default-export */
 import { parsePositiveInteger, newSortDataBy } from '../../../utilities';
-import { createRecord } from '../../../database/utilities/index';
 
 /**
  * Immutably clears the current focus
@@ -308,18 +307,10 @@ export const addMasterListItems = state => {
  * Action: { type: 'addItem', item, addedItemType }
  */
 export const addItem = (state, action) => {
-  const { database, pageObject, data } = state;
-  const { item, addedItemType } = action;
-  let addedItem;
+  const { data } = state;
+  const { item } = action;
 
-  database.write(() => {
-    if (pageObject.hasItem(item)) return;
-    addedItem = createRecord(database, addedItemType, pageObject, item);
-  });
-
-  if (addedItem) return { ...state, data: [addedItem, ...data], modalKey: '' };
-
-  return { ...state, modalKey: '' };
+  return { ...state, data: [item, ...data], modalKey: '' };
 };
 
 /**

--- a/src/utilities/getModalTitle.js
+++ b/src/utilities/getModalTitle.js
@@ -1,0 +1,24 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import { modalStrings } from '../localization';
+
+export const MODAL_KEYS = {
+  COMMENT_EDIT: 'commentEdit',
+  THEIR_REF_EDIT: 'theirRefEdit',
+  ITEM_SELECT: 'itemSelect',
+};
+
+export const getModalTitle = modalKey => {
+  switch (modalKey) {
+    default:
+    case MODAL_KEYS.ITEM_SELECT:
+      return modalStrings.search_for_an_item_to_add;
+    case MODAL_KEYS.COMMENT_EDIT:
+      return modalStrings.edit_the_invoice_comment;
+    case MODAL_KEYS.THEIR_REF_EDIT:
+      return modalStrings.edit_their_reference;
+  }
+};

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -16,3 +16,4 @@ export { getAllPeriodsForProgram, getAllPrograms } from './byProgram';
 export { requestPermission } from './requestPermission';
 export { backupValidation } from './fileSystem';
 export { debounce } from './underscoreMethods';
+export { getModalTitle, MODAL_KEYS } from './getModalTitle';

--- a/src/widgets/DataTable/DataTableHeaderRow.js
+++ b/src/widgets/DataTable/DataTableHeaderRow.js
@@ -1,0 +1,71 @@
+/* eslint-disable react/forbid-prop-types */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import HeaderRow from './HeaderRow';
+import HeaderCell from './HeaderCell';
+
+import { SortAscIcon, SortNeutralIcon, SortDescIcon } from '../icons';
+
+import { newDataTableStyles } from '../../globalStyles';
+
+/**
+ * Simple wrapper around HeaderRow component. Applies mSupply styles and extracts
+ * the generic shared logic for all data table pages header rows into one place.
+ *
+ * @param {Array}  columns     Array of column objects see columns.js
+ * @param {String} sortBy      columnKey indicating which column is sorted for the correct icon.
+ * @param {Bool}   isAscending Additional indicator for the column which is sorted by.
+ * @param {Func}   dispatch    Dispatch function for managing the row containers state.
+ * @param {Func}   sortAction  Action creator for generating a sorting action.
+ *
+ *
+ */
+const DataTableHeaderRow = React.memo(({ columns, sortBy, isAscending, dispatch, sortAction }) => (
+  <HeaderRow
+    renderCells={() =>
+      columns.map(({ key, title, sortable, width, alignText }, index) => {
+        const sortDirection = isAscending ? 'ASC' : 'DESC';
+        const directionForThisColumn = key === sortBy ? sortDirection : null;
+        const isLastCell = index === columns.length - 1;
+        const { headerCells, cellText } = newDataTableStyles;
+        return (
+          <HeaderCell
+            key={key}
+            title={title}
+            SortAscComponent={SortAscIcon}
+            SortDescComponent={SortDescIcon}
+            SortNeutralComponent={SortNeutralIcon}
+            columnKey={key}
+            onPressAction={sortable ? sortAction : null}
+            dispatch={dispatch}
+            sortDirection={directionForThisColumn}
+            sortable={sortable}
+            width={width}
+            containerStyle={headerCells[alignText || 'left']}
+            textStyle={cellText[alignText || 'left']}
+            isLastCell={isLastCell}
+          />
+        );
+      })
+    }
+  />
+));
+
+DataTableHeaderRow.propTypes = {
+  columns: PropTypes.arrayOf(PropTypes.object),
+  sortBy: PropTypes.string,
+  isAscending: PropTypes.bool.isRequired,
+  dispatch: PropTypes.func,
+  sortAction: PropTypes.func,
+};
+
+DataTableHeaderRow.defaultProps = {
+  columns: [],
+  sortBy: '',
+  dispatch: null,
+  sortAction: null,
+};
+
+export default DataTableHeaderRow;

--- a/src/widgets/DataTable/DataTableHeaderRow.js
+++ b/src/widgets/DataTable/DataTableHeaderRow.js
@@ -24,6 +24,7 @@ import { newDataTableStyles } from '../../globalStyles';
  */
 const DataTableHeaderRow = React.memo(({ columns, sortBy, isAscending, dispatch, sortAction }) => (
   <HeaderRow
+    style={newDataTableStyles.headerRow}
     renderCells={() =>
       columns.map(({ key, title, sortable, width, alignText }, index) => {
         const sortDirection = isAscending ? 'ASC' : 'DESC';

--- a/src/widgets/DataTable/index.js
+++ b/src/widgets/DataTable/index.js
@@ -6,5 +6,16 @@ import Row from './Row';
 import HeaderRow from './HeaderRow';
 import HeaderCell from './HeaderCell';
 import DataTable from './DataTable';
+import DataTableHeaderRow from './DataTableHeaderRow';
 
-export { DataTable, Cell, EditableCell, CheckableCell, TouchableCell, Row, HeaderRow, HeaderCell };
+export {
+  DataTable,
+  Cell,
+  DataTableHeaderRow,
+  EditableCell,
+  CheckableCell,
+  TouchableCell,
+  Row,
+  HeaderRow,
+  HeaderCell,
+};


### PR DESCRIPTION
Fixes #1136

## Change summary

- Put modal logic in the reducer
- Put selection logic in the reducer
- Extracted page info columns out, similar to columns/reducer methods. This will inject the `tableState` with a *method* (Require dispatch) to call which will return the page info columns for a page.
- Put `pageObject` in state (transaction for customerInvoice page)
- Adding items logic as reducer methods (including from master list. Requisition add from masterlist might need to change this logic a bit as it needs a store, simple change though.)
- Deleting items logic as reducer methods
- Added a wrapper around `HeaderRow` and `HeaderCell`
- Fixed `topLeftSection` styles


## Testing

*Internal changes, not really testable?*

### Related areas to think about

Note that the reducer can sometimes be called a couple of times for *any* dispatch (from what I have gathered). This is an optimization. Calling the reducer method is supposed to be non-blocking, which means that after a dispatch a render cycle can occur, which may call the reducer again. As the reducer *should* be pure it *shouldn't* matter. So, any reducer method should take care of any side effects it is executing*. I believe reducer being called can be cancelled and also if the diff is the same the result is not used.

*Added the line in `Transaction.addItemsFromMasterList* to for an early exit for this case

This is pretty significant, since we use database side effects in the reducer. I think it will be fine, we could add some middleware to handle the side effects, but could be over kill?


