### PR TITLE
#1195 SupplierRequisitionPage fixes

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,10 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+export { useDatabaseChangeListener } from './useDatabaseChangeListener';
+export { useDatabaseListener } from './useDatabaseListener';
+export { useExpiryDateMask } from './useExpiryDateMask';
+export { useNavigationFocusRefresh } from './useNavigationFocusRefresh';
+export { usePageReducer } from './usePageReducer';

--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -32,7 +32,7 @@ import { debounce } from '../utilities/index';
  * @param {Number} debounceTimeout        Timeout period for a regular debounce
  * @param {Number} instantDebounceTimeout Timeout period for an instant debounce
  */
-const usePageReducer = (
+export const usePageReducer = (
   page,
   initialState,
   initializer,

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -60,7 +60,7 @@ export const SupplierRequisitionsPage = ({ routeName, currentUser, dispatch: red
     keyExtractor: recordKeyExtractor,
     dataState: new Map(),
     searchTerm: '',
-    filterDataKeys: ['serialNumber'],
+    filterDataKeys: ['serialNumber', 'otherStoreName.name'],
     sortBy: 'serialNumber',
     isAscending: true,
     modalKey: '',

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -108,6 +108,17 @@ export const SupplierRequisitionsPage = ({ routeName, currentUser, dispatch: red
     }
   };
 
+  const getModalOnSelect = () => {
+    switch (modalKey) {
+      case SELECT_SUPPLIER:
+        return onCreateRequisition;
+      case PROGRAM_REQUISITION:
+        return onCreateProgramRequisition;
+      default:
+        return null;
+    }
+  };
+
   const renderRow = useCallback(
     listItem => {
       const { item, index } = listItem;
@@ -130,30 +141,6 @@ export const SupplierRequisitionsPage = ({ routeName, currentUser, dispatch: red
     [data, dataState]
   );
 
-  const PageButtons = useCallback(() => {
-    const { verticalContainer, topButton } = globalStyles;
-    return (
-      <View style={verticalContainer}>
-        <PageButton
-          style={topButton}
-          text={buttonStrings.new_requisition}
-          onPress={onNewRequisition}
-        />
-      </View>
-    );
-  });
-
-  const getModalOnSelect = () => {
-    switch (modalKey) {
-      case SELECT_SUPPLIER:
-        return onCreateRequisition;
-      case PROGRAM_REQUISITION:
-        return onCreateProgramRequisition;
-      default:
-        return null;
-    }
-  };
-
   const renderHeader = useCallback(
     () => (
       <DataTableHeaderRow
@@ -166,6 +153,19 @@ export const SupplierRequisitionsPage = ({ routeName, currentUser, dispatch: red
     ),
     [sortBy, isAscending]
   );
+
+  const PageButtons = useCallback(() => {
+    const { verticalContainer, topButton } = globalStyles;
+    return (
+      <View style={verticalContainer}>
+        <PageButton
+          style={topButton}
+          text={buttonStrings.new_requisition}
+          onPress={onNewRequisition}
+        />
+      </View>
+    );
+  }, []);
 
   const {
     newPageTopSectionContainer,

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -123,6 +123,7 @@ export const SupplierRequisitionsPage = ({ routeName, currentUser, dispatch: red
           dispatch={dispatch}
           getAction={getAction}
           onPress={onPressRow}
+          rowIndex={index}
         />
       );
     },

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -83,16 +83,18 @@ export const SupplierRequisitionsPage = ({ routeName, currentUser, dispatch: red
   const { SELECT_SUPPLIER, PROGRAM_REQUISITION } = MODAL_KEYS;
   const NEW_REQUISITON = usingPrograms ? PROGRAM_REQUISITION : SELECT_SUPPLIER;
 
-  const onPressRow = () => rowData => reduxDispatch(gotoSupplierRequisition(rowData));
+  const onPressRow = rowData => () => reduxDispatch(gotoSupplierRequisition(rowData));
   const onConfirmDelete = () => dispatch(deleteRequisitions());
   const onCancelDelete = () => dispatch(deselectAll());
   const onSearchFiltering = value => dispatch(filterData(value));
   const onNewRequisition = () => dispatch(openModal(NEW_REQUISITON));
   const onCloseModal = () => dispatch(closeModal());
+
   const onCreateRequisition = otherStoreName => {
     reduxDispatch(createSupplierRequisition({ otherStoreName, currentUser }));
     onCloseModal();
   };
+
   const onCreateProgramRequisition = requisitionParameters => {
     reduxDispatch(createSupplierRequisition({ ...requisitionParameters, currentUser }));
     dispatch(closeModal());
@@ -133,7 +135,7 @@ export const SupplierRequisitionsPage = ({ routeName, currentUser, dispatch: red
           columns={columns}
           dispatch={dispatch}
           getAction={getAction}
-          onPress={onPressRow}
+          onPress={onPressRow(item)}
           rowIndex={index}
         />
       );

--- a/src/pages/dataTableUtilities/columns.js
+++ b/src/pages/dataTableUtilities/columns.js
@@ -80,7 +80,7 @@ const COLUMNS = () => ({
   },
   supplier: {
     key: 'otherPartyName',
-    title: tableStrings.suplier,
+    title: tableStrings.supplier,
     sortable: true,
   },
   customer: {

--- a/src/pages/dataTableUtilities/columns.js
+++ b/src/pages/dataTableUtilities/columns.js
@@ -22,10 +22,10 @@ const PAGE_COLUMN_WIDTHS = {
 const PAGE_COLUMNS = {
   customerInvoice: ['itemCode', 'itemName', 'availableQuantity', 'totalQuantity', 'remove'],
   supplierInvoice: ['itemCode', 'itemName', 'totalQuantity', 'editableExpiryDate', 'remove'],
-  customerInvoices: ['serialNumber', 'otherPartyName', 'status', 'entryDate', 'comment', 'remove'],
+  customerInvoices: ['serialNumber', 'customer', 'status', 'entryDate', 'comment', 'remove'],
   supplierRequisitions: [
     'serialNumber',
-    'otherPartyName',
+    'supplier',
     'numberOfItems',
     'entryDate',
     'status',
@@ -78,7 +78,12 @@ const COLUMNS = () => ({
     title: tableStrings.invoice_number,
     sortable: true,
   },
-  otherPartyName: {
+  supplier: {
+    key: 'otherPartyName',
+    title: tableStrings.suplier,
+    sortable: true,
+  },
+  customer: {
     key: 'otherPartyName',
     title: tableStrings.customer,
     sortable: true,

--- a/src/pages/dataTableUtilities/index.js
+++ b/src/pages/dataTableUtilities/index.js
@@ -4,3 +4,5 @@
  */
 
 export * from './actions';
+
+export { recordKeyExtractor, getItemLayout } from './utilities';

--- a/src/widgets/DataTablePageView.js
+++ b/src/widgets/DataTablePageView.js
@@ -7,14 +7,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { newPageStyles } from '../../globalStyles';
+import { newPageStyles } from '../globalStyles';
 
 const { newPageContentContainer, newContainer } = newPageStyles;
 
 /**
  * Simple container for a standard data table page.
  */
-const DataTablePageView = props => {
+export const DataTablePageView = props => {
   const { children } = props;
   return (
     <View style={newPageContentContainer}>

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -23,6 +23,7 @@ export { ToggleBar } from './ToggleBar';
 export { ToggleSelector } from './ToggleSelector';
 export { NewExpiryDateInput } from './NewExpiryDateInput';
 export { SearchBar } from './SearchBar';
+export { DataTablePageView } from './DataTablePageView';
 export {
   SortAscIcon,
   SortNeutralIcon,


### PR DESCRIPTION
#### EPIC: #1043 

#### BRANCHES FROM #1204 

Fixes #1195 

## Change summary

- Defined anonymous functions explicitly - didn't memo - I don't think there's a need.
- Defined an `initialiseState` function. I think this should be in every page - like `CustomerInvoicesPage`?
- Added index file for hooks
- Fixed customer v supplier columns
- Exported `recordKeyExtractor`/`getItemLayout` from index in `dataTableUtilities`
- Shifted `DataTablePageView` to `src/widgets`

## Testing

See #1043 

### Related areas to think about

N/A
