### PR TITLE
#1140 data table default props optimisations

### DIFF
--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -153,6 +153,7 @@ export const CustomerInvoicePage = ({
               textStyle={editableCellText}
               textViewStyle={editableCellTextView}
               isLastCell={isLastCell}
+              debug
             />
           );
         case 'checkable':
@@ -173,6 +174,7 @@ export const CustomerInvoicePage = ({
               containerStyle={touchableCellContainer}
               width={width}
               isLastCell={isLastCell}
+              debug
             />
           );
         default:
@@ -184,6 +186,7 @@ export const CustomerInvoicePage = ({
               viewStyle={cellContainer[alignText || 'left']}
               textStyle={cellText[alignText || 'left']}
               isLastCell={isLastCell}
+              debug
             />
           );
       }
@@ -202,6 +205,7 @@ export const CustomerInvoicePage = ({
           rowKey={rowKey}
           renderCells={renderCells}
           style={index % 2 === 0 ? alternateRow : row}
+          debug
         />
       );
     },

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -3,7 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
@@ -75,7 +75,10 @@ export const CustomerInvoicePage = ({
   const [state, dispatch, instantDebouncedDispatch, debouncedDispatch] = usePageReducer(routeName, {
     pageObject: transaction,
     backingData: transaction.items,
-    data: transaction.items.sorted('item.name').slice(),
+    data: [
+      ...transaction.items.sorted('item.name').slice(),
+      ...transaction.items.sorted('item.name').slice(),
+    ],
     database,
     keyExtractor,
     dataState: new Map(),
@@ -257,6 +260,13 @@ export const CustomerInvoicePage = ({
     />
   );
 
+  const [renderTable, setRenderTable] = useState(false);
+  useEffect(() => {
+    setInterval(() => {
+      setRenderTable(yee => !yee);
+    }, 750);
+  }, []);
+
   const {
     newPageTopSectionContainer,
     newPageTopLeftSectionContainer,
@@ -277,13 +287,15 @@ export const CustomerInvoicePage = ({
         </View>
         <View style={newPageTopRightSectionContainer}>{renderButtons()}</View>
       </View>
-      <DataTable
-        data={data}
-        extraData={dataState}
-        renderRow={renderRow}
-        renderHeader={renderHeader}
-        keyExtractor={keyExtractor}
-      />
+      {renderTable && (
+        <DataTable
+          data={data}
+          extraData={dataState}
+          renderRow={renderRow}
+          renderHeader={renderHeader}
+          keyExtractor={keyExtractor}
+        />
+      )}
       <BottomConfirmModal
         isOpen={hasSelection}
         questionText={modalStrings.remove_these_items}

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -3,7 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
@@ -75,10 +75,7 @@ export const CustomerInvoicePage = ({
   const [state, dispatch, instantDebouncedDispatch, debouncedDispatch] = usePageReducer(routeName, {
     pageObject: transaction,
     backingData: transaction.items,
-    data: [
-      ...transaction.items.sorted('item.name').slice(),
-      ...transaction.items.sorted('item.name').slice(),
-    ],
+    data: transaction.items.sorted('item.name').slice(),
     database,
     keyExtractor,
     dataState: new Map(),
@@ -116,6 +113,15 @@ export const CustomerInvoicePage = ({
     () => <PageInfo columns={pageInfo(pageObject, dispatch)} isEditingDisabled={isFinalised} />,
     [comment, theirRef]
   );
+
+  const getItemLayout = useCallback((item, index) => {
+    const { height } = newDataTableStyles.row;
+    return {
+      length: height,
+      offset: height * index,
+      index,
+    };
+  }, []);
 
   const renderCells = useCallback((rowData, rowState = {}, rowKey) => {
     const {
@@ -260,13 +266,6 @@ export const CustomerInvoicePage = ({
     />
   );
 
-  const [renderTable, setRenderTable] = useState(false);
-  useEffect(() => {
-    setInterval(() => {
-      setRenderTable(yee => !yee);
-    }, 750);
-  }, []);
-
   const {
     newPageTopSectionContainer,
     newPageTopLeftSectionContainer,
@@ -287,15 +286,14 @@ export const CustomerInvoicePage = ({
         </View>
         <View style={newPageTopRightSectionContainer}>{renderButtons()}</View>
       </View>
-      {renderTable && (
-        <DataTable
-          data={data}
-          extraData={dataState}
-          renderRow={renderRow}
-          renderHeader={renderHeader}
-          keyExtractor={keyExtractor}
-        />
-      )}
+      <DataTable
+        data={data}
+        extraData={dataState}
+        renderRow={renderRow}
+        renderHeader={renderHeader}
+        keyExtractor={keyExtractor}
+        getItemLayout={getItemLayout}
+      />
       <BottomConfirmModal
         isOpen={hasSelection}
         questionText={modalStrings.remove_these_items}

--- a/src/widgets/DataTable/Cell.js
+++ b/src/widgets/DataTable/Cell.js
@@ -15,9 +15,8 @@ import { getAdjustedStyle } from './utilities';
  * @param {Bool}          isLastCell Indicator for if this cell is the last
  *                                   in a row. Removing the borderRight if true.
  */
-const Cell = React.memo(({ value, textStyle, viewStyle, width, isLastCell }) => {
-  console.log(`- Cell: ${value}`);
-
+const Cell = React.memo(({ value, textStyle, viewStyle, width, isLastCell, debug }) => {
+  if (debug) console.log(`- Cell: ${value}`);
   const internalViewStyle = getAdjustedStyle(viewStyle, width, isLastCell);
 
   return (
@@ -33,6 +32,7 @@ Cell.propTypes = {
   viewStyle: PropTypes.object,
   width: PropTypes.number,
   isLastCell: PropTypes.bool,
+  debug: PropTypes.bool,
 };
 
 Cell.defaultProps = {
@@ -41,6 +41,7 @@ Cell.defaultProps = {
   viewStyle: {},
   width: 0,
   isLastCell: false,
+  debug: false,
 };
 
 export default Cell;

--- a/src/widgets/DataTable/CheckableCell.js
+++ b/src/widgets/DataTable/CheckableCell.js
@@ -42,8 +42,9 @@ const CheckableCell = React.memo(
     containerStyle,
     width,
     isLastCell,
+    debug,
   }) => {
-    console.log(`- CheckableCell: ${rowKey},${columnKey}`);
+    if (debug) console.log(`- CheckableCell: ${rowKey},${columnKey}`);
 
     const onPressAction = isChecked ? onUncheckAction : onCheckAction;
 
@@ -88,6 +89,7 @@ CheckableCell.propTypes = {
   containerStyle: PropTypes.object,
   width: PropTypes.number,
   isLastCell: PropTypes.bool,
+  debug: PropTypes.bool,
 };
 
 CheckableCell.defaultProps = {
@@ -98,6 +100,7 @@ CheckableCell.defaultProps = {
   containerStyle: defaultStyles.containerStyle,
   width: 0,
   isLastCell: false,
+  debug: false,
 };
 
 export default CheckableCell;

--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StyleSheet, VirtualizedList, VirtualizedListPropTypes } from 'react-native';
 
 /**
@@ -16,12 +16,28 @@ import { StyleSheet, VirtualizedList, VirtualizedListPropTypes } from 'react-nat
  * @param {Func}   renderRow    Renaming of VirtualizedList renderItem prop.
  * @param {Func}   renderHeader Function which should return a header component
  */
-const DataTable = React.memo(({ renderRow, renderHeader, style, ...otherProps }) => (
-  <>
-    {renderHeader()}
-    <VirtualizedList style={style} renderItem={renderRow} {...otherProps} />
-  </>
-));
+let renderCount = 0;
+let totalTime = 0;
+const DataTable = React.memo(({ renderRow, renderHeader, style, ...otherProps }) => {
+  const start = Date.now();
+  useEffect(() => {
+    if (renderCount === 20) {
+      console.log('===========================================');
+      console.log(`${renderCount} render avg time: ${totalTime / renderCount}ms`);
+      console.log('===========================================');
+      renderCount += 1;
+    } else {
+      totalTime += Date.now() - start;
+      renderCount += 1;
+    }
+  }, []);
+  return (
+    <>
+      {renderHeader()}
+      <VirtualizedList style={style} renderItem={renderRow} {...otherProps} />
+    </>
+  );
+});
 
 const defaultStyles = StyleSheet.create({
   virtualizedList: {
@@ -35,14 +51,28 @@ DataTable.propTypes = {
   renderHeader: PropTypes.func,
   getItem: PropTypes.func,
   getItemCount: PropTypes.func,
+  getItemLayout: PropTypes.func,
+  updateCellsBatchingPeriod: PropTypes.number,
+  initialNumToRender: PropTypes.number,
+  removeClippedSubviews: PropTypes.bool,
+  windowSize: PropTypes.number,
   style: PropTypes.object,
 };
 
 DataTable.defaultProps = {
-  getItem: (items, index) => items[index],
-  getItemCount: items => items.length,
   renderHeader: null,
   style: defaultStyles.virtualizedList,
+  getItem: (items, index) => items[index],
+  getItemCount: items => items.length,
+  getItemLayout: (data, index) => ({
+    length: 45,
+    offset: 45 * index,
+    index,
+  }),
+  updateCellsBatchingPeriod: 500,
+  initialNumToRender: 20,
+  removeClippedSubviews: true,
+  windowSize: 5,
 };
 
 export default DataTable;

--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { StyleSheet, VirtualizedList, VirtualizedListPropTypes } from 'react-native';
 
 /**
@@ -16,28 +16,12 @@ import { StyleSheet, VirtualizedList, VirtualizedListPropTypes } from 'react-nat
  * @param {Func}   renderRow    Renaming of VirtualizedList renderItem prop.
  * @param {Func}   renderHeader Function which should return a header component
  */
-let renderCount = 0;
-let totalTime = 0;
-const DataTable = React.memo(({ renderRow, renderHeader, style, ...otherProps }) => {
-  const start = Date.now();
-  useEffect(() => {
-    if (renderCount === 20) {
-      console.log('===========================================');
-      console.log(`${renderCount} render avg time: ${totalTime / renderCount}ms`);
-      console.log('===========================================');
-      renderCount += 1;
-    } else {
-      totalTime += Date.now() - start;
-      renderCount += 1;
-    }
-  }, []);
-  return (
-    <>
-      {renderHeader()}
-      <VirtualizedList style={style} renderItem={renderRow} {...otherProps} />
-    </>
-  );
-});
+const DataTable = React.memo(({ renderRow, renderHeader, style, ...otherProps }) => (
+  <>
+    {renderHeader()}
+    <VirtualizedList style={style} renderItem={renderRow} {...otherProps} />
+  </>
+));
 
 const defaultStyles = StyleSheet.create({
   virtualizedList: {
@@ -51,8 +35,6 @@ DataTable.propTypes = {
   renderHeader: PropTypes.func,
   getItem: PropTypes.func,
   getItemCount: PropTypes.func,
-  getItemLayout: PropTypes.func,
-  updateCellsBatchingPeriod: PropTypes.number,
   initialNumToRender: PropTypes.number,
   removeClippedSubviews: PropTypes.bool,
   windowSize: PropTypes.number,
@@ -64,15 +46,9 @@ DataTable.defaultProps = {
   style: defaultStyles.virtualizedList,
   getItem: (items, index) => items[index],
   getItemCount: items => items.length,
-  getItemLayout: (data, index) => ({
-    length: 45,
-    offset: 45 * index,
-    index,
-  }),
-  updateCellsBatchingPeriod: 500,
   initialNumToRender: 20,
   removeClippedSubviews: true,
-  windowSize: 5,
+  windowSize: 11,
 };
 
 export default DataTable;

--- a/src/widgets/DataTable/EditableCell.js
+++ b/src/widgets/DataTable/EditableCell.js
@@ -49,13 +49,14 @@ const EditableCell = React.memo(
     textViewStyle,
     isLastCell,
     width,
+    debug,
   }) => {
     const onEdit = newValue => dispatch(editAction(newValue, rowKey, columnKey));
 
     const focusCell = () => dispatch(focusAction(rowKey, columnKey));
     const focusNextCell = () => dispatch(focusNextAction(rowKey, columnKey));
 
-    console.log(`- EditableCell: ${value}`);
+    if (debug) console.log(`- EditableCell: ${value}`);
 
     const internalViewStyle = getAdjustedStyle(viewStyle, width, isLastCell);
     const internalTextStyle = getAdjustedStyle(textStyle, width);
@@ -114,19 +115,21 @@ EditableCell.propTypes = {
   textInputStyle: PropTypes.object,
   textViewStyle: PropTypes.object,
   isLastCell: PropTypes.bool,
+  debug: PropTypes.bool,
 };
 
 EditableCell.defaultProps = {
   value: '',
   disabled: false,
   isFocused: false,
-  width: 0,
   touchableStyle: {},
   viewStyle: {},
   textStyle: {},
   textInputStyle: {},
   textViewStyle: {},
   isLastCell: false,
+  width: 0,
+  debug: false,
 };
 
 export default EditableCell;

--- a/src/widgets/DataTable/Row.js
+++ b/src/widgets/DataTable/Row.js
@@ -15,9 +15,11 @@ import { View } from 'react-native';
  *                          `(rowKey, columnKey) => {...}`
  * @param {object} viewStyle Style object for the wrapping View component
  */
-const Row = React.memo(({ rowData, rowState, rowKey, renderCells, style }) => {
-  console.log('=================================');
-  console.log(`Row: ${rowKey}`);
+const Row = React.memo(({ rowData, rowState, rowKey, renderCells, style, debug }) => {
+  if (debug) {
+    console.log('=================================');
+    console.log(`Row: ${rowKey}`);
+  }
   return <View style={style}>{renderCells(rowData, rowState, rowKey)}</View>;
 });
 
@@ -27,11 +29,13 @@ Row.propTypes = {
   rowKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   renderCells: PropTypes.func.isRequired,
   style: PropTypes.object,
+  debug: PropTypes.bool,
 };
 
 Row.defaultProps = {
   rowState: null,
   style: {},
+  debug: false,
 };
 
 export default Row;

--- a/src/widgets/DataTable/Row.js
+++ b/src/widgets/DataTable/Row.js
@@ -15,21 +15,7 @@ import { View } from 'react-native';
  *                          `(rowKey, columnKey) => {...}`
  * @param {object} viewStyle Style object for the wrapping View component
  */
-// let renderCount = 0;
-// let totalTime = 0;
 const Row = React.memo(({ rowData, rowState, rowKey, renderCells, style, debug }) => {
-  // const start = Date.now();
-  // useLayoutEffect(() => {
-  //   if (renderCount === 200) {
-  //     console.log('===========================================');
-  //     console.log(`${renderCount} row avg time: ${totalTime / renderCount}ms`);
-  //     console.log('===========================================');
-  //     renderCount += 1;
-  //   } else {
-  //     totalTime += Date.now() - start;
-  //     renderCount += 1;
-  //   }
-  // }, []);
   if (debug) {
     console.log('=================================');
     console.log(`Row: ${rowKey}`);

--- a/src/widgets/DataTable/Row.js
+++ b/src/widgets/DataTable/Row.js
@@ -15,7 +15,21 @@ import { View } from 'react-native';
  *                          `(rowKey, columnKey) => {...}`
  * @param {object} viewStyle Style object for the wrapping View component
  */
+// let renderCount = 0;
+// let totalTime = 0;
 const Row = React.memo(({ rowData, rowState, rowKey, renderCells, style, debug }) => {
+  // const start = Date.now();
+  // useLayoutEffect(() => {
+  //   if (renderCount === 200) {
+  //     console.log('===========================================');
+  //     console.log(`${renderCount} row avg time: ${totalTime / renderCount}ms`);
+  //     console.log('===========================================');
+  //     renderCount += 1;
+  //   } else {
+  //     totalTime += Date.now() - start;
+  //     renderCount += 1;
+  //   }
+  // }, []);
   if (debug) {
     console.log('=================================');
     console.log(`Row: ${rowKey}`);

--- a/src/widgets/DataTable/TouchableCell.js
+++ b/src/widgets/DataTable/TouchableCell.js
@@ -35,9 +35,10 @@ const TouchableCell = React.memo(
     width,
     textStyle,
     isLastCell,
+    debug,
     ...otherProps
   }) => {
-    console.log(`- TouchableCell: ${rowKey},${columnKey}`);
+    if (debug) console.log(`- TouchableCell: ${rowKey},${columnKey}`);
 
     const onPress = () => {
       dispatch(onPressAction(rowKey, columnKey));
@@ -68,15 +69,17 @@ TouchableCell.propTypes = {
   textStyle: PropTypes.object,
   isLastCell: PropTypes.bool,
   width: PropTypes.number,
+  debug: PropTypes.bool,
 };
 
 TouchableCell.defaultProps = {
   value: '',
   containerStyle: {},
   textStyle: {},
-  isLastCell: false,
   TouchableComponent: null,
+  isLastCell: false,
   width: 0,
+  debug: false,
 };
 
 export default TouchableCell;


### PR DESCRIPTION
Fixes #1140 

## Change summary

- debug prop to enable Row/Cell logging (default `false)
- getItemLayout based on height in styles (45). This allows the scrollbar to be scaled correctly from the start, rather than dynamically shrinking as you scroll. Can get ahead of row rendering but fills in very promptly. But you can scroll immediately to bottom of list without rebounding.
- initialNumToRender 20: 20 rows will be more than enough rows to fill the viewport in one render
- removeClippedSubviews true: magic faster row rendering wow
- windowSize 11: still snappy and in most use means not catching up to rows yet to render.  

initialNumToRender and maxToRenderPerBatch tweaks didn't feel better, so left defaults.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] table still works
- [ ] scrolling be fast as

### Related areas to think about
