### PR TITLE
#1144 database settings singletons

### DIFF
--- a/src/database/BaseDatabase.js
+++ b/src/database/BaseDatabase.js
@@ -1,0 +1,7 @@
+import { Database } from 'react-native-database';
+
+import { schema } from './schema';
+
+const BaseDatabaseInstance = new Database(schema);
+
+export default BaseDatabaseInstance;

--- a/src/database/BaseDatabase.js
+++ b/src/database/BaseDatabase.js
@@ -1,3 +1,16 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+/**
+ * Interface to a Realm, to be wrapped by
+ * SyncDatabase or UIDatabase.
+ *
+ * Only one instance will be active at any point
+ * in the applications life-cycle.
+ */
+
 import { Database } from 'react-native-database';
 
 import { schema } from './schema';

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-mutable-exports */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
@@ -28,7 +29,7 @@ const translateToCoreDatabaseType = type => {
   }
 };
 
-export class UIDatabase {
+class UIDatabase {
   constructor(database) {
     this.database = database;
     this.EXPORT_DIRECTORY = '/Download/mSupplyMobile_data';
@@ -172,4 +173,13 @@ export class UIDatabase {
   }
 }
 
-export default UIDatabase;
+let UIDatabaseInstance;
+
+export const getUIDatabaseInstance = database => {
+  if (!UIDatabaseInstance) {
+    UIDatabaseInstance = new UIDatabase(database);
+  }
+  return UIDatabaseInstance;
+};
+
+export default getUIDatabaseInstance;

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -3,7 +3,12 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-export { Database, CHANGE_TYPES, generateUUID } from 'react-native-database';
+import Database from './BaseDatabase';
+import { getUIDatabaseInstance } from './UIDatabase';
 
-export { UIDatabase } from './UIDatabase';
+export { CHANGE_TYPES, generateUUID } from 'react-native-database';
+
 export { createRecord, getNumberSequence, NUMBER_SEQUENCE_KEYS } from './utilities';
+export { getUIDatabaseInstance };
+
+export const UIDatabase = getUIDatabaseInstance(Database);

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -25,7 +25,7 @@ import { Scheduler } from 'sussol-utilities';
 import { NavigationActions } from 'react-navigation';
 
 import { FirstUsePage, FINALISABLE_PAGES } from './pages';
-import { MobileAppSettings } from './settings/MobileAppSettings';
+
 import { Synchroniser, PostSyncProcessor, SyncModal } from './sync';
 import { FinaliseButton, NavigationBar, SyncState, Spinner } from './widgets';
 import { FinaliseModal, LoginModal } from './widgets/modals';
@@ -33,8 +33,9 @@ import { FinaliseModal, LoginModal } from './widgets/modals';
 import { getCurrentParams, getCurrentRouteName, ReduxNavigator } from './navigation';
 import { migrateDataToVersion } from './dataMigration';
 import { SyncAuthenticator, UserAuthenticator } from './authentication';
-import { Database, UIDatabase } from './database';
-import { schema } from './database/schema';
+import Settings from './settings/MobileAppSettings';
+import Database from './database/BaseDatabase';
+import { UIDatabase } from './database';
 
 import globalStyles, {
   dataTableColors,
@@ -50,19 +51,12 @@ const AUTHENTICATION_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 class MSupplyMobileAppContainer extends React.Component {
   constructor(props, ...otherArgs) {
     super(props, ...otherArgs);
-    const database = new Database(schema);
-    this.database = new UIDatabase(database);
-    this.settings = new MobileAppSettings(this.database);
-    migrateDataToVersion(this.database, this.settings);
-    this.userAuthenticator = new UserAuthenticator(this.database, this.settings);
-    const syncAuthenticator = new SyncAuthenticator(this.settings);
-    this.synchroniser = new Synchroniser(
-      database,
-      syncAuthenticator,
-      this.settings,
-      props.dispatch
-    );
-    this.postSyncProcessor = new PostSyncProcessor(this.database, this.settings);
+
+    migrateDataToVersion(UIDatabase, Settings);
+    this.userAuthenticator = new UserAuthenticator(UIDatabase, Settings);
+    const syncAuthenticator = new SyncAuthenticator(Settings);
+    this.synchroniser = new Synchroniser(Database, syncAuthenticator, Settings, props.dispatch);
+    this.postSyncProcessor = new PostSyncProcessor(UIDatabase, Settings);
     this.scheduler = new Scheduler();
     const isInitialised = this.synchroniser.isInitialised();
     this.scheduler.schedule(this.synchronise, SYNC_INTERVAL);
@@ -121,7 +115,7 @@ class MSupplyMobileAppContainer extends React.Component {
   };
 
   runWithLoadingIndicator = async functionToRun => {
-    this.database.isLoading = true;
+    UIDatabase.isLoading = true;
     // We here set up an asyncronous promise that will be resolved after a timeout
     // of 1 millisecond. This allows a fraction of a delay for the javascript thread
     // to unblock and allow the spinner animation to start up. The |functionToRun| should
@@ -132,7 +126,7 @@ class MSupplyMobileAppContainer extends React.Component {
     });
     functionToRun();
     this.setState({ isLoading: false });
-    this.database.isLoading = false;
+    UIDatabase.isLoading = false;
   };
 
   synchronise = async () => {
@@ -207,7 +201,9 @@ class MSupplyMobileAppContainer extends React.Component {
 
   render() {
     const { dispatch, finaliseItem, navigationState, syncState } = this.props;
-
+    console.log('^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^');
+    console.log('rendering msupply');
+    console.log('^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^');
     const {
       confirmFinalise,
       currentUser,
@@ -243,8 +239,8 @@ class MSupplyMobileAppContainer extends React.Component {
           state={navigationState}
           dispatch={dispatch}
           screenProps={{
-            database: this.database,
-            settings: this.settings,
+            database: UIDatabase,
+            settings: Settings,
             logOut: this.logOut,
             currentUser,
             runWithLoadingIndicator: this.runWithLoadingIndicator,
@@ -258,7 +254,7 @@ class MSupplyMobileAppContainer extends React.Component {
           }}
         />
         <FinaliseModal
-          database={this.database}
+          database={UIDatabase}
           isOpen={confirmFinalise}
           onClose={() => this.setState({ confirmFinalise: false })}
           finaliseItem={finaliseItem}
@@ -266,7 +262,7 @@ class MSupplyMobileAppContainer extends React.Component {
           runWithLoadingIndicator={this.runWithLoadingIndicator}
         />
         <SyncModal
-          database={this.database}
+          database={UIDatabase}
           isOpen={syncModalIsOpen}
           state={syncState}
           onPressManualSync={this.synchronise}
@@ -274,7 +270,7 @@ class MSupplyMobileAppContainer extends React.Component {
         />
         <LoginModal
           authenticator={this.userAuthenticator}
-          settings={this.settings}
+          settings={Settings}
           isAuthenticated={currentUser !== null}
           onAuthentication={this.onAuthentication}
         />

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -201,9 +201,6 @@ class MSupplyMobileAppContainer extends React.Component {
 
   render() {
     const { dispatch, finaliseItem, navigationState, syncState } = this.props;
-    console.log('^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^');
-    console.log('rendering msupply');
-    console.log('^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^');
     const {
       confirmFinalise,
       currentUser,

--- a/src/settings/MobileAppSettings.js
+++ b/src/settings/MobileAppSettings.js
@@ -5,12 +5,13 @@ import DeviceInfo from 'react-native-device-info';
 import { SETTINGS_KEYS } from './index';
 import { MILLISECONDS_PER_DAY } from '../database/utilities';
 import { setCurrentLanguage, DEFAULT_LANGUAGE } from '../localization';
+import { UIDatabase } from '../database';
 
 const DEFAULT_AMC_MONTHS_LOOKBACK = 3; // three months
 
 export class MobileAppSettings extends Settings {
-  constructor(database) {
-    super(database);
+  constructor() {
+    super(UIDatabase);
     this.load();
     this.set(SETTINGS_KEYS.HARDWARE_UUID, DeviceInfo.getUniqueID());
     this.refreshGlobals();
@@ -62,4 +63,4 @@ export class MobileAppSettings extends Settings {
   }
 }
 
-export default MobileAppSettings;
+export default new MobileAppSettings();


### PR DESCRIPTION
Fixes #1144 

~~## NOTE: Branched from #1142~~

## Change summary

- Created a file `BaseDatabase.js` which exports an instance of `react-native-database`. Should be the single instance of this in the entire app.
- Created a method `getUIDatabaseInstance` in `UIDatabase.js` and exported that - removed the export of `UIDatabase`. Because of require cycles when importing `UIDatabase` into a realm data type (i.e. `Transaction` -> `schema` -> `BaseDatabase` -> `UIDatabase` -> `Transaction`), the database being wrapped needed to be injected. 
- Exported a single instance of `UIDatabase` from `database/index.js`, and trying to import `UIDatabase` will pass the same instance when the method is called (basically using a *slightly more* standard singleton pattern here).
- Added an import of `UIDatabase` to `Settings` and exported a single instance.
- Added imports of `UIDatabase`, `BaseDatabase` (for the synchroniser) and `Settings` to `mSupplyMobileAppContainer`
- Left the passing of database and settings in props, for now. Data table refactor will take care of a lot of that, I think, and the rest can be done in new issues related to fixing navigation/redux. New code can definitely import as needed.

**Note:** ECMAScript Imports are asynchronously loaded - the order cannot be guaranteed *see: [exploring JS](https://exploringjs.com/es6/ch_modules.html#sec_modules-in-browsers) or the [ECMA script specs](http://www.ecma-international.org/ecma-262/6.0/#sec-modules)*
However, scripts being imported *are* guaranteed to be *executed*, prior to importing. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Terrible test but: Should run as it did prior to this change..!

### Related areas to think about

Singletons are definitely a pattern that should be used [sparingly](https://www.google.com/search?client=firefox-b-d&q=why+singlestons+are+bad+js) but I think this is a good use case for getting into a better position to fix some more immediate problems. Possibly using a similar pattern for `Synchroniser` and the `Authenticators` would/could be a good idea also
