### PR TITLE
#1220 CustomerInvoicesPage fixes -- 8

### DIFF
--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -88,6 +88,11 @@ export class Stocktake extends Realm.Object {
     });
   }
 
+  /**
+   * Returns an Array of item objects that are currently in the stocktae.
+   *
+   * @return {Array} Realm.Item objects current in the stocktake.
+   */
   get itemsInStocktake() {
     return this.items.reduce((acc, stocktakeItem) => {
       const { item } = stocktakeItem;

--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -89,6 +89,15 @@ export class Stocktake extends Realm.Object {
   }
 
   /**
+   * Returns if this stocktakes snapshot quantities are outdated.
+   *
+   * @return {Bool} Indicator if this stocktake is outdated.
+   */
+  get isOutdated() {
+    return this.itemsOutdated.length > 0 && !this.isFinalised;
+  }
+
+  /**
    * Returns an Array of item objects that are currently in the stocktae.
    *
    * @return {Array} Realm.Item objects current in the stocktake.

--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -173,15 +173,6 @@ export class Stocktake extends Realm.Object {
    * @param  {Realm}                  database
    * @param  {Array.<StocktakeItem>}  stocktakeItems  Items to reset.
    */
-  // eslint-disable-next-line class-methods-use-this
-  resetStocktakeItems(database, stocktakeItems) {
-    database.write(() => {
-      stocktakeItems.forEach(stocktakeItem => {
-        stocktakeItem.reset(database);
-      });
-    });
-  }
-
   resetStocktake(database) {
     database.write(() => {
       this.itemsOutdated.forEach(outdatedItem => {

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -308,7 +308,7 @@ export class StocktakeItem extends Realm.Object {
    * @param {Realm}   database
    * @param {Options} option
    */
-  applyReasonToBatches(database, option) {
+  applyReason(database, option) {
     this.batches.forEach(batch => {
       const { id, countedTotalQuantity, snapshotTotalQuantity } = batch;
       let batchOption = option;

--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -50,9 +50,9 @@ export const usePageReducer = (
   debounceTimeout = 250,
   instantDebounceTimeout = 250
 ) => {
-  const columns = useMemo(() => getColumns(page), [page]);
-  const pageInfoColumns = useMemo(() => getPageInfoColumns(page), [page]);
-  const PageActions = useMemo(() => getPageActions(page), [page]);
+  const columns = useMemo(() => getColumns(page), []);
+  const pageInfoColumns = useMemo(() => getPageInfoColumns(page), []);
+  const PageActions = useMemo(() => getPageActions(page), []);
 
   const [pageState, setPageState] = useState({
     ...(initializer ? initializer(pageObject) : initialState),
@@ -66,14 +66,16 @@ export const usePageReducer = (
   const getState = () => stateRef.current;
 
   // Basic dispatch function.
-  const dispatch = action => {
+  const dispatch = useCallback(action => {
     const newState = DataTablePageReducer(getState(), action);
     setPageState(newState);
     stateRef.current = newState;
-  };
+  });
 
-  const thunkDispatcher = action =>
-    typeof action === 'function' ? action(thunkDispatcher, getState) : dispatch(action);
+  const thunkDispatcher = useCallback(
+    action => (typeof action === 'function' ? action(thunkDispatcher, getState) : dispatch(action)),
+    []
+  );
 
   const debouncedDispatch = useCallback(debounce(thunkDispatcher, debounceTimeout), []);
   const instantDebouncedDispatch = useCallback(

--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -15,25 +15,30 @@ import {
 import { debounce } from '../utilities/index';
 
 /**
- * Wrapper around useState, reimplementing useReducer with
- * thunks. For pages within the app - creates a
- * composed reducer through getReducer for a particular
- * page as well as fetching the required data table columns
- * and page info columns and inserting them into the initial
- * state of the component.
+ * Wrapper around useState, reimplementing useReducer with thunks.
+ *
+ * For DataTable pages within the app. Injects the initial state passed
+ * with three fields:
+ *
+ * columns: an array of column objects defining the DataTable for the page.
+ * getPageInfoColumns: closure function, returning an array of objects for
+ *                     the pages PageInfo component.
+ * PageActions: Object of composed ActionCreators for an individual page.
  *
  * Dispatch returned from useReducer is wrapped allowing the use
- * of thunks. Actions can return either a plain object or a function.
+ * of thunks. Action creators can return either a plain object or a function.
  * If a function is returned, it is called, rather than dispatched,
  * allowing actions to perform side-effects.
  *
- * Returns the current state as well as three dispatchers for
- * actions to the reducer - a regular dispatch and two debounced
- * dispatchers - which group sequential calls within the timeout
- * period, call either the last invocation or the first within
- * the timeout period.
+ * Returns the current state as well as three dispatchers for actions to the
+ * reducer - a thunk dispatch (as above) and two debounced dispatchers - which
+ * group sequential calls within a timeout period, calling either the last
+ * invocation or the first within the timeout period.
+ *
  * @param {String} page                   routeName for the current page.
  * @param {Object} initialState           Initial state of the reducer
+ * @param {Func}   initializer            Function to generate the initial state (optional)
+ * @param {Object} pageObject             base PageObject for the page i.e. a Requisition.
  * @param {Number} debounceTimeout        Timeout period for a regular debounce
  * @param {Number} instantDebounceTimeout Timeout period for an instant debounce
  */

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -48,14 +48,17 @@ export const gotoStocktakeManagePage = ({ stocktake, stocktakeName }) =>
  *
  * @param {Object} stocktake  The requisition to navigate to.
  */
-export const gotoStocktakeEditPage = stocktake =>
-  NavigationActions.navigate({
-    routeName: 'stocktakeEditor',
+export const gotoStocktakeEditPage = stocktake => {
+  const usesReasons = UIDatabase.objects('StocktakeReasons').length > 0;
+
+  return NavigationActions.navigate({
+    routeName: usesReasons ? 'stocktakeEditorWithReasons' : 'stocktakeEditor',
     params: {
       title: navStrings.stocktake,
       stocktake,
     },
   });
+};
 
 /**
  * Action creator for navigating to a customer invoice. Ensures the CI is at least

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -96,7 +96,7 @@ export const gotoCustomerInvoice = transaction => dispatch => {
  */
 export const gotoSupplierRequisition = requisition =>
   NavigationActions.navigate({
-    routeName: !requisition.program ? 'supplierRequisition' : 'programSupplierRequisition',
+    routeName: !requisition.program ? 'supplierRequisition' : 'supplierRequisitionWithProgram',
     params: {
       title: `${navStrings.requisition} ${requisition.serialNumber}`,
       requisition,

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -9,29 +9,26 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
 import { UIDatabase } from '../database';
-import { buttonStrings, modalStrings } from '../localization';
-import { recordKeyExtractor, getItemLayout } from './dataTableUtilities/utilities';
+import { MODAL_KEYS, newSortDataBy } from '../utilities';
+import { usePageReducer, useNavigationFocus } from '../hooks';
+import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
+import { gotoCustomerInvoice, createCustomerInvoice } from '../navigation/actions';
+
+import { PageButton, SearchBar, DataTablePageView } from '../widgets';
 import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
-import { PageButton, SearchBar } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
+
 import {
   selectRow,
   deselectRow,
   deselectAll,
-  sortData,
-  filterData,
-  openBasicModal,
-  closeBasicModal,
-  deleteTransactionsById,
-} from './dataTableUtilities/actions';
-import { MODAL_KEYS, newSortDataBy } from '../utilities';
-import usePageReducer from '../hooks/usePageReducer';
-import DataTablePageView from './containers/DataTablePageView';
+  deleteTransactions,
+} from './dataTableUtilities/actions/rowActions';
+import { sortData, filterData } from './dataTableUtilities/actions/tableActions';
+import { openModal, closeModal } from './dataTableUtilities/actions/pageActions';
 
-import { useNavigationFocusRefresh } from '../hooks/useNavigationFocusRefresh';
-
+import { buttonStrings, modalStrings } from '../localization';
 import { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
-import { gotoCustomerInvoice, createCustomerInvoice } from '../navigation/actions';
 
 const initializer = () => {
   const backingData = UIDatabase.objects('CustomerInvoice');
@@ -69,13 +66,13 @@ export const CustomerInvoicesPage = ({
   } = state;
 
   // Refresh data on navigating back to this page.
-  useNavigationFocusRefresh(dispatch, navigation);
+  useNavigationFocus(dispatch, navigation);
 
   // On Press Handlers
-  const closeModal = () => dispatch(closeBasicModal());
+  const onCloseModal = () => dispatch(closeModal());
   const onFilterData = value => dispatch(filterData(value));
-  const onNewInvoice = () => dispatch(openBasicModal(MODAL_KEYS.SELECT_CUSTOMER));
-  const onRemoveInvoices = () => dispatch(deleteTransactionsById());
+  const onNewInvoice = () => dispatch(openModal(MODAL_KEYS.SELECT_CUSTOMER));
+  const onRemoveInvoices = () => dispatch(deleteTransactions());
   const onCancelRemoval = () => dispatch(deselectAll());
   // Method is memoized in DataTableRow component - cannot memoize the returned closure.
   const onNavigateToInvoice = invoice => () => reduxDispatch(gotoCustomerInvoice(invoice));
@@ -95,7 +92,7 @@ export const CustomerInvoicesPage = ({
       case MODAL_KEYS.SELECT_CUSTOMER:
         return otherParty => {
           reduxDispatch(createCustomerInvoice(otherParty, currentUser));
-          closeModal();
+          onCloseModal();
         };
       default:
         return null;
@@ -182,7 +179,7 @@ export const CustomerInvoicesPage = ({
         fullScreen={false}
         isOpen={!!modalKey}
         modalKey={modalKey}
-        onClose={closeModal}
+        onClose={onCloseModal}
         onSelect={getModalOnSelect()}
         dispatch={dispatch}
       />

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -10,7 +10,7 @@ import { View } from 'react-native';
 
 import { UIDatabase } from '../database';
 import { MODAL_KEYS, newSortDataBy } from '../utilities';
-import { usePageReducer, useNavigationFocus } from '../hooks';
+import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
 import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
 import { gotoCustomerInvoice, createCustomerInvoice } from '../navigation/actions';
 
@@ -57,8 +57,11 @@ export const CustomerInvoicesPage = ({
     PageActions,
   } = state;
 
-  // Refresh data on navigating back to this page.
-  useNavigationFocus(dispatch, navigation);
+  // Listen to changes from sync and navigation events re-focusing this screen,
+  // such that any side effects that occur trigger a reconcilitation of data.
+  const refreshCallback = () => dispatch(PageActions.refreshData());
+  useNavigationFocus(refreshCallback, navigation);
+  useSyncListener(refreshCallback, ['Transaction']);
 
   const onCloseModal = () => dispatch(PageActions.closeModal());
   const onFilterData = value => dispatch(PageActions.filterData(value));

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -94,6 +94,7 @@ export const StocktakeEditPage = ({
   useRecordListener(refreshCallback, pageObject, 'Stocktake');
   useNavigationFocus(refreshCallback, navigation);
 
+  // If the Stocktake is outdated, force a reset of the stocktake on mount.
   useEffect(() => {
     if (stocktake.isOutdated) dispatch(PageActions.openModal(MODAL_KEYS.STOCKTAKE_OUTDATED_ITEM));
   }, []);

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -22,6 +22,7 @@ import { gotoStocktakeManagePage } from '../navigation/actions';
 
 import { buttonStrings } from '../localization';
 import { SUSSOL_ORANGE, newPageStyles } from '../globalStyles';
+import { useRecordListener, useNavigationFocus } from '../hooks/index';
 
 const stateInitialiser = pageObject => ({
   pageObject,
@@ -51,9 +52,10 @@ const stateInitialiser = pageObject => ({
  * { isSelected, isFocused, isDisabled },
  *
  * @prop {Object} stocktake The realm transaction object for this invoice.
- * @prop {Func} runWithLoadingIndicator Callback for displaying a fullscreen spinner.
+ * @prop {Func}   runWithLoadingIndicator Callback for displaying a fullscreen spinner.
  * @prop {String} routeName The current route name for the top of the navigation stack.
  * @prop {Func}   dispatch  Redux store dispatch function.
+ * @prop {Object} navigation App-wide stack navigator reference
  *
  */
 export const StocktakeEditPage = ({
@@ -61,6 +63,7 @@ export const StocktakeEditPage = ({
   stocktake,
   routeName,
   dispatch: reduxDispatch,
+  navigation,
 }) => {
   const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
     routeName,
@@ -84,6 +87,12 @@ export const StocktakeEditPage = ({
   } = state;
 
   const { isFinalised, comment, program } = pageObject;
+
+  // Listen to the stocktake become the top of the stack or being finalised,
+  // as these events are side-effects. Refreshing makes the state consistent again.
+  const refreshCallback = () => dispatch(PageActions.refreshData());
+  useRecordListener(refreshCallback, pageObject, 'Stocktake');
+  useNavigationFocus(refreshCallback, navigation);
 
   useEffect(() => {
     if (stocktake.isOutdated) dispatch(PageActions.openModal(MODAL_KEYS.STOCKTAKE_OUTDATED_ITEM));
@@ -243,4 +252,5 @@ StocktakeEditPage.propTypes = {
   stocktake: PropTypes.object.isRequired,
   routeName: PropTypes.string.isRequired,
   dispatch: PropTypes.func.isRequired,
+  navigation: PropTypes.object.isRequired,
 };

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -32,6 +32,20 @@ import { applyReason, editCountedQuantity } from './dataTableUtilities/actions/c
 import { buttonStrings } from '../localization';
 import { SUSSOL_ORANGE, newPageStyles } from '../globalStyles';
 
+const stateInitialiser = pageObject => ({
+  pageObject,
+  backingData: pageObject.items,
+  data: pageObject.items.sorted('item.name').slice(),
+  keyExtractor: recordKeyExtractor,
+  dataState: new Map(),
+  searchTerm: '',
+  filterDataKeys: ['item.name'],
+  sortBy: 'itemName',
+  isAscending: true,
+  modalKey: '',
+  modalValue: null,
+});
+
 /**
  * Renders a mSupply page with a stocktake loaded for editing
  *
@@ -57,20 +71,12 @@ export const StocktakeEditPage = ({
   routeName,
   dispatch: reduxDispatch,
 }) => {
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(routeName, {
-    pageObject: stocktake,
-    backingData: stocktake.items,
-    data: stocktake.items.sorted('item.name').slice(),
-    keyExtractor: recordKeyExtractor,
-    dataState: new Map(),
-    currentFocusedRowKey: null,
-    searchTerm: '',
-    filterDataKeys: ['item.name'],
-    sortBy: 'itemName',
-    isAscending: true,
-    modalKey: '',
-    modalValue: null,
-  });
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
+    routeName,
+    {},
+    stateInitialiser,
+    stocktake
+  );
 
   const {
     data,

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -70,13 +70,12 @@ export const StocktakeEditPage = ({
   );
 
   const {
+    pageObject,
     data,
     dataState,
     sortBy,
     isAscending,
     modalKey,
-    pageObject,
-    currentStocktakeItem,
     modalValue,
     keyExtractor,
     PageActions,
@@ -234,7 +233,6 @@ export const StocktakeEditPage = ({
         onSelect={getModalOnSelect()}
         dispatch={dispatch}
         currentValue={modalValue}
-        modalObject={currentStocktakeItem}
       />
     </DataTablePageView>
   );

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -19,15 +19,6 @@ import { PageButton, PageInfo, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
 import { gotoStocktakeManagePage } from '../navigation/actions';
-import { filterData, sortData } from './dataTableUtilities/actions/tableActions';
-import { selectRow, deselectRow } from './dataTableUtilities/actions/rowActions';
-import {
-  closeModal,
-  openModal,
-  editComment,
-  resetStocktake,
-} from './dataTableUtilities/actions/pageActions';
-import { applyReason, editCountedQuantity } from './dataTableUtilities/actions/cellActions';
 
 import { buttonStrings } from '../localization';
 import { SUSSOL_ORANGE, newPageStyles } from '../globalStyles';
@@ -83,31 +74,32 @@ export const StocktakeEditPage = ({
     dataState,
     sortBy,
     isAscending,
-    columns,
     modalKey,
-    getPageInfoColumns,
     pageObject,
     currentStocktakeItem,
     modalValue,
     keyExtractor,
     PageActions,
+    columns,
+    getPageInfoColumns,
   } = state;
 
   const { isFinalised, comment, program } = pageObject;
 
   useEffect(() => {
-    if (stocktake.isOutdated) dispatch(openModal(MODAL_KEYS.STOCKTAKE_OUTDATED_ITEM));
+    if (stocktake.isOutdated) dispatch(PageActions.openModal(MODAL_KEYS.STOCKTAKE_OUTDATED_ITEM));
   }, []);
 
-  const onFilterData = value => dispatch(filterData(value));
-  const onEditBatch = rowKey => openModal(MODAL_KEYS.EDIT_STOCKTAKE_BATCH, rowKey);
-  const onEditReason = rowKey => openModal(MODAL_KEYS.STOCKTAKE_REASON, rowKey);
-  const onEditComment = value => dispatch(editComment(value, 'Stocktake'));
-  const onCloseModal = () => dispatch(closeModal());
-  const onResetStocktake = () => runWithLoadingIndicator(() => dispatch(resetStocktake()));
-  const onApplyReason = ({ item }) => dispatch(applyReason(item));
+  const onFilterData = value => dispatch(PageActions.filterData(value));
+  const onEditBatch = rowKey => PageActions.openModal(MODAL_KEYS.EDIT_STOCKTAKE_BATCH, rowKey);
+  const onEditReason = rowKey => PageActions.openModal(MODAL_KEYS.STOCKTAKE_REASON, rowKey);
+  const onEditComment = value => dispatch(PageActions.editComment(value, 'Stocktake'));
+  const onCloseModal = () => dispatch(PageActions.closeModal());
+  const onApplyReason = ({ item }) => dispatch(PageActions.applyReason(item));
   const onConfirmBatchEdit = () => dispatch(PageActions.closeAndRefresh());
 
+  const onResetStocktake = () =>
+    runWithLoadingIndicator(() => dispatch(PageActions.resetStocktake()));
   const onManageStocktake = () =>
     reduxDispatch(gotoStocktakeManagePage({ stocktake, stocktakeName: stocktake.name }));
 
@@ -124,12 +116,12 @@ export const StocktakeEditPage = ({
   const getAction = useCallback((colKey, propName) => {
     switch (colKey) {
       case 'countedTotalQuantity':
-        return editCountedQuantity;
+        return PageActions.editCountedQuantity;
       case 'batch':
         return onEditBatch;
       case 'remove':
-        if (propName === 'onCheckAction') return selectRow;
-        return deselectRow;
+        if (propName === 'onCheckAction') return PageActions.selectRow;
+        return PageActions.deselectRow;
       case 'mostUsedReasonTitle':
         return onEditReason;
       default:
@@ -178,7 +170,7 @@ export const StocktakeEditPage = ({
       <DataTableHeaderRow
         columns={columns}
         dispatch={instantDebouncedDispatch}
-        sortAction={sortData}
+        sortAction={PageActions.sortData}
         isAscending={isAscending}
         sortBy={sortBy}
       />

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -91,9 +91,7 @@ export const StocktakeEditPage = ({
   const { isFinalised, comment, program } = pageObject;
 
   useEffect(() => {
-    if (stocktake.itemsOutdated.length && !isFinalised) {
-      dispatch(openModal(STOCKTAKE_OUTDATED_ITEM));
-    }
+    if (stocktake.isOutdated) dispatch(openModal(STOCKTAKE_OUTDATED_ITEM));
   }, []);
 
   const onFilterData = value => dispatch(filterData(value));

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -72,7 +72,6 @@ export const StocktakeEditPage = ({
     modalValue: null,
   });
 
-  const { STOCKTAKE_OUTDATED_ITEM } = MODAL_KEYS;
   const {
     data,
     dataState,
@@ -91,7 +90,7 @@ export const StocktakeEditPage = ({
   const { isFinalised, comment, program } = pageObject;
 
   useEffect(() => {
-    if (stocktake.isOutdated) dispatch(openModal(STOCKTAKE_OUTDATED_ITEM));
+    if (stocktake.isOutdated) dispatch(openModal(MODAL_KEYS.STOCKTAKE_OUTDATED_ITEM));
   }, []);
 
   const onFilterData = value => dispatch(filterData(value));

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -30,7 +30,7 @@ import {
 import { applyReason, editCountedQuantity } from './dataTableUtilities/actions/cellActions';
 
 import { buttonStrings } from '../localization';
-import { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
+import { SUSSOL_ORANGE, newPageStyles } from '../globalStyles';
 
 /**
  * Renders a mSupply page with a stocktake loaded for editing
@@ -122,38 +122,6 @@ export const StocktakeEditPage = ({
     }
   });
 
-  const renderRow = useCallback(
-    listItem => {
-      const { item, index } = listItem;
-      const rowKey = keyExtractor(item);
-      const { row, alternateRow } = newDataTableStyles;
-      return (
-        <DataTableRow
-          rowData={data[index]}
-          rowState={dataState.get(rowKey)}
-          rowKey={rowKey}
-          style={index % 2 === 0 ? alternateRow : row}
-          columns={columns}
-          isFinalised={isFinalised}
-          dispatch={dispatch}
-          getAction={getAction}
-          rowIndex={index}
-        />
-      );
-    },
-    [data, dataState]
-  );
-
-  const renderHeader = () => (
-    <DataTableHeaderRow
-      columns={columns}
-      dispatch={instantDebouncedDispatch}
-      sortAction={sortData}
-      isAscending={isAscending}
-      sortBy={sortBy}
-    />
-  );
-
   const getModalOnSelect = () => {
     switch (modalKey) {
       case MODAL_KEYS.STOCKTAKE_COMMENT_EDIT:
@@ -169,6 +137,57 @@ export const StocktakeEditPage = ({
         return null;
     }
   };
+
+  const renderRow = useCallback(
+    listItem => {
+      const { item, index } = listItem;
+      const rowKey = keyExtractor(item);
+
+      return (
+        <DataTableRow
+          rowData={data[index]}
+          rowState={dataState.get(rowKey)}
+          rowKey={rowKey}
+          columns={columns}
+          isFinalised={isFinalised}
+          dispatch={dispatch}
+          getAction={getAction}
+          rowIndex={index}
+        />
+      );
+    },
+    [data, dataState]
+  );
+
+  const renderHeader = useCallback(
+    () => (
+      <DataTableHeaderRow
+        columns={columns}
+        dispatch={instantDebouncedDispatch}
+        sortAction={sortData}
+        isAscending={isAscending}
+        sortBy={sortBy}
+      />
+    ),
+    [sortBy, isAscending]
+  );
+
+  const PageButtons = useCallback(
+    () => (
+      <View style={newPageTopRightSectionContainer}>
+        {!program && (
+          <PageButton
+            text={buttonStrings.manage_stocktake}
+            onPress={() =>
+              reduxDispatch(gotoStocktakeManagePage({ stocktake, stocktakeName: stocktake.name }))
+            }
+            isDisabled={isFinalised}
+          />
+        )}
+      </View>
+    ),
+    [program]
+  );
 
   const {
     newPageTopSectionContainer,
@@ -188,17 +207,7 @@ export const StocktakeEditPage = ({
             placeholder=""
           />
         </View>
-        <View style={newPageTopRightSectionContainer}>
-          {!program && (
-            <PageButton
-              text={buttonStrings.manage_stocktake}
-              onPress={() =>
-                reduxDispatch(gotoStocktakeManagePage({ stocktake, stocktakeName: stocktake.name }))
-              }
-              isDisabled={isFinalised}
-            />
-          )}
-        </View>
+        <PageButtons />
       </View>
       <DataTable
         data={data}

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -122,7 +122,7 @@ export const StocktakeEditPage = ({
     [comment, isFinalised]
   );
 
-  const getAction = useCallback((colKey, propName) => {
+  const getAction = (colKey, propName) => {
     switch (colKey) {
       case 'countedTotalQuantity':
         return PageActions.editCountedQuantity;
@@ -136,7 +136,7 @@ export const StocktakeEditPage = ({
       default:
         return null;
     }
-  });
+  };
 
   const getModalOnSelect = () => {
     switch (modalKey) {

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -100,6 +100,7 @@ export const StocktakeEditPage = ({
   const onCloseModal = () => dispatch(closeModal());
   const onResetStocktake = () => runWithLoadingIndicator(() => dispatch(resetStocktake()));
   const onApplyReason = ({ item }) => dispatch(applyReason(item));
+  const onConfirmBatchEdit = () => dispatch(PageActions.closeAndRefresh());
 
   const onManageStocktake = () =>
     reduxDispatch(gotoStocktakeManagePage({ stocktake, stocktakeName: stocktake.name }));
@@ -135,7 +136,7 @@ export const StocktakeEditPage = ({
       case MODAL_KEYS.STOCKTAKE_COMMENT_EDIT:
         return onEditComment;
       case MODAL_KEYS.EDIT_STOCKTAKE_BATCH:
-        return onCloseModal;
+        return onConfirmBatchEdit;
       case MODAL_KEYS.STOCKTAKE_OUTDATED_ITEM:
         return onResetStocktake;
       case MODAL_KEYS.ENFORCE_STOCKTAKE_REASON:
@@ -231,7 +232,7 @@ export const StocktakeEditPage = ({
         fullScreen={false}
         isOpen={!!modalKey}
         modalKey={modalKey}
-        onClose={onCloseModal}
+        onClose={modalKey === MODAL_KEYS.EDIT_STOCKTAKE_BATCH ? onConfirmBatchEdit : onCloseModal}
         onSelect={getModalOnSelect()}
         dispatch={dispatch}
         currentValue={modalValue}

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -14,7 +14,7 @@ import { UIDatabase } from '../database';
 
 import { usePageReducer } from '../hooks';
 import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
-import { createStocktake, addItemsToStocktake } from '../navigation/actions';
+import { createStocktake, updateStocktake } from '../navigation/actions';
 
 import { BottomTextEditor } from '../widgets/modals';
 import { ToggleBar, DataTablePageView } from '../widgets';
@@ -93,7 +93,7 @@ export const StocktakeManagePage = ({
   const onConfirmStocktake = () => {
     runWithLoadingIndicator(() => {
       const itemIds = Array.from(dataState.keys()).filter(id => id);
-      if (stocktake) return reduxDispatch(addItemsToStocktake(stocktake, itemIds));
+      if (stocktake) return reduxDispatch(updateStocktake(stocktake, itemIds));
       return reduxDispatch(createStocktake({ stocktakeName: name, itemIds }));
     });
   };

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -14,26 +14,11 @@ import { UIDatabase } from '../database';
 
 import { usePageReducer } from '../hooks/usePageReducer';
 import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
+import { createStocktake, addItemsToStocktake } from '../navigation/actions';
 
 import { BottomTextEditor } from '../widgets/modals';
 import { ToggleBar, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
-
-import {
-  filterData,
-  sortData,
-  hideStockOut,
-  showStockOut,
-} from './dataTableUtilities/actions/tableActions';
-import {
-  selectRow,
-  deselectRow,
-  selectAll,
-  deselectAll,
-  selectItems,
-} from './dataTableUtilities/actions/rowActions';
-import { createStocktake, addItemsToStocktake } from '../navigation/actions';
-import { editName } from './dataTableUtilities/actions/pageActions';
 
 import { buttonStrings, modalStrings } from '../localization';
 import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
@@ -67,25 +52,26 @@ export const StocktakeManagePage = ({
     dataState,
     sortBy,
     isAscending,
-    columns,
     hasSelection,
     showAll,
     allSelected,
     name,
     keyExtractor,
+    PageActions,
+    columns,
   } = state;
 
   // On navigating to this screen, if a stocktake is passed through, update the selection with
   // the items already in the stocktake.
   useEffect(() => {
-    if (stocktake) dispatch(selectItems(stocktake.itemsInStocktake));
+    if (stocktake) dispatch(PageActions.selectItems(stocktake.itemsInStocktake));
   }, []);
 
   const getAction = useCallback((colKey, propName) => {
     switch (colKey) {
       case 'selected':
-        if (propName === 'onCheckAction') return selectRow;
-        return deselectRow;
+        if (propName === 'onCheckAction') return PageActions.selectRow;
+        return PageActions.deselectRow;
       default:
         return null;
     }
@@ -101,12 +87,14 @@ export const StocktakeManagePage = ({
       toggles={[
         {
           text: buttonStrings.hide_stockouts,
-          onPress: () => (showAll ? dispatch(hideStockOut()) : dispatch(showStockOut())),
+          onPress: () =>
+            showAll ? dispatch(PageActions.hideStockOut()) : dispatch(PageActions.showStockOut()),
           isOn: !showAll,
         },
         {
           text: buttonStrings.all_items_selected,
-          onPress: () => (allSelected ? dispatch(deselectAll()) : dispatch(selectAll())),
+          onPress: () =>
+            allSelected ? dispatch(PageActions.deselectAll()) : dispatch(PageActions.selectAll()),
           isOn: allSelected,
         },
       ]}
@@ -138,7 +126,7 @@ export const StocktakeManagePage = ({
     <DataTableHeaderRow
       columns={columns}
       dispatch={instantDebouncedDispatch}
-      sortAction={sortData}
+      sortAction={PageActions.sortData}
       isAscending={isAscending}
       sortBy={sortBy}
     />
@@ -168,7 +156,7 @@ export const StocktakeManagePage = ({
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
           <SearchBar
-            onChange={value => debouncedDispatch(filterData(value))}
+            onChange={value => debouncedDispatch(PageActions.filterData(value))}
             style={searchBar}
             color={SUSSOL_ORANGE}
             placeholder=""
@@ -192,7 +180,7 @@ export const StocktakeManagePage = ({
         value={name}
         placeholder={modalStrings.give_your_stocktake_a_name}
         onConfirm={confirmStocktake}
-        onChangeText={value => dispatch(editName(value))}
+        onChangeText={value => dispatch(PageActions.editName(value))}
       />
     </DataTablePageView>
   );

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -12,7 +12,7 @@ import { SearchBar } from 'react-native-ui-components';
 
 import { UIDatabase } from '../database';
 
-import { usePageReducer } from '../hooks/usePageReducer';
+import { usePageReducer } from '../hooks';
 import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
 import { createStocktake, addItemsToStocktake } from '../navigation/actions';
 
@@ -21,7 +21,7 @@ import { ToggleBar, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
 import { buttonStrings, modalStrings } from '../localization';
-import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
+import { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
 
 export const StocktakeManagePage = ({
   routeName,
@@ -57,6 +57,7 @@ export const StocktakeManagePage = ({
     allSelected,
     name,
     keyExtractor,
+    searchTerm,
     PageActions,
     columns,
   } = state;
@@ -79,22 +80,15 @@ export const StocktakeManagePage = ({
 
   const Toggle = () => (
     <ToggleBar
-      style={globalStyles.toggleBar}
-      textOffStyle={globalStyles.toggleText}
-      textOnStyle={globalStyles.toggleTextSelected}
-      toggleOffStyle={globalStyles.toggleOption}
-      toggleOnStyle={globalStyles.toggleOptionSelected}
       toggles={[
         {
           text: buttonStrings.hide_stockouts,
-          onPress: () =>
-            showAll ? dispatch(PageActions.hideStockOut()) : dispatch(PageActions.showStockOut()),
+          onPress: () => dispatch(PageActions.toggleStockOut(showAll)),
           isOn: !showAll,
         },
         {
           text: buttonStrings.all_items_selected,
-          onPress: () =>
-            allSelected ? dispatch(PageActions.deselectAll()) : dispatch(PageActions.selectAll()),
+          onPress: () => dispatch(PageActions.toggleAllSelected(allSelected)),
           isOn: allSelected,
         },
       ]}
@@ -156,10 +150,11 @@ export const StocktakeManagePage = ({
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
           <SearchBar
-            onChange={value => debouncedDispatch(PageActions.filterData(value))}
+            onChangeText={value => debouncedDispatch(PageActions.filterData(value))}
             style={searchBar}
             color={SUSSOL_ORANGE}
             placeholder=""
+            value={searchTerm}
           />
         </View>
         <View style={newPageTopRightSectionContainer}>

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -12,26 +12,28 @@ import { SearchBar } from 'react-native-ui-components';
 import { buttonStrings, modalStrings } from '../localization';
 import { UIDatabase } from '../database';
 import { BottomTextEditor } from '../widgets/modals';
-import { ToggleBar } from '../widgets';
+import { ToggleBar, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
+
+import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
+import { usePageReducer } from '../hooks/usePageReducer';
+
+import { createStocktake, addItemsToStocktake } from '../navigation/actions';
+import { recordKeyExtractor, getItemLayout } from './dataTableUtilities/utilities';
 import {
-  sortData,
   filterData,
+  sortData,
+  hideStockOut,
+  showStockOut,
+} from './dataTableUtilities/actions/tableActions';
+import {
   selectRow,
   deselectRow,
   selectAll,
   deselectAll,
-  hideStockOut,
-  showStockOut,
   selectItems,
-  editName,
-} from './dataTableUtilities/actions';
-
-import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
-import usePageReducer from '../hooks/usePageReducer';
-import DataTablePageView from './containers/DataTablePageView';
-import { createStocktake, addItemsToStocktake } from '../navigation/actions';
-import { recordKeyExtractor, getItemLayout } from './dataTableUtilities/utilities';
+} from './dataTableUtilities/actions/rowActions';
+import { editName } from './dataTableUtilities/actions/pageActions';
 
 export const StocktakeManagePage = ({
   routeName,
@@ -193,9 +195,13 @@ export const StocktakeManagePage = ({
   );
 };
 
+StocktakeManagePage.defaultProps = {
+  stocktake: null,
+};
+
 StocktakeManagePage.propTypes = {
   runWithLoadingIndicator: PropTypes.func.isRequired,
   routeName: PropTypes.string.isRequired,
   dispatch: PropTypes.func.isRequired,
-  stocktake: PropTypes.object.isRequired,
+  stocktake: PropTypes.object,
 };

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -9,17 +9,16 @@ import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
-import { buttonStrings, modalStrings } from '../localization';
+
 import { UIDatabase } from '../database';
+
+import { usePageReducer } from '../hooks/usePageReducer';
+import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
+
 import { BottomTextEditor } from '../widgets/modals';
 import { ToggleBar, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
-import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
-import { usePageReducer } from '../hooks/usePageReducer';
-
-import { createStocktake, addItemsToStocktake } from '../navigation/actions';
-import { recordKeyExtractor, getItemLayout } from './dataTableUtilities/utilities';
 import {
   filterData,
   sortData,
@@ -33,7 +32,11 @@ import {
   deselectAll,
   selectItems,
 } from './dataTableUtilities/actions/rowActions';
+import { createStocktake, addItemsToStocktake } from '../navigation/actions';
 import { editName } from './dataTableUtilities/actions/pageActions';
+
+import { buttonStrings, modalStrings } from '../localization';
+import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
 
 export const StocktakeManagePage = ({
   routeName,

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -78,22 +78,18 @@ export const StocktakeManagePage = ({
     }
   });
 
-  const Toggle = () => (
-    <ToggleBar
-      toggles={[
-        {
-          text: buttonStrings.hide_stockouts,
-          onPress: () => dispatch(PageActions.toggleStockOut(showAll)),
-          isOn: !showAll,
-        },
-        {
-          text: buttonStrings.all_items_selected,
-          onPress: () => dispatch(PageActions.toggleAllSelected(allSelected)),
-          isOn: allSelected,
-        },
-      ]}
-    />
-  );
+  const confirmStocktake = () => {
+    const itemIds = Array.from(dataState.keys()).filter(id => id);
+
+    const updateExistingStocktake = () => reduxDispatch(addItemsToStocktake(stocktake, itemIds));
+    const createNewStocktake = () =>
+      reduxDispatch(createStocktake({ stocktakeName: name, itemIds }));
+
+    runWithLoadingIndicator(() => {
+      if (stocktake) return updateExistingStocktake();
+      return createNewStocktake();
+    });
+  };
 
   const renderRow = useCallback(
     listItem => {
@@ -116,28 +112,38 @@ export const StocktakeManagePage = ({
     [data, dataState, showAll, hasSelection]
   );
 
-  const renderHeader = () => (
-    <DataTableHeaderRow
-      columns={columns}
-      dispatch={instantDebouncedDispatch}
-      sortAction={PageActions.sortData}
-      isAscending={isAscending}
-      sortBy={sortBy}
-    />
+  const renderHeader = useCallback(
+    () => (
+      <DataTableHeaderRow
+        columns={columns}
+        dispatch={instantDebouncedDispatch}
+        sortAction={PageActions.sortData}
+        isAscending={isAscending}
+        sortBy={sortBy}
+      />
+    ),
+    []
   );
 
-  const confirmStocktake = () => {
-    const itemIds = Array.from(dataState.keys()).filter(id => id);
-
-    const updateExistingStocktake = () => reduxDispatch(addItemsToStocktake(stocktake, itemIds));
-    const createNewStocktake = () =>
-      reduxDispatch(createStocktake({ stocktakeName: name, itemIds }));
-
-    runWithLoadingIndicator(() => {
-      if (stocktake) return updateExistingStocktake();
-      return createNewStocktake();
-    });
-  };
+  const Toggle = useCallback(
+    () => (
+      <ToggleBar
+        toggles={[
+          {
+            text: buttonStrings.hide_stockouts,
+            onPress: () => dispatch(PageActions.toggleStockOut(showAll)),
+            isOn: !showAll,
+          },
+          {
+            text: buttonStrings.all_items_selected,
+            onPress: () => dispatch(PageActions.toggleAllSelected(allSelected)),
+            isOn: allSelected,
+          },
+        ]}
+      />
+    ),
+    [showAll, allSelected]
+  );
 
   const {
     newPageTopSectionContainer,

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -23,29 +23,37 @@ import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTabl
 import { buttonStrings, modalStrings } from '../localization';
 import { SUSSOL_ORANGE, newPageStyles } from '../globalStyles';
 
+const stateInitialiser = pageObject => {
+  const backingData = UIDatabase.objects('Item');
+  return {
+    pageObject,
+    backingData,
+    data: backingData.sorted('name').slice(),
+    keyExtractor: recordKeyExtractor,
+    dataState: new Map(),
+    searchTerm: '',
+    filterDataKeys: ['name', 'code'],
+    name: pageObject ? pageObject.name : '',
+    sortBy: 'name',
+    isAscending: true,
+    hasSelection: false,
+    allSelected: false,
+    showAll: true,
+  };
+};
+
 export const StocktakeManagePage = ({
   routeName,
   dispatch: reduxDispatch,
   stocktake,
   runWithLoadingIndicator,
 }) => {
-  const [state, dispatch, instantDebouncedDispatch, debouncedDispatch] = usePageReducer(routeName, {
-    pageObject: stocktake,
-    backingData: UIDatabase.objects('Item'),
-    data: UIDatabase.objects('Item')
-      .sorted('name')
-      .slice(),
-    keyExtractor: recordKeyExtractor,
-    dataState: new Map(),
-    searchTerm: '',
-    filterDataKeys: ['name', 'code'],
-    sortBy: 'name',
-    isAscending: true,
-    hasSelection: false,
-    allSelected: false,
-    showAll: true,
-    name: stocktake ? stocktake.name : '',
-  });
+  const [state, dispatch, instantDebouncedDispatch, debouncedDispatch] = usePageReducer(
+    routeName,
+    {},
+    stateInitialiser,
+    stocktake
+  );
 
   const {
     data,
@@ -81,10 +89,10 @@ export const StocktakeManagePage = ({
   const onNameChange = value => dispatch(PageActions.editName(value));
   const onSelectAll = () => dispatch(PageActions.toggleAllSelected(allSelected));
   const onHideStock = () => dispatch(PageActions.toggleStockOut(showAll));
-  const onConfirmStocktake = () => {
-    const itemIds = Array.from(dataState.keys()).filter(id => id);
 
+  const onConfirmStocktake = () => {
     runWithLoadingIndicator(() => {
+      const itemIds = Array.from(dataState.keys()).filter(id => id);
       if (stocktake) return reduxDispatch(addItemsToStocktake(stocktake, itemIds));
       return reduxDispatch(createStocktake({ stocktakeName: name, itemIds }));
     });

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -33,7 +33,7 @@ const stateInitialiser = () => {
   const backingData = UIDatabase.objects('Stocktake');
   return {
     backingData,
-    data: backingData.sorted('createdDate', false).slice(),
+    data: backingData.sorted('createdDate', true).slice(),
     keyExtractor: recordKeyExtractor,
     dataState: new Map(),
     searchTerm: '',
@@ -119,6 +119,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
           dispatch={dispatch}
           getAction={getAction}
           onPress={onRowPress}
+          rowIndex={index}
         />
       );
     },

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -21,7 +21,7 @@ import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
 import { buttonStrings, modalStrings } from '../localization';
-import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
+import globalStyles, { SUSSOL_ORANGE, newPageStyles } from '../globalStyles';
 
 import {
   gotoStocktakeManagePage,
@@ -105,14 +105,11 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     listItem => {
       const { item, index } = listItem;
       const rowKey = keyExtractor(item);
-      const { row, alternateRow } = newDataTableStyles;
-
       return (
         <DataTableRow
           rowData={data[index]}
           rowState={dataState.get(rowKey)}
           rowKey={rowKey}
-          style={index % 2 === 0 ? alternateRow : row}
           columns={columns}
           dispatch={dispatch}
           getAction={getAction}

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -18,16 +18,6 @@ import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
 import { PageButton, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
-import {
-  selectRow,
-  deselectRow,
-  deselectAll,
-  deleteStocktakes,
-} from './dataTableUtilities/actions/rowActions';
-
-import { filterData, sortData } from './dataTableUtilities/actions/tableActions';
-import { openModal, closeModal } from './dataTableUtilities/actions/pageActions';
-
 import { getItemLayout, recordKeyExtractor } from './dataTableUtilities/utilities';
 import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
 import { usePageReducer } from '../hooks/usePageReducer';
@@ -62,11 +52,12 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     dataState,
     sortBy,
     isAscending,
-    columns,
     modalKey,
     hasSelection,
     usingPrograms,
     keyExtractor,
+    columns,
+    PageActions,
   } = state;
 
   const { PROGRAM_STOCKTAKE } = MODAL_KEYS;
@@ -74,8 +65,8 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
   const getAction = useCallback((colKey, propName) => {
     switch (colKey) {
       case 'remove':
-        if (propName === 'onCheckAction') return selectRow;
-        return deselectRow;
+        if (propName === 'onCheckAction') return PageActions.selectRow;
+        return PageActions.deselectRow;
       default:
         return null;
     }
@@ -104,7 +95,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
   );
 
   const newStocktake = () => {
-    if (usingPrograms) return dispatch(openModal(PROGRAM_STOCKTAKE));
+    if (usingPrograms) return dispatch(PageActions.openModal(PROGRAM_STOCKTAKE));
     return reduxDispatch(gotoStocktakeManagePage({ stocktakeName: '' }));
   };
 
@@ -126,7 +117,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
       case PROGRAM_STOCKTAKE:
         return ({ stocktakeName, program }) => {
           reduxDispatch(createStocktake({ program, stocktakeName, currentUser }));
-          dispatch(closeModal());
+          dispatch(PageActions.closeModal());
         };
       default:
         return null;
@@ -137,7 +128,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     <DataTableHeaderRow
       columns={columns}
       dispatch={instantDebouncedDispatch}
-      sortAction={sortData}
+      sortAction={PageActions.sortData}
       isAscending={isAscending}
       sortBy={sortBy}
     />
@@ -154,7 +145,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
           <SearchBar
-            onChange={value => debouncedDispatch(filterData(value))}
+            onChange={value => debouncedDispatch(PageActions.filterData(value))}
             style={searchBar}
             color={SUSSOL_ORANGE}
             placeholder=""
@@ -173,15 +164,15 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
       <BottomConfirmModal
         isOpen={hasSelection}
         questionText={modalStrings.remove_these_items}
-        onCancel={() => dispatch(deselectAll())}
-        onConfirm={() => dispatch(deleteStocktakes())}
+        onCancel={() => dispatch(PageActions.deselectAll())}
+        onConfirm={() => dispatch(PageActions.deleteStocktakes())}
         confirmText={modalStrings.remove}
       />
       <DataTablePageModal
         fullScreen={false}
         isOpen={!!modalKey}
         modalKey={modalKey}
-        onClose={() => dispatch(closeModal())}
+        onClose={() => dispatch(PageActions.closeModal())}
         onSelect={getModalOnSelect()}
         dispatch={dispatch}
       />

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -15,30 +15,28 @@ import { buttonStrings, modalStrings } from '../localization';
 import { UIDatabase } from '../database';
 import Settings from '../settings/MobileAppSettings';
 import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
-import { PageButton } from '../widgets';
+import { PageButton, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
+
 import {
-  sortData,
-  filterData,
   selectRow,
   deselectRow,
   deselectAll,
-  closeBasicModal,
-  deleteRequisitions,
-  openBasicModal,
-} from './dataTableUtilities/actions';
+  deleteStocktakes,
+} from './dataTableUtilities/actions/rowActions';
+
+import { filterData, sortData } from './dataTableUtilities/actions/tableActions';
+import { openModal, closeModal } from './dataTableUtilities/actions/pageActions';
+
 import { getItemLayout, recordKeyExtractor } from './dataTableUtilities/utilities';
 import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
-import usePageReducer from '../hooks/usePageReducer';
-import DataTablePageView from './containers/DataTablePageView';
+import { usePageReducer } from '../hooks/usePageReducer';
 
 import {
   gotoStocktakeManagePage,
   createStocktake,
   gotoStocktakeEditPage,
 } from '../navigation/actions';
-
-const keyExtractor = item => item.id;
 
 export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch }) => {
   const [state, dispatch, instantDebouncedDispatch, debouncedDispatch] = usePageReducer(routeName, {
@@ -68,6 +66,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     modalKey,
     hasSelection,
     usingPrograms,
+    keyExtractor,
   } = state;
 
   const { PROGRAM_STOCKTAKE } = MODAL_KEYS;
@@ -105,7 +104,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
   );
 
   const newStocktake = () => {
-    if (usingPrograms) return dispatch(openBasicModal(PROGRAM_STOCKTAKE));
+    if (usingPrograms) return dispatch(openModal(PROGRAM_STOCKTAKE));
     return reduxDispatch(gotoStocktakeManagePage({ stocktakeName: '' }));
   };
 
@@ -127,7 +126,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
       case PROGRAM_STOCKTAKE:
         return ({ stocktakeName, program }) => {
           reduxDispatch(createStocktake({ program, stocktakeName, currentUser }));
-          dispatch(closeBasicModal());
+          dispatch(closeModal());
         };
       default:
         return null;
@@ -175,14 +174,14 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
         isOpen={hasSelection}
         questionText={modalStrings.remove_these_items}
         onCancel={() => dispatch(deselectAll())}
-        onConfirm={() => dispatch(deleteRequisitions())}
+        onConfirm={() => dispatch(deleteStocktakes())}
         confirmText={modalStrings.remove}
       />
       <DataTablePageModal
         fullScreen={false}
         isOpen={!!modalKey}
         modalKey={modalKey}
-        onClose={() => dispatch(closeBasicModal())}
+        onClose={() => dispatch(closeModal())}
         onSelect={getModalOnSelect()}
         dispatch={dispatch}
       />

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -13,7 +13,7 @@ import { UIDatabase } from '../database';
 import Settings from '../settings/MobileAppSettings';
 
 import { MODAL_KEYS, getAllPrograms } from '../utilities';
-import { usePageReducer } from '../hooks';
+import { usePageReducer, useSyncListener, useNavigationFocus } from '../hooks';
 import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
 
 import { PageButton, DataTablePageView, SearchBar } from '../widgets';
@@ -29,7 +29,7 @@ import {
   gotoStocktakeEditPage,
 } from '../navigation/actions';
 
-export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch }) => {
+export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch, navigation }) => {
   const [state, dispatch, instantDebouncedDispatch, debouncedDispatch] = usePageReducer(routeName, {
     backingData: UIDatabase.objects('Stocktake'),
     data: UIDatabase.objects('Stocktake')
@@ -61,6 +61,12 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     columns,
     PageActions,
   } = state;
+
+  const callback = useCallback(() => dispatch(PageActions.refreshData()), []);
+  // Listen to sync changing stocktake data - refresh if there are any.
+  useSyncListener(callback, ['Stocktake']);
+  // Listen to navigation focusing this page - fresh if so.
+  useNavigationFocus(callback, navigation);
 
   const getAction = (colKey, propName) => {
     switch (colKey) {
@@ -185,4 +191,5 @@ StocktakesPage.propTypes = {
   routeName: PropTypes.string.isRequired,
   dispatch: PropTypes.func.isRequired,
   currentUser: PropTypes.object.isRequired,
+  navigation: PropTypes.object.isRequired,
 };

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -10,17 +10,19 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { SearchBar } from 'react-native-ui-components';
 
-import { MODAL_KEYS, getAllPrograms } from '../utilities';
-import { buttonStrings, modalStrings } from '../localization';
 import { UIDatabase } from '../database';
 import Settings from '../settings/MobileAppSettings';
-import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
+
+import { MODAL_KEYS, getAllPrograms } from '../utilities';
+import { usePageReducer } from '../hooks';
+import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
+
 import { PageButton, DataTablePageView } from '../widgets';
+import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
-import { getItemLayout, recordKeyExtractor } from './dataTableUtilities/utilities';
+import { buttonStrings, modalStrings } from '../localization';
 import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
-import { usePageReducer } from '../hooks/usePageReducer';
 
 import {
   gotoStocktakeManagePage,

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -62,7 +62,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     PageActions,
   } = state;
 
-  const getAction = useCallback((colKey, propName) => {
+  const getAction = (colKey, propName) => {
     switch (colKey) {
       case 'remove':
         if (propName === 'onCheckAction') return PageActions.selectRow;
@@ -70,7 +70,24 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
       default:
         return null;
     }
-  });
+  };
+
+  const getModalOnSelect = () => {
+    switch (modalKey) {
+      case MODAL_KEYS.PROGRAM_STOCKTAKE:
+        return ({ stocktakeName, program }) => {
+          reduxDispatch(createStocktake({ program, stocktakeName, currentUser }));
+          dispatch(PageActions.closeModal());
+        };
+      default:
+        return null;
+    }
+  };
+
+  const newStocktake = () => {
+    if (usingPrograms) return dispatch(PageActions.openModal(MODAL_KEYS.PROGRAM_STOCKTAKE));
+    return reduxDispatch(gotoStocktakeManagePage({ stocktakeName: '' }));
+  };
 
   const renderRow = useCallback(
     listItem => {
@@ -94,10 +111,15 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     [data, dataState]
   );
 
-  const newStocktake = () => {
-    if (usingPrograms) return dispatch(PageActions.openModal(MODAL_KEYS.PROGRAM_STOCKTAKE));
-    return reduxDispatch(gotoStocktakeManagePage({ stocktakeName: '' }));
-  };
+  const renderHeader = () => (
+    <DataTableHeaderRow
+      columns={columns}
+      dispatch={instantDebouncedDispatch}
+      sortAction={PageActions.sortData}
+      isAscending={isAscending}
+      sortBy={sortBy}
+    />
+  );
 
   const renderButtons = () => {
     const { verticalContainer, topButton } = globalStyles;
@@ -111,28 +133,6 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
       </View>
     );
   };
-
-  const getModalOnSelect = () => {
-    switch (modalKey) {
-      case MODAL_KEYS.PROGRAM_STOCKTAKE:
-        return ({ stocktakeName, program }) => {
-          reduxDispatch(createStocktake({ program, stocktakeName, currentUser }));
-          dispatch(PageActions.closeModal());
-        };
-      default:
-        return null;
-    }
-  };
-
-  const renderHeader = () => (
-    <DataTableHeaderRow
-      columns={columns}
-      dispatch={instantDebouncedDispatch}
-      sortAction={PageActions.sortData}
-      isAscending={isAscending}
-      sortBy={sortBy}
-    />
-  );
 
   const {
     newPageTopSectionContainer,

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -8,7 +8,6 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
-import { SearchBar } from 'react-native-ui-components';
 
 import { UIDatabase } from '../database';
 import Settings from '../settings/MobileAppSettings';
@@ -17,7 +16,7 @@ import { MODAL_KEYS, getAllPrograms } from '../utilities';
 import { usePageReducer } from '../hooks';
 import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
 
-import { PageButton, DataTablePageView } from '../widgets';
+import { PageButton, DataTablePageView, SearchBar } from '../widgets';
 import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
@@ -54,6 +53,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     dataState,
     sortBy,
     isAscending,
+    searchTerm,
     modalKey,
     hasSelection,
     usingPrograms,
@@ -147,10 +147,11 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
           <SearchBar
-            onChange={value => debouncedDispatch(PageActions.filterData(value))}
+            onChangeText={value => debouncedDispatch(PageActions.filterData(value))}
             style={searchBar}
             color={SUSSOL_ORANGE}
             placeholder=""
+            value={searchTerm}
           />
         </View>
         <View style={newPageTopRightSectionContainer}>{renderButtons()}</View>

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -62,8 +62,6 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     PageActions,
   } = state;
 
-  const { PROGRAM_STOCKTAKE } = MODAL_KEYS;
-
   const getAction = useCallback((colKey, propName) => {
     switch (colKey) {
       case 'remove':
@@ -97,7 +95,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
   );
 
   const newStocktake = () => {
-    if (usingPrograms) return dispatch(PageActions.openModal(PROGRAM_STOCKTAKE));
+    if (usingPrograms) return dispatch(PageActions.openModal(MODAL_KEYS.PROGRAM_STOCKTAKE));
     return reduxDispatch(gotoStocktakeManagePage({ stocktakeName: '' }));
   };
 
@@ -116,7 +114,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
 
   const getModalOnSelect = () => {
     switch (modalKey) {
-      case PROGRAM_STOCKTAKE:
+      case MODAL_KEYS.PROGRAM_STOCKTAKE:
         return ({ stocktakeName, program }) => {
           reduxDispatch(createStocktake({ program, stocktakeName, currentUser }));
           dispatch(PageActions.closeModal());

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -40,24 +40,35 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
     sortBy: 'itemName',
     isAscending: true,
     modalKey: '',
+    modalValue: null,
     hasSelection: false,
   });
 
   const {
+    pageObject,
     data,
     dataState,
     sortBy,
     isAscending,
-    columns,
     modalKey,
-    getPageInfoColumns,
-    pageObject,
+    modalValue,
     hasSelection,
     searchTerm,
     PageActions,
+    columns,
+    getPageInfoColumns,
   } = state;
 
   const { isFinalised, comment, theirRef } = pageObject;
+
+  const onAddItem = item => dispatch(PageActions.addTransactionBatch(item));
+  const onEditComment = value => dispatch(PageActions.editComment(value, 'Transaction'));
+  const onEditTheirRef = value => dispatch(PageActions.editTheirRef(value, 'Transaction'));
+  const onNewInvoice = () => dispatch(PageActions.openModal(MODAL_KEYS.SELECT_ITEM));
+  const onFilterData = value => dispatch(PageActions.filterData(value));
+  const onCancelDelete = () => dispatch(PageActions.deselectAll());
+  const onConfirmDelete = () => dispatch(PageActions.deleteTransactionBatches());
+  const onCloseModal = () => dispatch(PageActions.closeModal());
 
   const renderPageInfo = useCallback(
     () => (
@@ -86,11 +97,14 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
   const getModalOnSelect = () => {
     switch (modalKey) {
       case MODAL_KEYS.SELECT_ITEM:
-        return item => dispatch(PageActions.addTransactionBatch(item));
+        return onAddItem;
       case MODAL_KEYS.TRANSACTION_COMMENT_EDIT:
-        return value => dispatch(PageActions.editComment(value, 'Transaction'));
+        console.log('#################################');
+        console.log('COMMENT EDIT');
+        console.log('#################################');
+        return onEditComment;
       case MODAL_KEYS.THEIR_REF_EDIT:
-        return value => dispatch(PageActions.editTheirRef(value, 'Transaction'));
+        return onEditTheirRef;
       default:
         return null;
     }
@@ -123,7 +137,7 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
         <PageButton
           style={topButton}
           text={buttonStrings.new_item}
-          onPress={() => dispatch(PageActions.openModal(MODAL_KEYS.SELECT_ITEM))}
+          onPress={onNewInvoice}
           isDisabled={isFinalised}
         />
       </View>
@@ -140,7 +154,7 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
         sortBy={sortBy}
       />
     ),
-    []
+    [sortBy, isAscending]
   );
 
   const {
@@ -155,7 +169,7 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
         <View style={newPageTopLeftSectionContainer}>
           {renderPageInfo()}
           <SearchBar
-            onChangeText={value => dispatch(PageActions.filterData(value))}
+            onChangeText={onFilterData}
             style={searchBar}
             color={SUSSOL_ORANGE}
             placeholder=""
@@ -178,17 +192,18 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
       <BottomConfirmModal
         isOpen={hasSelection}
         questionText={modalStrings.remove_these_items}
-        onCancel={() => dispatch(PageActions.deselectAll())}
-        onConfirm={() => dispatch(PageActions.deleteTransactionBatches())}
+        onCancel={onCancelDelete}
+        onConfirm={onConfirmDelete}
         confirmText={modalStrings.remove}
       />
       <DataTablePageModal
         fullScreen={false}
         isOpen={!!modalKey}
         modalKey={modalKey}
-        onClose={() => dispatch(PageActions.closeModal())}
+        onClose={onCloseModal}
         onSelect={getModalOnSelect()}
         dispatch={dispatch}
+        currentValue={modalValue}
       />
     </DataTablePageView>
   );

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -99,9 +99,6 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
       case MODAL_KEYS.SELECT_ITEM:
         return onAddItem;
       case MODAL_KEYS.TRANSACTION_COMMENT_EDIT:
-        console.log('#################################');
-        console.log('COMMENT EDIT');
-        console.log('#################################');
         return onEditComment;
       case MODAL_KEYS.THEIR_REF_EDIT:
         return onEditTheirRef;

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -19,7 +19,7 @@ import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
 
 import { usePageReducer, useRecordListener } from '../hooks';
 
-import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
+import globalStyles, { SUSSOL_ORANGE, newPageStyles } from '../globalStyles';
 import { buttonStrings, modalStrings, programStrings } from '../localization';
 
 const stateInitialiser = requisition => {
@@ -155,13 +155,12 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
     listItem => {
       const { item, index } = listItem;
       const rowKey = keyExtractor(item);
-      const { row, alternateRow } = newDataTableStyles;
+
       return (
         <DataTableRow
           rowData={data[index]}
           rowState={dataState.get(rowKey)}
           rowKey={rowKey}
-          style={index % 2 === 0 ? alternateRow : row}
           columns={columns}
           isFinalised={isFinalised}
           dispatch={dispatch}

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -20,7 +20,7 @@ import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
 import { createSupplierRequisition, gotoSupplierRequisition } from '../navigation/actions';
 import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
 
-import globalStyles, { SUSSOL_ORANGE, newDataTableStyles, newPageStyles } from '../globalStyles';
+import globalStyles, { SUSSOL_ORANGE, newPageStyles } from '../globalStyles';
 import { buttonStrings, modalStrings } from '../localization';
 
 const initialiseState = () => {
@@ -130,13 +130,11 @@ export const SupplierRequisitionsPage = ({
     listItem => {
       const { item, index } = listItem;
       const rowKey = recordKeyExtractor(item);
-      const { row, alternateRow } = newDataTableStyles;
       return (
         <DataTableRow
           rowData={data[index]}
           rowState={dataState.get(rowKey)}
           rowKey={rowKey}
-          style={index % 2 === 0 ? alternateRow : row}
           columns={columns}
           dispatch={dispatch}
           getAction={getAction}

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -130,7 +130,7 @@ export const removeReason = rowKey => (dispatch, getState) => {
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  objectToEdit.applyReasonToBatches(UIDatabase);
+  objectToEdit.applyReason(UIDatabase);
 
   dispatch(refreshRow(rowKey));
 };
@@ -165,7 +165,7 @@ export const enforceReasonChoice = rowKey => (dispatch, getState) => {
 export const applyReason = value => (dispatch, getState) => {
   const { modalValue, keyExtractor } = getState();
 
-  modalValue.applyReasonToBatches(UIDatabase, value);
+  modalValue.applyReason(UIDatabase, value);
 
   const rowKey = keyExtractor(modalValue);
 

--- a/src/pages/dataTableUtilities/actions/getPageActions.js
+++ b/src/pages/dataTableUtilities/actions/getPageActions.js
@@ -8,7 +8,6 @@ import { CellActionsLookup, editCountedQuantityWithReason } from './cellActions'
 import { RowActionsLookup } from './rowActions';
 import { TableActionsLookup } from './tableActions';
 import { PageActionsLookup } from './pageActions';
-import { UIDatabase } from '../../../database/index';
 
 /**
  * Serves a page the actions it requires given it's routeName.
@@ -39,8 +38,12 @@ const stocktakeEditorWithReasons = {
   editCountedQuantity: editCountedQuantityWithReason,
 };
 
-const PAGE_ACTIONS = {
-  BasePageActions,
+/**
+ * If actions need to be overriden for a particular routeName,
+ * adding them here will pass that new set of actions to the
+ * screen when navigating.
+ */
+const NON_DEFAULT_PAGE_ACTIONS = {
   stocktakeEditorWithReasons,
 };
 
@@ -49,15 +52,4 @@ const PAGE_ACTIONS = {
  *
  * @param {String} routeName Name of the route being navigated to.
  */
-export const getPageActions = routeName => {
-  switch (routeName) {
-    case 'stocktakeEditor': {
-      const usesReasons = UIDatabase.objects('StocktakeReasons').length > 0;
-      return usesReasons ? PAGE_ACTIONS.stocktakeEditorWithReasons : PAGE_ACTIONS.BasePageActions;
-    }
-
-    default: {
-      return PAGE_ACTIONS.BasePageActions;
-    }
-  }
-};
+export const getPageActions = routeName => NON_DEFAULT_PAGE_ACTIONS[routeName] || BasePageActions;

--- a/src/pages/dataTableUtilities/actions/pageActions.js
+++ b/src/pages/dataTableUtilities/actions/pageActions.js
@@ -31,6 +31,22 @@ export const editName = value => ({ type: ACTIONS.EDIT_NAME, payload: { value } 
 export const closeModal = () => ({ type: ACTIONS.CLOSE_MODAL });
 
 /**
+ * Splitter action creator, assumes the current modalValue is an instance
+ * of some rowData - extracting the key and refreshing the row before
+ * closing the modal.
+ * use case: opening a stocktake batch and refreshing the stocktake edit page row.
+ */
+export const closeAndRefresh = () => (dispatch, getState) => {
+  const { modalValue, keyExtractor } = getState();
+
+  const rowKey = keyExtractor(modalValue);
+
+  // Avoiding refresh row dependency cycle.
+  dispatch({ type: ACTIONS.REFRESH_ROW, payload: { rowKey } });
+  dispatch(closeModal());
+};
+
+/**
  * Opens a modal given a modal key. Can pass an optional value
  * to set as `modalValue`
  *
@@ -149,4 +165,5 @@ export const PageActionsLookup = {
   editComment,
   editMonthsToSupply,
   resetStocktake,
+  closeAndRefresh,
 };

--- a/src/pages/dataTableUtilities/actions/rowActions.js
+++ b/src/pages/dataTableUtilities/actions/rowActions.js
@@ -78,6 +78,16 @@ export const selectAll = () => ({
 });
 
 /**
+ * Wrapper around deselectAll and selectAll, determining which should
+ * be dispatched.
+ * @param {Bool} allSelected indicator whether all items are currently selected.
+ */
+export const toggleAllSelected = allSelected => {
+  if (allSelected) return deselectAll();
+  return selectAll();
+};
+
+/**
  * Sets all rowState objects within the passed items array,
  * in the stores dataState map to isSelected
  *

--- a/src/pages/dataTableUtilities/actions/rowActions.js
+++ b/src/pages/dataTableUtilities/actions/rowActions.js
@@ -181,6 +181,7 @@ export const RowActionsLookup = {
   deselectRow,
   deselectAll,
   selectAll,
+  toggleAllSelected,
   selectItems,
   deleteSelectedBatches,
   deleteSelectedItems,

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -217,6 +217,7 @@ export const TableActionsLookup = {
   hideStockOut,
   showOverStocked,
   showStockOut,
+  toggleStockOut,
   addMasterListItems,
   addItem,
   addTransactionBatch,

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -66,6 +66,15 @@ export const showOverStocked = () => refreshData();
 export const showStockOut = () => refreshData();
 
 /**
+ *  Wrapper around hideStockout and showStockout. Determines which
+ *  should be dispatched.
+ */
+export const toggleStockOut = showAll => {
+  if (showAll) return hideStockOut();
+  return showStockOut();
+};
+
+/**
  * Adds all items from master lists, according to the type of pageObject.
  * i.e. a CustomerInvoice adds items from all of the custoemrs masterlists.
  * where as a Supplier Requisition adds items from all of this stores

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -66,8 +66,9 @@ export const showOverStocked = () => refreshData();
 export const showStockOut = () => refreshData();
 
 /**
- *  Wrapper around hideStockout and showStockout. Determines which
- *  should be dispatched.
+ * Wrapper around hideStockout and showStockout. Determines which
+ * should be dispatched.
+ * @param {Bool} showAll Indicator whether all rows are currently showing.
  */
 export const toggleStockOut = showAll => {
   if (showAll) return hideStockOut();

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -12,7 +12,7 @@ const PAGE_COLUMN_WIDTHS = {
   customerInvoices: [1.5, 2.5, 2, 1.5, 3, 1],
   supplierRequisitions: [1.5, 2, 1, 1, 1, 1],
   supplierRequisition: [1.4, 3.5, 2, 1.5, 2, 2, 1],
-  programSupplierRequisition: [1.5, 3.5, 0.5, 0.5, 2, 1.5, 2, 2, 1],
+  supplierRequisitionWithProgram: [1.5, 3.5, 0.5, 0.5, 2, 1.5, 2, 2, 1],
   stocktakes: [6, 2, 2, 1],
   stocktakeManager: [2, 6, 1],
   stocktakeEditor: [1, 2.8, 1.2, 1.2, 1, 0.8],
@@ -40,7 +40,7 @@ const PAGE_COLUMNS = {
     'requiredQuantity',
     'remove',
   ],
-  programSupplierRequisition: [
+  supplierRequisitionWithProgram: [
     'itemCode',
     'itemName',
     'unit',

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -21,7 +21,7 @@ const PAGE_COLUMN_WIDTHS = {
 
 const PAGE_COLUMNS = {
   customerInvoice: ['itemCode', 'itemName', 'availableQuantity', 'totalQuantity', 'remove'],
-  supplierInvoice: ['itemCode', 'itemName', 'totalQuantity', 'editableExpiryDate', 'remove'],
+  supplierInvoice: ['itemCode', 'itemName', 'totalQuantity', 'expiryDate', 'remove'],
   customerInvoices: ['serialNumber', 'customer', 'status', 'entryDate', 'comment', 'remove'],
   supplierRequisitions: [
     'serialNumber',
@@ -59,7 +59,7 @@ const PAGE_COLUMNS = {
     'snapshotTotalQuantity',
     'countedTotalQuantity',
     'difference',
-    'modalControl',
+    'batches',
   ],
   stocktakeEditorReasons: [
     'itemCode',
@@ -68,175 +68,264 @@ const PAGE_COLUMNS = {
     'countedTotalQuantity',
     'difference',
     'reason',
-    'modalControl',
+    'batches',
   ],
 };
 
 const COLUMNS = () => ({
+  // CODE COLUMNS
   serialNumber: {
+    type: 'string',
     key: 'serialNumber',
     title: tableStrings.invoice_number,
     sortable: true,
-  },
-  supplier: {
-    key: 'otherPartyName',
-    title: tableStrings.supplier,
-    sortable: true,
-  },
-  customer: {
-    key: 'otherPartyName',
-    title: tableStrings.customer,
-    sortable: true,
-  },
-  comment: {
-    key: 'comment',
-    title: tableStrings.comment,
-    lines: 2,
+    editable: false,
   },
   itemCode: {
+    type: 'string',
     key: 'itemCode',
     title: tableStrings.item_code,
     sortable: true,
+    editable: false,
   },
+  code: {
+    type: 'string',
+    key: 'code',
+    title: tableStrings.code,
+    alignText: 'left',
+    sortable: true,
+    editable: false,
+  },
+
+  // STRING COLUMNS
+
   itemName: {
+    type: 'string',
     key: 'itemName',
     title: tableStrings.item_name,
     sortable: true,
+    editable: false,
   },
+  name: {
+    type: 'string',
+    key: 'name',
+    title: tableStrings.name,
+    alignText: 'left',
+    sortable: true,
+    editable: false,
+  },
+  supplier: {
+    type: 'string',
+    key: 'otherPartyName',
+    title: tableStrings.supplier,
+    sortable: true,
+    editable: false,
+  },
+  customer: {
+    type: 'string',
+    key: 'otherPartyName',
+    title: tableStrings.customer,
+    sortable: true,
+    editable: false,
+  },
+  comment: {
+    type: 'string',
+    key: 'comment',
+    title: tableStrings.comment,
+    lines: 2,
+    editable: false,
+  },
+  unit: {
+    type: 'string',
+    key: 'unit',
+    title: tableStrings.unit,
+    alignText: 'center',
+    sortable: false,
+    editable: false,
+  },
+  status: {
+    type: 'string',
+    key: 'status',
+    title: tableStrings.status,
+    sortable: true,
+    editable: false,
+  },
+
+  // EDITABLE STRING COLUMNS
+
+  batchName: {
+    type: 'editableString',
+    key: 'batch',
+    title: tableStrings.batch_name,
+    alignText: 'center',
+  },
+
+  // NUMERIC COLUMNS
+
   availableQuantity: {
+    type: 'numeric',
     key: 'availableQuantity',
     title: tableStrings.available_stock,
-    sortable: true,
     alignText: 'right',
+    sortable: true,
+    editable: false,
+  },
+  numberOfItems: {
+    type: 'numeric',
+    key: 'numberOfItems',
+    title: tableStrings.items,
+    alignText: 'right',
+    sortable: true,
+    editable: false,
+  },
+  ourStockOnHand: {
+    type: 'numeric',
+    key: 'ourStockOnHand',
+    title: tableStrings.current_stock,
+    alignText: 'right',
+    sortable: true,
+    editable: false,
+  },
+  suggestedQuantity: {
+    type: 'numeric',
+    key: 'suggestedQuantity',
+    title: tableStrings.suggested_quantity,
+    alignText: 'right',
+    sortable: true,
+    editable: false,
+  },
+  difference: {
+    type: 'numeric',
+    key: 'difference',
+    title: tableStrings.difference,
+    alignText: 'right',
+    sortable: true,
+    editable: false,
+  },
+  snapshotTotalQuantity: {
+    type: 'numeric',
+    key: 'snapshotTotalQuantity',
+    title: tableStrings.snapshot_quantity,
+    alignText: 'right',
+    sortable: true,
+    editable: false,
+  },
+  theirStockOnHand: {
+    type: 'numeric',
+    key: 'stockOnHand',
+    title: tableStrings.their_stock,
+    alignText: 'right',
+    sortable: true,
+    editable: false,
+  },
+  price: {
+    type: 'numeric',
+    key: 'price',
+    title: tableStrings.price,
+    alignText: 'center',
+    editable: false,
+    sortable: true,
+  },
+  monthlyUsage: {
+    type: 'numeric',
+    key: 'monthlyUsage',
+    title: tableStrings.monthly_usage,
+    alignText: 'right',
+    sortable: true,
+    editable: false,
+  },
+
+  // EDITABLE NUMERIC COLUMNS
+
+  requiredQuantity: {
+    type: 'editableNumeric',
+    key: 'requiredQuantity',
+    title: tableStrings.required_quantity,
+    alignText: 'right',
+    sortable: true,
+    editable: true,
+  },
+  countedTotalQuantity: {
+    type: 'editableNumeric',
+    key: 'countedTotalQuantity',
+    title: tableStrings.actual_quantity,
+    alignText: 'right',
+    sortable: true,
+    editable: true,
   },
   totalQuantity: {
+    type: 'editableNumeric',
     key: 'totalQuantity',
-    type: 'editable',
     title: tableStrings.quantity,
-    sortable: true,
     alignText: 'right',
+    sortable: true,
+    editable: true,
   },
-  remove: {
-    key: 'remove',
-    type: 'checkable',
-    title: tableStrings.remove,
-    alignText: 'center',
-  },
-  editableExpiryDate: {
-    key: 'expiryDate',
-    type: 'editableDate',
-    title: tableStrings.batch_expiry,
-    alignText: 'center',
+
+  // DATE COLUMNS
+
+  createdDate: {
+    type: 'date',
+    key: 'createdDate',
+    title: tableStrings.created_date,
+    alignText: 'left',
+    sortable: true,
+    editable: false,
   },
   entryDate: {
     type: 'date',
     key: 'entryDate',
     title: tableStrings.entered_date,
     sortable: true,
+    editable: false,
   },
-  numberOfItems: {
-    key: 'numberOfItems',
-    title: tableStrings.items,
-    sortable: true,
-    alignText: 'right',
-  },
-  status: {
-    type: 'status',
-    key: 'status',
-    title: tableStrings.status,
-    sortable: true,
-  },
-  ourStockOnHand: {
-    key: 'ourStockOnHand',
-    title: tableStrings.current_stock,
-    sortable: true,
-    alignText: 'right',
-  },
-  monthlyUsage: {
-    key: 'monthlyUsage',
-    title: tableStrings.monthly_usage,
-    sortable: true,
-    alignText: 'right',
-  },
-  suggestedQuantity: {
-    key: 'suggestedQuantity',
-    title: tableStrings.suggested_quantity,
-    sortable: true,
-    alignText: 'right',
-  },
-  requiredQuantity: {
-    type: 'editable',
-    key: 'requiredQuantity',
-    title: tableStrings.required_quantity,
-    sortable: true,
-    alignText: 'right',
-  },
-  price: {
-    key: 'price',
-    title: tableStrings.price,
+
+  // EDITABLE DATE COLUMNS
+  expiryDate: {
+    type: 'editableDate',
+    key: 'expiryDate',
+    title: tableStrings.batch_expiry,
     alignText: 'center',
+    sortable: false,
+    editable: true,
   },
-  unit: {
-    key: 'unit',
-    title: tableStrings.unit,
-    alignText: 'center',
-  },
-  code: {
-    key: 'code',
-    title: tableStrings.code,
-    alignText: 'left',
-    sortable: true,
-  },
-  name: {
-    key: 'name',
-    title: tableStrings.name,
-    alignText: 'left',
-    sortable: true,
-  },
-  createdDate: {
-    key: 'createdDate',
-    type: 'date',
-    title: tableStrings.created_date,
-    alignText: 'left',
-    sortable: true,
-  },
-  selected: {
-    key: 'selected',
+
+  // CHECKABLE COLUMNS
+  remove: {
     type: 'checkable',
+    key: 'remove',
+    title: tableStrings.remove,
+    alignText: 'center',
+    sortable: false,
+    editable: false,
+  },
+
+  selected: {
+    type: 'checkable',
+    key: 'selected',
     title: tableStrings.selected,
     alignText: 'center',
+    sortable: false,
+    editable: false,
   },
-  difference: {
-    key: 'difference',
-    title: tableStrings.difference,
-    sortable: true,
-    alignText: 'right',
-  },
-  countedTotalQuantity: {
-    type: 'editable',
-    key: 'countedTotalQuantity',
-    title: tableStrings.actual_quantity,
-    sortable: true,
-    alignText: 'right',
-  },
-  snapshotTotalQuantity: {
-    key: 'snapshotTotalQuantity',
-    title: tableStrings.snapshot_quantity,
-    sortable: true,
-    alignText: 'right',
-  },
-  modalControl: {
-    key: 'modalControl',
-    type: 'modalControl',
+
+  // MISC COLUMNS
+
+  batches: {
+    type: 'icon',
+    key: 'batch',
     title: tableStrings.batches,
     sortable: false,
     alignText: 'center',
+    editable: false,
   },
   reason: {
-    type: 'reason',
+    type: 'dropDown',
     key: 'mostUsedReasonTitle',
     title: tableStrings.reason,
     alignText: 'right',
+    sortable: false,
+    editable: false,
   },
 });
 

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -4,7 +4,6 @@
  */
 
 import { tableStrings } from '../../localization';
-import { UIDatabase } from '../../database/index';
 
 const PAGE_COLUMN_WIDTHS = {
   customerInvoice: [2, 4, 2, 2, 1],
@@ -16,7 +15,7 @@ const PAGE_COLUMN_WIDTHS = {
   stocktakes: [6, 2, 2, 1],
   stocktakeManager: [2, 6, 1],
   stocktakeEditor: [1, 2.8, 1.2, 1.2, 1, 0.8],
-  stocktakeEditorReasons: [1, 2.8, 1.2, 1.2, 1, 1, 0.8],
+  stocktakeEditorWithReasons: [1, 2.8, 1.2, 1.2, 1, 1, 0.8],
 };
 
 const PAGE_COLUMNS = {
@@ -61,7 +60,7 @@ const PAGE_COLUMNS = {
     'difference',
     'batches',
   ],
-  stocktakeEditorReasons: [
+  stocktakeEditorWithReasons: [
     'itemCode',
     'itemName',
     'snapshotTotalQuantity',
@@ -323,33 +322,15 @@ const COLUMNS = () => ({
     type: 'dropDown',
     key: 'mostUsedReasonTitle',
     title: tableStrings.reason,
-    alignText: 'right',
+    alignText: 'center',
     sortable: false,
     editable: false,
   },
 });
 
 const getColumns = page => {
-  let columnKeys;
-  let widths;
-
-  switch (page) {
-    case 'stocktakeEditor':
-      {
-        const usesReasons = UIDatabase.objects('StocktakeReasons').length > 0;
-        if (usesReasons) {
-          columnKeys = PAGE_COLUMNS.stocktakeEditorReasons;
-          widths = PAGE_COLUMN_WIDTHS.stocktakeEditorReasons;
-        } else {
-          columnKeys = PAGE_COLUMNS[page];
-          widths = PAGE_COLUMN_WIDTHS[page];
-        }
-      }
-      break;
-    default:
-      columnKeys = PAGE_COLUMNS[page];
-      widths = PAGE_COLUMN_WIDTHS[page];
-  }
+  const widths = PAGE_COLUMN_WIDTHS[page];
+  const columnKeys = PAGE_COLUMNS[page];
 
   if (!columnKeys) return [];
   if (!(columnKeys.length === widths.length)) return [];

--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -39,6 +39,7 @@ const PER_PAGE_INFO_COLUMNS = {
     ['period', 'otherParty', 'programMonthsToSupply', 'requisitionComment'],
   ],
   stocktakeEditor: [['stocktakeName', 'stocktakeComment']],
+  stocktakeEditorWithReasons: [['stocktakeName', 'stocktakeComment']],
 };
 
 const PAGE_INFO_ROWS = (pageObject, dispatch, PageActions) => ({

--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -34,7 +34,7 @@ const PER_PAGE_INFO_COLUMNS = {
     ['entryDate', 'enteredBy'],
     ['otherParty', 'monthsToSupply', 'requisitionComment'],
   ],
-  programSupplierRequisition: [
+  supplierRequisitionWithProgram: [
     ['program', 'orderType', 'entryDate', 'enteredBy'],
     ['period', 'otherParty', 'programMonthsToSupply', 'requisitionComment'],
   ],

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -49,7 +49,9 @@ export const PAGES = {
   supplierInvoice: props => <PageContainer page={SupplierInvoicePage} {...props} />,
   supplierInvoices: props => <PageContainer page={SupplierInvoicesPage} {...props} />,
   supplierRequisition: props => <PageContainer page={SupplierRequisitionPage} {...props} />,
-  programSupplierRequisition: props => <PageContainer page={SupplierRequisitionPage} {...props} />,
+  supplierRequisitionWithProgram: props => (
+    <PageContainer page={SupplierRequisitionPage} {...props} />
+  ),
   supplierRequisitions: props => <PageContainer page={SupplierRequisitionsPage} {...props} />,
 };
 
@@ -84,7 +86,7 @@ export const FINALISABLE_PAGES = {
     recordToFinaliseKey: 'requisition',
     finaliseText: 'finalise_supplier_requisition',
   },
-  programSupplierRequisition: {
+  supplierRequisitionWithProgram: {
     checkForError: checkForSupplierRequisitionError,
     recordType: 'Requisition',
     recordToFinaliseKey: 'requisition',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -44,6 +44,7 @@ export const PAGES = {
   root: props => <PageContainer page={MenuPage} {...props} />,
   stock: props => <PageContainer page={StockPage} {...props} />,
   stocktakeEditor: props => <PageContainer page={StocktakeEditPage} {...props} />,
+  stocktakeEditorWithReasons: props => <PageContainer page={StocktakeEditPage} {...props} />,
   stocktakeManager: props => <PageContainer page={StocktakeManagePage} {...props} />,
   stocktakes: props => <PageContainer page={StocktakesPage} {...props} />,
   supplierInvoice: props => <PageContainer page={SupplierInvoicePage} {...props} />,

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -231,7 +231,7 @@ const DataTableRow = React.memo(
           }
         }
       });
-    }, [isFinalised, rowState]);
+    }, [isFinalised, rowState, rowData, rowIndex]);
 
     const onPressCallback = useCallback(onPress, []);
 

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -233,11 +233,9 @@ const DataTableRow = React.memo(
       });
     }, [isFinalised, rowState, rowData, rowIndex]);
 
-    const onPressCallback = useCallback(onPress, []);
-
     return (
       <Row
-        onPress={onPressCallback}
+        onPress={onPress}
         style={style}
         renderCells={renderCells}
         debug

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -201,6 +201,7 @@ const DataTableRow = React.memo(
             case 'dropDown':
               return (
                 <DropDownCell
+                  key={columnKey}
                   isDisabled={isFinalised}
                   dispatch={dispatch}
                   onPressAction={getAction(columnKey)}

--- a/src/widgets/DataTable/Row.js
+++ b/src/widgets/DataTable/Row.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/forbid-prop-types */
 
-import React, { useContext } from 'react';
+import React, { useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { TouchableOpacity, View } from 'react-native';
@@ -47,12 +47,12 @@ const Row = React.memo(
     }
 
     const { adjustToTop } = useContext(RefContext);
-
+    const onPressRow = useCallback(() => onPress(rowData));
     const onFocus = () => adjustToTop(rowIndex);
 
     const Container = onPress ? TouchableOpacity : View;
     return (
-      <Container onPress={onPress} style={style} onFocus={onFocus}>
+      <Container onPress={onPressRow} style={style} onFocus={onFocus}>
         {renderCells(rowData, rowState, rowKey, rowIndex)}
       </Container>
     );

--- a/src/widgets/DropDownCell.js
+++ b/src/widgets/DropDownCell.js
@@ -27,17 +27,29 @@ const {
  * @param {String}  value           Text value for this cell.
  * @param {Bool}    isLastCell      Indicator whether this cell is the last cell in a row.
  * @param {Number}  width           Flex width of this cell.
+ * @param {String}  placeholder     Text to display when no value is selected.
  * @param {Bool}    debug           Indicator whether logging should occur for this cell.
  */
 const DropDownCell = React.memo(
-  ({ isDisabled, dispatch, onPressAction, rowKey, columnKey, value, isLastCell, width, debug }) => {
+  ({
+    isDisabled,
+    dispatch,
+    onPressAction,
+    rowKey,
+    columnKey,
+    value,
+    isLastCell,
+    width,
+    placeholder,
+    debug,
+  }) => {
     const internalFontStyle = value ? dropDownFont : dropDownPlaceholderFont;
 
     const TouchableChild = () => (
       <View style={{ flexDirection: 'row' }}>
         <View style={dropDownCellTextContainer}>
           <Text numberOfLines={1} ellipsizeMode="tail" style={internalFontStyle}>
-            {value || 'N/A'}
+            {value || { placeholder }}
           </Text>
         </View>
         {!!value && (
@@ -71,6 +83,7 @@ DropDownCell.defaultProps = {
   isDisabled: false,
   value: '',
   isLastCell: false,
+  placeholder: 'N/A',
   debug: false,
 };
 DropDownCell.propTypes = {
@@ -83,4 +96,5 @@ DropDownCell.propTypes = {
   value: PropTypes.string,
   isLastCell: PropTypes.bool,
   debug: PropTypes.bool,
+  placeholder: PropTypes.string,
 };

--- a/src/widgets/GenericChoiceList.js
+++ b/src/widgets/GenericChoiceList.js
@@ -91,7 +91,7 @@ GenericChoiceList.defaultProps = {
 GenericChoiceList.propTypes = {
   keyToDisplay: PropTypes.string.isRequired,
   onPress: PropTypes.func.isRequired,
-  data: PropTypes.array.isRequired,
+  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
   highlightIndex: PropTypes.number,
   highlightValue: PropTypes.string,
 };

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -66,12 +66,10 @@ export const DataTablePageModal = ({
             renderRightText={item => `${item.totalQuantity}`}
           />
         );
+      case MODAL_KEYS.THEIR_REF_EDIT:
       case MODAL_KEYS.STOCKTAKE_COMMENT_EDIT:
       case MODAL_KEYS.TRANSACTION_COMMENT_EDIT:
       case MODAL_KEYS.REQUISITION_COMMENT_EDIT:
-        return <TextEditor text={currentValue} onEndEditing={onSelect} />;
-
-      case MODAL_KEYS.THEIR_REF_EDIT:
         return <TextEditor text={currentValue} onEndEditing={onSelect} />;
 
       case MODAL_KEYS.SELECT_CUSTOMER:

--- a/src/widgets/modals/ModalContainer.js
+++ b/src/widgets/modals/ModalContainer.js
@@ -52,11 +52,7 @@ const ModalContainer = ({ fullScreen, isVisible, onClose, title, children, noCan
     <View style={titleBar}>
       <View style={flexSpacer} />
       {!!title && <Text style={titleFont}>{title}</Text>}
-      {onClose && !noCancel && (
-        <View style={closeButtonContainer}>
-          <CloseButton />
-        </View>
-      )}
+      <View style={closeButtonContainer}>{onClose && !noCancel && <CloseButton />}</View>
     </View>
   );
 
@@ -120,10 +116,8 @@ const localStyles = StyleSheet.create({
   },
   fullScreenChildrenContainer: {
     flex: 1,
-    alignItems: 'stretch',
     paddingLeft: PAGE_CONTENT_PADDING_HORIZONTAL,
     paddingRight: PAGE_CONTENT_PADDING_HORIZONTAL,
-    opacity: 0.94,
   },
   childrenContainer: {
     flex: 1,


### PR DESCRIPTION
#### EPIC: #1043 
#### BRANCHED FROM: #1222 

### NOTE: Branch not runnable due to many files being shifted - branch at #1224 is when the app is runnable again.

Fixes #1220 

## Change summary

- Added use of custom hooks: `useNavigationFocus` and `useSyncListener` to refresh on incoming sync (if a traansaction comes in) as well as on re-focusing the screen
- Added use of `PageActions` for actions
- Explictly defined functions for callbacks

## Testing

See #1043 

### Related areas to think about

N/A
