### PR TITLE
#1145 onPress prop to Row component

### DIFF
--- a/src/widgets/DataTable/Row.js
+++ b/src/widgets/DataTable/Row.js
@@ -4,6 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { View } from 'react-native';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 
 /**
  * Renders a row of children as outputted by renderCells render prop
@@ -11,14 +12,22 @@ import { View } from 'react-native';
  * @param {object} rowData Data to pass to renderCells callback
  * @param {string|number} rowKey Unique key associated to row
  * @param {object} rowState State to pass to renderCells callBack
+ * @param {func} onPress function to call on pressing the row. See below.
+ * @param {object} viewStyle Style object for the wrapping View component
  * @param {func} renderCells renderProp callBack for rendering cells based on rowData and rowState
  *                          `(rowKey, columnKey) => {...}`
- * @param {object} viewStyle Style object for the wrapping View component
+ * Tap gesture events will be captured in this component for any taps on cells within
+ * this container.
  */
-const Row = React.memo(({ rowData, rowState, rowKey, renderCells, style }) => {
+const Row = React.memo(({ rowData, rowState, rowKey, renderCells, style, onPress }) => {
   console.log('=================================');
   console.log(`Row: ${rowKey}`);
-  return <View style={style}>{renderCells(rowData, rowState, rowKey)}</View>;
+  const Container = onPress ? TouchableOpacity : View;
+  return (
+    <Container onPress={onPress} style={style}>
+      {renderCells(rowData, rowState, rowKey)}
+    </Container>
+  );
 });
 
 Row.propTypes = {
@@ -27,11 +36,13 @@ Row.propTypes = {
   rowKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   renderCells: PropTypes.func.isRequired,
   style: PropTypes.object,
+  onPress: PropTypes.func,
 };
 
 Row.defaultProps = {
   rowState: null,
   style: {},
+  onPress: null,
 };
 
 export default Row;

--- a/src/widgets/DataTable/Row.js
+++ b/src/widgets/DataTable/Row.js
@@ -8,16 +8,16 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 
 /**
  * Renders a row of children as outputted by renderCells render prop
+ * Tap gesture events will be captured in this component for any taps
+ * on cells within this container.
  *
  * @param {object} rowData Data to pass to renderCells callback
  * @param {string|number} rowKey Unique key associated to row
  * @param {object} rowState State to pass to renderCells callBack
- * @param {func} onPress function to call on pressing the row. See below.
+ * @param {func} onPress function to call on pressing the row.
  * @param {object} viewStyle Style object for the wrapping View component
  * @param {func} renderCells renderProp callBack for rendering cells based on rowData and rowState
  *                          `(rowKey, columnKey) => {...}`
- * Tap gesture events will be captured in this component for any taps on cells within
- * this container.
  */
 const Row = React.memo(({ rowData, rowState, rowKey, renderCells, style, onPress }) => {
   console.log('=================================');


### PR DESCRIPTION
#### EPIC #1043 

#### Note: Branched from #1136 

Fixes #1145

## Change summary

- Adds a simple `onPress` props to `Row`

As in the docstring, the behaviour is odd when you have a cell which is `Touchable` and the `Row`, as both events will be fired. I cannot find a way to cancel the propogation of a native event being fired on a child component. I think the solution is to wrap each non-touchable cell in a `Touchable` which would trigger the `Row` `onPress`. This would require a bit more refactoring and the use-case isn't needed right now.

Note that this is a bit weird because `EditableCell` uses an `onPress`

## Testing
- [ ] Clicking a `Row` component with an `onPress` prop triggers the `onPress`.
- [ ] Clicking a `Row` without an `onPress` prop does nothing

### Related areas to think about

I wouldn't be opposed to having a `mSupplyRow` component which would do a lot of the rendering of cells as well as handling logic related to having clickable rows and adding an icon indicating that a row is clickable!
