### PR TITLE
#1248 Price/Unit Columns

### DIFF
--- a/src/database/DataTypes/RequisitionItem.js
+++ b/src/database/DataTypes/RequisitionItem.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/prefer-default-export */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
@@ -5,8 +6,11 @@
 
 import Realm from 'realm';
 
-import { Requisition } from './Requisition';
 import { parsePositiveInteger } from '../../utilities';
+
+import { UIDatabase } from '..';
+
+import { SETTINGS_KEYS } from '../../settings';
 
 /**
  * A requisition item (i.e. a requisition line).
@@ -119,8 +123,33 @@ export class RequisitionItem extends Realm.Object {
    * Gets the unit string for this requisition items related item.
    * @return {string}
    */
-  get itemUnit() {
+  get unitString() {
     return this.item.unitString;
+  }
+
+  /**
+   * Gets the price of this requisition item as the maximum price of all
+   * MasterListItems for MasterLists which are related to this store.
+   */
+  get price() {
+    // Get this stores Name record.
+    const thisStoresNameId = UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_NAME_ID);
+    const thisStoresName = UIDatabase.get('Name', thisStoresNameId);
+
+    // Get all MasterList IDs related to this store.
+    const masterListIds = UIDatabase.objects('MasterListNameJoin')
+      .filtered('name == $0', thisStoresName)
+      .map(({ masterList }) => masterList.id);
+
+    // Query string: Query for all MasterList.IDs related to this store and this item.
+    const queryString = `${masterListIds
+      .map(id => `masterList.id == '${id}'`)
+      .join(' OR ')} AND item = $0`;
+
+    // Return the maximum price of all MasterListItems.
+    return UIDatabase.objects('MasterListItem')
+      .filtered(queryString, this)
+      .max('price');
   }
 
   /**
@@ -165,5 +194,3 @@ RequisitionItem.schema = {
     option: { type: 'Options', optional: true },
   },
 };
-
-export default Requisition;

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -2,12 +2,12 @@ import Realm from 'realm';
 
 import { complement } from 'set-manipulator';
 
-import { NUMBER_SEQUENCE_KEYS } from '../index';
 import {
   addBatchToParent,
   createRecord,
   getTotal,
   reuseNumber as reuseSerialNumber,
+  NUMBER_SEQUENCE_KEYS,
 } from '../utilities';
 
 /**

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -136,6 +136,10 @@ class UIDatabase {
     }
   }
 
+  get(...args) {
+    return this.database.get(...args);
+  }
+
   addListener(...args) {
     return this.database.addListener(...args);
   }
@@ -174,6 +178,11 @@ class UIDatabase {
 
   write(...args) {
     return this.database.write(...args);
+  }
+
+  getSetting(key) {
+    const setting = this.database.get('Setting', key, 'key');
+    return setting && setting.value;
   }
 }
 

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -182,7 +182,7 @@ class UIDatabase {
 
   getSetting(key) {
     const setting = this.database.get('Setting', key, 'key');
-    return setting && setting.value;
+    return (setting && setting.value) || '';
   }
 }
 

--- a/src/pages/dataTableUtilities/constants.js
+++ b/src/pages/dataTableUtilities/constants.js
@@ -44,7 +44,7 @@ export const COLUMN_KEYS = {
   SUGGESTED_QUANTITY: 'suggestedQuantity',
   SUPPLIED_QUANTITY: 'suppliedQuantity',
   TOTAL_QUANTITY: 'totalQuantity',
-  UNIT: 'unit',
+  UNIT: 'unitString',
   VALUE: 'value',
 };
 

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -14,7 +14,7 @@ const PAGE_COLUMN_WIDTHS = {
   customerInvoices: [1.5, 2.5, 2, 1.5, 3, 1],
   supplierRequisitions: [1.5, 2, 1, 1, 1, 1],
   supplierRequisition: [1.4, 3.5, 2, 1.5, 2, 2, 1],
-  supplierRequisitionWithProgram: [1.5, 3.5, 0.5, 0.5, 2, 1.5, 2, 2, 1],
+  supplierRequisitionWithProgram: [1.5, 3.5, 1, 1, 2, 1.5, 2, 2, 1],
   stocktakes: [6, 2, 2, 1],
   stocktakeManager: [2, 6, 1],
   stocktakeEditor: [1, 2.8, 1.2, 1.2, 1, 0.8],
@@ -342,7 +342,7 @@ const COLUMNS = () => ({
     title: tableStrings.price,
     alignText: 'center',
     editable: false,
-    sortable: true,
+    sortable: false,
   },
   [COLUMN_NAMES.MONTHLY_USAGE]: {
     type: COLUMN_TYPES.NUMERIC,


### PR DESCRIPTION
Fixes #1248 

## Change summary

- Added pass through of `get` from `UIDatabase` so we can use it now
- Added new call `getSetting` to `UIDatabase` as because all of the many layers on the database there are many dependency cycles - easier to just import `UIDatabase`
- Added pricing algorith mfor requisition items - max price of all master list items for this store

## Testing

See #1043 

### Related areas to think about


N/A
