### PR TITLE
#1199 Stocktake reasons fixes -- 6

### DIFF
--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -7,7 +7,7 @@ import Realm from 'realm';
 import { complement } from 'set-manipulator';
 
 import { createRecord, getTotal } from '../utilities';
-import UIDatabase from '../UIDatabase';
+import { UIDatabase } from '..';
 
 /**
  * A requisition.

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -1,4 +1,5 @@
 import Realm from 'realm';
+
 import { createRecord } from '../utilities';
 
 /**
@@ -131,6 +132,13 @@ export class StocktakeBatch extends Realm.Object {
   }
 
   /**
+   * @return {String} this batches reason title, or an empty string.
+   */
+  get reasonTitle() {
+    return (this.option && this.option.title) || '';
+  }
+
+  /**
    * Set counted total quantity.
    *
    * @param  {number}  quantity
@@ -138,6 +146,16 @@ export class StocktakeBatch extends Realm.Object {
   set countedTotalQuantity(quantity) {
     // Handle packsize of 0.
     this.countedNumberOfPacks = this.packSize ? quantity / this.packSize : 0;
+  }
+
+  /**
+   * Applies a reason to this batch
+   */
+  applyReason(database, reason) {
+    database.write(() => {
+      this.option = reason;
+      database.save('StocktakeBatch', this);
+    });
   }
 
   /**

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -308,7 +308,7 @@ export class StocktakeItem extends Realm.Object {
    * @param {Realm}   database
    * @param {Options} option
    */
-  applyReasonToBatches(database, option) {
+  applyReason(database, option) {
     this.batches.forEach(batch => {
       const { id, countedTotalQuantity, snapshotTotalQuantity } = batch;
       let batchOption = option;

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -142,7 +142,7 @@ export class StocktakeItem extends Realm.Object {
    * Returns the title of the most common option within this stocktakeItem's batches
    * @return {string} The title of the reason with the highest frequency
    */
-  get mostUsedReasonTitle() {
+  get reasonTitle() {
     if (!this.batches.length) return '';
 
     // Mapping table for ranking reasons by usage
@@ -298,7 +298,7 @@ export class StocktakeItem extends Realm.Object {
   createNewBatch(database) {
     const batchString = `stocktake_${this.stocktake.serialNumber}`;
     const itemBatch = createRecord(database, 'ItemBatch', this.item, batchString);
-    createRecord(database, 'StocktakeBatch', this, itemBatch, true);
+    return createRecord(database, 'StocktakeBatch', this, itemBatch, true);
   }
 
   /**

--- a/src/localization/modalStrings.js
+++ b/src/localization/modalStrings.js
@@ -26,9 +26,7 @@ export const modalStrings = new LocalizedStrings({
     finalise_customer_invoice: 'Finalise will lock this invoice permanently.',
     finalise_supplier_requisition: 'Finalise will send this requisition and lock it permanently.',
     finalise_customer_requisition:
-      // eslint-disable-next-line no-multi-str
-      'Finalise will generate a finalised customer invoice, adjust inventory, and lock this\
-       requisition permanently.',
+      'Finalise will generate a finalised customer invoice, adjust inventory, and lock this requisition permanently.',
     finalise_stocktake: 'Finalise will adjust inventory and lock this stocktake permanently.',
     finalise_supplier_invoice: 'Finalise will adjust inventory and lock this invoice permanently.',
     following_items_reduced_more_than_available_stock:

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -48,14 +48,17 @@ export const gotoStocktakeManagePage = ({ stocktake, stocktakeName }) =>
  *
  * @param {Object} stocktake  The requisition to navigate to.
  */
-export const gotoStocktakeEditPage = stocktake =>
-  NavigationActions.navigate({
-    routeName: 'stocktakeEditor',
+export const gotoStocktakeEditPage = stocktake => {
+  const usesReasons = UIDatabase.objects('StocktakeReasons').length > 0;
+
+  return NavigationActions.navigate({
+    routeName: usesReasons ? 'stocktakeEditorWithReasons' : 'stocktakeEditor',
     params: {
       title: navStrings.stocktake,
       stocktake,
     },
   });
+};
 
 /**
  * Action creator for navigating to a customer invoice. Ensures the CI is at least

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -96,7 +96,7 @@ export const gotoCustomerInvoice = transaction => dispatch => {
  */
 export const gotoSupplierRequisition = requisition =>
   NavigationActions.navigate({
-    routeName: !requisition.program ? 'supplierRequisition' : 'programSupplierRequisition',
+    routeName: !requisition.program ? 'supplierRequisition' : 'supplierRequisitionWithProgram',
     params: {
       title: `${navStrings.requisition} ${requisition.serialNumber}`,
       requisition,

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -93,6 +93,38 @@ export const gotoCustomerInvoice = transaction => dispatch => {
 };
 
 /**
+ * Action creator for navigating to a SupplierInvoice. Ensures the SI is finalised, if
+ * confirmed before navigating. This should not occur, but if this is not enforced, a
+ * user can reduce the amount of stock in a SI which has been used in a CI, which causes
+ * inventory adjustments instantly.
+ *
+ * @param {Object} transaction The SI to navigate to.
+ * @param {Object} dispatch    Redux dispatch method.
+ */
+export const gotoSupplierInvoice = transaction => dispatch => {
+  const { isConfirmed } = transaction;
+
+  // Supplier invoices are `new` or `finalised`. Ensure any `confirmed` invoices are
+  // `finalised` before navigating.
+  if (isConfirmed) {
+    UIDatabase.write(() => {
+      transaction.finalise(UIDatabase);
+      UIDatabase.save('Transaction', transaction);
+    });
+  }
+
+  const navigationAction = NavigationActions.navigate({
+    routeName: 'supplierInvoice',
+    params: {
+      title: `${navStrings.invoice} ${transaction.serialNumber}`,
+      transaction,
+    },
+  });
+
+  dispatch(navigationAction);
+};
+
+/**
  * Navigate to the SupplierRequisitionPage.
  *
  * @param {Object} requisition  SupplierRequisition to navigate to.
@@ -100,6 +132,20 @@ export const gotoCustomerInvoice = transaction => dispatch => {
 export const gotoSupplierRequisition = requisition =>
   NavigationActions.navigate({
     routeName: !requisition.program ? 'supplierRequisition' : 'supplierRequisitionWithProgram',
+    params: {
+      title: `${navStrings.requisition} ${requisition.serialNumber}`,
+      requisition,
+    },
+  });
+
+/**
+ * Navigate to the CustomerRequisitionPage.
+ *
+ * @param {Object} requisition  Customer requisition to navigate to.
+ */
+export const gotoCustomerRequisition = requisition =>
+  NavigationActions.navigate({
+    routeName: 'customerRequisition',
     params: {
       title: `${navStrings.requisition} ${requisition.serialNumber}`,
       requisition,
@@ -183,6 +229,22 @@ export const createCustomerInvoice = (otherParty, currentUser) => dispatch => {
   });
 
   dispatch(gotoCustomerInvoice(newCustomerInvoice));
+};
+
+/**
+ * Action creator which first creates a supplier invoice, and then navigates to it
+ * for editing.
+ *
+ * @param {Object} otherParty     The other party of the invoice (Supplier)
+ * @param {Object} currentUser    The currently logged in user.
+ */
+export const createSupplierInvoice = (otherParty, currentUser) => dispatch => {
+  let newCustomerInvoice;
+  UIDatabase.write(() => {
+    newCustomerInvoice = createRecord(UIDatabase, 'SupplierInvoice', otherParty, currentUser);
+  });
+
+  dispatch(gotoSupplierInvoice(newCustomerInvoice));
 };
 
 /**

--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -1,351 +1,235 @@
+/* eslint-disable react/forbid-prop-types */
+/* eslint-disable import/prefer-default-export */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-
 import { View } from 'react-native';
 
-import { GenericPage } from './GenericPage';
-import { PageContentModal } from '../widgets/modals';
-import { PageButton, PageInfo, TextEditor } from '../widgets';
+import { MODAL_KEYS } from '../utilities';
 
-import { formatDate, sortDataBy } from '../utilities';
-import { buttonStrings, modalStrings, pageInfoStrings, tableStrings } from '../localization';
+import { DataTablePageModal } from '../widgets/modals';
+import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
+import { DataTablePageView, PageButton, PageInfo, SearchBar } from '../widgets';
 
-import globalStyles from '../globalStyles';
+import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
 
-const DATA_TYPES_SYNCHRONISED = ['RequisitionItem', 'Item', 'ItemBatch'];
+import { usePageReducer, useRecordListener } from '../hooks';
 
-const MODAL_KEYS = {
-  COMMENT_EDIT: 'commentEdit',
-  ITEM_SELECT: 'itemSelect',
-  MONTHS_SELECT: 'monthsSelect',
-};
+import globalStyles, { SUSSOL_ORANGE, newPageStyles } from '../globalStyles';
+import { buttonStrings } from '../localization';
+
+const stateInitialiser = pageObject => ({
+  pageObject,
+  backingData: pageObject.items,
+  data: pageObject.items.sorted('item.name').slice(),
+  keyExtractor: recordKeyExtractor,
+  dataState: new Map(),
+  searchTerm: '',
+  filterDataKeys: ['item.name', 'item.code'],
+  sortBy: 'itemName',
+  isAscending: true,
+  modalKey: '',
+});
 
 /**
- * Check whether a given requisition is safe to be finalised.
- * If requisition is safe to finalise, return null, else return
- * an appropriate error message.
+ * Renders a mSupply mobile page with a customer requisition loaded for editing
  *
- * @param   {object}  requisition  The requisition to check
- * @return  {string}               An error message if not able
- *                                 to be finalised
+ * State:
+ * Uses a reducer to manage state with `backingData` being a realm results
+ * of items to display. `data` is a plain JS array of realm objects. data is
+ * hydrated from the `backingData` for displaying in the interface.
+ * i.e: When filtering, data is populated from filtered items of `backingData`.
  *
- * TODO: implement method body.
+ * dataState is a simple map of objects corresponding to a row being displayed,
+ * holding the state of a given row. Each object has the shape :
+ * { isSelected, isDisabled },
+ *
+ * @prop {Object} requisition The realm transaction object for this invoice.
+ * @prop {Func}   runWithLoadingIndicator Callback for displaying a fullscreen spinner.
+ * @prop {String} routeName The current route name for the top of the navigation stack.
  */
-export const checkForFinaliseError = requisition => null; // eslint-disable-line no-unused-vars
+export const CustomerRequisitionPage = ({ requisition, runWithLoadingIndicator, routeName }) => {
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
+    routeName,
+    {},
+    stateInitialiser,
+    requisition
+  );
 
-export class CustomerRequisitionPage extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      modalKey: null,
-      modalIsOpen: false,
-      selection: [],
-    };
-    this.dataFilters = {
-      searchTerm: '',
-      sortBy: 'itemName',
-      isAscending: true,
-    };
-  }
+  const {
+    data,
+    dataState,
+    sortBy,
+    isAscending,
+    modalKey,
+    pageObject,
+    keyExtractor,
+    modalValue,
+    searchTerm,
+    PageActions,
+    columns,
+    getPageInfoColumns,
+  } = state;
 
-  /**
-   * Respond to the user editing the number in the required quantity column.
-   *
-   * @param   {string}  key              Should always be 'requiredQuantity'
-   * @param   {object}  requisitionItem  The requisition item from the row being edited
-   * @param   {string}  newValue         The value the user entered in the cell
-   * @return  {none}
-   */
-  onEndEditing = (key, requisitionItem, newValue) => {
-    // This will update associated CustomerInvoice if one exists or if linked
-    // CustomerInvoice does not exist, suppliedQuantity will not be updated
-    if (key !== 'suppliedQuantity') return;
-    const { database } = this.props;
-    database.write(() => requisitionItem.setSuppliedQuantity(database, newValue));
-  };
+  // Listen for changes to this pages requisition. Refreshing data on side effects i.e. finalizing.
+  useRecordListener(() => dispatch(PageActions.refreshData()), requisition, 'Requisition');
 
-  onUseRequestedQuantities = () => {
-    const { database, requisition } = this.props;
-    database.write(() => {
-      requisition.items.forEach(requisitionItem =>
-        requisitionItem.setSuppliedQuantity(database, requisitionItem.requiredQuantity)
-      );
-    });
+  const { isFinalised, comment } = pageObject;
 
-    this.refreshData();
-  };
+  // On click handlers
+  const onCloseModal = () => dispatch(PageActions.closeModal());
+  const onAddItem = value => dispatch(PageActions.addRequisitionItem(value));
+  const onEditComment = value => dispatch(PageActions.editComment(value, 'Requisition'));
+  const onFilterData = value => dispatch(PageActions.filterData(value));
 
-  onUseSuggestedQuantities = () => {
-    const { database, requisition } = this.props;
-    database.write(() => {
-      requisition.items.forEach(requisitionItem =>
-        requisitionItem.setSuppliedQuantity(database, requisitionItem.suggestedQuantity)
-      );
-    });
+  const onSetSuppliedToRequested = () =>
+    runWithLoadingIndicator(() => dispatch(PageActions.setSuppliedToRequested()));
+  const onSetSuppliedToSuggested = () =>
+    runWithLoadingIndicator(() => dispatch(PageActions.setSuppliedToSuggested()));
 
-    this.refreshData();
-  };
+  const renderPageInfo = useCallback(
+    () => (
+      <PageInfo
+        columns={getPageInfoColumns(pageObject, dispatch, PageActions)}
+        isEditingDisabled={isFinalised}
+      />
+    ),
+    [comment, isFinalised]
+  );
 
-  onSelectionChange = newSelection => this.setState({ selection: newSelection });
-
-  getModalTitle = () => {
-    const { modalKey } = this.state;
-    const { ITEM_SELECT, COMMENT_EDIT } = MODAL_KEYS;
-
-    switch (modalKey) {
-      default:
-      case ITEM_SELECT:
-        return modalStrings.search_for_an_item_to_add;
-      case COMMENT_EDIT:
-        return modalStrings.edit_the_requisition_comment;
-    }
-  };
-
-  updateDataFilters = (newSearchTerm, newSortBy, newIsAscending) => {
-    // (... != null) checks for null or undefined (implicitly type coerced to null).
-    if (newSearchTerm != null) this.dataFilters.searchTerm = newSearchTerm;
-    if (newSortBy != null) this.dataFilters.sortBy = newSortBy;
-    if (newIsAscending != null) this.dataFilters.isAscending = newIsAscending;
-  };
-
-  /**
-   * Returns updated data filtered by |searchTerm| and ordered by |sortBy| and |isAscending|.
-   */
-  refreshData = (newSearchTerm, newSortBy, newIsAscending) => {
-    const { requisition } = this.props;
-
-    this.updateDataFilters(newSearchTerm, newSortBy, newIsAscending);
-    const { searchTerm, sortBy, isAscending } = this.dataFilters;
-    const data = requisition.items.filtered(
-      'item.name BEGINSWITH[c] $0 OR item.code BEGINSWITH[c] $0',
-      searchTerm
-    );
-    let sortDataType;
-    switch (sortBy) {
-      case 'itemCode':
-      case 'itemName':
-        sortDataType = 'string';
-        break;
-      case 'monthlyUsage':
-      case 'suggestedQuantity':
-      case 'requiredQuantity':
-        sortDataType = 'number';
-        break;
-      default:
-        sortDataType = 'realm';
-    }
-    this.setState({
-      data: sortDataBy(data, sortBy, sortDataType, isAscending),
-    });
-  };
-
-  openModal = key => this.setState({ modalKey: key, modalIsOpen: true });
-
-  closeModal = () => this.setState({ modalIsOpen: false });
-
-  openCommentEditor = () => this.openModal(MODAL_KEYS.COMMENT_EDIT);
-
-  renderPageInfo = () => {
-    const { requisition } = this.props;
-    const infoColumns = [
-      [
-        {
-          title: `${pageInfoStrings.months_stock_required}:`,
-          info: requisition.monthsToSupply,
-        },
-        {
-          title: `${pageInfoStrings.entry_date}:`,
-          info: formatDate(requisition.entryDate),
-        },
-      ],
-      [
-        {
-          title: `${pageInfoStrings.customer}:`,
-          info: requisition.otherStoreName ? requisition.otherStoreName.name : '',
-        },
-        {
-          title: `${pageInfoStrings.comment}:`,
-          info: requisition.comment,
-          onPress: this.openCommentEditor,
-          editableType: 'text',
-        },
-      ],
-    ];
-    return <PageInfo columns={infoColumns} isEditingDisabled={requisition.isFinalised} />;
-  };
-
-  renderCell = (key, requisitionItem) => {
-    const { requisition } = this.props;
-    switch (key) {
-      case 'monthlyUsage':
-      case 'suggestedQuantity':
-      case 'requiredQuantity':
-      case 'ourStockOnHand':
-        return Math.round(requisitionItem[key]);
+  const getAction = colKey => {
+    switch (colKey) {
       case 'suppliedQuantity':
-        return {
-          type: requisition.isFinalised ? 'text' : 'editable',
-          cellContents: requisitionItem.suppliedQuantity || 0,
-        };
-      case 'remove':
-        return {
-          type: 'checkable',
-          icon: 'md-remove-circle',
-          isDisabled: requisition.isFinalised,
-        };
+        return PageActions.editSuppliedQuantity;
       default:
-        return requisitionItem[key];
+        return null;
     }
   };
 
-  renderModalContent = () => {
-    const { database, requisition } = this.props;
-    const { modalKey } = this.state;
-
-    const { COMMENT_EDIT } = MODAL_KEYS;
+  const getModalOnSelect = () => {
     switch (modalKey) {
+      case MODAL_KEYS.SELECT_ITEM:
+        return onAddItem;
+      case MODAL_KEYS.REQUISITION_COMMENT_EDIT:
+        return onEditComment;
       default:
-      case COMMENT_EDIT:
-        return (
-          <TextEditor
-            text={requisition.comment}
-            onEndEditing={newComment => {
-              if (newComment !== requisition.comment) {
-                database.write(() => {
-                  requisition.comment = newComment;
-                  database.save('Requisition', requisition);
-                });
-              }
-              this.closeModal();
-            }}
-          />
-        );
+        return null;
     }
   };
 
-  renderButtons = () => {
-    const { requisition } = this.props;
+  const renderRow = useCallback(
+    listItem => {
+      const { item, index } = listItem;
+      const rowKey = keyExtractor(item);
+      return (
+        <DataTableRow
+          rowData={data[index]}
+          rowKey={rowKey}
+          columns={columns}
+          isFinalised={isFinalised}
+          dispatch={dispatch}
+          getAction={getAction}
+          rowIndex={index}
+        />
+      );
+    },
+    [data, dataState]
+  );
+
+  const renderHeader = useCallback(
+    () => (
+      <DataTableHeaderRow
+        columns={columns}
+        dispatch={instantDebouncedDispatch}
+        sortAction={PageActions.sortData}
+        isAscending={isAscending}
+        sortBy={sortBy}
+      />
+    ),
+    [sortBy, isAscending]
+  );
+
+  const UseSuggestedQuantitiesButton = () => (
+    <View>
+      <PageButton
+        style={globalStyles.topButton}
+        text={buttonStrings.use_suggested_quantities}
+        onPress={onSetSuppliedToSuggested}
+        isDisabled={isFinalised}
+      />
+    </View>
+  );
+
+  const UseRequestedQuantitiesButton = () => (
+    <PageButton
+      style={globalStyles.topButton}
+      text={buttonStrings.use_requested_quantities}
+      onPress={onSetSuppliedToRequested}
+      isDisabled={requisition.isFinalised}
+    />
+  );
+
+  const PageButtons = useCallback(() => {
+    const { verticalContainer } = globalStyles;
 
     return (
-      <View style={globalStyles.pageTopRightSectionContainer}>
-        <View style={globalStyles.verticalContainer}>
-          <PageButton
-            style={globalStyles.topButton}
-            text={buttonStrings.use_requested_quantities}
-            onPress={this.onUseRequestedQuantities}
-            isDisabled={requisition.isFinalised}
-          />
-          <PageButton
-            style={globalStyles.topButton}
-            text={buttonStrings.use_suggested_quantities}
-            onPress={this.onUseSuggestedQuantities}
-            isDisabled={requisition.isFinalised}
-          />
-        </View>
+      <View style={verticalContainer}>
+        <UseRequestedQuantitiesButton />
+        <UseSuggestedQuantitiesButton />
       </View>
     );
-  };
+  }, []);
 
-  render() {
-    const { database, genericTablePageStyles, requisition, topRoute } = this.props;
-    const { data, modalIsOpen, selection } = this.state;
-
-    return (
-      <GenericPage
+  const {
+    newPageTopSectionContainer,
+    newPageTopLeftSectionContainer,
+    newPageTopRightSectionContainer,
+    searchBar,
+  } = newPageStyles;
+  return (
+    <DataTablePageView>
+      <View style={newPageTopSectionContainer}>
+        <View style={newPageTopLeftSectionContainer}>
+          {renderPageInfo()}
+          <SearchBar
+            onChangeText={onFilterData}
+            style={searchBar}
+            color={SUSSOL_ORANGE}
+            placeholder=""
+            value={searchTerm}
+          />
+        </View>
+        <View style={newPageTopRightSectionContainer}>
+          <PageButtons />
+        </View>
+      </View>
+      <DataTable
         data={data}
-        refreshData={this.refreshData}
-        renderCell={this.renderCell}
-        renderTopLeftComponent={this.renderPageInfo}
-        renderTopRightComponent={this.renderButtons}
-        onEndEditing={this.onEndEditing}
-        onSelectionChange={this.onSelectionChange}
-        defaultSortKey={this.dataFilters.sortBy}
-        defaultSortDirection={this.dataFilters.isAscending ? 'ascending' : 'descending'}
-        columns={[
-          {
-            key: 'itemCode',
-            width: 1.5,
-            title: tableStrings.code,
-            sortable: true,
-          },
-          {
-            key: 'itemName',
-            width: 4,
-            title: tableStrings.item_name,
-            sortable: true,
-          },
-          {
-            key: 'ourStockOnHand',
-            width: 1.5,
-            title: tableStrings.our_stock,
-            alignText: 'center',
-          },
-          {
-            key: 'stockOnHand',
-            width: 1.5,
-            title: tableStrings.their_stock,
-            alignText: 'center',
-          },
-          {
-            key: 'monthlyUsage',
-            width: 2,
-            title: tableStrings.monthly_usage,
-            sortable: true,
-            alignText: 'right',
-          },
-          {
-            key: 'suggestedQuantity',
-            width: 2,
-            title: tableStrings.suggested_quantity,
-            sortable: true,
-            alignText: 'right',
-          },
-          {
-            key: 'requiredQuantity',
-            width: 2,
-            title: tableStrings.required_quantity,
-            sortable: true,
-            alignText: 'right',
-          },
-          {
-            key: 'suppliedQuantity',
-            width: 2,
-            title: tableStrings.supply_quantity,
-            sortable: true,
-            alignText: 'right',
-          },
-        ]}
-        dataTypesSynchronised={DATA_TYPES_SYNCHRONISED}
-        finalisableDataType="Requisition"
-        database={database}
-        selection={selection}
-        {...genericTablePageStyles}
-        topRoute={topRoute}
-      >
-        <PageContentModal
-          isOpen={modalIsOpen && !requisition.isFinalised}
-          onClose={this.closeModal}
-          title={this.getModalTitle()}
-        >
-          {this.renderModalContent()}
-        </PageContentModal>
-      </GenericPage>
-    );
-  }
-}
+        renderRow={renderRow}
+        renderHeader={renderHeader}
+        keyExtractor={keyExtractor}
+        getItemLayout={getItemLayout}
+        columns={columns}
+      />
+      <DataTablePageModal
+        fullScreen={false}
+        isOpen={!!modalKey}
+        modalKey={modalKey}
+        onClose={onCloseModal}
+        onSelect={getModalOnSelect()}
+        dispatch={dispatch}
+        currentValue={modalValue}
+      />
+    </DataTablePageView>
+  );
+};
 
-export default CustomerRequisitionPage;
-
-/* eslint-disable react/require-default-props, react/forbid-prop-types */
 CustomerRequisitionPage.propTypes = {
-  database: PropTypes.object.isRequired,
-  genericTablePageStyles: PropTypes.object,
-  topRoute: PropTypes.bool,
   runWithLoadingIndicator: PropTypes.func.isRequired,
   requisition: PropTypes.object.isRequired,
+  routeName: PropTypes.string.isRequired,
 };

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -122,7 +122,7 @@ export const StocktakeEditPage = ({
     [comment, isFinalised]
   );
 
-  const getAction = useCallback((colKey, propName) => {
+  const getAction = (colKey, propName) => {
     switch (colKey) {
       case 'countedTotalQuantity':
         return PageActions.editCountedQuantity;
@@ -136,7 +136,7 @@ export const StocktakeEditPage = ({
       default:
         return null;
     }
-  });
+  };
 
   const getModalOnSelect = () => {
     switch (modalKey) {

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -131,7 +131,7 @@ export const StocktakeEditPage = ({
       case 'remove':
         if (propName === 'onCheckAction') return PageActions.selectRow;
         return PageActions.deselectRow;
-      case 'mostUsedReasonTitle':
+      case 'reasonTitle':
         return onEditReason;
       default:
         return null;

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -1,251 +1,195 @@
+/* eslint-disable react/forbid-prop-types */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { View } from 'react-native';
 
-import { PageButton } from '../widgets';
-import { GenericPage } from './GenericPage';
-import { SelectModal, BottomConfirmModal } from '../widgets/modals';
+import { UIDatabase } from '../database';
+import { MODAL_KEYS, newSortDataBy } from '../utilities';
+import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
+import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
+import { gotoSupplierInvoice, createSupplierInvoice } from '../navigation/actions';
 
-import { createRecord } from '../database';
-import { formatStatus, sortDataBy } from '../utilities';
-import { buttonStrings, modalStrings, navStrings, tableStrings } from '../localization';
+import { PageButton, SearchBar, DataTablePageView } from '../widgets';
+import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
+import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
-const DATA_TYPES_SYNCHRONISED = ['Transaction'];
+import { buttonStrings, modalStrings } from '../localization';
+import { SUSSOL_ORANGE, newPageStyles } from '../globalStyles';
 
-/**
- * Renders the page for displaying supplier invoices.
- *
- * @prop   {Realm}          database      App wide database.
- * @prop   {func}           navigateTo    CallBack for navigation stack.
- * @state  {Realm.Results}  transactions  Filtered to have only |supplier_invoice|.
- */
-export class SupplierInvoicesPage extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      transactions: props.database.objects('SupplierInvoice'),
-      isCreatingInvoice: false,
-      selection: [],
-    };
-    this.dataFilters = {
-      searchTerm: '',
-      sortBy: 'serialNumber',
-      isAscending: false,
-    };
-  }
-
-  onDeleteConfirm = () => {
-    const { selection, transactions } = this.state;
-    const { database } = this.props;
-    database.write(() => {
-      const transactionsToDelete = [];
-      for (let i = 0; i < selection.length; i += 1) {
-        const transaction = transactions.find(
-          currentTransaction => currentTransaction.id === selection[i]
-        );
-        if (transaction.isValid() && !transaction.isFinalised) {
-          transactionsToDelete.push(transaction);
-        }
-      }
-      database.delete('Transaction', transactionsToDelete);
-    });
-    this.setState({ selection: [] }, this.refreshData);
+const initializer = () => {
+  const backingData = UIDatabase.objects('SupplierInvoice');
+  return {
+    backingData,
+    data: newSortDataBy(backingData.slice(), 'serialNumber', false),
+    keyExtractor: recordKeyExtractor,
+    dataState: new Map(),
+    searchTerm: '',
+    filterDataKeys: ['otherParty.name'],
+    sortBy: 'serialNumber',
+    isAscending: false,
+    modalKey: '',
+    hasSelection: false,
   };
+};
 
-  onDeleteCancel = () => this.setState({ selection: [] }, this.refreshData);
+export const SupplierInvoicesPage = ({
+  currentUser,
+  routeName,
+  navigation,
+  dispatch: reduxDispatch,
+}) => {
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(routeName, {}, initializer);
 
-  onSelectionChange = newSelection => this.setState({ selection: newSelection });
+  const {
+    data,
+    dataState,
+    sortBy,
+    isAscending,
+    modalKey,
+    hasSelection,
+    keyExtractor,
+    searchTerm,
+    columns,
+    PageActions,
+  } = state;
 
-  onRowPress = invoice => this.navigateToInvoice(invoice);
+  // Listen to changes from sync and navigation events re-focusing this screen,
+  // such that any side effects that occur trigger a reconcilitation of data.
+  const refreshCallback = () => dispatch(PageActions.refreshData());
+  useNavigationFocus(refreshCallback, navigation);
+  useSyncListener(refreshCallback, ['Transaction']);
 
-  /**
-   * Create new supplier invoice and navigate user to the edit supplier invoice page.
-   */
-  onNewSupplierInvoice = otherParty => {
-    const { database, currentUser } = this.props;
-    let invoice;
-    database.write(() => {
-      invoice = createRecord(database, 'SupplierInvoice', otherParty, currentUser);
-    });
-    this.navigateToInvoice(invoice);
-  };
+  const onCloseModal = () => dispatch(PageActions.closeModal());
+  const onFilterData = value => dispatch(PageActions.filterData(value));
+  const onNewInvoice = () => dispatch(PageActions.openModal(MODAL_KEYS.SELECT_SUPPLIER));
+  const onConfirmDelete = () => dispatch(PageActions.deleteTransactions());
+  const onCancelDelete = () => dispatch(PageActions.deselectAll());
 
-  navigateToInvoice = invoice => {
-    // To open a supplier invoice in the supplier invoice page, it must be new or finalised, but not
-    // confirmed. If this is not enforced, a user has the ability to reduce the amount of stock on a
-    // confirmed supplier invoice which has already been issued in a customer invoice.
-
-    const { database, navigateTo } = this.props;
-
-    // Supplier invoices are initialised with the status 'new', and then jump to 'finalised'.
-    // Invoices with status 'confirmed' should not occur, but are handled here in case of an
-    // anomoly.
-    if (invoice.isConfirmed) {
-      database.write(() => {
-        invoice.finalise(database);
-        database.save('Transaction', invoice);
-      });
-    }
-
-    this.setState({ selection: [] }, this.refreshData); // Clear any invoices selected for deletion.
-
-    navigateTo('supplierInvoice', `${navStrings.invoice} ${invoice.serialNumber}`, {
-      transaction: invoice,
-    });
-  };
-
-  updateDataFilters = (newSearchTerm, newSortBy, newIsAscending) => {
-    // (... != null) checks for null or undefined (implicitly type coerced to null).
-    if (newSearchTerm != null) this.dataFilters.searchTerm = newSearchTerm;
-    if (newSortBy != null) this.dataFilters.sortBy = newSortBy;
-    if (newIsAscending != null) this.dataFilters.isAscending = newIsAscending;
-  };
-
-  /**
-   * Returns updated data fitlered by |searchTerm| and ordered by |sortBy| and |isAscending|.
-   */
-  refreshData = (newSearchTerm, newSortBy, newIsAscending) => {
-    const { transactions } = this.state;
-
-    this.updateDataFilters(newSearchTerm, newSortBy, newIsAscending);
-    const { searchTerm, sortBy, isAscending } = this.dataFilters;
-
-    const data = transactions.filtered('serialNumber BEGINSWITH[c] $0', searchTerm);
-
-    let sortDataType;
-    switch (sortBy) {
-      case 'serialNumber':
-        sortDataType = 'number';
-        break;
-      case 'otherPartyName':
-        sortDataType = 'string';
-        break;
-      default:
-        sortDataType = 'realm';
-    }
-    this.setState({
-      data: sortDataBy(data, sortBy, sortDataType, isAscending),
-    });
-  };
-
-  renderCell = (key, invoice) => {
-    switch (key) {
-      default:
-        return invoice[key];
-      case 'status':
-        return formatStatus(invoice.status);
-      case 'entryDate':
-        return (invoice.entryDate && invoice.entryDate.toDateString()) || 'N/A';
-      case 'remove':
-        return {
-          type: 'checkable',
-          icon: 'md-remove-circle',
-          isDisabled: invoice.isFinalised || !invoice.isExternalSupplierInvoice,
-        };
-    }
-  };
-
-  renderNewInvoiceButton = () => (
-    <PageButton
-      text={buttonStrings.new_supplier_invoice}
-      onPress={() => this.setState({ isCreatingInvoice: true })}
-    />
+  const onNavigateToInvoice = useCallback(
+    invoice => reduxDispatch(gotoSupplierInvoice(invoice)),
+    []
   );
 
-  render() {
-    const { database, genericTablePageStyles, topRoute } = this.props;
-    const { data, isCreatingInvoice, selection } = this.state;
+  const onCreateInvoice = otherParty => {
+    reduxDispatch(createSupplierInvoice(otherParty, currentUser));
+    onCloseModal();
+  };
 
-    return (
-      <GenericPage
+  const getAction = (colKey, propName) => {
+    switch (colKey) {
+      case 'remove':
+        if (propName === 'onCheckAction') return PageActions.selectRow;
+        return PageActions.deselectRow;
+      default:
+        return null;
+    }
+  };
+
+  const getModalOnSelect = () => {
+    switch (modalKey) {
+      case MODAL_KEYS.SELECT_SUPPLIER:
+        return onCreateInvoice;
+      default:
+        return null;
+    }
+  };
+
+  const renderRow = useCallback(
+    listItem => {
+      const { item, index } = listItem;
+      const rowKey = keyExtractor(item);
+      return (
+        <DataTableRow
+          rowData={data[index]}
+          rowState={dataState.get(rowKey)}
+          rowKey={rowKey}
+          columns={columns}
+          dispatch={dispatch}
+          getAction={getAction}
+          rowIndex={index}
+          onPress={onNavigateToInvoice}
+        />
+      );
+    },
+    [data, dataState]
+  );
+
+  const renderHeader = useCallback(
+    () => (
+      <DataTableHeaderRow
+        columns={columns}
+        dispatch={instantDebouncedDispatch}
+        sortAction={PageActions.sortData}
+        isAscending={isAscending}
+        sortBy={sortBy}
+      />
+    ),
+    [sortBy, isAscending]
+  );
+
+  const NewInvoiceButton = () => (
+    <PageButton text={buttonStrings.new_invoice} onPress={onNewInvoice} />
+  );
+
+  const {
+    newPageTopSectionContainer,
+    newPageTopLeftSectionContainer,
+    newPageTopRightSectionContainer,
+    searchBar,
+  } = newPageStyles;
+  return (
+    <DataTablePageView>
+      <View style={newPageTopSectionContainer}>
+        <View style={newPageTopLeftSectionContainer}>
+          <SearchBar
+            onChangeText={onFilterData}
+            color={SUSSOL_ORANGE}
+            value={searchTerm}
+            style={searchBar}
+          />
+        </View>
+        <View style={newPageTopRightSectionContainer}>
+          <NewInvoiceButton />
+        </View>
+      </View>
+      <DataTable
         data={data}
-        refreshData={this.refreshData}
-        renderCell={this.renderCell}
-        renderTopRightComponent={this.renderNewInvoiceButton}
-        onRowPress={this.onRowPress}
-        onSelectionChange={this.onSelectionChange}
-        defaultSortKey={this.dataFilters.sortBy}
-        defaultSortDirection={this.dataFilters.isAscending ? 'ascending' : 'descending'}
-        columns={[
-          {
-            key: 'serialNumber',
-            width: 1.5,
-            title: tableStrings.invoice_number,
-            sortable: true,
-          },
-          {
-            key: 'otherPartyName',
-            width: 2.5,
-            title: tableStrings.supplier,
-            sortable: true,
-          },
-          {
-            key: 'status',
-            width: 2,
-            title: tableStrings.status,
-            sortable: true,
-          },
-          {
-            key: 'entryDate',
-            width: 2,
-            title: tableStrings.entered_date,
-            sortable: true,
-          },
-          {
-            key: 'comment',
-            width: 3,
-            title: tableStrings.comment,
-            lines: 2,
-          },
-          {
-            key: 'remove',
-            width: 1,
-            title: tableStrings.remove,
-            alignText: 'center',
-          },
-        ]}
-        dataTypesSynchronised={DATA_TYPES_SYNCHRONISED}
-        database={database}
-        selection={selection}
-        {...genericTablePageStyles}
-        topRoute={topRoute}
-      >
-        <BottomConfirmModal
-          isOpen={selection.length > 0}
-          questionText={modalStrings.remove_these_items}
-          onCancel={() => this.onDeleteCancel()}
-          onConfirm={() => this.onDeleteConfirm()}
-          confirmText={modalStrings.remove}
-        />
-        <SelectModal
-          isOpen={isCreatingInvoice}
-          options={database.objects('ExternalSupplier')}
-          placeholderText={modalStrings.start_typing_to_select_supplier}
-          queryString="name BEGINSWITH[c] $0"
-          sortByString="name"
-          onSelect={name => {
-            this.onNewSupplierInvoice(name);
-            this.setState({ isCreatingInvoice: false });
-          }}
-          onClose={() => this.setState({ isCreatingInvoice: false })}
-          title={modalStrings.search_for_the_supplier}
-        />
-      </GenericPage>
-    );
-  }
-}
+        extraData={dataState}
+        renderRow={renderRow}
+        renderHeader={renderHeader}
+        keyExtractor={keyExtractor}
+        getItemLayout={getItemLayout}
+        columns={columns}
+      />
+      <BottomConfirmModal
+        isOpen={hasSelection}
+        questionText={modalStrings.delete_these_invoices}
+        onCancel={onCancelDelete}
+        onConfirm={onConfirmDelete}
+        confirmText={modalStrings.delete}
+      />
+      <DataTablePageModal
+        fullScreen={false}
+        isOpen={!!modalKey}
+        modalKey={modalKey}
+        onClose={onCloseModal}
+        onSelect={getModalOnSelect()}
+        dispatch={dispatch}
+      />
+    </DataTablePageView>
+  );
+};
 
 export default SupplierInvoicesPage;
 
-/* eslint-disable react/forbid-prop-types, react/require-default-props */
 SupplierInvoicesPage.propTypes = {
   currentUser: PropTypes.object.isRequired,
-  database: PropTypes.object,
-  navigateTo: PropTypes.func.isRequired,
-  genericTablePageStyles: PropTypes.object,
-  topRoute: PropTypes.bool,
+  routeName: PropTypes.string.isRequired,
+  navigation: PropTypes.object.isRequired,
+  dispatch: PropTypes.func.isRequired,
 };

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -248,14 +248,14 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
         onPress: onShowOverStocked,
       },
     ];
-    return <ToggleBar style={globalStyles.toggleBar} toggles={toggleProps} />;
+    return <ToggleBar toggles={toggleProps} />;
   }, [showAll]);
 
   const ViewRegimenDataButton = useCallback(
     () => (
       <View>
         <PageButton
-          style={{ ...globalStyles.topButton }}
+          style={globalStyles.topButton}
           text={buttonStrings.view_regimen_data}
           onPress={onViewRegimenData}
         />

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -130,7 +130,7 @@ export const removeReason = rowKey => (dispatch, getState) => {
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  objectToEdit.applyReasonToBatches(UIDatabase);
+  objectToEdit.applyReason(UIDatabase);
 
   dispatch(refreshRow(rowKey));
 };
@@ -165,7 +165,7 @@ export const enforceReasonChoice = rowKey => (dispatch, getState) => {
 export const applyReason = value => (dispatch, getState) => {
   const { modalValue, keyExtractor } = getState();
 
-  modalValue.applyReasonToBatches(UIDatabase, value);
+  modalValue.applyReason(UIDatabase, value);
 
   const rowKey = keyExtractor(modalValue);
 

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -18,6 +18,33 @@ import { openModal, closeModal } from './pageActions';
 export const refreshRow = rowKey => ({ type: ACTIONS.REFRESH_ROW, payload: { rowKey } });
 
 /**
+ * Edits a rows underlying `batch` field.
+ *
+ * @param {Date}    value       The new batch name value.
+ * @param {String}  rowKey      Key of the row to edit.
+ * @param {String}  objectType  Type of object to edit i.e. 'TransactionBatch'
+ */
+export const editBatchName = (value, rowKey, objectType) => (dispatch, getState) => {
+  const { data, keyExtractor } = getState();
+
+  const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
+
+  const { batch } = objectToEdit;
+
+  if (value !== batch) {
+    UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
+
+    dispatch(refreshRow(rowKey));
+  }
+};
+
+/**
+ * Wrapper around editBatchName for StocktakeBatches
+ */
+export const editStocktakeBatchName = (value, rowKey) =>
+  editBatchName(value, rowKey, 'StocktakeBatch');
+
+/**
  * Edits a rows underlying `expiryDate` field.
  *
  * @param {Date}    newDate     The new date to set as the expiry.
@@ -42,6 +69,9 @@ export const editExpiryDate = (newDate, rowKey, objectType) => (dispatch, getSta
  */
 export const editTransactionBatchExpiryDate = (newDate, rowKey) =>
   editExpiryDate(newDate, rowKey, 'TransactionBatch');
+
+export const editStocktakeBatchExpiryDate = (newDate, rowKey) =>
+  editExpiryDate(newDate, rowKey, 'StocktakeBatch');
 
 /**
  * Edits the field `totalQuantity` of a rows underlying data object.
@@ -121,6 +151,25 @@ export const editCountedQuantity = (value, rowKey) => (dispatch, getState) => {
 };
 
 /**
+ * Edits a StocktakeBatches underlying `countedTotalQuantity`
+ *
+ * @param {String|Number}   value  New value for the underlying `countedTotalQuantity` field
+ * @param {String}          rowKey Key of the row to edit.
+ */
+export const editStocktakeBatchCountedQuantity = (value, rowKey) => (dispatch, getState) => {
+  const { data, keyExtractor } = getState();
+
+  const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
+
+  UIDatabase.write(() => {
+    objectToEdit.countedTotalQuantity = value;
+    UIDatabase.save('StocktakeBatch', UIDatabase);
+  });
+
+  dispatch(refreshRow(rowKey));
+};
+
+/**
  * Removes a reason from a rows underlying data.
  *
  * @param {String} rowKey   Key for the row to edit.
@@ -177,14 +226,18 @@ export const CellActionsLookup = {
   refreshRow,
   editExpiryDate,
   editTransactionBatchExpiryDate,
+  editStocktakeBatchExpiryDate,
   editTotalQuantity,
   editSuppliedQuantity,
   editRequiredQuantity,
   editRequisitionItemRequiredQuantity,
   editCountedQuantity,
+  editStocktakeBatchCountedQuantity,
   removeReason,
   enforceReasonChoice,
   applyReason,
+  editBatchName,
+  editStocktakeBatchName,
 };
 
 /**
@@ -209,5 +262,17 @@ export const CellActionsLookup = {
  */
 export const editCountedQuantityWithReason = (value, rowKey) => dispatch => {
   dispatch(editCountedQuantity(value, rowKey));
+  dispatch(enforceReasonChoice(rowKey));
+};
+
+/**
+ * Wrapper around `editStocktakeBatchCountedQuantity`, splitting the action to enforce a
+ * reason also.
+ *
+ * @param {String|Number}   value  New value for the underlying `countedTotalQuantity` field
+ * @param {String}          rowKey Key of the row to edit.
+ */
+export const editStocktakeBatchCountedQuantityWithReason = (value, rowKey) => dispatch => {
+  dispatch(editStocktakeBatchCountedQuantity(value, rowKey));
   dispatch(enforceReasonChoice(rowKey));
 };

--- a/src/pages/dataTableUtilities/actions/getPageActions.js
+++ b/src/pages/dataTableUtilities/actions/getPageActions.js
@@ -4,7 +4,11 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import { CellActionsLookup, editCountedQuantityWithReason } from './cellActions';
+import {
+  CellActionsLookup,
+  editCountedQuantityWithReason,
+  editStocktakeBatchCountedQuantityWithReason,
+} from './cellActions';
 import { RowActionsLookup } from './rowActions';
 import { TableActionsLookup } from './tableActions';
 import { PageActionsLookup } from './pageActions';
@@ -38,6 +42,11 @@ const stocktakeEditorWithReasons = {
   editCountedQuantity: editCountedQuantityWithReason,
 };
 
+const stocktakeBatchEditModalWithReasons = {
+  ...BasePageActions,
+  editStocktakeBatchCountedQuantity: editStocktakeBatchCountedQuantityWithReason,
+};
+
 /**
  * If actions need to be overriden for a particular routeName,
  * adding them here will pass that new set of actions to the
@@ -45,6 +54,7 @@ const stocktakeEditorWithReasons = {
  */
 const NON_DEFAULT_PAGE_ACTIONS = {
   stocktakeEditorWithReasons,
+  stocktakeBatchEditModalWithReasons,
 };
 
 /**

--- a/src/pages/dataTableUtilities/actions/getPageActions.js
+++ b/src/pages/dataTableUtilities/actions/getPageActions.js
@@ -8,7 +8,6 @@ import { CellActionsLookup, editCountedQuantityWithReason } from './cellActions'
 import { RowActionsLookup } from './rowActions';
 import { TableActionsLookup } from './tableActions';
 import { PageActionsLookup } from './pageActions';
-import { UIDatabase } from '../../../database/index';
 
 /**
  * Serves a page the actions it requires given it's routeName.
@@ -39,8 +38,12 @@ const stocktakeEditorWithReasons = {
   editCountedQuantity: editCountedQuantityWithReason,
 };
 
-const PAGE_ACTIONS = {
-  BasePageActions,
+/**
+ * If actions need to be overriden for a particular routeName,
+ * adding them here will pass that new set of actions to the
+ * screen when navigating.
+ */
+const NON_DEFAULT_PAGE_ACTIONS = {
   stocktakeEditorWithReasons,
 };
 
@@ -49,15 +52,4 @@ const PAGE_ACTIONS = {
  *
  * @param {String} routeName Name of the route being navigated to.
  */
-export const getPageActions = routeName => {
-  switch (routeName) {
-    case 'stocktakeEditor': {
-      const usesReasons = UIDatabase.objects('StocktakeReasons').length > 0;
-      return usesReasons ? PAGE_ACTIONS.stocktakeEditorWithReasons : PAGE_ACTIONS.BasePageActions;
-    }
-
-    default: {
-      return PAGE_ACTIONS.BasePageActions;
-    }
-  }
-};
+export const getPageActions = routeName => NON_DEFAULT_PAGE_ACTIONS[routeName] || BasePageActions;

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -34,6 +34,17 @@ export const filterData = searchTerm => ({
 });
 
 /**
+ * Adds a record to the current stores `data`. Prepends the
+ * added record.
+ *
+ * @param {Any} record A record to add to the current data.
+ */
+export const addRecord = record => ({
+  type: ACTIONS.ADD_RECORD,
+  payload: { record },
+});
+
+/**
  * Refreshes the underlying data array by slicing backingData.
  * BackingData is a live realm collection which side effects i.e.
  * finalising can make out of sync with the data array used for display.
@@ -117,7 +128,7 @@ export const addItem = (item, addedItemType) => (dispatch, getState) => {
   if (!pageObject.hasItem(item)) {
     UIDatabase.write(() => {
       const addedItem = createRecord(UIDatabase, addedItemType, pageObject, item);
-      dispatch({ type: ACTIONS.ADD_RECORD, payload: { record: addedItem } });
+      dispatch(addRecord(addedItem));
     });
   } else {
     dispatch(closeModal());
@@ -146,7 +157,22 @@ export const addTransactionBatch = item => (dispatch, getState) => {
     const transItem = createRecord(UIDatabase, 'TransactionItem', pageObject, item);
     const itemBatch = createRecord(UIDatabase, 'ItemBatch', item, '');
     const addedBatch = createRecord(UIDatabase, 'TransactionBatch', transItem, itemBatch);
-    dispatch({ type: ACTIONS.ADD_RECORD, payload: { record: addedBatch } });
+    dispatch(addRecord(addedBatch));
+  });
+};
+
+/**
+ * Creates a stocktake batch and ItemBatch associated with the stores
+ * pageObject - assumed to be a StocktakeItem.
+ *
+ * use case: StocktakeEditBatchModal adding empty batches.
+ */
+export const addStocktakeBatch = () => (dispatch, getState) => {
+  const { pageObject } = getState();
+
+  UIDatabase.write(() => {
+    const addedBatch = pageObject.createNewBatch(UIDatabase);
+    dispatch(addRecord(addedBatch));
   });
 };
 
@@ -228,4 +254,5 @@ export const TableActionsLookup = {
   addRequisitionItem,
   addStocktakeItem,
   addTransactionItem,
+  addStocktakeBatch,
 };

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -12,7 +12,7 @@ const PAGE_COLUMN_WIDTHS = {
   customerInvoices: [1.5, 2.5, 2, 1.5, 3, 1],
   supplierRequisitions: [1.5, 2, 1, 1, 1, 1],
   supplierRequisition: [1.4, 3.5, 2, 1.5, 2, 2, 1],
-  programSupplierRequisition: [1.5, 3.5, 0.5, 0.5, 2, 1.5, 2, 2, 1],
+  supplierRequisitionWithProgram: [1.5, 3.5, 0.5, 0.5, 2, 1.5, 2, 2, 1],
   stocktakes: [6, 2, 2, 1],
   stocktakeManager: [2, 6, 1],
   stocktakeEditor: [1, 2.8, 1.2, 1.2, 1, 0.8],
@@ -40,7 +40,7 @@ const PAGE_COLUMNS = {
     'requiredQuantity',
     'remove',
   ],
-  programSupplierRequisition: [
+  supplierRequisitionWithProgram: [
     'itemCode',
     'itemName',
     'unit',

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -8,6 +8,7 @@ import { tableStrings } from '../../localization';
 const PAGE_COLUMN_WIDTHS = {
   customerInvoice: [2, 4, 2, 2, 1],
   supplierInvoice: [2, 4, 2, 2, 1],
+  supplierInvoices: [1.5, 2.5, 2, 1.5, 3, 1],
   customerInvoices: [1.5, 2.5, 2, 1.5, 3, 1],
   supplierRequisitions: [1.5, 2, 1, 1, 1, 1],
   supplierRequisition: [1.4, 3.5, 2, 1.5, 2, 2, 1],
@@ -16,14 +17,20 @@ const PAGE_COLUMN_WIDTHS = {
   stocktakeManager: [2, 6, 1],
   stocktakeEditor: [1, 2.8, 1.2, 1.2, 1, 0.8],
   stocktakeEditorWithReasons: [1, 2.8, 1.2, 1.2, 1, 1, 0.8],
+  customerRequisitions: [1.5, 2, 1, 1, 1],
+  customerRequisition: [2, 4, 1.5, 1.5, 2, 2, 2, 2],
+  stocktakeBatchEditModal: [1, 1, 1, 1, 1],
+  stocktakeBatchEditModalWithReasons: [1, 1, 1, 1, 1, 1],
+  regimenDataModal: [4, 1, 5],
 };
 
 const PAGE_COLUMNS = {
   customerInvoice: ['itemCode', 'itemName', 'availableQuantity', 'totalQuantity', 'remove'],
+  customerInvoices: ['invoiceNumber', 'customer', 'status', 'entryDate', 'comment', 'remove'],
   supplierInvoice: ['itemCode', 'itemName', 'totalQuantity', 'expiryDate', 'remove'],
-  customerInvoices: ['serialNumber', 'customer', 'status', 'entryDate', 'comment', 'remove'],
+  supplierInvoices: ['invoiceNumber', 'supplier', 'status', 'entryDate', 'comment', 'remove'],
   supplierRequisitions: [
-    'serialNumber',
+    'requisitionNumber',
     'supplier',
     'numberOfItems',
     'entryDate',
@@ -36,7 +43,7 @@ const PAGE_COLUMNS = {
     'ourStockOnHand',
     'monthlyUsage',
     'suggestedQuantity',
-    'requiredQuantity',
+    'editableRequiredQuantity',
     'remove',
   ],
   supplierRequisitionWithProgram: [
@@ -47,7 +54,7 @@ const PAGE_COLUMNS = {
     'ourStockOnHand',
     'monthlyUsage',
     'suggestedQuantity',
-    'requiredQuantity',
+    'editableRequiredQuantity',
     'remove',
   ],
   stocktakes: ['name', 'createdDate', 'status', 'remove'],
@@ -69,14 +76,48 @@ const PAGE_COLUMNS = {
     'reason',
     'batches',
   ],
+  customerRequisitions: ['requisitionNumber', 'customer', 'numberOfItems', 'entryDate', 'status'],
+  customerRequisition: [
+    'itemCode',
+    'itemName',
+    'ourStockOnHand',
+    'theirStockOnHand',
+    'monthlyUsage',
+    'suggestedQuantity',
+    'requiredQuantity',
+    'suppliedQuantity',
+  ],
+  stocktakeBatchEditModal: [
+    'batchName',
+    'expiryDate',
+    'snapshotTotalQuantity',
+    'countedTotalQuantity',
+    'difference',
+  ],
+  stocktakeBatchEditModalWithReasons: [
+    'batchName',
+    'expiryDate',
+    'snapshotTotalQuantity',
+    'countedTotalQuantity',
+    'difference',
+    'reason',
+  ],
+  regimenDataModal: ['question', 'editableValue', 'editableComment'],
 };
 
 const COLUMNS = () => ({
   // CODE COLUMNS
-  serialNumber: {
+  invoiceNumber: {
     type: 'string',
     key: 'serialNumber',
     title: tableStrings.invoice_number,
+    sortable: true,
+    editable: false,
+  },
+  requisitionNumber: {
+    type: 'string',
+    key: 'serialNumber',
+    title: tableStrings.requisition_number,
     sortable: true,
     editable: false,
   },
@@ -149,6 +190,14 @@ const COLUMNS = () => ({
     sortable: true,
     editable: false,
   },
+  question: {
+    type: 'string',
+    key: 'name',
+    title: 'Question',
+    textAlign: 'left',
+    sortable: false,
+    editable: false,
+  },
 
   // EDITABLE STRING COLUMNS
 
@@ -157,6 +206,23 @@ const COLUMNS = () => ({
     key: 'batch',
     title: tableStrings.batch_name,
     alignText: 'center',
+    editable: true,
+  },
+  editableComment: {
+    type: 'editableString',
+    key: 'comment',
+    title: tableStrings.comment,
+    textAlign: 'right',
+    sortable: false,
+    editable: true,
+  },
+  editableValue: {
+    type: 'editableString',
+    key: 'value',
+    title: 'Value',
+    textAlign: 'right',
+    sortable: false,
+    editable: true,
   },
 
   // NUMERIC COLUMNS
@@ -185,10 +251,26 @@ const COLUMNS = () => ({
     sortable: true,
     editable: false,
   },
+  theirStockOnHand: {
+    type: 'numeric',
+    key: 'stockOnHand',
+    title: tableStrings.their_stock,
+    alignText: 'right',
+    sortable: true,
+    editable: false,
+  },
   suggestedQuantity: {
     type: 'numeric',
     key: 'suggestedQuantity',
     title: tableStrings.suggested_quantity,
+    alignText: 'right',
+    sortable: true,
+    editable: false,
+  },
+  requiredQuantity: {
+    type: 'numeric',
+    key: 'requiredQuantity',
+    title: tableStrings.required_quantity,
     alignText: 'right',
     sortable: true,
     editable: false,
@@ -205,14 +287,6 @@ const COLUMNS = () => ({
     type: 'numeric',
     key: 'snapshotTotalQuantity',
     title: tableStrings.snapshot_quantity,
-    alignText: 'right',
-    sortable: true,
-    editable: false,
-  },
-  theirStockOnHand: {
-    type: 'numeric',
-    key: 'stockOnHand',
-    title: tableStrings.their_stock,
     alignText: 'right',
     sortable: true,
     editable: false,
@@ -236,7 +310,7 @@ const COLUMNS = () => ({
 
   // EDITABLE NUMERIC COLUMNS
 
-  requiredQuantity: {
+  editableRequiredQuantity: {
     type: 'editableNumeric',
     key: 'requiredQuantity',
     title: tableStrings.required_quantity,
@@ -256,6 +330,14 @@ const COLUMNS = () => ({
     type: 'editableNumeric',
     key: 'totalQuantity',
     title: tableStrings.quantity,
+    alignText: 'right',
+    sortable: true,
+    editable: true,
+  },
+  suppliedQuantity: {
+    type: 'editableNumeric',
+    key: 'suppliedQuantity',
+    title: tableStrings.supply_quantity,
     alignText: 'right',
     sortable: true,
     editable: true,
@@ -320,7 +402,7 @@ const COLUMNS = () => ({
   },
   reason: {
     type: 'dropDown',
-    key: 'mostUsedReasonTitle',
+    key: 'reasonTitle',
     title: tableStrings.reason,
     alignText: 'center',
     sortable: false,

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -4,7 +4,6 @@
  */
 
 import { tableStrings } from '../../localization';
-import { UIDatabase } from '../../database/index';
 
 const PAGE_COLUMN_WIDTHS = {
   customerInvoice: [2, 4, 2, 2, 1],
@@ -16,7 +15,7 @@ const PAGE_COLUMN_WIDTHS = {
   stocktakes: [6, 2, 2, 1],
   stocktakeManager: [2, 6, 1],
   stocktakeEditor: [1, 2.8, 1.2, 1.2, 1, 0.8],
-  stocktakeEditorReasons: [1, 2.8, 1.2, 1.2, 1, 1, 0.8],
+  stocktakeEditorWithReasons: [1, 2.8, 1.2, 1.2, 1, 1, 0.8],
 };
 
 const PAGE_COLUMNS = {
@@ -61,7 +60,7 @@ const PAGE_COLUMNS = {
     'difference',
     'batches',
   ],
-  stocktakeEditorReasons: [
+  stocktakeEditorWithReasons: [
     'itemCode',
     'itemName',
     'snapshotTotalQuantity',
@@ -323,33 +322,15 @@ const COLUMNS = () => ({
     type: 'dropDown',
     key: 'mostUsedReasonTitle',
     title: tableStrings.reason,
-    alignText: 'right',
+    alignText: 'center',
     sortable: false,
     editable: false,
   },
 });
 
 const getColumns = page => {
-  let columnKeys;
-  let widths;
-
-  switch (page) {
-    case 'stocktakeEditor':
-      {
-        const usesReasons = UIDatabase.objects('StocktakeReasons').length > 0;
-        if (usesReasons) {
-          columnKeys = PAGE_COLUMNS.stocktakeEditorReasons;
-          widths = PAGE_COLUMN_WIDTHS.stocktakeEditorReasons;
-        } else {
-          columnKeys = PAGE_COLUMNS[page];
-          widths = PAGE_COLUMN_WIDTHS[page];
-        }
-      }
-      break;
-    default:
-      columnKeys = PAGE_COLUMNS[page];
-      widths = PAGE_COLUMN_WIDTHS[page];
-  }
+  const widths = PAGE_COLUMN_WIDTHS[page];
+  const columnKeys = PAGE_COLUMNS[page];
 
   if (!columnKeys) return [];
   if (!(columnKeys.length === widths.length)) return [];

--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -3,7 +3,7 @@
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2016
  */
-import { pageInfoStrings, programStrings } from '../../localization';
+import { pageInfoStrings, programStrings, tableStrings } from '../../localization';
 import { formatDate } from '../../utilities';
 
 import { MODAL_KEYS } from '../../utilities/getModalTitle';
@@ -36,10 +36,13 @@ const PER_PAGE_INFO_COLUMNS = {
   ],
   supplierRequisitionWithProgram: [
     ['program', 'orderType', 'entryDate', 'enteredBy'],
-    ['period', 'otherParty', 'programMonthsToSupply', 'requisitionComment'],
+    ['period', 'otherParty', 'editableMonthsToSupply', 'requisitionComment'],
   ],
   stocktakeEditor: [['stocktakeName', 'stocktakeComment']],
   stocktakeEditorWithReasons: [['stocktakeName', 'stocktakeComment']],
+  customerRequisition: [['monthsToSupply', 'entryDate'], ['customer', 'requisitionComment']],
+  stocktakeBatchEditModal: [['itemName']],
+  stocktakeBatchEditModalWithReasons: [['itemName']],
 };
 
 const PAGE_INFO_ROWS = (pageObject, dispatch, PageActions) => ({
@@ -57,7 +60,7 @@ const PAGE_INFO_ROWS = (pageObject, dispatch, PageActions) => ({
   },
   customer: {
     title: `${pageInfoStrings.customer}:`,
-    info: pageObject.otherParty && pageObject.otherParty.name,
+    info: pageObject.otherPartyName,
   },
   theirRef: {
     title: `${pageInfoStrings.their_ref}:`,
@@ -95,7 +98,7 @@ const PAGE_INFO_ROWS = (pageObject, dispatch, PageActions) => ({
     title: `${programStrings.order_type}:`,
     info: pageObject.orderType,
   },
-  monthsToSupply: {
+  editableMonthsToSupply: {
     title: `${pageInfoStrings.months_stock_required}:`,
     info: pageObject.monthsToSupply,
     onPress: () => dispatch(PageActions.openModal(MODAL_KEYS.SELECT_MONTH)),
@@ -105,7 +108,7 @@ const PAGE_INFO_ROWS = (pageObject, dispatch, PageActions) => ({
     title: `${programStrings.period}:`,
     info: pageObject.period && pageObject.period.toInfoString(),
   },
-  programMonthsToSupply: {
+  monthsToSupply: {
     title: `${pageInfoStrings.months_stock_required}:`,
     info: pageObject.monthsToSupply,
   },
@@ -114,6 +117,11 @@ const PAGE_INFO_ROWS = (pageObject, dispatch, PageActions) => ({
     info: pageObject.name,
     onPress: null,
     editableType: 'text',
+  },
+  itemName: {
+    title: `${tableStrings.item_name}`,
+    info: pageObject.itemName,
+    onPress: null,
   },
 });
 

--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -39,6 +39,7 @@ const PER_PAGE_INFO_COLUMNS = {
     ['period', 'otherParty', 'programMonthsToSupply', 'requisitionComment'],
   ],
   stocktakeEditor: [['stocktakeName', 'stocktakeComment']],
+  stocktakeEditorWithReasons: [['stocktakeName', 'stocktakeComment']],
 };
 
 const PAGE_INFO_ROWS = (pageObject, dispatch, PageActions) => ({

--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -34,7 +34,7 @@ const PER_PAGE_INFO_COLUMNS = {
     ['entryDate', 'enteredBy'],
     ['otherParty', 'monthsToSupply', 'requisitionComment'],
   ],
-  programSupplierRequisition: [
+  supplierRequisitionWithProgram: [
     ['program', 'orderType', 'entryDate', 'enteredBy'],
     ['period', 'otherParty', 'programMonthsToSupply', 'requisitionComment'],
   ],

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -49,7 +49,9 @@ export const PAGES = {
   supplierInvoice: props => <PageContainer page={SupplierInvoicePage} {...props} />,
   supplierInvoices: props => <PageContainer page={SupplierInvoicesPage} {...props} />,
   supplierRequisition: props => <PageContainer page={SupplierRequisitionPage} {...props} />,
-  programSupplierRequisition: props => <PageContainer page={SupplierRequisitionPage} {...props} />,
+  supplierRequisitionWithProgram: props => (
+    <PageContainer page={SupplierRequisitionPage} {...props} />
+  ),
   supplierRequisitions: props => <PageContainer page={SupplierRequisitionsPage} {...props} />,
 };
 
@@ -84,7 +86,7 @@ export const FINALISABLE_PAGES = {
     recordToFinaliseKey: 'requisition',
     finaliseText: 'finalise_supplier_requisition',
   },
-  programSupplierRequisition: {
+  supplierRequisitionWithProgram: {
     checkForError: checkForSupplierRequisitionError,
     recordType: 'Requisition',
     recordToFinaliseKey: 'requisition',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -44,6 +44,7 @@ export const PAGES = {
   root: props => <PageContainer page={MenuPage} {...props} />,
   stock: props => <PageContainer page={StockPage} {...props} />,
   stocktakeEditor: props => <PageContainer page={StocktakeEditPage} {...props} />,
+  stocktakeEditorWithReasons: props => <PageContainer page={StocktakeEditPage} {...props} />,
   stocktakeManager: props => <PageContainer page={StocktakeManagePage} {...props} />,
   stocktakes: props => <PageContainer page={StocktakesPage} {...props} />,
   supplierInvoice: props => <PageContainer page={SupplierInvoicePage} {...props} />,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -15,10 +15,7 @@ import {
   checkForFinaliseError as checkForCustomerRequisitionFinaliseError,
 } from './CustomerRequisitionPage';
 import { StockPage } from './StockPage';
-import {
-  StocktakeEditPage,
-  // checkForFinaliseError as checkForStocktakeFinaliseError,
-} from './StocktakeEditPage';
+import { StocktakeEditPage } from './StocktakeEditPage';
 import { StocktakeManagePage } from './StocktakeManagePage';
 import { StocktakesPage } from './StocktakesPage';
 import { SupplierInvoicePage } from './SupplierInvoicePage';
@@ -30,6 +27,7 @@ import {
   checkForCustomerInvoiceError,
   checkForSupplierInvoiceError,
   checkForSupplierRequisitionError,
+  checkForStocktakeError,
 } from '../utilities';
 
 export { FirstUsePage } from './FirstUsePage';
@@ -76,7 +74,13 @@ export const FINALISABLE_PAGES = {
     finaliseText: 'finalise_customer_requisition',
   },
   stocktakeEditor: {
-    // checkForError: checkForStocktakeFinaliseError,
+    checkForError: checkForStocktakeError,
+    recordType: 'Stocktake',
+    recordToFinaliseKey: 'stocktake',
+    finaliseText: 'finalise_stocktake',
+  },
+  stocktakeEditorWithReasons: {
+    checkForError: checkForStocktakeError,
     recordType: 'Stocktake',
     recordToFinaliseKey: 'stocktake',
     finaliseText: 'finalise_stocktake',

--- a/src/utilities/finalisation.js
+++ b/src/utilities/finalisation.js
@@ -5,6 +5,7 @@
  */
 
 import { modalStrings } from '../localization';
+import { formatErrorItemNames } from './formatters';
 
 /**
  * Check whether a given customer invoice is safe to be finalised. If safe to finalise,
@@ -61,3 +62,27 @@ export function checkForSupplierRequisitionError(requisition) {
 
   return null;
 }
+
+/**
+ * Check whether a given stocktake is safe to be finalised.
+ * If stocktake is safe to finalise, return null, else return an appropriate error
+ * message.
+ *
+ * @param  {object}  stocktake  The stocktake to check.
+ * @return {string}             Null if safe to be finalised, else an error message.
+ */
+export const checkForStocktakeError = stocktake => {
+  const { hasSomeCountedItems, itemsBelowMinimum } = stocktake;
+
+  if (!hasSomeCountedItems) {
+    return modalStrings.stocktake_no_counted_items;
+  }
+
+  if (itemsBelowMinimum.length > 0) {
+    return (
+      modalStrings.following_items_reduced_more_than_available_stock +
+      formatErrorItemNames(itemsBelowMinimum)
+    );
+  }
+  return null;
+};

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -21,6 +21,7 @@ export {
   checkForCustomerInvoiceError,
   checkForSupplierInvoiceError,
   checkForSupplierRequisitionError,
+  checkForStocktakeError,
 } from './finalisation';
 
 export { formatErrorItemNames } from './formatters';

--- a/src/utilities/sortDataBy.js
+++ b/src/utilities/sortDataBy.js
@@ -59,6 +59,8 @@ const sortKeyToType = {
   snapshotTotalQuantity: 'number',
   countedTotalQuantity: 'number',
   difference: 'number',
+  stockOnHand: 'number',
+  suppliedQuantity: 'number',
 };
 
 /**

--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -94,7 +94,7 @@ const DataTable = React.memo(({ renderRow, renderHeader, style, data, columns, .
 
   return (
     <RefContext.Provider value={contextValue}>
-      {renderHeader()}
+      {renderHeader && renderHeader()}
       <VirtualizedList
         ref={virtualizedListRef}
         keyboardDismissMode="none"
@@ -132,9 +132,9 @@ DataTable.defaultProps = {
   style: defaultStyles.virtualizedList,
   getItem: (items, index) => items[index],
   getItemCount: items => items.length,
-  initialNumToRender: 20,
+  initialNumToRender: 10,
   removeClippedSubviews: true,
-  windowSize: 4,
+  windowSize: 2,
   columns: [],
 };
 

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -201,6 +201,7 @@ const DataTableRow = React.memo(
             case 'dropDown':
               return (
                 <DropDownCell
+                  key={columnKey}
                   isDisabled={isFinalised}
                   dispatch={dispatch}
                   onPressAction={getAction(columnKey)}

--- a/src/widgets/DropDownCell.js
+++ b/src/widgets/DropDownCell.js
@@ -49,7 +49,7 @@ const DropDownCell = React.memo(
       <View style={{ flexDirection: 'row' }}>
         <View style={dropDownCellTextContainer}>
           <Text numberOfLines={1} ellipsizeMode="tail" style={internalFontStyle}>
-            {value || { placeholder }}
+            {value || placeholder}
           </Text>
         </View>
         {!!value && (

--- a/src/widgets/DropDownCell.js
+++ b/src/widgets/DropDownCell.js
@@ -27,17 +27,29 @@ const {
  * @param {String}  value           Text value for this cell.
  * @param {Bool}    isLastCell      Indicator whether this cell is the last cell in a row.
  * @param {Number}  width           Flex width of this cell.
+ * @param {String}  placeholder     Text to display when no value is selected.
  * @param {Bool}    debug           Indicator whether logging should occur for this cell.
  */
 const DropDownCell = React.memo(
-  ({ isDisabled, dispatch, onPressAction, rowKey, columnKey, value, isLastCell, width, debug }) => {
+  ({
+    isDisabled,
+    dispatch,
+    onPressAction,
+    rowKey,
+    columnKey,
+    value,
+    isLastCell,
+    width,
+    placeholder,
+    debug,
+  }) => {
     const internalFontStyle = value ? dropDownFont : dropDownPlaceholderFont;
 
     const TouchableChild = () => (
       <View style={{ flexDirection: 'row' }}>
         <View style={dropDownCellTextContainer}>
           <Text numberOfLines={1} ellipsizeMode="tail" style={internalFontStyle}>
-            {value || 'N/A'}
+            {value || { placeholder }}
           </Text>
         </View>
         {!!value && (
@@ -71,6 +83,7 @@ DropDownCell.defaultProps = {
   isDisabled: false,
   value: '',
   isLastCell: false,
+  placeholder: 'N/A',
   debug: false,
 };
 DropDownCell.propTypes = {
@@ -83,4 +96,5 @@ DropDownCell.propTypes = {
   value: PropTypes.string,
   isLastCell: PropTypes.bool,
   debug: PropTypes.bool,
+  placeholder: PropTypes.string,
 };

--- a/src/widgets/GenericChoiceList.js
+++ b/src/widgets/GenericChoiceList.js
@@ -91,7 +91,7 @@ GenericChoiceList.defaultProps = {
 GenericChoiceList.propTypes = {
   keyToDisplay: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
-  data: PropTypes.array.isRequired,
+  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
   highlightIndex: PropTypes.number,
   highlightValue: PropTypes.string,
 };

--- a/src/widgets/ToggleBar/ToggleBar.js
+++ b/src/widgets/ToggleBar/ToggleBar.js
@@ -108,12 +108,12 @@ const localStyles = StyleSheet.create({
   toggleOffStyle: {
     alignItems: 'center',
     justifyContent: 'center',
-    width: 140,
+    width: 142,
   },
   toggleOnStyle: {
     alignItems: 'center',
     justifyContent: 'center',
-    width: 140,
+    width: 142,
     backgroundColor: 'rgb(114, 211, 242)',
   },
 });

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -13,13 +13,13 @@ import { AutocompleteSelector } from '../AutocompleteSelector';
 import { TextEditor } from '../TextEditor';
 import { ByProgramModal } from './ByProgramModal';
 import { ToggleSelector } from '../ToggleSelector';
+import { RegimenDataModal } from './RegimenDataModal';
 import { NewConfirmModal } from './NewConfirmModal';
 import { GenericChoiceList } from '../GenericChoiceList';
 import { UIDatabase } from '../../database';
 import { modalStrings } from '../../localization';
 import Settings from '../../settings/MobileAppSettings';
 
-import { RequisitionRegimenModalTable } from '../../pages/expansions/RequisitionRegimenModalTable';
 import {
   dataTableColors,
   dataTableStyles,
@@ -66,12 +66,10 @@ export const DataTablePageModal = ({
             renderRightText={item => `${item.totalQuantity}`}
           />
         );
+      case MODAL_KEYS.THEIR_REF_EDIT:
       case MODAL_KEYS.STOCKTAKE_COMMENT_EDIT:
       case MODAL_KEYS.TRANSACTION_COMMENT_EDIT:
       case MODAL_KEYS.REQUISITION_COMMENT_EDIT:
-        return <TextEditor text={currentValue} onEndEditing={onSelect} />;
-
-      case MODAL_KEYS.THEIR_REF_EDIT:
         return <TextEditor text={currentValue} onEndEditing={onSelect} />;
 
       case MODAL_KEYS.SELECT_CUSTOMER:
@@ -120,7 +118,7 @@ export const DataTablePageModal = ({
 
       case MODAL_KEYS.VIEW_REGIMEN_DATA:
         return (
-          <RequisitionRegimenModalTable
+          <RegimenDataModal
             database={UIDatabase}
             requisition={currentValue}
             genericTablePageStyles={{
@@ -160,7 +158,7 @@ export const DataTablePageModal = ({
         return (
           <GenericChoiceList
             data={UIDatabase.objects('StocktakeReasons')}
-            highlightValue={currentValue.mostUsedReasonTitle}
+            highlightValue={currentValue.reasonTitle}
             keyToDisplay="title"
             onPress={onSelect}
           />

--- a/src/widgets/modals/ModalContainer.js
+++ b/src/widgets/modals/ModalContainer.js
@@ -52,11 +52,7 @@ const ModalContainer = ({ fullScreen, isVisible, onClose, title, children, noCan
     <View style={titleBar}>
       <View style={flexSpacer} />
       {!!title && <Text style={titleFont}>{title}</Text>}
-      {onClose && !noCancel && (
-        <View style={closeButtonContainer}>
-          <CloseButton />
-        </View>
-      )}
+      <View style={closeButtonContainer}>{onClose && !noCancel && <CloseButton />}</View>
     </View>
   );
 
@@ -120,10 +116,8 @@ const localStyles = StyleSheet.create({
   },
   fullScreenChildrenContainer: {
     flex: 1,
-    alignItems: 'stretch',
     paddingLeft: PAGE_CONTENT_PADDING_HORIZONTAL,
     paddingRight: PAGE_CONTENT_PADDING_HORIZONTAL,
-    opacity: 0.94,
   },
   childrenContainer: {
     flex: 1,

--- a/src/widgets/modals/NewStocktakeBatchModal.js
+++ b/src/widgets/modals/NewStocktakeBatchModal.js
@@ -1,406 +1,186 @@
 /* eslint-disable react/forbid-prop-types */
+/* eslint-disable import/prefer-default-export */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
+import { View } from 'react-native';
 
-import { TouchableOpacity, StyleSheet, View, Text } from 'react-native';
-import Icon from 'react-native-vector-icons/FontAwesome';
-import { GenericPage } from '../../pages/GenericPage';
-import { Button, PageButton, ExpiryTextInput, PageInfo, GenericChoiceList } from '..';
-import { PageContentModal } from './PageContentModal';
+import { MODAL_KEYS } from '../../utilities';
+import { usePageReducer } from '../../hooks';
+import { recordKeyExtractor, getItemLayout } from '../../pages/dataTableUtilities';
 
-import {
-  programStrings,
-  tableStrings,
-  buttonStrings,
-  modalStrings,
-  pageInfoStrings,
-} from '../../localization';
-import { parsePositiveInteger } from '../../utilities';
-import globalStyles, {
-  WARM_GREY,
-  SUSSOL_ORANGE,
-  DARK_GREY,
-  dataTableStyles,
-  expansionPageStyles,
-} from '../../globalStyles';
+import { GenericChoiceList } from '../GenericChoiceList';
+import { PageInfo, DataTablePageView, PageButton } from '..';
+import { DataTable, DataTableHeaderRow, DataTableRow } from '../DataTable';
 
-const MODAL_KEYS = {
-  REASON_EDIT: 'reasonEdit',
-};
-export class NewStocktakeBatchModal extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      currentBatch: null,
-      reasons: [],
-      isModalOpen: false,
-      modalKey: null,
-    };
-  }
+import { newPageStyles } from '../../globalStyles';
 
-  componentDidMount = () => {
-    const { database } = this.props;
-    const queryString = 'type == $0 && isActive == true';
-    const reasons = database.objects('Options').filtered(queryString, 'stocktakeLineAdjustment');
-    this.setState({ reasons });
-  };
+import { UIDatabase } from '../../database';
+import ModalContainer from './ModalContainer';
+import { buttonStrings } from '../../localization/index';
 
-  openModal = (key, currentBatch) => {
-    this.setState({ modalKey: key, isModalOpen: true, currentBatch });
-  };
+const stateInitialiser = pageObject => ({
+  pageObject,
+  backingData: pageObject.batches,
+  data: pageObject.batches.slice(),
+  keyExtractor: recordKeyExtractor,
+  dataState: new Map(),
+  sortBy: 'itemName',
+  isAscending: true,
+  modalKey: '',
+  modalValue: null,
+});
 
-  closeModal = () => {
-    this.setState({ isModalOpen: false });
-  };
+/**
+ * Renders a stateful modal with a stocktake item and it's batches loaded
+ * for editing.
+ *
+ * State:
+ * Uses a reducer to manage state with `backingData` being a realm results
+ * of items to display. `data` is a plain JS array of realm objects. data is
+ * hydrated from the `backingData` for displaying in the interface.
+ * i.e: When filtering, data is populated from filtered items of `backingData`.
+ *
+ * dataState is a simple map of objects corresponding to a row being displayed,
+ * holding the state of a given row. Each object has the shape :
+ * { isSelected, isFocused, isDisabled },
+ *
+ * @prop {Object} stocktakeItem The realm transaction object for this invoice.
+ *
+ */
+export const NewStocktakeBatchModal = ({ stocktakeItem }) => {
+  const usingReasons = useMemo(() => UIDatabase.objects('StocktakeReasons').length > 0, []);
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
+    usingReasons ? 'stocktakeBatchEditModalWithReasons' : 'stocktakeBatchEditModal',
+    {},
+    stateInitialiser,
+    stocktakeItem
+  );
 
-  reasonModalConfirm = ({ item: option }) => {
-    if (option) {
-      const { database } = this.props;
-      const { currentBatch } = this.state;
-      const { id } = currentBatch;
-      database.write(() => database.update('StocktakeBatch', { id, option }));
-    }
-    this.closeModal();
-  };
+  const {
+    pageObject,
+    data,
+    dataState,
+    sortBy,
+    isAscending,
+    modalKey,
+    modalValue,
+    keyExtractor,
+    PageActions,
+    columns,
+    getPageInfoColumns,
+  } = state;
 
-  /**
-   * Opens the reason modal for applying a reason to a stocktakeBatch
-   * if the snapshot quantity and counted total quantity differ.
-   * Otherwise, removes the reason from the stocktake items batches.
-   * @param {Object} stocktakeBatch
-   */
-  assignReason = stocktakeBatch => {
-    const { REASON_EDIT } = MODAL_KEYS;
-    const { database } = this.props;
-    const { id, option, shouldHaveReason } = stocktakeBatch;
-    if (shouldHaveReason) {
-      if (!option) this.openModal(REASON_EDIT, stocktakeBatch);
-    } else database.write(() => database.update('StocktakeBatch', { id, option: null }));
-  };
+  const onEditReason = rowKey => PageActions.openModal(MODAL_KEYS.STOCKTAKE_REASON, rowKey);
+  const onCloseModal = () => dispatch(PageActions.closeModal());
+  const onApplyReason = ({ item }) => dispatch(PageActions.applyReason(item));
 
-  onEndEditing = (key, stocktakeBatch, newValue) => {
-    const { reasons, isModalOpen } = this.state;
-    const { database } = this.props;
-    const { id } = stocktakeBatch;
+  const renderPageInfo = useCallback(
+    () => <PageInfo columns={getPageInfoColumns(pageObject, dispatch, PageActions)} />,
+    []
+  );
 
-    if (!newValue) return;
-    // If the reason modal is open just ignore any change to the current line
-    if (isModalOpen) return;
-    switch (key) {
-      case 'countedTotalQuantity': {
-        const quantity = parsePositiveInteger(newValue);
-        if (quantity === null) return;
-        database.write(() => {
-          stocktakeBatch.countedTotalQuantity = quantity;
-        });
-        database.save(stocktakeBatch);
-        if (reasons.length > 0) this.assignReason(stocktakeBatch);
-        break;
-      }
-      case 'batch': {
-        let newBatchName = '';
-        if (newValue !== `(${tableStrings.no_batch_name})`) newBatchName = newValue;
-        database.write(() => database.update('StocktakeBatch', { id, batch: newBatchName }));
-        break;
-      }
-      case 'expiryDate':
-        database.write(() => database.update('StocktakeBatch', { id, expiryDate: newValue }));
-        break;
-      default:
-        break;
-    }
-  };
-
-  refreshData = () => {
-    const { stocktakeItem } = this.props;
-    this.setState({ data: stocktakeItem.batches });
-  };
-
-  renderCell = (key, stocktakeBatch) => {
-    const { stocktakeItem } = this.props;
-    const { stocktake } = stocktakeItem;
-    const isEditable = !stocktake.isFinalised;
-    const { option } = stocktakeBatch;
-    const { REASON_EDIT } = MODAL_KEYS;
-    switch (key) {
+  const getAction = colKey => {
+    switch (colKey) {
       case 'batch':
-        return {
-          type: isEditable ? 'editable' : 'text',
-          cellContents:
-            stocktakeBatch[key] && stocktakeBatch[key] !== ''
-              ? stocktakeBatch[key]
-              : `(${tableStrings.no_batch_name})`,
-          keyboardType: 'default',
-        };
-      case 'countedTotalQuantity': {
-        const emptyCellContents = isEditable ? '' : tableStrings.not_counted;
-        return {
-          type: isEditable ? 'editable' : 'text',
-          cellContents: stocktakeBatch.hasBeenCounted
-            ? stocktakeBatch.countedTotalQuantity
-            : emptyCellContents,
-          placeholder: tableStrings.not_counted,
-        };
-      }
-      case 'expiryDate': {
-        return (
-          <ExpiryTextInput
-            key={stocktakeBatch.id}
-            isEditable={isEditable}
-            onEndEditing={newValue => {
-              this.onEndEditing(key, stocktakeBatch, newValue);
-              this.refreshData();
-            }}
-            text={stocktakeBatch[key]}
-            style={dataTableStyles.text}
-          />
-        );
-      }
-      case 'difference': {
-        const { difference } = stocktakeBatch;
-        const prefix = difference > 0 ? '+' : '';
-        return { cellContents: `${prefix}${difference}` };
-      }
-      case 'reason': {
-        const onPress = this.openModal.bind(this, REASON_EDIT, stocktakeBatch);
-        const editable = option && isEditable;
-        return (
-          <TouchableOpacity
-            key={stocktakeBatch.id}
-            onPress={editable ? onPress : null}
-            style={localStyles.reasonCell}
-          >
-            {editable && <Icon name="external-link" size={14} color={SUSSOL_ORANGE} />}
-            <Text style={{ width: '80%' }} numberOfLines={1} ellipsizeMode="tail">
-              {stocktakeBatch.option ? stocktakeBatch.option.title : programStrings.not_applicable}
-            </Text>
-          </TouchableOpacity>
-        );
-      }
+        return PageActions.editStocktakeBatchName;
+      case 'countedTotalQuantity':
+        return PageActions.editStocktakeBatchCountedQuantity;
+      case 'expiryDate':
+        return PageActions.editStocktakeBatchExpiryDate;
+      case 'reasonTitle':
+        return onEditReason;
       default:
-        return {
-          cellContents: stocktakeBatch[key],
-        };
-    }
-  };
-
-  renderAddBatchButton = () => {
-    const { database, stocktakeItem } = this.props;
-
-    const addNewBatch = () => {
-      database.write(() => {
-        stocktakeItem.createNewBatch(database);
-      });
-      this.refreshData();
-    };
-
-    return (
-      <PageButton
-        text={buttonStrings.add_batch}
-        onPress={addNewBatch}
-        isDisabled={stocktakeItem.stocktake.isFinalised}
-        style={localStyles.addBatchButton}
-      />
-    );
-  };
-
-  renderPageInfo = () => {
-    const { stocktakeItem } = this.props;
-    const { itemName } = stocktakeItem;
-
-    const infoColumns = [
-      [
-        {
-          title: pageInfoStrings.by_batch,
-          info: itemName,
-        },
-      ],
-    ];
-    return <PageInfo columns={infoColumns} />;
-  };
-
-  renderFooter = () => {
-    const { onConfirm } = this.props;
-    return (
-      <View style={localStyles.footer}>
-        <Button
-          text={buttonStrings.done}
-          disabledColor={WARM_GREY}
-          style={[globalStyles.button, localStyles.OKButton]}
-          textStyle={[globalStyles.buttonText, localStyles.OKButtonText]}
-          onPress={onConfirm}
-        />
-      </View>
-    );
-  };
-
-  getModalTitle = () => {
-    const { modalKey } = this.state;
-    const { REASON_EDIT } = MODAL_KEYS;
-    switch (modalKey) {
-      default:
-        return '';
-      case REASON_EDIT:
-        return programStrings.select_a_reason;
-    }
-  };
-
-  renderModalContent = () => {
-    const { modalKey, currentBatch, reasons } = this.state;
-    const { option } = currentBatch;
-    const highlightValue = option && option.title;
-    const { REASON_EDIT } = MODAL_KEYS;
-    switch (modalKey) {
-      default: {
         return null;
-      }
-      case REASON_EDIT: {
-        return (
-          <GenericChoiceList
-            data={reasons}
-            highlightValue={highlightValue}
-            keyToDisplay="title"
-            onPress={this.reasonModalConfirm}
-            title={modalStrings.select_a_reason}
-          />
-        );
-      }
     }
   };
 
-  getColumns = () => {
-    const { reasons } = this.state;
-    const columns = [
-      {
-        key: 'batch',
-        width: 2,
-        title: tableStrings.batch_name,
-        alignText: 'center',
-      },
-      {
-        key: 'expiryDate',
-        width: 1,
-        title: tableStrings.expiry,
-        alignText: 'center',
-      },
-      {
-        key: 'snapshotTotalQuantity',
-        width: 1,
-        title: unwrapText(tableStrings.snapshot_quantity),
-        alignText: 'right',
-      },
-      {
-        key: 'countedTotalQuantity',
-        width: 1,
-        title: unwrapText(tableStrings.actual_quantity),
-        alignText: 'right',
-      },
-      {
-        key: 'difference',
-        width: 1,
-        title: tableStrings.difference,
-        alignText: 'right',
-      },
-    ];
-    if (reasons.length > 0) {
-      columns.push({
-        key: 'reason',
-        width: 1,
-        title: tableStrings.reason,
-        alignText: 'right',
-      });
-    }
-    return columns;
-  };
-
-  render() {
-    const { database, genericTablePageStyles } = this.props;
-    const { data, isModalOpen, modalKey, currentBatch } = this.state;
-    const { REASON_EDIT } = MODAL_KEYS;
-
-    return (
-      <>
-        <GenericPage
-          data={data}
-          renderCell={this.renderCell}
-          refreshData={this.refreshData}
-          hideSearchBar={true}
-          dontRenderSearchBar={true}
-          onEndEditing={this.onEndEditing}
-          renderTopLeftComponent={this.renderPageInfo}
-          renderTopRightComponent={this.renderAddBatchButton}
-          columns={this.getColumns()}
-          dataTypesLinked={['StocktakeBatch', 'Stocktake']}
-          database={database}
-          pageStyles={expansionPageStyles}
-          {...genericTablePageStyles}
+  const renderRow = useCallback(
+    listItem => {
+      const { item, index } = listItem;
+      const rowKey = keyExtractor(item);
+      return (
+        <DataTableRow
+          rowData={data[index]}
+          rowState={dataState.get(rowKey)}
+          rowKey={rowKey}
+          columns={columns}
+          dispatch={dispatch}
+          getAction={getAction}
+          rowIndex={index}
         />
-        {isModalOpen && (
-          <PageContentModal
-            isOpen={isModalOpen}
-            onClose={currentBatch && currentBatch.enforceReason ? null : this.closeModal}
-            title={this.getModalTitle()}
-            coverScreen={modalKey === REASON_EDIT}
-          >
-            {this.renderModalContent()}
-          </PageContentModal>
-        )}
-        {this.renderFooter()}
-      </>
-    );
-  }
-}
+      );
+    },
+    [data, dataState]
+  );
 
-NewStocktakeBatchModal.defaultProps = {
-  genericTablePageStyles: {},
+  const renderHeader = useCallback(
+    () => (
+      <DataTableHeaderRow
+        columns={columns}
+        dispatch={instantDebouncedDispatch}
+        sortAction={PageActions.sortData}
+        isAscending={isAscending}
+        sortBy={sortBy}
+      />
+    ),
+    [sortBy, isAscending]
+  );
+
+  const PageButtons = () => (
+    <PageButton
+      text={buttonStrings.add_batch}
+      onPress={() => dispatch(PageActions.addStocktakeBatch())}
+      isDisabled={stocktakeItem.stocktake.isFinalised}
+    />
+  );
+
+  const {
+    newPageTopSectionContainer,
+    newPageTopLeftSectionContainer,
+    newPageTopRightSectionContainer,
+  } = newPageStyles;
+  return (
+    <DataTablePageView>
+      <View style={newPageTopSectionContainer}>
+        <View style={newPageTopLeftSectionContainer}>{renderPageInfo()}</View>
+        <View style={newPageTopRightSectionContainer}>
+          <PageButtons />
+        </View>
+      </View>
+      <DataTable
+        data={data}
+        extraData={dataState}
+        renderRow={renderRow}
+        renderHeader={renderHeader}
+        keyExtractor={keyExtractor}
+        getItemLayout={getItemLayout}
+        columns={columns}
+        windowSize={1}
+        initialNumToRender={0}
+      />
+      <ModalContainer
+        fullScreen={modalKey === MODAL_KEYS.ENFORCE_STOCKTAKE_REASON}
+        isVisible={!!modalKey}
+        onClose={onCloseModal}
+      >
+        <GenericChoiceList
+          data={UIDatabase.objects('StocktakeReasons')}
+          highlightValue={(modalValue && modalValue.reasonTitle) || ''}
+          keyToDisplay="title"
+          onPress={onApplyReason}
+        />
+      </ModalContainer>
+    </DataTablePageView>
+  );
 };
 
 NewStocktakeBatchModal.propTypes = {
-  database: PropTypes.object.isRequired,
-  genericTablePageStyles: PropTypes.object,
   stocktakeItem: PropTypes.object.isRequired,
-  isOpen: PropTypes.bool.isRequired,
-  onConfirm: PropTypes.func.isRequired,
 };
 
 export default NewStocktakeBatchModal;
-
-const unwrapText = text => text.replace(/\n/g, ' ');
-const localStyles = StyleSheet.create({
-  addBatchButton: {
-    height: 30,
-    width: 90,
-  },
-  modal: {
-    height: '100%',
-    width: '100%',
-    padding: 20,
-    backgroundColor: DARK_GREY,
-  },
-  footer: {
-    flex: 1,
-    maxHeight: 50,
-    alignItems: 'flex-end',
-    justifyContent: 'flex-end',
-  },
-  OKButton: {
-    backgroundColor: SUSSOL_ORANGE,
-  },
-  OKButtonText: {
-    color: 'white',
-    fontSize: 16,
-  },
-  reasonCell: {
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingLeft: 10,
-    paddingRight: 10,
-  },
-});

--- a/src/widgets/modals/RegimenDataModal.js
+++ b/src/widgets/modals/RegimenDataModal.js
@@ -1,0 +1,120 @@
+/* eslint-disable react/forbid-prop-types */
+/* eslint-disable import/prefer-default-export */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React, { useEffect, useReducer } from 'react';
+import PropTypes from 'prop-types';
+
+import { DataTablePageView } from '..';
+import { UIDatabase } from '../../database';
+import { DataTable, DataTableHeaderRow, DataTableRow } from '../DataTable';
+import { getColumns, getItemLayout } from '../../pages/dataTableUtilities';
+
+const reducer = (state, action) => {
+  const { type, payload } = action;
+  switch (type) {
+    case 'UPDATE': {
+      const { data, customData } = state;
+      const { value, rowKey, field } = payload;
+
+      // Find the index and object to edit.
+      const indexToEdit = data.findIndex(datum => datum.code === rowKey);
+      const objectToEdit = data[indexToEdit];
+
+      // Create a new object that has been edited and customData for updating.
+      data[indexToEdit] = { ...objectToEdit, [field]: value };
+      const newCustomData = { ...customData, regimenData: data };
+
+      return { ...state, customData: newCustomData, data: [...data] };
+    }
+    default:
+      return state;
+  }
+};
+
+const actions = {
+  updateValue: (value, rowKey) => ({
+    type: 'UPDATE',
+    payload: { rowKey, value, field: 'value' },
+  }),
+  updateComment: (value, rowKey) => ({
+    type: 'UPDATE',
+    payload: { rowKey, value, field: 'comment' },
+  }),
+};
+
+const stateInitialiser = requisition => ({
+  requisition,
+  customData: requisition.parsedCustomData,
+  data: requisition.parsedCustomData.regimenData,
+  keyExtractor: item => item.code,
+  columns: getColumns('regimenDataModal'),
+});
+
+/**
+ * Renders page to be displayed in StocktakeEditPage -> expansion.
+ *
+ * @prop {Object} requisition Requisition with regimen data to edit.
+ */
+export const RegimenDataModal = ({ requisition }) => {
+  const [state, dispatch] = useReducer(reducer, requisition, stateInitialiser);
+
+  const { data, keyExtractor, columns, customData } = state;
+  const { isFinalised } = requisition;
+
+  useEffect(() => {
+    UIDatabase.write(() => {
+      requisition.saveCustomData(customData);
+    });
+  }, [customData]);
+
+  const getAction = columnKey => {
+    switch (columnKey) {
+      default:
+      case 'comment':
+        return actions.updateComment;
+      case 'value':
+        return actions.updateValue;
+    }
+  };
+
+  const renderRow = listItem => {
+    const { item, index } = listItem;
+    const rowKey = item.code;
+    return (
+      <DataTableRow
+        rowData={data[index]}
+        rowKey={rowKey}
+        columns={columns}
+        isFinalised={isFinalised}
+        dispatch={dispatch}
+        getAction={getAction}
+        rowIndex={index}
+      />
+    );
+  };
+
+  const renderHeader = () => <DataTableHeaderRow columns={columns} />;
+
+  return (
+    <DataTablePageView>
+      <DataTable
+        data={data}
+        renderRow={renderRow}
+        renderHeader={renderHeader}
+        keyExtractor={keyExtractor}
+        getItemLayout={getItemLayout}
+        columns={columns}
+        windowSize={1}
+        initialNumToRender={0}
+      />
+    </DataTablePageView>
+  );
+};
+
+RegimenDataModal.propTypes = {
+  requisition: PropTypes.object.isRequired,
+};


### PR DESCRIPTION
#### EPIC: #1043 
#### BRANCHED FROM #1217 

### NOTE: Branch not runnable due to many files being shifted - branch at #1224 is when the app is runnable again.

Fixes #1199

## Change summary

- Renamed `StocktakeItem.applyReasonToBatches` -> `StocktakeItem.applyReason`
- Shifted logic checking for reasons to navigation thunk.
- Added `stocktakeEditPageWithReasons` route
- Fixed `GenericChoiceList` prop type error
- Fixed `DropDownCell` missing placeholder prop

## Testing

See #1043 

### Related areas to think about

N/A
