### PR TITLE
#1170 Extract key extractor & item layout functions

### DIFF
--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -12,7 +12,7 @@ import { SearchBar } from 'react-native-ui-components';
 
 import { MODAL_KEYS, getModalTitle } from '../utilities';
 import { buttonStrings, modalStrings } from '../localization';
-import { DEFAULT_KEY_EXTRACTOR, DEFAULT_GET_ITEM_LAYOUT } from './dataTableUtilities/utilities';
+import { recordKeyExtractor, getItemLayout } from './dataTableUtilities/utilities';
 import { UIDatabase } from '../database';
 import { BottomConfirmModal, PageContentModal } from '../widgets/modals';
 import {
@@ -78,7 +78,7 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
     pageObject: transaction,
     backingData: transaction.items,
     data: transaction.items.sorted('item.name').slice(),
-    keyExtractor: DEFAULT_KEY_EXTRACTOR,
+    keyExtractor: recordKeyExtractor,
     dataState: new Map(),
     currentFocusedRowKey: null,
     searchTerm: '',
@@ -272,7 +272,7 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
     />
   );
 
-  const getItemLayout = useCallback(DEFAULT_GET_ITEM_LAYOUT, []);
+  const memoizedGetItemLayout = useCallback(getItemLayout, []);
 
   const {
     newPageTopSectionContainer,
@@ -300,7 +300,7 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
         renderRow={renderRow}
         renderHeader={renderHeader}
         keyExtractor={keyExtractor}
-        getItemLayout={getItemLayout}
+        getItemLayout={memoizedGetItemLayout}
       />
       <BottomConfirmModal
         isOpen={hasSelection}

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -12,6 +12,7 @@ import { SearchBar } from 'react-native-ui-components';
 
 import { MODAL_KEYS, getModalTitle } from '../utilities';
 import { buttonStrings, modalStrings } from '../localization';
+import { DEFAULT_KEY_EXTRACTOR, DEFAULT_GET_ITEM_LAYOUT } from './dataTableUtilities/utilities';
 import { UIDatabase } from '../database';
 import { BottomConfirmModal, PageContentModal } from '../widgets/modals';
 import {
@@ -55,8 +56,6 @@ import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '
 import usePageReducer from '../hooks/usePageReducer';
 import DataTablePageView from './containers/DataTablePageView';
 
-const keyExtractor = item => item.id;
-
 /**
  * Renders a mSupply mobile page with customer invoice loaded for editing
  *
@@ -79,7 +78,7 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
     pageObject: transaction,
     backingData: transaction.items,
     data: transaction.items.sorted('item.name').slice(),
-    keyExtractor,
+    keyExtractor: DEFAULT_KEY_EXTRACTOR,
     dataState: new Map(),
     currentFocusedRowKey: null,
     searchTerm: '',
@@ -102,6 +101,7 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
     pageObject,
     hasSelection,
     backingData,
+    keyExtractor,
   } = state;
   const { isFinalised, comment, theirRef } = pageObject;
 
@@ -114,15 +114,6 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
     () => <PageInfo columns={pageInfo(pageObject, dispatch)} isEditingDisabled={isFinalised} />,
     [comment, theirRef, isFinalised]
   );
-
-  const getItemLayout = useCallback((item, index) => {
-    const { height } = newDataTableStyles.row;
-    return {
-      length: height,
-      offset: height * index,
-      index,
-    };
-  }, []);
 
   const renderCells = useCallback(
     (rowData, rowState = {}, rowKey) => {
@@ -280,6 +271,8 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
       sortBy={sortBy}
     />
   );
+
+  const getItemLayout = useCallback(DEFAULT_GET_ITEM_LAYOUT, []);
 
   const {
     newPageTopSectionContainer,

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -10,7 +10,7 @@ import { SearchBar } from 'react-native-ui-components';
 
 import { UIDatabase, createRecord } from '../database';
 import { buttonStrings, modalStrings, navStrings } from '../localization';
-import { DEFAULT_KEY_EXTRACTOR, DEFAULT_GET_ITEM_LAYOUT } from './dataTableUtilities/utilities';
+import { recordKeyExtractor, getItemLayout } from './dataTableUtilities/utilities';
 import { BottomConfirmModal, SelectModal } from '../widgets/modals';
 import {
   PageButton,
@@ -41,7 +41,7 @@ const initialState = () => {
   return {
     backingData,
     data: newSortDataBy(backingData.slice(), 'serialNumber', false),
-    keyExtractor: DEFAULT_KEY_EXTRACTOR,
+    keyExtractor: recordKeyExtractor,
     dataState: new Map(),
     searchTerm: '',
     filterDataKeys: ['otherParty.name'],
@@ -174,7 +174,7 @@ export const CustomerInvoicesPage = ({ currentUser, navigateTo, routeName }) => 
     [data, dataState, renderCells]
   );
 
-  const getItemLayout = useCallback(DEFAULT_GET_ITEM_LAYOUT, []);
+  const memoizedGetItemLayout = useCallback(getItemLayout, []);
 
   const {
     newPageTopSectionContainer,
@@ -201,7 +201,7 @@ export const CustomerInvoicesPage = ({ currentUser, navigateTo, routeName }) => 
         renderRow={renderRow}
         renderHeader={renderHeader}
         keyExtractor={keyExtractor}
-        getItemLayout={getItemLayout}
+        getItemLayout={memoizedGetItemLayout}
       />
       <BottomConfirmModal
         isOpen={hasSelection}

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -10,6 +10,7 @@ import { SearchBar } from 'react-native-ui-components';
 
 import { UIDatabase, createRecord } from '../database';
 import { buttonStrings, modalStrings, navStrings } from '../localization';
+import { DEFAULT_KEY_EXTRACTOR, DEFAULT_GET_ITEM_LAYOUT } from './dataTableUtilities/utilities';
 import { BottomConfirmModal, SelectModal } from '../widgets/modals';
 import {
   PageButton,
@@ -35,14 +36,12 @@ import DataTablePageView from './containers/DataTablePageView';
 
 import { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
 
-const keyExtractor = item => item.id;
-
 const initialState = () => {
   const backingData = UIDatabase.objects('CustomerInvoice');
   return {
     backingData,
     data: newSortDataBy(backingData.slice(), 'serialNumber', false),
-    keyExtractor,
+    keyExtractor: DEFAULT_KEY_EXTRACTOR,
     dataState: new Map(),
     searchTerm: '',
     filterDataKeys: ['otherParty.name'],
@@ -58,7 +57,16 @@ export const CustomerInvoicesPage = ({ currentUser, navigateTo, routeName }) => 
     routeName,
     initialState()
   );
-  const { data, dataState, sortBy, isAscending, columns, modalKey, hasSelection } = state;
+  const {
+    data,
+    dataState,
+    sortBy,
+    isAscending,
+    columns,
+    modalKey,
+    hasSelection,
+    keyExtractor,
+  } = state;
 
   const renderNewInvoiceButton = () => (
     <PageButton
@@ -92,15 +100,6 @@ export const CustomerInvoicesPage = ({ currentUser, navigateTo, routeName }) => 
     });
     navigateToInvoice(invoice);
   };
-
-  const getItemLayout = useCallback((item, index) => {
-    const { height } = newDataTableStyles.row;
-    return {
-      length: height,
-      offset: height * index,
-      index,
-    };
-  }, []);
 
   const renderHeader = () => (
     <DataTableHeaderRow
@@ -174,6 +173,8 @@ export const CustomerInvoicesPage = ({ currentUser, navigateTo, routeName }) => 
     },
     [data, dataState, renderCells]
   );
+
+  const getItemLayout = useCallback(DEFAULT_GET_ITEM_LAYOUT, []);
 
   const {
     newPageTopSectionContainer,

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -9,6 +9,7 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
+import { recordKeyExtractor, getItemLayout } from './dataTableUtilities/utilities';
 
 import { MODAL_KEYS, getModalTitle } from '../utilities';
 import { buttonStrings, modalStrings } from '../localization';
@@ -68,7 +69,7 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
       .getTransactionBatches(UIDatabase)
       .sorted('itemName')
       .slice(),
-    keyExtractor,
+    keyExtractor: recordKeyExtractor,
     dataState: new Map(),
     currentFocusedRowKey: null,
     searchTerm: '',
@@ -96,15 +97,6 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
   const { ITEM_SELECT, COMMENT_EDIT, THEIR_REF_EDIT } = MODAL_KEYS;
 
   if (isFinalised && data.length !== backingData.length) dispatch(refreshData());
-
-  const getItemLayout = useCallback((_, index) => {
-    const { height } = newDataTableStyles.row;
-    return {
-      length: height,
-      offset: height * index,
-      index,
-    };
-  }, []);
 
   const renderPageInfo = useCallback(
     () => <PageInfo columns={pageInfo(pageObject, dispatch)} isEditingDisabled={isFinalised} />,
@@ -278,6 +270,8 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
     />
   );
 
+  const memoizedGetItemLayout = useCallback(getItemLayout, []);
+
   const {
     newPageTopSectionContainer,
     newPageTopLeftSectionContainer,
@@ -304,7 +298,7 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
         renderRow={renderRow}
         renderHeader={renderHeader}
         keyExtractor={keyExtractor}
-        getItemLayout={getItemLayout}
+        getItemLayout={memoizedGetItemLayout}
       />
       <BottomConfirmModal
         isOpen={hasSelection}

--- a/src/pages/dataTableUtilities/utilities.js
+++ b/src/pages/dataTableUtilities/utilities.js
@@ -14,7 +14,7 @@ import newDataTableStyles from '../../globalStyles/newDataTableStyles';
  * Should be memoized in a component for use.
  * @param {Number} index index of a row in VirtualizedList.
  */
-export const DEFAULT_GET_ITEM_LAYOUT = (_, index) => {
+export const getItemLayout = (_, index) => {
   const { height } = newDataTableStyles.row;
   return {
     length: height,
@@ -28,4 +28,4 @@ export const DEFAULT_GET_ITEM_LAYOUT = (_, index) => {
  *
  * @param {Object} item Any item to extract a key from.
  */
-export const DEFAULT_KEY_EXTRACTOR = item => item.id;
+export const recordKeyExtractor = item => item.id;

--- a/src/pages/dataTableUtilities/utilities.js
+++ b/src/pages/dataTableUtilities/utilities.js
@@ -1,0 +1,31 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import newDataTableStyles from '../../globalStyles/newDataTableStyles';
+
+/**
+ * Utility methods used for DataTable pages.s
+ */
+
+/**
+ * Simple get item layout for DataTable pages.
+ * Should be memoized in a component for use.
+ * @param {Number} index index of a row in VirtualizedList.
+ */
+export const DEFAULT_GET_ITEM_LAYOUT = (_, index) => {
+  const { height } = newDataTableStyles.row;
+  return {
+    length: height,
+    offset: height * index,
+    index,
+  };
+};
+
+/**
+ * Simple keyExtractor for DataTable pages.
+ *
+ * @param {Object} item Any item to extract a key from.
+ */
+export const DEFAULT_KEY_EXTRACTOR = item => item.id;


### PR DESCRIPTION
Fixes #1170 

## Change summary

- Adds `getItemLayout` and `keyExtractor` to a utilities file.

Not the greatest factoring, but might prevent a mistake in the future

## Testing

Steps to reproduce or otherwise test the changes of this PR:

*internal change can't test?*

### Related areas to think about

N/A
