### PR TITLE
#1172 useNavigationFocusRefresh custom hook

### DIFF
--- a/src/hooks/useNavigationFocusRefresh.js
+++ b/src/hooks/useNavigationFocusRefresh.js
@@ -1,0 +1,39 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import { useEffect, useState } from 'react';
+import { refreshData } from '../pages/dataTableUtilities/actions';
+
+/**
+ * Simple custom hook which subscribes to navigation focus event,
+ * (navigating to a page), which will refresh data on that page
+ * when navigating to it. Main use case is popping a page from the
+ * stack and returning to a page whose state has been altered but
+ * the UI has not updated/re-rendered.
+ *
+ * - ENSURE THE CALLING SCREEN HAS A `refreshData` REDUCER CASE.
+ * - Only events for the calling page are subscribed to.
+ * - Initial navigation focus event is NOT captured.
+ *
+ * @param {Func}   dispatch   Page reducer
+ * @param {Object} navigation react-navigation navigator object.
+ */
+export const useNavigationFocusRefresh = (dispatch, navigation) => {
+  const [subscription, setSubscription] = useState(null);
+
+  const unSubscribe = () => subscription.remove();
+
+  // On-mount, On-unmount effect, subscribing/unsubscribing to willFocus navigation
+  // events.
+  useEffect(() => {
+    const newSubscription = navigation.addListener('willFocus', () => dispatch(refreshData()));
+    setSubscription(newSubscription);
+
+    return () => subscription.remove();
+  }, []);
+
+  return [subscription, unSubscribe];
+};

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -33,6 +33,8 @@ import { MODAL_KEYS, newSortDataBy } from '../utilities';
 import usePageReducer from '../hooks/usePageReducer';
 import DataTablePageView from './containers/DataTablePageView';
 
+import { useNavigationFocusRefresh } from '../hooks/useNavigationFocusRefresh';
+
 import { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
 
 const keyExtractor = item => item.id;
@@ -53,12 +55,14 @@ const initialState = () => {
   };
 };
 
-export const CustomerInvoicesPage = ({ currentUser, navigateTo, routeName }) => {
+export const CustomerInvoicesPage = ({ currentUser, navigateTo, routeName, navigation }) => {
   const [state, dispatch, instantDebouncedDispatch, debouncedDispatch] = usePageReducer(
     routeName,
     initialState()
   );
   const { data, dataState, sortBy, isAscending, columns, modalKey, hasSelection } = state;
+
+  useNavigationFocusRefresh(dispatch, navigation);
 
   const renderNewInvoiceButton = () => (
     <PageButton
@@ -230,4 +234,5 @@ CustomerInvoicesPage.propTypes = {
   currentUser: PropTypes.object.isRequired,
   navigateTo: PropTypes.func.isRequired,
   routeName: PropTypes.string.isRequired,
+  navigation: PropTypes.object.isRequired,
 };

--- a/src/pages/PageContainer.js
+++ b/src/pages/PageContainer.js
@@ -40,6 +40,7 @@ const extractPropsForPage = props => {
     ...restOfNavigationState,
     navigateTo,
     ...restOfProps,
+    navigation,
   };
 };
 

--- a/src/pages/dataTableUtilities/reducer/getReducer.js
+++ b/src/pages/dataTableUtilities/reducer/getReducer.js
@@ -70,6 +70,7 @@ const customerInvoices = {
   openBasicModal,
   closeBasicModal,
   deleteRecordsById,
+  refreshData,
 };
 
 const PAGE_REDUCERS = {


### PR DESCRIPTION
Fixes #1172 

## Change summary

- Adds a hook which will listen to navigation `willFocus` event, which will fire a `refreshData` dispatch on a screen being refocused

## Testing

Steps to reproduce or otherwise test the changes of this PR:

*create a customer invoice, unfinalised, navigate back*

- [ ] `CustomerInvoicesPage` -> `CustomerInvoicePage` -- finalise -> `CustomerInvoicesPage`, table should be refreshed and show that the invoice is finalised

### Related areas to think about

N/A
