### PR TITLE
#1167 CustomerInvoicesPage fixes

### DIFF
--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -35,6 +35,7 @@ import { debounce } from '../utilities/index';
 const usePageReducer = (
   page,
   initialState,
+  initializer,
   debounceTimeout = 250,
   instantDebounceTimeout = 250
 ) => {
@@ -43,7 +44,7 @@ const usePageReducer = (
   const memoizedReducer = useMemo(() => getReducer(page), []);
 
   const [pageState, setPageState] = useState({
-    ...initialState,
+    ...(initializer ? initializer() : initialState),
     columns,
     pageInfo,
   });

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -72,6 +72,7 @@ export const CustomerInvoicesPage = ({
   useNavigationFocusRefresh(dispatch, navigation);
 
   // On Press Handlers
+  const closeModal = () => dispatch(closeBasicModal());
   const onFilterData = value => dispatch(filterData(value));
   const onNewInvoice = () => dispatch(openBasicModal(MODAL_KEYS.SELECT_CUSTOMER));
   const onRemoveInvoices = () => dispatch(deleteTransactionsById());
@@ -94,7 +95,7 @@ export const CustomerInvoicesPage = ({
       case MODAL_KEYS.SELECT_CUSTOMER:
         return otherParty => {
           reduxDispatch(createCustomerInvoice(otherParty, currentUser));
-          dispatch(closeBasicModal());
+          closeModal();
         };
       default:
         return null;
@@ -181,7 +182,7 @@ export const CustomerInvoicesPage = ({
         fullScreen={false}
         isOpen={!!modalKey}
         modalKey={modalKey}
-        onClose={() => dispatch(closeBasicModal())}
+        onClose={closeModal}
         onSelect={getModalOnSelect()}
         dispatch={dispatch}
       />

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -68,6 +68,7 @@ export const CustomerInvoicesPage = ({
     searchTerm,
   } = state;
 
+  // Refresh data on navigating back to this page.
   useNavigationFocusRefresh(dispatch, navigation);
 
   // On Press Handlers
@@ -128,7 +129,7 @@ export const CustomerInvoicesPage = ({
           dispatch={dispatch}
           getAction={getAction}
           rowIndex={index}
-          onPress={onNavigateToInvoice}
+          onPress={onNavigateToInvoice(item)}
         />
       );
     },

--- a/src/pages/dataTableUtilities/columns.js
+++ b/src/pages/dataTableUtilities/columns.js
@@ -9,7 +9,7 @@ import { UIDatabase } from '../../database/index';
 const PAGE_COLUMN_WIDTHS = {
   customerInvoice: [2, 4, 2, 2, 1],
   supplierInvoice: [2, 4, 2, 2, 1],
-  customerInvoices: [1.5, 2.5, 2, 3, 1],
+  customerInvoices: [1.5, 2.5, 2, 1.5, 3, 1],
   supplierRequisitions: [1.5, 2, 1, 1, 1, 1],
   supplierRequisition: [1.4, 3.5, 2, 1.5, 2, 2, 1],
   programSupplierRequisition: [1.5, 3.5, 0.5, 0.5, 2, 1.5, 2, 2, 1],
@@ -22,7 +22,7 @@ const PAGE_COLUMN_WIDTHS = {
 const PAGE_COLUMNS = {
   customerInvoice: ['itemCode', 'itemName', 'availableQuantity', 'totalQuantity', 'remove'],
   supplierInvoice: ['itemCode', 'itemName', 'totalQuantity', 'editableExpiryDate', 'remove'],
-  customerInvoices: ['serialNumber', 'otherPartyName', 'status', 'comment', 'delete'],
+  customerInvoices: ['serialNumber', 'otherPartyName', 'status', 'entryDate', 'comment', 'remove'],
   supplierRequisitions: [
     'serialNumber',
     'otherPartyName',

--- a/src/utilities/getModalTitle.js
+++ b/src/utilities/getModalTitle.js
@@ -10,6 +10,7 @@ export const MODAL_KEYS = {
   THEIR_REF_EDIT: 'theirRefEdit',
   REQUISITION_COMMENT_EDIT: 'comment',
   ITEM_SELECT: 'itemSelect',
+  SELECT_CUSTOMER: 'selectCustomer',
   SELECT_SUPPLIER: 'selectSupplier',
   PROGRAM_REQUISITION: 'programRequisition',
   MONTHS_SELECT: 'monthsToSupply',

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -213,9 +213,11 @@ const DataTableRow = React.memo(
       });
     }, [isFinalised, focusedColumnKey, rowState]);
 
+    const onPressCallback = useCallback(onPress, []);
+
     return (
       <Row
-        onPress={onPress}
+        onPress={onPressCallback}
         style={style}
         renderCells={renderCells}
         debug


### PR DESCRIPTION
Fixes #1167 

## Change summary

- Added columns: expiry date, status
- Added use of `DataTableRow` and `DataTablePageModal`.
- Added use of redux for navigation.
- Added `useNavigationFocusListener` with a couple of changes to make it safer.

## Testing

See #1043 

### Related areas to think about

Memoizing on press handlers: Memoizing all of these is basically memoizing everything and defeats the purpose. The press handlers which aren't memoized ARE causing re-renders, but only on smaller components - `SearchBar`, buttons etc. [ row onPress is handled by `DataTableRow` and doesn't cause re-renders - using a binding or closure means no memoizing].

This is a pretty good case to use class based components for pages, rather than functional. That means no hooks - but I don't know if that's a good enough reason to use functional components for these larger stateful pages.