### PR TITLE
#1138 StocktakeBatchModal refactor -- 13

### DIFF
--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -1,4 +1,5 @@
 import Realm from 'realm';
+
 import { createRecord } from '../utilities';
 
 /**
@@ -131,6 +132,13 @@ export class StocktakeBatch extends Realm.Object {
   }
 
   /**
+   * @return {String} this batches reason title, or an empty string.
+   */
+  get reasonTitle() {
+    return (this.option && this.option.title) || '';
+  }
+
+  /**
    * Set counted total quantity.
    *
    * @param  {number}  quantity
@@ -138,6 +146,16 @@ export class StocktakeBatch extends Realm.Object {
   set countedTotalQuantity(quantity) {
     // Handle packsize of 0.
     this.countedNumberOfPacks = this.packSize ? quantity / this.packSize : 0;
+  }
+
+  /**
+   * Applies a reason to this batch
+   */
+  applyReason(database, reason) {
+    database.write(() => {
+      this.option = reason;
+      database.save('StocktakeBatch', this);
+    });
   }
 
   /**

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -142,7 +142,7 @@ export class StocktakeItem extends Realm.Object {
    * Returns the title of the most common option within this stocktakeItem's batches
    * @return {string} The title of the reason with the highest frequency
    */
-  get mostUsedReasonTitle() {
+  get reasonTitle() {
     if (!this.batches.length) return '';
 
     // Mapping table for ranking reasons by usage

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -298,7 +298,7 @@ export class StocktakeItem extends Realm.Object {
   createNewBatch(database) {
     const batchString = `stocktake_${this.stocktake.serialNumber}`;
     const itemBatch = createRecord(database, 'ItemBatch', this.item, batchString);
-    createRecord(database, 'StocktakeBatch', this, itemBatch, true);
+    return createRecord(database, 'StocktakeBatch', this, itemBatch, true);
   }
 
   /**

--- a/src/localization/modalStrings.js
+++ b/src/localization/modalStrings.js
@@ -26,9 +26,7 @@ export const modalStrings = new LocalizedStrings({
     finalise_customer_invoice: 'Finalise will lock this invoice permanently.',
     finalise_supplier_requisition: 'Finalise will send this requisition and lock it permanently.',
     finalise_customer_requisition:
-      // eslint-disable-next-line no-multi-str
-      'Finalise will generate a finalised customer invoice, adjust inventory, and lock this\
-       requisition permanently.',
+      'Finalise will generate a finalised customer invoice, adjust inventory, and lock this requisition permanently.',
     finalise_stocktake: 'Finalise will adjust inventory and lock this stocktake permanently.',
     finalise_supplier_invoice: 'Finalise will adjust inventory and lock this invoice permanently.',
     following_items_reduced_more_than_available_stock:

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -131,7 +131,7 @@ export const StocktakeEditPage = ({
       case 'remove':
         if (propName === 'onCheckAction') return PageActions.selectRow;
         return PageActions.deselectRow;
-      case 'mostUsedReasonTitle':
+      case 'reasonTitle':
         return onEditReason;
       default:
         return null;

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -151,6 +151,25 @@ export const editCountedQuantity = (value, rowKey) => (dispatch, getState) => {
 };
 
 /**
+ * Edits a StocktakeBatches underlying `countedTotalQuantity`
+ *
+ * @param {String|Number}   value  New value for the underlying `countedTotalQuantity` field
+ * @param {String}          rowKey Key of the row to edit.
+ */
+export const editStocktakeBatchCountedQuantity = (value, rowKey) => (dispatch, getState) => {
+  const { data, keyExtractor } = getState();
+
+  const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
+
+  UIDatabase.write(() => {
+    objectToEdit.countedTotalQuantity = value;
+    UIDatabase.save('StocktakeBatch', UIDatabase);
+  });
+
+  dispatch(refreshRow(rowKey));
+};
+
+/**
  * Removes a reason from a rows underlying data.
  *
  * @param {String} rowKey   Key for the row to edit.
@@ -213,6 +232,7 @@ export const CellActionsLookup = {
   editRequiredQuantity,
   editRequisitionItemRequiredQuantity,
   editCountedQuantity,
+  editStocktakeBatchCountedQuantity,
   removeReason,
   enforceReasonChoice,
   applyReason,
@@ -242,5 +262,17 @@ export const CellActionsLookup = {
  */
 export const editCountedQuantityWithReason = (value, rowKey) => dispatch => {
   dispatch(editCountedQuantity(value, rowKey));
+  dispatch(enforceReasonChoice(rowKey));
+};
+
+/**
+ * Wrapper around `editStocktakeBatchCountedQuantity`, splitting the action to enforce a
+ * reason also.
+ *
+ * @param {String|Number}   value  New value for the underlying `countedTotalQuantity` field
+ * @param {String}          rowKey Key of the row to edit.
+ */
+export const editStocktakeBatchCountedQuantityWithReason = (value, rowKey) => dispatch => {
+  dispatch(editStocktakeBatchCountedQuantity(value, rowKey));
   dispatch(enforceReasonChoice(rowKey));
 };

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -18,6 +18,33 @@ import { openModal, closeModal } from './pageActions';
 export const refreshRow = rowKey => ({ type: ACTIONS.REFRESH_ROW, payload: { rowKey } });
 
 /**
+ * Edits a rows underlying `batch` field.
+ *
+ * @param {Date}    value       The new batch name value.
+ * @param {String}  rowKey      Key of the row to edit.
+ * @param {String}  objectType  Type of object to edit i.e. 'TransactionBatch'
+ */
+export const editBatchName = (value, rowKey, objectType) => (dispatch, getState) => {
+  const { data, keyExtractor } = getState();
+
+  const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
+
+  const { batch } = objectToEdit;
+
+  if (value !== batch) {
+    UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
+
+    dispatch(refreshRow(rowKey));
+  }
+};
+
+/**
+ * Wrapper around editBatchName for StocktakeBatches
+ */
+export const editStocktakeBatchName = (value, rowKey) =>
+  editBatchName(value, rowKey, 'StocktakeBatch');
+
+/**
  * Edits a rows underlying `expiryDate` field.
  *
  * @param {Date}    newDate     The new date to set as the expiry.
@@ -42,6 +69,9 @@ export const editExpiryDate = (newDate, rowKey, objectType) => (dispatch, getSta
  */
 export const editTransactionBatchExpiryDate = (newDate, rowKey) =>
   editExpiryDate(newDate, rowKey, 'TransactionBatch');
+
+export const editStocktakeBatchExpiryDate = (newDate, rowKey) =>
+  editExpiryDate(newDate, rowKey, 'StocktakeBatch');
 
 /**
  * Edits the field `totalQuantity` of a rows underlying data object.
@@ -177,6 +207,7 @@ export const CellActionsLookup = {
   refreshRow,
   editExpiryDate,
   editTransactionBatchExpiryDate,
+  editStocktakeBatchExpiryDate,
   editTotalQuantity,
   editSuppliedQuantity,
   editRequiredQuantity,
@@ -185,6 +216,8 @@ export const CellActionsLookup = {
   removeReason,
   enforceReasonChoice,
   applyReason,
+  editBatchName,
+  editStocktakeBatchName,
 };
 
 /**

--- a/src/pages/dataTableUtilities/actions/getPageActions.js
+++ b/src/pages/dataTableUtilities/actions/getPageActions.js
@@ -44,7 +44,7 @@ const stocktakeEditorWithReasons = {
 
 const stocktakeBatchEditModalWithReasons = {
   ...BasePageActions,
-  editCountedQuantity: editStocktakeBatchCountedQuantityWithReason,
+  editStocktakeBatchCountedQuantity: editStocktakeBatchCountedQuantityWithReason,
 };
 
 /**

--- a/src/pages/dataTableUtilities/actions/getPageActions.js
+++ b/src/pages/dataTableUtilities/actions/getPageActions.js
@@ -4,7 +4,11 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import { CellActionsLookup, editCountedQuantityWithReason } from './cellActions';
+import {
+  CellActionsLookup,
+  editCountedQuantityWithReason,
+  editStocktakeBatchCountedQuantityWithReason,
+} from './cellActions';
 import { RowActionsLookup } from './rowActions';
 import { TableActionsLookup } from './tableActions';
 import { PageActionsLookup } from './pageActions';
@@ -38,6 +42,11 @@ const stocktakeEditorWithReasons = {
   editCountedQuantity: editCountedQuantityWithReason,
 };
 
+const stocktakeBatchEditModalWithReasons = {
+  ...BasePageActions,
+  editCountedQuantity: editStocktakeBatchCountedQuantityWithReason,
+};
+
 /**
  * If actions need to be overriden for a particular routeName,
  * adding them here will pass that new set of actions to the
@@ -45,6 +54,7 @@ const stocktakeEditorWithReasons = {
  */
 const NON_DEFAULT_PAGE_ACTIONS = {
   stocktakeEditorWithReasons,
+  stocktakeBatchEditModalWithReasons,
 };
 
 /**

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -34,6 +34,17 @@ export const filterData = searchTerm => ({
 });
 
 /**
+ * Adds a record to the current stores `data`. Prepends the
+ * added record.
+ *
+ * @param {Any} record A record to add to the current data.
+ */
+export const addRecord = record => ({
+  type: ACTIONS.ADD_RECORD,
+  payload: { record },
+});
+
+/**
  * Refreshes the underlying data array by slicing backingData.
  * BackingData is a live realm collection which side effects i.e.
  * finalising can make out of sync with the data array used for display.
@@ -117,7 +128,7 @@ export const addItem = (item, addedItemType) => (dispatch, getState) => {
   if (!pageObject.hasItem(item)) {
     UIDatabase.write(() => {
       const addedItem = createRecord(UIDatabase, addedItemType, pageObject, item);
-      dispatch({ type: ACTIONS.ADD_RECORD, payload: { record: addedItem } });
+      dispatch(addRecord(addedItem));
     });
   } else {
     dispatch(closeModal());
@@ -146,7 +157,22 @@ export const addTransactionBatch = item => (dispatch, getState) => {
     const transItem = createRecord(UIDatabase, 'TransactionItem', pageObject, item);
     const itemBatch = createRecord(UIDatabase, 'ItemBatch', item, '');
     const addedBatch = createRecord(UIDatabase, 'TransactionBatch', transItem, itemBatch);
-    dispatch({ type: ACTIONS.ADD_RECORD, payload: { record: addedBatch } });
+    dispatch(addRecord(addedBatch));
+  });
+};
+
+/**
+ * Creates a stocktake batch and ItemBatch associated with the stores
+ * pageObject - assumed to be a StocktakeItem.
+ *
+ * use case: StocktakeEditBatchModal adding empty batches.
+ */
+export const addStocktakeBatch = () => (dispatch, getState) => {
+  const { pageObject } = getState();
+
+  UIDatabase.write(() => {
+    const addedBatch = pageObject.createNewBatch(UIDatabase);
+    dispatch(addRecord(addedBatch));
   });
 };
 
@@ -228,4 +254,5 @@ export const TableActionsLookup = {
   addRequisitionItem,
   addStocktakeItem,
   addTransactionItem,
+  addStocktakeBatch,
 };

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -19,6 +19,8 @@ const PAGE_COLUMN_WIDTHS = {
   stocktakeEditorWithReasons: [1, 2.8, 1.2, 1.2, 1, 1, 0.8],
   customerRequisitions: [1.5, 2, 1, 1, 1],
   customerRequisition: [2, 4, 1.5, 1.5, 2, 2, 2, 2],
+  stocktakeBatchEditModal: [1, 1, 1, 1, 1],
+  stocktakeBatchEditModalWithReasons: [1, 1, 1, 1, 1, 1],
 };
 
 const PAGE_COLUMNS = {
@@ -83,6 +85,21 @@ const PAGE_COLUMNS = {
     'suggestedQuantity',
     'requiredQuantity',
     'suppliedQuantity',
+  ],
+  stocktakeBatchEditModal: [
+    'batchName',
+    'expiryDate',
+    'snapshotTotalQuantity',
+    'countedTotalQuantity',
+    'difference',
+  ],
+  stocktakeBatchEditModalWithReasons: [
+    'batchName',
+    'expiryDate',
+    'snapshotTotalQuantity',
+    'countedTotalQuantity',
+    'difference',
+    'reason',
   ],
 };
 

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -376,7 +376,7 @@ const COLUMNS = () => ({
   },
   reason: {
     type: 'dropDown',
-    key: 'mostUsedReasonTitle',
+    key: 'reasonTitle',
     title: tableStrings.reason,
     alignText: 'center',
     sortable: false,

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -18,7 +18,7 @@ const PAGE_COLUMN_WIDTHS = {
   stocktakeEditor: [1, 2.8, 1.2, 1.2, 1, 0.8],
   stocktakeEditorWithReasons: [1, 2.8, 1.2, 1.2, 1, 1, 0.8],
   customerRequisitions: [1.5, 2, 1, 1, 1],
-  customerRequisition: [1.5, 4, 1.5, 1.5, 2, 2, 2, 2],
+  customerRequisition: [2, 4, 1.5, 1.5, 2, 2, 2, 2],
 };
 
 const PAGE_COLUMNS = {

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -73,7 +73,7 @@ const PAGE_COLUMNS = {
     'reason',
     'batches',
   ],
-  customerRequisitions: ['serialNumber', 'supplier', 'numberOfItems', 'entryDate', 'status'],
+  customerRequisitions: ['serialNumber', 'customer', 'numberOfItems', 'entryDate', 'status'],
   customerRequisition: [
     'itemCode',
     'itemName',

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -196,6 +196,7 @@ const COLUMNS = () => ({
     key: 'batch',
     title: tableStrings.batch_name,
     alignText: 'center',
+    editable: true,
   },
 
   // NUMERIC COLUMNS

--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -3,7 +3,7 @@
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2016
  */
-import { pageInfoStrings, programStrings } from '../../localization';
+import { pageInfoStrings, programStrings, tableStrings } from '../../localization';
 import { formatDate } from '../../utilities';
 
 import { MODAL_KEYS } from '../../utilities/getModalTitle';
@@ -41,6 +41,8 @@ const PER_PAGE_INFO_COLUMNS = {
   stocktakeEditor: [['stocktakeName', 'stocktakeComment']],
   stocktakeEditorWithReasons: [['stocktakeName', 'stocktakeComment']],
   customerRequisition: [['monthsToSupply', 'entryDate'], ['customer', 'requisitionComment']],
+  stocktakeBatchEditModal: [['itemName']],
+  stocktakeBatchEditModalWithReasons: [['itemName']],
 };
 
 const PAGE_INFO_ROWS = (pageObject, dispatch, PageActions) => ({
@@ -115,6 +117,11 @@ const PAGE_INFO_ROWS = (pageObject, dispatch, PageActions) => ({
     info: pageObject.name,
     onPress: null,
     editableType: 'text',
+  },
+  itemName: {
+    title: `${tableStrings.item_name}`,
+    info: pageObject.itemName,
+    onPress: null,
   },
 });
 

--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -58,7 +58,7 @@ const PAGE_INFO_ROWS = (pageObject, dispatch, PageActions) => ({
   },
   customer: {
     title: `${pageInfoStrings.customer}:`,
-    info: pageObject.otherParty && pageObject.otherParty.name,
+    info: pageObject.otherPartyName,
   },
   theirRef: {
     title: `${pageInfoStrings.their_ref}:`,

--- a/src/utilities/sortDataBy.js
+++ b/src/utilities/sortDataBy.js
@@ -59,6 +59,8 @@ const sortKeyToType = {
   snapshotTotalQuantity: 'number',
   countedTotalQuantity: 'number',
   difference: 'number',
+  stockOnHand: 'number',
+  suppliedQuantity: 'number',
 };
 
 /**

--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -132,9 +132,9 @@ DataTable.defaultProps = {
   style: defaultStyles.virtualizedList,
   getItem: (items, index) => items[index],
   getItemCount: items => items.length,
-  initialNumToRender: 20,
+  initialNumToRender: 1,
   removeClippedSubviews: true,
-  windowSize: 4,
+  windowSize: 2,
   columns: [],
 };
 

--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -132,7 +132,7 @@ DataTable.defaultProps = {
   style: defaultStyles.virtualizedList,
   getItem: (items, index) => items[index],
   getItemCount: items => items.length,
-  initialNumToRender: 1,
+  initialNumToRender: 10,
   removeClippedSubviews: true,
   windowSize: 2,
   columns: [],

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -158,7 +158,7 @@ export const DataTablePageModal = ({
         return (
           <GenericChoiceList
             data={UIDatabase.objects('StocktakeReasons')}
-            highlightValue={currentValue.mostUsedReasonTitle}
+            highlightValue={currentValue.reasonTitle}
             keyToDisplay="title"
             onPress={onSelect}
           />

--- a/src/widgets/modals/NewStocktakeBatchModal.js
+++ b/src/widgets/modals/NewStocktakeBatchModal.js
@@ -1,406 +1,186 @@
 /* eslint-disable react/forbid-prop-types */
+/* eslint-disable import/prefer-default-export */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
+import { View } from 'react-native';
 
-import { TouchableOpacity, StyleSheet, View, Text } from 'react-native';
-import Icon from 'react-native-vector-icons/FontAwesome';
-import { GenericPage } from '../../pages/GenericPage';
-import { Button, PageButton, ExpiryTextInput, PageInfo, GenericChoiceList } from '..';
-import { PageContentModal } from './PageContentModal';
+import { MODAL_KEYS } from '../../utilities';
+import { usePageReducer } from '../../hooks';
+import { recordKeyExtractor, getItemLayout } from '../../pages/dataTableUtilities';
 
-import {
-  programStrings,
-  tableStrings,
-  buttonStrings,
-  modalStrings,
-  pageInfoStrings,
-} from '../../localization';
-import { parsePositiveInteger } from '../../utilities';
-import globalStyles, {
-  WARM_GREY,
-  SUSSOL_ORANGE,
-  DARK_GREY,
-  dataTableStyles,
-  expansionPageStyles,
-} from '../../globalStyles';
+import { GenericChoiceList } from '../GenericChoiceList';
+import { PageInfo, DataTablePageView, PageButton } from '..';
+import { DataTable, DataTableHeaderRow, DataTableRow } from '../DataTable';
 
-const MODAL_KEYS = {
-  REASON_EDIT: 'reasonEdit',
-};
-export class NewStocktakeBatchModal extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      currentBatch: null,
-      reasons: [],
-      isModalOpen: false,
-      modalKey: null,
-    };
-  }
+import { newPageStyles } from '../../globalStyles';
 
-  componentDidMount = () => {
-    const { database } = this.props;
-    const queryString = 'type == $0 && isActive == true';
-    const reasons = database.objects('Options').filtered(queryString, 'stocktakeLineAdjustment');
-    this.setState({ reasons });
-  };
+import { UIDatabase } from '../../database';
+import ModalContainer from './ModalContainer';
+import { buttonStrings } from '../../localization/index';
 
-  openModal = (key, currentBatch) => {
-    this.setState({ modalKey: key, isModalOpen: true, currentBatch });
-  };
+const stateInitialiser = pageObject => ({
+  pageObject,
+  backingData: pageObject.batches,
+  data: pageObject.batches.slice(),
+  keyExtractor: recordKeyExtractor,
+  dataState: new Map(),
+  sortBy: 'itemName',
+  isAscending: true,
+  modalKey: '',
+  modalValue: null,
+});
 
-  closeModal = () => {
-    this.setState({ isModalOpen: false });
-  };
+/**
+ * Renders a mSupply page with a stocktake loaded for editing
+ *
+ * State:
+ * Uses a reducer to manage state with `backingData` being a realm results
+ * of items to display. `data` is a plain JS array of realm objects. data is
+ * hydrated from the `backingData` for displaying in the interface.
+ * i.e: When filtering, data is populated from filtered items of `backingData`.
+ *
+ * dataState is a simple map of objects corresponding to a row being displayed,
+ * holding the state of a given row. Each object has the shape :
+ * { isSelected, isFocused, isDisabled },
+ *
+ * @prop {Object} stocktake The realm transaction object for this invoice.
+ * @prop {Func}   runWithLoadingIndicator Callback for displaying a fullscreen spinner.
+ * @prop {String} routeName The current route name for the top of the navigation stack.
+ * @prop {Func}   dispatch  Redux store dispatch function.
+ * @prop {Object} navigation App-wide stack navigator reference
+ *
+ */
+export const NewStocktakeBatchModal = ({ stocktakeItem }) => {
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
+    'stocktakeBatchEditModal',
+    {},
+    stateInitialiser,
+    stocktakeItem
+  );
 
-  reasonModalConfirm = ({ item: option }) => {
-    if (option) {
-      const { database } = this.props;
-      const { currentBatch } = this.state;
-      const { id } = currentBatch;
-      database.write(() => database.update('StocktakeBatch', { id, option }));
-    }
-    this.closeModal();
-  };
+  const {
+    pageObject,
+    data,
+    dataState,
+    sortBy,
+    isAscending,
+    modalKey,
+    modalValue,
+    keyExtractor,
+    PageActions,
+    columns,
+    getPageInfoColumns,
+  } = state;
 
-  /**
-   * Opens the reason modal for applying a reason to a stocktakeBatch
-   * if the snapshot quantity and counted total quantity differ.
-   * Otherwise, removes the reason from the stocktake items batches.
-   * @param {Object} stocktakeBatch
-   */
-  assignReason = stocktakeBatch => {
-    const { REASON_EDIT } = MODAL_KEYS;
-    const { database } = this.props;
-    const { id, option, shouldHaveReason } = stocktakeBatch;
-    if (shouldHaveReason) {
-      if (!option) this.openModal(REASON_EDIT, stocktakeBatch);
-    } else database.write(() => database.update('StocktakeBatch', { id, option: null }));
-  };
+  const onEditReason = rowKey => PageActions.openModal(MODAL_KEYS.STOCKTAKE_REASON, rowKey);
+  const onCloseModal = () => dispatch(PageActions.closeModal());
+  const onApplyReason = ({ item }) => dispatch(PageActions.applyReason(item));
 
-  onEndEditing = (key, stocktakeBatch, newValue) => {
-    const { reasons, isModalOpen } = this.state;
-    const { database } = this.props;
-    const { id } = stocktakeBatch;
+  const renderPageInfo = useCallback(
+    () => <PageInfo columns={getPageInfoColumns(pageObject, dispatch, PageActions)} />,
+    []
+  );
 
-    if (!newValue) return;
-    // If the reason modal is open just ignore any change to the current line
-    if (isModalOpen) return;
-    switch (key) {
-      case 'countedTotalQuantity': {
-        const quantity = parsePositiveInteger(newValue);
-        if (quantity === null) return;
-        database.write(() => {
-          stocktakeBatch.countedTotalQuantity = quantity;
-        });
-        database.save(stocktakeBatch);
-        if (reasons.length > 0) this.assignReason(stocktakeBatch);
-        break;
-      }
-      case 'batch': {
-        let newBatchName = '';
-        if (newValue !== `(${tableStrings.no_batch_name})`) newBatchName = newValue;
-        database.write(() => database.update('StocktakeBatch', { id, batch: newBatchName }));
-        break;
-      }
-      case 'expiryDate':
-        database.write(() => database.update('StocktakeBatch', { id, expiryDate: newValue }));
-        break;
-      default:
-        break;
-    }
-  };
-
-  refreshData = () => {
-    const { stocktakeItem } = this.props;
-    this.setState({ data: stocktakeItem.batches });
-  };
-
-  renderCell = (key, stocktakeBatch) => {
-    const { stocktakeItem } = this.props;
-    const { stocktake } = stocktakeItem;
-    const isEditable = !stocktake.isFinalised;
-    const { option } = stocktakeBatch;
-    const { REASON_EDIT } = MODAL_KEYS;
-    switch (key) {
+  const getAction = colKey => {
+    switch (colKey) {
       case 'batch':
-        return {
-          type: isEditable ? 'editable' : 'text',
-          cellContents:
-            stocktakeBatch[key] && stocktakeBatch[key] !== ''
-              ? stocktakeBatch[key]
-              : `(${tableStrings.no_batch_name})`,
-          keyboardType: 'default',
-        };
-      case 'countedTotalQuantity': {
-        const emptyCellContents = isEditable ? '' : tableStrings.not_counted;
-        return {
-          type: isEditable ? 'editable' : 'text',
-          cellContents: stocktakeBatch.hasBeenCounted
-            ? stocktakeBatch.countedTotalQuantity
-            : emptyCellContents,
-          placeholder: tableStrings.not_counted,
-        };
-      }
-      case 'expiryDate': {
-        return (
-          <ExpiryTextInput
-            key={stocktakeBatch.id}
-            isEditable={isEditable}
-            onEndEditing={newValue => {
-              this.onEndEditing(key, stocktakeBatch, newValue);
-              this.refreshData();
-            }}
-            text={stocktakeBatch[key]}
-            style={dataTableStyles.text}
-          />
-        );
-      }
-      case 'difference': {
-        const { difference } = stocktakeBatch;
-        const prefix = difference > 0 ? '+' : '';
-        return { cellContents: `${prefix}${difference}` };
-      }
-      case 'reason': {
-        const onPress = this.openModal.bind(this, REASON_EDIT, stocktakeBatch);
-        const editable = option && isEditable;
-        return (
-          <TouchableOpacity
-            key={stocktakeBatch.id}
-            onPress={editable ? onPress : null}
-            style={localStyles.reasonCell}
-          >
-            {editable && <Icon name="external-link" size={14} color={SUSSOL_ORANGE} />}
-            <Text style={{ width: '80%' }} numberOfLines={1} ellipsizeMode="tail">
-              {stocktakeBatch.option ? stocktakeBatch.option.title : programStrings.not_applicable}
-            </Text>
-          </TouchableOpacity>
-        );
-      }
+        return PageActions.editStocktakeBatchName;
+      case 'countedTotalQuantity':
+        return PageActions.editStocktakeBatchCountedQuantity;
+      case 'expiryDate':
+        return PageActions.editStocktakeBatchExpiryDate;
+      case 'mostUsedReasonTitle':
+        return onEditReason;
       default:
-        return {
-          cellContents: stocktakeBatch[key],
-        };
-    }
-  };
-
-  renderAddBatchButton = () => {
-    const { database, stocktakeItem } = this.props;
-
-    const addNewBatch = () => {
-      database.write(() => {
-        stocktakeItem.createNewBatch(database);
-      });
-      this.refreshData();
-    };
-
-    return (
-      <PageButton
-        text={buttonStrings.add_batch}
-        onPress={addNewBatch}
-        isDisabled={stocktakeItem.stocktake.isFinalised}
-        style={localStyles.addBatchButton}
-      />
-    );
-  };
-
-  renderPageInfo = () => {
-    const { stocktakeItem } = this.props;
-    const { itemName } = stocktakeItem;
-
-    const infoColumns = [
-      [
-        {
-          title: pageInfoStrings.by_batch,
-          info: itemName,
-        },
-      ],
-    ];
-    return <PageInfo columns={infoColumns} />;
-  };
-
-  renderFooter = () => {
-    const { onConfirm } = this.props;
-    return (
-      <View style={localStyles.footer}>
-        <Button
-          text={buttonStrings.done}
-          disabledColor={WARM_GREY}
-          style={[globalStyles.button, localStyles.OKButton]}
-          textStyle={[globalStyles.buttonText, localStyles.OKButtonText]}
-          onPress={onConfirm}
-        />
-      </View>
-    );
-  };
-
-  getModalTitle = () => {
-    const { modalKey } = this.state;
-    const { REASON_EDIT } = MODAL_KEYS;
-    switch (modalKey) {
-      default:
-        return '';
-      case REASON_EDIT:
-        return programStrings.select_a_reason;
-    }
-  };
-
-  renderModalContent = () => {
-    const { modalKey, currentBatch, reasons } = this.state;
-    const { option } = currentBatch;
-    const highlightValue = option && option.title;
-    const { REASON_EDIT } = MODAL_KEYS;
-    switch (modalKey) {
-      default: {
         return null;
-      }
-      case REASON_EDIT: {
-        return (
-          <GenericChoiceList
-            data={reasons}
-            highlightValue={highlightValue}
-            keyToDisplay="title"
-            onPress={this.reasonModalConfirm}
-            title={modalStrings.select_a_reason}
-          />
-        );
-      }
     }
   };
 
-  getColumns = () => {
-    const { reasons } = this.state;
-    const columns = [
-      {
-        key: 'batch',
-        width: 2,
-        title: tableStrings.batch_name,
-        alignText: 'center',
-      },
-      {
-        key: 'expiryDate',
-        width: 1,
-        title: tableStrings.expiry,
-        alignText: 'center',
-      },
-      {
-        key: 'snapshotTotalQuantity',
-        width: 1,
-        title: unwrapText(tableStrings.snapshot_quantity),
-        alignText: 'right',
-      },
-      {
-        key: 'countedTotalQuantity',
-        width: 1,
-        title: unwrapText(tableStrings.actual_quantity),
-        alignText: 'right',
-      },
-      {
-        key: 'difference',
-        width: 1,
-        title: tableStrings.difference,
-        alignText: 'right',
-      },
-    ];
-    if (reasons.length > 0) {
-      columns.push({
-        key: 'reason',
-        width: 1,
-        title: tableStrings.reason,
-        alignText: 'right',
-      });
-    }
-    return columns;
-  };
-
-  render() {
-    const { database, genericTablePageStyles } = this.props;
-    const { data, isModalOpen, modalKey, currentBatch } = this.state;
-    const { REASON_EDIT } = MODAL_KEYS;
-
-    return (
-      <>
-        <GenericPage
-          data={data}
-          renderCell={this.renderCell}
-          refreshData={this.refreshData}
-          hideSearchBar={true}
-          dontRenderSearchBar={true}
-          onEndEditing={this.onEndEditing}
-          renderTopLeftComponent={this.renderPageInfo}
-          renderTopRightComponent={this.renderAddBatchButton}
-          columns={this.getColumns()}
-          dataTypesLinked={['StocktakeBatch', 'Stocktake']}
-          database={database}
-          pageStyles={expansionPageStyles}
-          {...genericTablePageStyles}
+  const renderRow = useCallback(
+    listItem => {
+      const { item, index } = listItem;
+      const rowKey = keyExtractor(item);
+      return (
+        <DataTableRow
+          rowData={data[index]}
+          rowState={dataState.get(rowKey)}
+          rowKey={rowKey}
+          columns={columns}
+          dispatch={dispatch}
+          getAction={getAction}
+          rowIndex={index}
         />
-        {isModalOpen && (
-          <PageContentModal
-            isOpen={isModalOpen}
-            onClose={currentBatch && currentBatch.enforceReason ? null : this.closeModal}
-            title={this.getModalTitle()}
-            coverScreen={modalKey === REASON_EDIT}
-          >
-            {this.renderModalContent()}
-          </PageContentModal>
-        )}
-        {this.renderFooter()}
-      </>
-    );
-  }
-}
+      );
+    },
+    [data, dataState]
+  );
 
-NewStocktakeBatchModal.defaultProps = {
-  genericTablePageStyles: {},
+  const renderHeader = useCallback(
+    () => (
+      <DataTableHeaderRow
+        columns={columns}
+        dispatch={instantDebouncedDispatch}
+        sortAction={PageActions.sortData}
+        isAscending={isAscending}
+        sortBy={sortBy}
+      />
+    ),
+    [sortBy, isAscending]
+  );
+
+  const PageButtons = () => (
+    <PageButton
+      text={buttonStrings.add_batch}
+      onPress={() => dispatch(PageActions.addStocktakeBatch())}
+      isDisabled={stocktakeItem.stocktake.isFinalised}
+    />
+  );
+
+  const {
+    newPageTopSectionContainer,
+    newPageTopLeftSectionContainer,
+    newPageTopRightSectionContainer,
+  } = newPageStyles;
+  return (
+    <DataTablePageView>
+      <View style={newPageTopSectionContainer}>
+        <View style={newPageTopLeftSectionContainer}>{renderPageInfo()}</View>
+        <View style={newPageTopRightSectionContainer}>
+          <PageButtons />
+        </View>
+      </View>
+      <DataTable
+        data={data}
+        extraData={dataState}
+        renderRow={renderRow}
+        renderHeader={renderHeader}
+        keyExtractor={keyExtractor}
+        getItemLayout={getItemLayout}
+        columns={columns}
+      />
+      <ModalContainer
+        fullScreen={modalKey === MODAL_KEYS.ENFORCE_STOCKTAKE_REASON}
+        isVisible={!!modalKey}
+        onClose={onCloseModal}
+      >
+        <GenericChoiceList
+          data={UIDatabase.objects('StocktakeReasons')}
+          highlightValue={modalValue}
+          keyToDisplay="title"
+          onPress={onApplyReason}
+        />
+      </ModalContainer>
+    </DataTablePageView>
+  );
 };
 
 NewStocktakeBatchModal.propTypes = {
-  database: PropTypes.object.isRequired,
-  genericTablePageStyles: PropTypes.object,
   stocktakeItem: PropTypes.object.isRequired,
-  isOpen: PropTypes.bool.isRequired,
-  onConfirm: PropTypes.func.isRequired,
 };
 
 export default NewStocktakeBatchModal;
-
-const unwrapText = text => text.replace(/\n/g, ' ');
-const localStyles = StyleSheet.create({
-  addBatchButton: {
-    height: 30,
-    width: 90,
-  },
-  modal: {
-    height: '100%',
-    width: '100%',
-    padding: 20,
-    backgroundColor: DARK_GREY,
-  },
-  footer: {
-    flex: 1,
-    maxHeight: 50,
-    alignItems: 'flex-end',
-    justifyContent: 'flex-end',
-  },
-  OKButton: {
-    backgroundColor: SUSSOL_ORANGE,
-  },
-  OKButtonText: {
-    color: 'white',
-    fontSize: 16,
-  },
-  reasonCell: {
-    flex: 1,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingLeft: 10,
-    paddingRight: 10,
-  },
-});

--- a/src/widgets/modals/NewStocktakeBatchModal.js
+++ b/src/widgets/modals/NewStocktakeBatchModal.js
@@ -36,7 +36,8 @@ const stateInitialiser = pageObject => ({
 });
 
 /**
- * Renders a mSupply page with a stocktake loaded for editing
+ * Renders a stateful modal with a stocktake item and it's batches loaded
+ * for editing.
  *
  * State:
  * Uses a reducer to manage state with `backingData` being a realm results
@@ -48,16 +49,12 @@ const stateInitialiser = pageObject => ({
  * holding the state of a given row. Each object has the shape :
  * { isSelected, isFocused, isDisabled },
  *
- * @prop {Object} stocktake The realm transaction object for this invoice.
- * @prop {Func}   runWithLoadingIndicator Callback for displaying a fullscreen spinner.
- * @prop {String} routeName The current route name for the top of the navigation stack.
- * @prop {Func}   dispatch  Redux store dispatch function.
- * @prop {Object} navigation App-wide stack navigator reference
+ * @prop {Object} stocktakeItem The realm transaction object for this invoice.
  *
  */
 export const NewStocktakeBatchModal = ({ stocktakeItem }) => {
   const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    'stocktakeBatchEditModal',
+    'stocktakeBatchEditModalWithReasons',
     {},
     stateInitialiser,
     stocktakeItem
@@ -94,7 +91,7 @@ export const NewStocktakeBatchModal = ({ stocktakeItem }) => {
         return PageActions.editStocktakeBatchCountedQuantity;
       case 'expiryDate':
         return PageActions.editStocktakeBatchExpiryDate;
-      case 'mostUsedReasonTitle':
+      case 'reasonTitle':
         return onEditReason;
       default:
         return null;
@@ -162,6 +159,8 @@ export const NewStocktakeBatchModal = ({ stocktakeItem }) => {
         keyExtractor={keyExtractor}
         getItemLayout={getItemLayout}
         columns={columns}
+        windowSize={1}
+        initialNumToRender={1}
       />
       <ModalContainer
         fullScreen={modalKey === MODAL_KEYS.ENFORCE_STOCKTAKE_REASON}

--- a/src/widgets/modals/NewStocktakeBatchModal.js
+++ b/src/widgets/modals/NewStocktakeBatchModal.js
@@ -160,7 +160,6 @@ export const NewStocktakeBatchModal = ({ stocktakeItem }) => {
         getItemLayout={getItemLayout}
         columns={columns}
         windowSize={1}
-        initialNumToRender={1}
       />
       <ModalContainer
         fullScreen={modalKey === MODAL_KEYS.ENFORCE_STOCKTAKE_REASON}

--- a/src/widgets/modals/NewStocktakeBatchModal.js
+++ b/src/widgets/modals/NewStocktakeBatchModal.js
@@ -5,7 +5,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
@@ -53,8 +53,9 @@ const stateInitialiser = pageObject => ({
  *
  */
 export const NewStocktakeBatchModal = ({ stocktakeItem }) => {
+  const usingReasons = useMemo(() => UIDatabase.objects('StocktakeReasons').length > 0, []);
   const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    'stocktakeBatchEditModalWithReasons',
+    usingReasons ? 'stocktakeBatchEditModalWithReasons' : 'stocktakeBatchEditModal',
     {},
     stateInitialiser,
     stocktakeItem
@@ -160,6 +161,7 @@ export const NewStocktakeBatchModal = ({ stocktakeItem }) => {
         getItemLayout={getItemLayout}
         columns={columns}
         windowSize={1}
+        initialNumToRender={0}
       />
       <ModalContainer
         fullScreen={modalKey === MODAL_KEYS.ENFORCE_STOCKTAKE_REASON}
@@ -168,7 +170,7 @@ export const NewStocktakeBatchModal = ({ stocktakeItem }) => {
       >
         <GenericChoiceList
           data={UIDatabase.objects('StocktakeReasons')}
-          highlightValue={modalValue}
+          highlightValue={(modalValue && modalValue.reasonTitle) || ''}
           keyToDisplay="title"
           onPress={onApplyReason}
         />


### PR DESCRIPTION
#### EPIC: #1043 
#### BRANCHED FROM #1227 

Fixes #1138 

## Change summary

- Refactors stocktake batch modal to use the new data table.
- Added getters to `StocktakeBatch` and modified some in `StocktakeItem` to be consistent with each other.

I don't really like this modal in general, I don't think it should be a modal. Don't really like having it so stateful, but I don't think there's really an option. Definitely open to suggestions - but resisted the urge to make this not a modal heh

## Testing

See #1043 

### Related areas to think about

Would be good to go through the `Realm` models and really clean them up soon
