### PR TITLE
#1181 New DataTable auto-scroll and focus logic

### DIFF
--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -125,6 +125,7 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
           isFinalised={isFinalised}
           dispatch={dispatch}
           getAction={getAction}
+          rowIndex={index}
         />
       );
     },

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -20,8 +20,6 @@ import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTabl
 
 import {
   editTotalQuantity,
-  focusCell,
-  focusNext,
   selectRow,
   deselectRow,
   deselectAll,
@@ -126,8 +124,6 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
           columns={columns}
           isFinalised={isFinalised}
           dispatch={dispatch}
-          focusCellAction={focusCell}
-          focusNextAction={focusNext}
           getAction={getAction}
         />
       );
@@ -205,6 +201,7 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
         renderHeader={renderHeader}
         keyExtractor={keyExtractor}
         getItemLayout={memoizedGetItemLayout}
+        columns={columns}
       />
       <BottomConfirmModal
         isOpen={hasSelection}

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -107,6 +107,7 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
           isFinalised={isFinalised}
           dispatch={dispatch}
           getAction={getAction}
+          rowIndex={index}
         />
       );
     },

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -19,8 +19,6 @@ import { AutocompleteSelector, PageButton, PageInfo, TextEditor } from '../widge
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
 import {
-  focusCell,
-  focusNext,
   deselectAll,
   sortData,
   filterData,
@@ -108,8 +106,6 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
           columns={columns}
           isFinalised={isFinalised}
           dispatch={dispatch}
-          focusCellAction={focusCell}
-          focusNextAction={focusNext}
           getAction={getAction}
         />
       );
@@ -203,6 +199,7 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
         renderHeader={renderHeader}
         keyExtractor={keyExtractor}
         getItemLayout={memoizedGetItemLayout}
+        columns={columns}
       />
       <BottomConfirmModal
         isOpen={hasSelection}

--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -126,7 +126,7 @@ DataTable.defaultProps = {
   getItemCount: items => items.length,
   initialNumToRender: 20,
   removeClippedSubviews: true,
-  windowSize: 2,
+  windowSize: 4,
   columns: [],
 };
 

--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -38,9 +38,11 @@ const DataTable = React.memo(({ renderRow, renderHeader, style, data, columns, .
   // Array of column keys for determining ref indicies.
   const editableColumnKeys = useMemo(
     () =>
-      columns.reduce((acc, column) => {
-        if (column.type === 'editable' || column.type === 'date') return [...acc, column.key];
-        return acc;
+      columns.reduce((columnKeys, column) => {
+        if (column.type === 'editable' || column.type === 'date') {
+          return [...columnKeys, column.key];
+        }
+        return columnKeys;
       }, []),
     [columns]
   );

--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -7,34 +7,70 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { StyleSheet, VirtualizedList, VirtualizedListPropTypes } from 'react-native';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 /**
  * Base DataTable component. Thin wrapper around VirtualizedList, providing
  * a header component. All VirtualizedList props can be passed through,
  * however renderItem is renamed renderRow.
  *
+ * Managing focus and scrolling:
+ * Can manage focusing and auto-scrolling for editable cells.
+ * Three parameters are passed in `renderRow`:
+ * - `getCellRef`  : lazily creates a ref for a cell.
+ * - `focusNext`   : Focus' the next editable cell. Call during onEditingSubmit.
+ * - `adjustToTop` : Scrolls so the focused row is at the top of the list.
+ *
  * @param {Func}   renderRow    Renaming of VirtualizedList renderItem prop.
  * @param {Func}   renderHeader Function which should return a header component
  */
-const DataTable = React.memo(({ renderRow, renderHeader, style, ...otherProps }) => (
-  <>
-    {renderHeader()}
-    <KeyboardAwareScrollView
-      style={style}
-      enabled
-      behaviour="padding"
-      keyboardShouldPersistTaps="always"
-    >
-      <VirtualizedList
-        keyboardShouldPersistTaps="always"
-        style={style}
-        renderItem={renderRow}
-        {...otherProps}
-      />
-    </KeyboardAwareScrollView>
-  </>
-));
+const DataTable = React.memo(
+  ({ renderRow, renderHeader, style, data, numberEditableColumns = 1, ...otherProps }) => {
+    const numberOfEditableCells = data.length * numberEditableColumns;
+
+    // Create an array for each editable cell ref.
+    const refs = Array.from({ length: numberOfEditableCells });
+
+    // Reference to the virtualized list for scroll operations.
+    const virtualizedListRef = React.createRef();
+
+    // Callback passed to cells which will create a ref if there isn't already one,
+    // and pass back the reference for the cell position.
+    const getCellRef = refIndex => {
+      if (refs[refIndex]) return refs[refIndex];
+      const newRef = React.createRef(refIndex);
+      refs[refIndex] = newRef;
+      return newRef;
+    };
+
+    // Focuses the next editable cell in the list. Back to the top on last row.
+    const focusNext = refIndex => {
+      // Cell ref of the next editable cell, or the first if the last is passed.s
+      const cellRef = getCellRef((refIndex + 1) % numberOfEditableCells);
+      cellRef.current.focus();
+    };
+
+    // Adjusts the passed row to the top of the list.
+    const adjustToTop = rowIndex => {
+      virtualizedListRef.current.scrollToIndex({ index: rowIndex });
+    };
+
+    return (
+      <>
+        {renderHeader()}
+        <VirtualizedList
+          ref={virtualizedListRef}
+          keyboardDismissMode="none"
+          data={data}
+          keyboardShouldPersistTaps="always"
+          style={style}
+          disableVirtualization={true}
+          renderItem={rowItem => renderRow(rowItem, focusNext, getCellRef, adjustToTop)}
+          {...otherProps}
+        />
+      </>
+    );
+  }
+);
 
 const defaultStyles = StyleSheet.create({
   virtualizedList: {
@@ -52,6 +88,7 @@ DataTable.propTypes = {
   removeClippedSubviews: PropTypes.bool,
   windowSize: PropTypes.number,
   style: PropTypes.object,
+  numberEditableColumns: PropTypes.number,
 };
 
 DataTable.defaultProps = {
@@ -61,7 +98,8 @@ DataTable.defaultProps = {
   getItemCount: items => items.length,
   initialNumToRender: 20,
   removeClippedSubviews: true,
-  windowSize: 11,
+  windowSize: 1,
+  numberEditableColumns: 1,
 };
 
 export default DataTable;

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 import { newDataTableStyles } from '../../globalStyles';
 
 import Row from './Row';
-import EditableCell from './EditableCell';
 import Cell from './Cell';
 import CheckableCell from './CheckableCell';
 import { NewExpiryDateInput } from '../NewExpiryDateInput';
@@ -21,6 +20,7 @@ import {
   DisabledCheckedComponent,
   DisabledUncheckedComponent,
 } from '../icons';
+import TextInputCell from './TextInputCell';
 
 /**
  * Wrapper component for a mSupply DataTable page row.
@@ -28,17 +28,15 @@ import {
  * will generate the appropriate cell for a given columnKey.
  * Doesn't need to be used, but is a convenience component.
  *
- * @param {Object} rowData  Data object for a row i.e. ItemBatch object
- * @param {Object} rowState State object for a row, see: Row.js
- * @param {Object} style    Style object the be passed to inner Row
- * @param {String} rowKey   Unique key for a row
- * @param {Array} columns   Array of column objects, see: columns.js
- * @param {Bool} isFinalised    Boolean indicating if the DataTable page is finalised.
- * @param {Func} focusCellAction    Action for focusing a cell.
- * @param {Func} focusNextAction    Action for focusing the next cell.
- * @param {Func} dispatch   Dispatch function for containing reducer.
- * @param {Func} getAction  Function to return an action for a cell
- *                          (colKey, propName) => actionObject
+ * @param {Object} rowData     Data object for a row i.e. ItemBatch object
+ * @param {Object} rowState    State object for a row, see: Row.js
+ * @param {Object} style       Style object the be passed to inner Row
+ * @param {String} rowKey      Unique key for a row
+ * @param {Array}  columns     Array of column objects, see: columns.js
+ * @param {Bool}   isFinalised Boolean indicating if the DataTable page is finalised.
+ * @param {Func}   dispatch    Dispatch function for containing reducer.
+ * @param {Func}   getAction   Function to return an action for a cell
+ *                             (colKey, propName) => actionObject
  */
 const DataTableRow = React.memo(
   ({
@@ -49,10 +47,9 @@ const DataTableRow = React.memo(
     columns,
     isFinalised,
     dispatch,
-    focusCellAction,
-    focusNextAction,
     getAction,
     onPress,
+    rowIndex,
   }) => {
     // Key of the current column focused.
     const focusedColumnKey = rowState && rowState.focusedColumn;
@@ -74,11 +71,10 @@ const DataTableRow = React.memo(
         const isDisabled = isFinalised || (rowState && rowState.isDisabled);
         const isFocused = focusedColumnKey === columnKey;
         const cellAlignment = alignText || 'left';
-
         switch (type) {
           case 'editable':
             return (
-              <EditableCell
+              <TextInputCell
                 key={columnKey}
                 value={rowData[columnKey]}
                 rowKey={rowKey}
@@ -86,8 +82,6 @@ const DataTableRow = React.memo(
                 editAction={getAction(columnKey)}
                 isFocused={isFocused}
                 isDisabled={isDisabled}
-                focusAction={focusCellAction}
-                focusNextAction={focusNextAction}
                 dispatch={dispatch}
                 width={width}
                 viewStyle={cellContainer[cellAlignment]}
@@ -97,6 +91,7 @@ const DataTableRow = React.memo(
                 textInputStyle={cellText[cellAlignment]}
                 textStyle={editableCellUnfocused[cellAlignment]}
                 cellTextStyle={editableCellText}
+                rowIndex={rowIndex}
               />
             );
 
@@ -131,11 +126,10 @@ const DataTableRow = React.memo(
                 editAction={getAction(columnKey)}
                 isFocused={isFocused}
                 isDisabled={isDisabled}
-                focusAction={focusCellAction}
-                focusNextAction={focusNextAction}
                 dispatch={dispatch}
                 width={width}
                 isLastCell={isLastCell}
+                rowIndex={rowIndex}
               />
             );
 
@@ -163,6 +157,7 @@ const DataTableRow = React.memo(
         rowKey={rowKey}
         rowData={rowData}
         rowState={rowState}
+        rowIndex={rowIndex}
       />
     );
   }
@@ -170,12 +165,11 @@ const DataTableRow = React.memo(
 
 DataTableRow.defaultProps = {
   isFinalised: false,
-  focusCellAction: null,
-  focusNextAction: null,
   getAction: null,
   onPress: null,
   rowState: null,
 };
+
 DataTableRow.propTypes = {
   onPress: PropTypes.func,
   rowData: PropTypes.object.isRequired,
@@ -185,9 +179,8 @@ DataTableRow.propTypes = {
   columns: PropTypes.array.isRequired,
   dispatch: PropTypes.func.isRequired,
   isFinalised: PropTypes.bool,
-  focusCellAction: PropTypes.func,
-  focusNextAction: PropTypes.func,
   getAction: PropTypes.func,
+  rowIndex: PropTypes.number.isRequired,
 };
 
 export default DataTableRow;

--- a/src/widgets/DataTable/RefContext.js
+++ b/src/widgets/DataTable/RefContext.js
@@ -1,0 +1,25 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+/**
+ * Context of values relating to focus and scrolling with refs.
+ *
+ * Provider is DataTable.js - see for details.
+ * Consumers are any editable cell and each row.
+ * Context shape:
+ * {
+ *   getRefIndex,
+ *   getCellRef,
+ *   focusNextCell,
+ *   adjustToTop,
+ * }
+ *
+ */
+
+import React from 'react';
+
+const RefContext = React.createContext();
+
+export default RefContext;

--- a/src/widgets/DataTable/Row.js
+++ b/src/widgets/DataTable/Row.js
@@ -1,9 +1,11 @@
 /* eslint-disable react/forbid-prop-types */
 
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import { TouchableOpacity, View } from 'react-native';
+
+import RefContext from './RefContext';
 
 /**
  * Renders a row of children as outputted by renderCells render prop
@@ -33,41 +35,25 @@ import { TouchableOpacity, View } from 'react-native';
  * @param {func} onPress function to call on pressing the row.
  * @param {object} viewStyle Style object for the wrapping View component
  * @param {boolean} debug Set to `true` to console.log(`Row: ${rowKey}`)
- * @param {func}  getCellRef function passed from DataTable - see above.
- * @param {func}  adjustToTop function passed from DataTable, scrolling this row to the top.
- * @param {func}  focusNextCell function passed from DataTable - see above.
  * @param {number}  rowIndex  index of this row within DataTable.
  * @param {func} renderCells renderProp callBack for rendering cells based on rowData and rowState
  *                          `(rowKey, columnKey) => {...}`
  */
 const Row = React.memo(
-  ({
-    rowData,
-    rowState,
-    rowKey,
-    renderCells,
-    style,
-    onPress,
-    debug,
-    focusNextCell,
-    rowIndex,
-    getCellRef,
-    adjustToTop,
-  }) => {
+  ({ rowData, rowState, rowKey, renderCells, style, onPress, debug, rowIndex }) => {
     if (debug) {
       console.log('=================================');
       console.log(`Row: ${rowKey}`);
     }
+
+    const { adjustToTop } = useContext(RefContext);
+
+    const onFocus = () => adjustToTop(rowIndex);
+
     const Container = onPress ? TouchableOpacity : View;
     return (
-      <Container
-        onPress={onPress}
-        style={style}
-        onFocus={() => {
-          adjustToTop(rowIndex);
-        }}
-      >
-        {renderCells(rowData, rowState, rowKey, rowIndex, getCellRef, focusNextCell)}
+      <Container onPress={onPress} style={style} onFocus={onFocus}>
+        {renderCells(rowData, rowState, rowKey, rowIndex)}
       </Container>
     );
   }
@@ -81,10 +67,7 @@ Row.propTypes = {
   style: PropTypes.object,
   onPress: PropTypes.func,
   debug: PropTypes.bool,
-  focusNextCell: PropTypes.func,
   rowIndex: PropTypes.number.isRequired,
-  getCellRef: PropTypes.func,
-  adjustToTop: PropTypes.func,
 };
 
 Row.defaultProps = {
@@ -92,9 +75,6 @@ Row.defaultProps = {
   style: {},
   onPress: null,
   debug: true,
-  focusNextCell: null,
-  getCellRef: null,
-  adjustToTop: null,
 };
 
 export default Row;

--- a/src/widgets/DataTable/Row.js
+++ b/src/widgets/DataTable/Row.js
@@ -8,7 +8,24 @@ import { TouchableOpacity, View } from 'react-native';
 /**
  * Renders a row of children as outputted by renderCells render prop
  * Tap gesture events will be captured in this component for any taps
- * on cells within this container.
+ * on cells within this container which do not handle the event themselves.
+ *
+ * onFocus on a child will scroll the underlying list to this row.
+ *
+ * Passes two functions to cells to handle focusing the next editable
+ * cell.
+ * - `getRef(refIndex)` returns a reference to use in an editable cell.
+ * - `focusNextCell(refIndex)` - focuses the next editable cell.
+ *
+ * refIndex: (RowIndex * NumberOfEditableCells) + EditableCellIndexInRow
+ *
+ * Example, where C = non editable, E = editable.
+ * Row1: C C E C C E
+ * Row2: C C E C C E
+ * Row3: C C E C C E
+ *
+ * Last editable cell in Row 3 = 2 * 2 + 1
+ * First editable cell in Row 2 = 1 * 2 + 0
  *
  * @param {object} rowData Data to pass to renderCells callback
  * @param {string|number} rowKey Unique key associated to row
@@ -16,21 +33,45 @@ import { TouchableOpacity, View } from 'react-native';
  * @param {func} onPress function to call on pressing the row.
  * @param {object} viewStyle Style object for the wrapping View component
  * @param {boolean} debug Set to `true` to console.log(`Row: ${rowKey}`)
+ * @param {func}  getCellRef function passed from DataTable - see above.
+ * @param {func}  adjustToTop function passed from DataTable, scrolling this row to the top.
+ * @param {func}  focusNextCell function passed from DataTable - see above.
+ * @param {number}  rowIndex  index of this row within DataTable.
  * @param {func} renderCells renderProp callBack for rendering cells based on rowData and rowState
  *                          `(rowKey, columnKey) => {...}`
  */
-const Row = React.memo(({ rowData, rowState, rowKey, renderCells, style, onPress, debug }) => {
-  if (debug) {
-    console.log('=================================');
-    console.log(`Row: ${rowKey}`);
+const Row = React.memo(
+  ({
+    rowData,
+    rowState,
+    rowKey,
+    renderCells,
+    style,
+    onPress,
+    debug,
+    focusNextCell,
+    rowIndex,
+    getCellRef,
+    adjustToTop,
+  }) => {
+    if (debug) {
+      console.log('=================================');
+      console.log(`Row: ${rowKey}`);
+    }
+    const Container = onPress ? TouchableOpacity : View;
+    return (
+      <Container
+        onPress={onPress}
+        style={style}
+        onFocus={() => {
+          adjustToTop(rowIndex);
+        }}
+      >
+        {renderCells(rowData, rowState, rowKey, rowIndex, getCellRef, focusNextCell)}
+      </Container>
+    );
   }
-  const Container = onPress ? TouchableOpacity : View;
-  return (
-    <Container onPress={onPress} style={style}>
-      {renderCells(rowData, rowState, rowKey)}
-    </Container>
-  );
-});
+);
 
 Row.propTypes = {
   rowData: PropTypes.any.isRequired,
@@ -40,13 +81,20 @@ Row.propTypes = {
   style: PropTypes.object,
   onPress: PropTypes.func,
   debug: PropTypes.bool,
+  focusNextCell: PropTypes.func,
+  rowIndex: PropTypes.number.isRequired,
+  getCellRef: PropTypes.func,
+  adjustToTop: PropTypes.func,
 };
 
 Row.defaultProps = {
   rowState: null,
   style: {},
   onPress: null,
-  debug: false,
+  debug: true,
+  focusNextCell: null,
+  getCellRef: null,
+  adjustToTop: null,
 };
 
 export default Row;

--- a/src/widgets/DataTable/TextInputCell.js
+++ b/src/widgets/DataTable/TextInputCell.js
@@ -42,17 +42,17 @@ const TextInputCell = React.memo(
     placeholderColour,
     editAction,
     dispatch,
-    viewStyle,
-    textInputStyle,
     isLastCell,
     width,
     debug,
     keyboardType,
     placeholder,
-    cellTextStyle,
     getRef,
     focusNextCell,
     refIndex,
+    viewStyle,
+    textInputStyle,
+    cellTextStyle,
   }) => {
     if (debug) console.log(`- TextInputCell: ${value}`);
     const usingPlaceholder = placeholder && !value;

--- a/src/widgets/DataTable/TextInputCell.js
+++ b/src/widgets/DataTable/TextInputCell.js
@@ -30,6 +30,7 @@ import { getAdjustedStyle } from './utilities';
  *                                   removing the borderRight,
  * @param {func}  editAction         Action creator for handling editing of this cell.
  *                                   `(newValue, rowKey, columnKey) => {...}`
+ * @param {String} underlineColor    Underline colour of TextInput on Android.
  */
 const TextInputCell = React.memo(
   ({
@@ -49,6 +50,7 @@ const TextInputCell = React.memo(
     rowIndex,
     textInputStyle,
     cellTextStyle,
+    underlineColor,
   }) => {
     if (debug) console.log(`- TextInputCell: ${value}`);
 
@@ -88,7 +90,7 @@ const TextInputCell = React.memo(
           placeholderTextColor={placeholderColour}
           onChangeText={onEdit}
           onSubmitEditing={focusNext}
-          underlineColorAndroid="#CDCDCD"
+          underlineColorAndroid={underlineColor}
           keyboardType={keyboardType}
           blurOnSubmit={false}
         />
@@ -113,6 +115,7 @@ TextInputCell.propTypes = {
   debug: PropTypes.bool,
   placeholder: PropTypes.string,
   rowIndex: PropTypes.number.isRequired,
+  underlineColor: PropTypes.string,
   keyboardType: PropTypes.oneOf([
     'default',
     'number-pad',
@@ -135,6 +138,7 @@ TextInputCell.defaultProps = {
   keyboardType: 'numeric',
   placeholder: '',
   placeholderColour: '#CDCDCD',
+  underlineColor: '#CDCDCD',
 };
 
 export default TextInputCell;

--- a/src/widgets/DataTable/TextInputCell.js
+++ b/src/widgets/DataTable/TextInputCell.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { View, TextInput } from 'react-native';
 
 import Cell from './Cell';
+import RefContext from './RefContext';
 
 import { getAdjustedStyle } from './utilities';
 
@@ -11,27 +12,24 @@ import { getAdjustedStyle } from './utilities';
  * Renders a cell that on press or focus contains a TextInput for
  * editing values.
  *
- * @param {string|number} value The value to render in cell
- * @param {string|number} rowKey Unique key associated to row cell is in
- * @param {string|number} columnKey Unique key associated to column cell is in
- * @param {bool} isDisabled If `true` will render a plain Cell element with no interaction
+ * @param {string|number} value      The value to render in cell
+ * @param {string|number} rowKey     Unique key associated to row cell is in
+ * @param {string|number} columnKey  Unique key associated to column cell is in
+ * @param {bool} isDisabled          If `true` will render a plain Cell element with no interaction
  * @param {String} placeholderColour Placholder text colour
- * @param {func} editAction Action creator for handling editing of this cell.
- *                          `(newValue, rowKey, columnKey) => {...}`
- * @param {func}  dispatch Reducer dispatch callback for handling actions
- * @param {Object}  viewStyle Style object for the wrapping View component
- * @param {Object}  textStyle Style object for the inner Text component
- * @param {Object}  textInputStyle  Style object for TextInput component.
- * @param {Bool}  isLastCell Indicator if this cell is last in a row, removing the borderRight,
- * @param {Number}  width Optional flex property to inject into styles.
- * @param {bool}    debug Logs rendering of this component.
- * @param {string}  keyboardType Type of keyboard for the TextInput.
- * @param {string}  placeholder placeholder text
- * @param {Object} cellTextStyle text style for the disabled Cell component.
- * @param {Func}    getRef function returning a ref for this cell. See DataTable.js
- * @param {Func}    focusNextCell Functioning to focus the next cell. See DataTable.js
- * @param {Func}    refIndex      reference index for this cell. See Row.js
- *
+ * @param {func}  dispatch           Reducer dispatch callback for handling actions
+ * @param {Object}  viewStyle        Style object for the wrapping View component
+ * @param {Object}  textStyle        Style object for the inner Text component
+ * @param {Object}  textInputStyle   Style object for TextInput component.
+ * @param {Number}  width            Optional flex property to inject into styles.
+ * @param {bool}    debug            Logs rendering of this component.
+ * @param {string}  keyboardType     Type of keyboard for the TextInput.
+ * @param {string}  placeholder      placeholder text
+ * @param {Object} cellTextStyle     text style for the disabled Cell component.
+ * @param {Bool}  isLastCell         Indicator if this cell is last in a row,
+ *                                   removing the borderRight,
+ * @param {func}  editAction         Action creator for handling editing of this cell.
+ *                                   `(newValue, rowKey, columnKey) => {...}`
  */
 const TextInputCell = React.memo(
   ({
@@ -47,15 +45,17 @@ const TextInputCell = React.memo(
     debug,
     keyboardType,
     placeholder,
-    getRef,
-    focusNextCell,
-    refIndex,
     viewStyle,
+    rowIndex,
     textInputStyle,
     cellTextStyle,
   }) => {
     if (debug) console.log(`- TextInputCell: ${value}`);
+
     const usingPlaceholder = placeholder && !value;
+
+    const { focusNextCell, getRefIndex, getCellRef } = React.useContext(RefContext);
+    const refIndex = getRefIndex(rowIndex, columnKey);
 
     const onEdit = newValue => dispatch(editAction(newValue, rowKey, columnKey));
     const focusNext = () => focusNextCell(refIndex);
@@ -81,7 +81,7 @@ const TextInputCell = React.memo(
     return (
       <View style={internalViewStyle}>
         <TextInput
-          ref={getRef(refIndex)}
+          ref={getCellRef(refIndex)}
           placeholder={placeholder}
           style={internalTextStyle}
           value={usingPlaceholder ? '' : String(value)}
@@ -112,6 +112,7 @@ TextInputCell.propTypes = {
   isLastCell: PropTypes.bool,
   debug: PropTypes.bool,
   placeholder: PropTypes.string,
+  rowIndex: PropTypes.number.isRequired,
   keyboardType: PropTypes.oneOf([
     'default',
     'number-pad',
@@ -120,9 +121,6 @@ TextInputCell.propTypes = {
     'email-address',
     'phone-pad',
   ]),
-  getRef: PropTypes.func.isRequired,
-  focusNextCell: PropTypes.func.isRequired,
-  refIndex: PropTypes.func.isRequired,
 };
 
 TextInputCell.defaultProps = {

--- a/src/widgets/DataTable/TextInputCell.js
+++ b/src/widgets/DataTable/TextInputCell.js
@@ -1,0 +1,142 @@
+/* eslint-disable react/forbid-prop-types */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View, TextInput } from 'react-native';
+
+import Cell from './Cell';
+
+import { getAdjustedStyle } from './utilities';
+
+/**
+ * Renders a cell that on press or focus contains a TextInput for
+ * editing values.
+ *
+ * @param {string|number} value The value to render in cell
+ * @param {string|number} rowKey Unique key associated to row cell is in
+ * @param {string|number} columnKey Unique key associated to column cell is in
+ * @param {bool} isDisabled If `true` will render a plain Cell element with no interaction
+ * @param {String} placeholderColour Placholder text colour
+ * @param {func} editAction Action creator for handling editing of this cell.
+ *                          `(newValue, rowKey, columnKey) => {...}`
+ * @param {func}  dispatch Reducer dispatch callback for handling actions
+ * @param {Object}  viewStyle Style object for the wrapping View component
+ * @param {Object}  textStyle Style object for the inner Text component
+ * @param {Object}  textInputStyle  Style object for TextInput component.
+ * @param {Bool}  isLastCell Indicator if this cell is last in a row, removing the borderRight,
+ * @param {Number}  width Optional flex property to inject into styles.
+ * @param {bool}    debug Logs rendering of this component.
+ * @param {string}  keyboardType Type of keyboard for the TextInput.
+ * @param {string}  placeholder placeholder text
+ * @param {Object} cellTextStyle text style for the disabled Cell component.
+ * @param {Func}    getRef function returning a ref for this cell. See DataTable.js
+ * @param {Func}    focusNextCell Functioning to focus the next cell. See DataTable.js
+ * @param {Func}    refIndex      reference index for this cell. See Row.js
+ *
+ */
+const TextInputCell = React.memo(
+  ({
+    value,
+    rowKey,
+    columnKey,
+    isDisabled,
+    placeholderColour,
+    editAction,
+    dispatch,
+    viewStyle,
+    textInputStyle,
+    isLastCell,
+    width,
+    debug,
+    keyboardType,
+    placeholder,
+    cellTextStyle,
+    getRef,
+    focusNextCell,
+    refIndex,
+  }) => {
+    if (debug) console.log(`- TextInputCell: ${value}`);
+    const usingPlaceholder = placeholder && !value;
+
+    const onEdit = newValue => dispatch(editAction(newValue, rowKey, columnKey));
+    const focusNext = () => focusNextCell(refIndex);
+
+    // Render a plain Cell if disabled.
+    if (isDisabled) {
+      return (
+        <Cell
+          key={columnKey}
+          viewStyle={viewStyle}
+          textStyle={cellTextStyle}
+          value={value}
+          width={width}
+          isLastCell={isLastCell}
+        />
+      );
+    }
+
+    const internalViewStyle = getAdjustedStyle(viewStyle, width, isLastCell);
+    const internalTextStyle = getAdjustedStyle(textInputStyle, width);
+
+    // Render a Cell with a textInput.
+    return (
+      <View style={internalViewStyle}>
+        <TextInput
+          ref={getRef(refIndex)}
+          placeholder={placeholder}
+          style={internalTextStyle}
+          value={usingPlaceholder ? '' : String(value)}
+          placeholderTextColor={placeholderColour}
+          onChangeText={onEdit}
+          onSubmitEditing={focusNext}
+          underlineColorAndroid="#CDCDCD"
+          keyboardType={keyboardType}
+          blurOnSubmit={false}
+        />
+      </View>
+    );
+  }
+);
+
+TextInputCell.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  rowKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  columnKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  isDisabled: PropTypes.bool,
+  placeholderColour: PropTypes.string,
+  editAction: PropTypes.func.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  cellTextStyle: PropTypes.object,
+  viewStyle: PropTypes.object,
+  width: PropTypes.number,
+  textInputStyle: PropTypes.object,
+  isLastCell: PropTypes.bool,
+  debug: PropTypes.bool,
+  placeholder: PropTypes.string,
+  keyboardType: PropTypes.oneOf([
+    'default',
+    'number-pad',
+    'decimal-pad',
+    'numeric',
+    'email-address',
+    'phone-pad',
+  ]),
+  getRef: PropTypes.func.isRequired,
+  focusNextCell: PropTypes.func.isRequired,
+  refIndex: PropTypes.func.isRequired,
+};
+
+TextInputCell.defaultProps = {
+  value: '',
+  isDisabled: false,
+  viewStyle: {},
+  cellTextStyle: {},
+  textInputStyle: {},
+  isLastCell: false,
+  width: 0,
+  debug: false,
+  keyboardType: 'numeric',
+  placeholder: '',
+  placeholderColour: '#CDCDCD',
+};
+
+export default TextInputCell;

--- a/src/widgets/NewExpiryDateInput.js
+++ b/src/widgets/NewExpiryDateInput.js
@@ -1,17 +1,23 @@
+/* eslint-disable react/forbid-prop-types */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-/* eslint-disable react/forbid-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { View, TouchableWithoutFeedback, Text, TextInput } from 'react-native';
-import { useExpiryDateMask } from '../hooks/useExpiryDateMask';
+
+import { View, TextInput } from 'react-native';
+
 import Cell from './DataTable/Cell';
-import { dataTableColors, newDataTableStyles } from '../globalStyles/index';
-import { getAdjustedStyle } from './DataTable/utilities';
+
+import { useExpiryDateMask } from '../hooks/useExpiryDateMask';
+
+import { newDataTableStyles } from '../globalStyles/index';
 import { parseExpiryDate, formatExpiryDate } from '../utilities';
+
+import { getAdjustedStyle } from './DataTable/utilities';
+import RefContext from './DataTable/RefContext';
 
 /**
  * Renders an expiry date cell, managing its own state and not submitting
@@ -29,26 +35,18 @@ import { parseExpiryDate, formatExpiryDate } from '../utilities';
  * @param {bool} disabled If `true` will render a plain Cell element with no interaction
  * @param {bool} isFocused If `false` will TouchableOpacity that dispatches a focusAction
  *                         when pressed. When `true` will render a TextInput with focus
- * @param {func} editAction Action creator for handling editing of this cell.
- *                          `(newValue, rowKey, columnKey) => {...}`
- * @param {func} focusAction Action creator for handling focusing of this cell.
- *                          `(rowKey, columnKey) => {...}`
- * @param {func} focusNextAction Action creator for handling focusing of this cell.
- *                          `(rowKey, columnKey) => {...}`
+
  * @param {func}  dispatch Reducer dispatch callback for handling actions
  * @param {Number}  width Optional flex property to inject into styles.
  * @param {Bool}  isLastCell Indicator for if this cell is the last
  *                                   in a row. Removing the borderRight if true.
  * @param {String}  placeholder String to display when the cell is empty.
+ * @param {func} editAction Action creator for handling editing of this cell.
+ *                          `(newValue, rowKey, columnKey) => {...}`
  *
  */
 
-const {
-  expiryBatchTextView,
-  expiryBatchView,
-  expiryBatchText,
-  expiryBatchPlaceholderText,
-} = newDataTableStyles;
+const { expiryBatchView, expiryBatchText, expiryBatchPlaceholderText } = newDataTableStyles;
 
 export const NewExpiryDateInput = React.memo(
   ({
@@ -56,17 +54,24 @@ export const NewExpiryDateInput = React.memo(
     rowKey,
     columnKey,
     isDisabled,
-    isFocused,
+    placeholderColour,
     editAction,
-    focusAction,
-    focusNextAction,
     dispatch,
     isLastCell,
     width,
     debug,
     placeholder,
+    rowIndex,
   }) => {
     if (debug) console.log(`- ExpiryTextInputCell: ${value}`);
+
+    const { focusNextCell, getRefIndex, getCellRef } = React.useContext(RefContext);
+
+    console.log('#################################');
+    console.log(columnKey);
+    console.log('#################################');
+
+    const refIndex = getRefIndex(rowIndex, columnKey);
 
     // Customhook managing the editing of an expiry date to stay valid.
     const [expiryDate, setExpiryDate, finaliseExpiryDate] = useExpiryDateMask(
@@ -83,7 +88,7 @@ export const NewExpiryDateInput = React.memo(
 
     const onSubmit = () => {
       finishEditingExpiryDate();
-      dispatch(focusNextAction(rowKey, columnKey));
+      focusNextCell(refIndex);
     };
 
     const usingPlaceholder = placeholder && !expiryDate;
@@ -106,40 +111,21 @@ export const NewExpiryDateInput = React.memo(
 
     const internalViewStyle = getAdjustedStyle(expiryBatchView, width, isLastCell);
 
-    // Too many TextInputs causes React Native to crash, so only
-    // truly mount the TextInput when the Cell is focused.
-    // Use TouchableWithoutFeedback because we want the appearance and
-    // feedback to resemble a TextInput regardless of focus.
-    if (!isFocused) {
-      const text = usingPlaceholder ? placeholder : expiryDate;
-
-      return (
-        <TouchableWithoutFeedback onPress={() => dispatch(focusAction(rowKey, columnKey))}>
-          <View style={internalViewStyle}>
-            <View style={expiryBatchTextView}>
-              <Text ellipsizeMode="tail" numberOfLines={1} style={textStyle}>
-                {text}
-              </Text>
-            </View>
-          </View>
-        </TouchableWithoutFeedback>
-      );
-    }
-
     // Render a Cell with a textInput.
     return (
       <View style={internalViewStyle}>
         <TextInput
+          ref={getCellRef(refIndex)}
           placeholder={placeholder}
           style={textStyle}
           value={expiryDate}
+          placeholderTextColor={placeholderColour}
           onChangeText={setExpiryDate}
-          autoFocus={isFocused}
           onSubmitEditing={onSubmit}
           onEndEditing={finishEditingExpiryDate}
-          underlineColorAndroid={dataTableColors.editableCellUnderline}
+          underlineColorAndroid="#CDCDCD"
           keyboardType="numeric"
-          selectTextOnFocus
+          blurOnSubmit={false}
         />
       </View>
     );
@@ -151,25 +137,24 @@ NewExpiryDateInput.propTypes = {
   rowKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   columnKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   isDisabled: PropTypes.bool,
-  isFocused: PropTypes.bool,
   editAction: PropTypes.func.isRequired,
-  focusAction: PropTypes.func.isRequired,
-  focusNextAction: PropTypes.func.isRequired,
   dispatch: PropTypes.func.isRequired,
   width: PropTypes.number,
   isLastCell: PropTypes.bool,
   debug: PropTypes.bool,
   placeholder: PropTypes.string,
+  rowIndex: PropTypes.number.isRequired,
+  placeholderColour: PropTypes.string,
 };
 
 NewExpiryDateInput.defaultProps = {
   value: '',
   isDisabled: false,
-  isFocused: false,
   isLastCell: false,
   width: 0,
   debug: false,
   placeholder: 'mm/yyyy',
+  placeholderColour: '#CDCDCD',
 };
 
 export default NewExpiryDateInput;

--- a/src/widgets/NewExpiryDateInput.js
+++ b/src/widgets/NewExpiryDateInput.js
@@ -43,6 +43,7 @@ import RefContext from './DataTable/RefContext';
  * @param {String}  placeholder String to display when the cell is empty.
  * @param {func} editAction Action creator for handling editing of this cell.
  *                          `(newValue, rowKey, columnKey) => {...}`
+ * @param {String} underlineColor    Underline colour of TextInput on Android.
  *
  */
 
@@ -62,6 +63,7 @@ export const NewExpiryDateInput = React.memo(
     debug,
     placeholder,
     rowIndex,
+    underlineColor,
   }) => {
     if (debug) console.log(`- ExpiryTextInputCell: ${value}`);
 
@@ -119,7 +121,7 @@ export const NewExpiryDateInput = React.memo(
           onChangeText={setExpiryDate}
           onSubmitEditing={onSubmit}
           onEndEditing={finishEditingExpiryDate}
-          underlineColorAndroid="#CDCDCD"
+          underlineColorAndroid={underlineColor}
           keyboardType="numeric"
           blurOnSubmit={false}
         />
@@ -141,6 +143,7 @@ NewExpiryDateInput.propTypes = {
   placeholder: PropTypes.string,
   rowIndex: PropTypes.number.isRequired,
   placeholderColour: PropTypes.string,
+  underlineColor: PropTypes.string,
 };
 
 NewExpiryDateInput.defaultProps = {
@@ -151,6 +154,7 @@ NewExpiryDateInput.defaultProps = {
   debug: false,
   placeholder: 'mm/yyyy',
   placeholderColour: '#CDCDCD',
+  underlineColor: '#CDCDCD',
 };
 
 export default NewExpiryDateInput;

--- a/src/widgets/NewExpiryDateInput.js
+++ b/src/widgets/NewExpiryDateInput.js
@@ -67,10 +67,6 @@ export const NewExpiryDateInput = React.memo(
 
     const { focusNextCell, getRefIndex, getCellRef } = React.useContext(RefContext);
 
-    console.log('#################################');
-    console.log(columnKey);
-    console.log('#################################');
-
     const refIndex = getRefIndex(rowIndex, columnKey);
 
     // Customhook managing the editing of an expiry date to stay valid.


### PR DESCRIPTION
#### EPIC: #1043 

Fixes #1181 

## Change summary

- Adds scrolling to top logic for a row when focused
- Adds focus next logic for cells

## Testing

See #1043 

### Related areas to think about

- At the time of this PR, only two pages `SupplierInvoice` and `CustomerInvoice` had been completed. Possibly breaking change on any new pages after that.
- This decreases the size of the tables viewport. I think this is a good tradeoff as the currently edited area is far more responsive while trading for scrolling behaviour (hiding rows which aren't in the viewport for a second or so when scrolling). This also means we don't need to use the hack for react-native rendering 100+ text inputs and crashing.
- Remove hack-editable cell for above area and focus cell/focus next reducer logic? Keep it because why not?
