### PR TITLE
#1249 extract state initialisers

### DIFF
--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -45,6 +45,7 @@ import { debounce } from '../utilities/index';
  */
 export const usePageReducer = (
   initialState,
+  initialiser,
   debounceTimeout = 250,
   instantDebounceTimeout = 250
 ) => {
@@ -52,10 +53,10 @@ export const usePageReducer = (
   const columns = useMemo(() => getColumns(page), []);
   const pageInfoColumns = useMemo(() => getPageInfoColumns(page), []);
   const PageActions = useMemo(() => getPageActions(page), []);
-  const initialiser = useMemo(() => getPageInitialiser(page), []);
+  const pageInitialiser = useMemo(() => initialiser || getPageInitialiser(page), []);
 
   const [pageState, setPageState] = useState({
-    ...(initialiser ? initialiser(pageObject) : initialState),
+    ...(pageInitialiser ? pageInitialiser(pageObject) : initialState),
     columns,
     getPageInfoColumns: pageInfoColumns,
     PageActions,

--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -43,13 +43,12 @@ import { debounce } from '../utilities/index';
  * @param {Number} instantDebounceTimeout Timeout period for an instant debounce
  */
 export const usePageReducer = (
-  page,
   initialState,
   initializer,
-  pageObject,
   debounceTimeout = 250,
   instantDebounceTimeout = 250
 ) => {
+  const { page, pageObject } = initialState;
   const columns = useMemo(() => getColumns(page), []);
   const pageInfoColumns = useMemo(() => getPageInfoColumns(page), []);
   const PageActions = useMemo(() => getPageActions(page), []);

--- a/src/hooks/usePageReducer.js
+++ b/src/hooks/usePageReducer.js
@@ -10,6 +10,7 @@ import {
   getPageActions,
   getColumns,
   getPageInfoColumns,
+  getPageInitialiser,
 } from '../pages/dataTableUtilities';
 
 import { debounce } from '../utilities/index';
@@ -37,14 +38,13 @@ import { debounce } from '../utilities/index';
  *
  * @param {String} page                   routeName for the current page.
  * @param {Object} initialState           Initial state of the reducer
- * @param {Func}   initializer            Function to generate the initial state (optional)
+ * @param {Func}   initialiser            Function to generate the initial state (optional)
  * @param {Object} pageObject             base PageObject for the page i.e. a Requisition.
  * @param {Number} debounceTimeout        Timeout period for a regular debounce
  * @param {Number} instantDebounceTimeout Timeout period for an instant debounce
  */
 export const usePageReducer = (
   initialState,
-  initializer,
   debounceTimeout = 250,
   instantDebounceTimeout = 250
 ) => {
@@ -52,9 +52,10 @@ export const usePageReducer = (
   const columns = useMemo(() => getColumns(page), []);
   const pageInfoColumns = useMemo(() => getPageInfoColumns(page), []);
   const PageActions = useMemo(() => getPageActions(page), []);
+  const initialiser = useMemo(() => getPageInitialiser(page), []);
 
   const [pageState, setPageState] = useState({
-    ...(initializer ? initializer(pageObject) : initialState),
+    ...(initialiser ? initialiser(pageObject) : initialState),
     columns,
     getPageInfoColumns: pageInfoColumns,
     PageActions,

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -11,7 +11,7 @@ import { View } from 'react-native';
 
 import { MODAL_KEYS } from '../utilities';
 import { useRecordListener, usePageReducer } from '../hooks';
-import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
+import { getItemLayout } from './dataTableUtilities';
 
 import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
 import { PageButton, PageInfo, SearchBar, DataTablePageView } from '../widgets';
@@ -19,21 +19,6 @@ import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTabl
 
 import { buttonStrings, modalStrings } from '../localization';
 import globalStyles, { newPageStyles } from '../globalStyles';
-
-const stateInitialiser = pageObject => ({
-  pageObject,
-  backingData: pageObject.items,
-  data: pageObject.items.sorted('item.name').slice(),
-  keyExtractor: recordKeyExtractor,
-  dataState: new Map(),
-  searchTerm: '',
-  filterDataKeys: ['item.name'],
-  sortBy: 'itemName',
-  isAscending: true,
-  modalKey: '',
-  modalValue: null,
-  hasSelection: false,
-});
 
 /**
  * Renders a mSupply mobile page with customer invoice loaded for editing
@@ -54,10 +39,7 @@ const stateInitialiser = pageObject => ({
  */
 export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, routeName }) => {
   const initialState = { page: routeName, pageObject: transaction };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    initialState,
-    stateInitialiser
-  );
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
 
   const {
     data,

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -53,11 +53,10 @@ const stateInitialiser = pageObject => ({
  * @prop {String} routeName The current route name for the top of the navigation stack.
  */
 export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, routeName }) => {
+  const initialState = { page: routeName, pageObject: transaction };
   const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    routeName,
-    {},
-    stateInitialiser,
-    transaction
+    initialState,
+    stateInitialiser
   );
 
   const {

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -43,7 +43,8 @@ export const CustomerInvoicesPage = ({
   navigation,
   dispatch: reduxDispatch,
 }) => {
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(routeName, {}, initializer);
+  const initialState = { page: routeName };
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState, initializer);
   const {
     data,
     dataState,

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -8,10 +8,9 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { UIDatabase } from '../database';
-import { MODAL_KEYS, newSortDataBy } from '../utilities';
+import { MODAL_KEYS } from '../utilities';
 import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
-import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
+import { getItemLayout } from './dataTableUtilities';
 import { gotoCustomerInvoice, createCustomerInvoice } from '../navigation/actions';
 
 import { PageButton, SearchBar, DataTablePageView } from '../widgets';
@@ -21,22 +20,6 @@ import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTabl
 import { buttonStrings, modalStrings } from '../localization';
 import { newPageStyles } from '../globalStyles';
 
-const initializer = () => {
-  const backingData = UIDatabase.objects('CustomerInvoice');
-  return {
-    backingData,
-    data: newSortDataBy(backingData.slice(), 'serialNumber', false),
-    keyExtractor: recordKeyExtractor,
-    dataState: new Map(),
-    searchTerm: '',
-    filterDataKeys: ['otherParty.name'],
-    sortBy: 'serialNumber',
-    isAscending: false,
-    modalKey: '',
-    hasSelection: false,
-  };
-};
-
 export const CustomerInvoicesPage = ({
   currentUser,
   routeName,
@@ -44,7 +27,7 @@ export const CustomerInvoicesPage = ({
   dispatch: reduxDispatch,
 }) => {
   const initialState = { page: routeName };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState, initializer);
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
   const {
     data,
     dataState,

--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -15,25 +15,12 @@ import { DataTablePageModal } from '../widgets/modals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 import { DataTablePageView, PageButton, PageInfo, SearchBar } from '../widgets';
 
-import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
+import { getItemLayout } from './dataTableUtilities';
 
 import { usePageReducer, useRecordListener } from '../hooks';
 
 import globalStyles, { newPageStyles } from '../globalStyles';
 import { buttonStrings } from '../localization';
-
-const stateInitialiser = pageObject => ({
-  pageObject,
-  backingData: pageObject.items,
-  data: pageObject.items.sorted('item.name').slice(),
-  keyExtractor: recordKeyExtractor,
-  dataState: new Map(),
-  searchTerm: '',
-  filterDataKeys: ['item.name', 'item.code'],
-  sortBy: 'itemName',
-  isAscending: true,
-  modalKey: '',
-});
 
 /**
  * Renders a mSupply mobile page with a customer requisition loaded for editing
@@ -54,10 +41,7 @@ const stateInitialiser = pageObject => ({
  */
 export const CustomerRequisitionPage = ({ requisition, runWithLoadingIndicator, routeName }) => {
   const initialState = { page: routeName, pageObject: requisition };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    initialState,
-    stateInitialiser
-  );
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
 
   const {
     data,

--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -53,11 +53,10 @@ const stateInitialiser = pageObject => ({
  * @prop {String} routeName The current route name for the top of the navigation stack.
  */
 export const CustomerRequisitionPage = ({ requisition, runWithLoadingIndicator, routeName }) => {
+  const initialState = { page: routeName, pageObject: requisition };
   const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    routeName,
-    {},
-    stateInitialiser,
-    requisition
+    initialState,
+    stateInitialiser
   );
 
   const {

--- a/src/pages/CustomerRequisitionsPage.js
+++ b/src/pages/CustomerRequisitionsPage.js
@@ -21,7 +21,7 @@ import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
 
 import { newPageStyles } from '../globalStyles';
 
-const initialiseState = () => {
+const stateInitialiser = () => {
   const backingData = UIDatabase.objects('ResponseRequisition');
   const data = newSortDataBy(backingData.slice(), 'serialNumber', false);
   return {
@@ -54,7 +54,8 @@ const initialiseState = () => {
  * @prop {Object} navigation    Reference to the main application stack navigator.
  */
 export const CustomerRequisitionsPage = ({ routeName, dispatch: reduxDispatch, navigation }) => {
-  const [state, dispatch, debouncedDispatch] = usePageReducer(routeName, {}, initialiseState);
+  const initialState = { page: routeName };
+  const [state, dispatch, debouncedDispatch] = usePageReducer(initialState, stateInitialiser);
 
   const { data, sortBy, isAscending, searchTerm, PageActions, columns, keyExtractor } = state;
 

--- a/src/pages/CustomerRequisitionsPage.js
+++ b/src/pages/CustomerRequisitionsPage.js
@@ -12,28 +12,11 @@ import { View } from 'react-native';
 import { SearchBar, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
-import { UIDatabase } from '../database';
-
-import { newSortDataBy } from '../utilities';
 import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
 import { gotoCustomerRequisition } from '../navigation/actions';
 import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
 
 import { newPageStyles } from '../globalStyles';
-
-const stateInitialiser = () => {
-  const backingData = UIDatabase.objects('ResponseRequisition');
-  const data = newSortDataBy(backingData.slice(), 'serialNumber', false);
-  return {
-    backingData,
-    data,
-    keyExtractor: recordKeyExtractor,
-    searchTerm: '',
-    filterDataKeys: ['serialNumber', 'otherStoreName.name'],
-    sortBy: 'serialNumber',
-    isAscending: false,
-  };
-};
 
 /**
  * Renders a mSupply mobile page with a list of Customer requisitions.
@@ -55,7 +38,7 @@ const stateInitialiser = () => {
  */
 export const CustomerRequisitionsPage = ({ routeName, dispatch: reduxDispatch, navigation }) => {
   const initialState = { page: routeName };
-  const [state, dispatch, debouncedDispatch] = usePageReducer(initialState, stateInitialiser);
+  const [state, dispatch, debouncedDispatch] = usePageReducer(initialState);
 
   const { data, sortBy, isAscending, searchTerm, PageActions, columns, keyExtractor } = state;
 

--- a/src/pages/StockPage.js
+++ b/src/pages/StockPage.js
@@ -9,8 +9,7 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { recordKeyExtractor, getItemLayout } from './dataTableUtilities/utilities';
-import { UIDatabase } from '../database';
+import { getItemLayout } from './dataTableUtilities/utilities';
 
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
@@ -20,22 +19,6 @@ import { usePageReducer, useSyncListener } from '../hooks';
 import { DataTablePageView, SearchBar } from '../widgets';
 
 import { ItemDetails } from '../widgets/modals/ItemDetails';
-
-const stateInitialiser = () => {
-  const backingData = UIDatabase.objects('Item').sorted('name');
-
-  return {
-    backingData,
-    data: backingData.slice(),
-    keyExtractor: recordKeyExtractor,
-    dataState: new Map(),
-    searchTerm: '',
-    filterDataKeys: ['name'],
-    sortBy: 'name',
-    isAscending: true,
-    selectedRow: null,
-  };
-};
 
 /**
  * Renders a mSupply mobile page with Items and their stock levels.
@@ -53,11 +36,8 @@ const stateInitialiser = () => {
  * @prop {Object} routeName Name of the current route.
  */
 export const StockPage = ({ routeName }) => {
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    routeName,
-    {},
-    stateInitialiser
-  );
+  const initialState = { page: routeName };
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
 
   const {
     data,

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -11,7 +11,7 @@ import { View } from 'react-native';
 
 import { MODAL_KEYS } from '../utilities';
 import { usePageReducer } from '../hooks/usePageReducer';
-import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
+import { getItemLayout } from './dataTableUtilities';
 
 import { DataTablePageModal } from '../widgets/modals';
 import { PageButton, PageInfo, DataTablePageView, SearchBar } from '../widgets';
@@ -22,20 +22,6 @@ import { gotoStocktakeManagePage } from '../navigation/actions';
 import { buttonStrings } from '../localization';
 import { newPageStyles } from '../globalStyles';
 import { useRecordListener, useNavigationFocus } from '../hooks/index';
-
-const stateInitialiser = pageObject => ({
-  pageObject,
-  backingData: pageObject.items,
-  data: pageObject.items.sorted('item.name').slice(),
-  keyExtractor: recordKeyExtractor,
-  dataState: new Map(),
-  searchTerm: '',
-  filterDataKeys: ['item.name'],
-  sortBy: 'itemName',
-  isAscending: true,
-  modalKey: '',
-  modalValue: null,
-});
 
 /**
  * Renders a mSupply page with a stocktake loaded for editing
@@ -65,10 +51,7 @@ export const StocktakeEditPage = ({
   navigation,
 }) => {
   const initialState = { page: routeName, pageObject: stocktake };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    initialState,
-    stateInitialiser
-  );
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
 
   const {
     pageObject,

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -64,11 +64,10 @@ export const StocktakeEditPage = ({
   dispatch: reduxDispatch,
   navigation,
 }) => {
+  const initialState = { page: routeName, pageObject: stocktake };
   const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    routeName,
-    {},
-    stateInitialiser,
-    stocktake
+    initialState,
+    stateInitialiser
   );
 
   const {

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -47,11 +47,10 @@ export const StocktakeManagePage = ({
   stocktake,
   runWithLoadingIndicator,
 }) => {
+  const initialState = { page: routeName, pageObject: stocktake };
   const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    routeName,
-    {},
-    stateInitialiser,
-    stocktake
+    initialState,
+    stateInitialiser
   );
 
   const {

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -9,10 +9,8 @@ import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { UIDatabase } from '../database';
-
 import { usePageReducer } from '../hooks';
-import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
+import { getItemLayout } from './dataTableUtilities';
 import { createStocktake, updateStocktake } from '../navigation/actions';
 
 import { BottomTextEditor } from '../widgets/modals';
@@ -22,25 +20,6 @@ import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTabl
 import { buttonStrings, modalStrings } from '../localization';
 import { newPageStyles } from '../globalStyles';
 
-const stateInitialiser = pageObject => {
-  const backingData = UIDatabase.objects('Item');
-  return {
-    pageObject,
-    backingData,
-    data: backingData.sorted('name').slice(),
-    keyExtractor: recordKeyExtractor,
-    dataState: new Map(),
-    searchTerm: '',
-    filterDataKeys: ['name', 'code'],
-    name: pageObject ? pageObject.name : '',
-    sortBy: 'name',
-    isAscending: true,
-    hasSelection: false,
-    allSelected: false,
-    showAll: true,
-  };
-};
-
 export const StocktakeManagePage = ({
   routeName,
   dispatch: reduxDispatch,
@@ -48,10 +27,7 @@ export const StocktakeManagePage = ({
   runWithLoadingIndicator,
 }) => {
   const initialState = { page: routeName, pageObject: stocktake };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    initialState,
-    stateInitialiser
-  );
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
 
   const {
     data,

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -50,9 +50,9 @@ const stateInitialiser = () => {
 };
 
 export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch, navigation }) => {
+  const initialState = { page: routeName };
   const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    routeName,
-    {},
+    initialState,
     stateInitialiser
   );
 

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -9,12 +9,9 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { UIDatabase } from '../database';
-import Settings from '../settings/MobileAppSettings';
-
-import { MODAL_KEYS, getAllPrograms } from '../utilities';
+import { MODAL_KEYS } from '../utilities';
 import { usePageReducer, useSyncListener, useNavigationFocus } from '../hooks';
-import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
+import { getItemLayout } from './dataTableUtilities';
 
 import { PageButton, DataTablePageView, SearchBar, ToggleBar } from '../widgets';
 import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
@@ -29,32 +26,9 @@ import {
   gotoStocktakeEditPage,
 } from '../navigation/actions';
 
-const stateInitialiser = () => {
-  const backingData = UIDatabase.objects('Stocktake');
-  return {
-    backingData,
-    data: backingData
-      .filtered('status != $0', 'finalised')
-      .sorted('createdDate', true)
-      .slice(),
-    keyExtractor: recordKeyExtractor,
-    dataState: new Map(),
-    searchTerm: '',
-    filterDataKeys: ['name'],
-    sortBy: 'createdDate',
-    isAscending: false,
-    modalKey: '',
-    hasSelection: false,
-    usingPrograms: getAllPrograms(Settings, UIDatabase).length > 0,
-  };
-};
-
 export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch, navigation }) => {
   const initialState = { page: routeName };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    initialState,
-    stateInitialiser
-  );
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
 
   const {
     data,

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -9,11 +9,9 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { UIDatabase } from '../database';
-
 import { MODAL_KEYS } from '../utilities';
 import { usePageReducer, useRecordListener } from '../hooks';
-import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
+import { getItemLayout } from './dataTableUtilities';
 
 import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
 import { PageButton, PageInfo, SearchBar, DataTablePageView } from '../widgets';
@@ -22,30 +20,9 @@ import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTabl
 import { buttonStrings, modalStrings } from '../localization';
 import globalStyles, { newPageStyles } from '../globalStyles';
 
-const stateInitialiser = pageObject => {
-  const backingData = pageObject.getTransactionBatches(UIDatabase);
-  return {
-    pageObject,
-    backingData,
-    data: backingData.sorted('itemName').slice(),
-    keyExtractor: recordKeyExtractor,
-    dataState: new Map(),
-    searchTerm: '',
-    filterDataKeys: ['itemName'],
-    sortBy: 'itemName',
-    isAscending: true,
-    modalKey: '',
-    modalValue: null,
-    hasSelection: false,
-  };
-};
-
 export const SupplierInvoicePage = ({ routeName, transaction }) => {
   const initialState = { page: routeName, pageObject: transaction };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    initialState,
-    stateInitialiser
-  );
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
 
   const {
     pageObject,

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -41,11 +41,10 @@ const stateInitialiser = pageObject => {
 };
 
 export const SupplierInvoicePage = ({ routeName, transaction }) => {
+  const initialState = { page: routeName, pageObject: transaction };
   const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    routeName,
-    {},
-    stateInitialiser,
-    transaction
+    initialState,
+    stateInitialiser
   );
 
   const {

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -21,7 +21,7 @@ import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTabl
 import { buttonStrings, modalStrings } from '../localization';
 import { newPageStyles } from '../globalStyles';
 
-const initializer = () => {
+const stateInitialiser = () => {
   const backingData = UIDatabase.objects('SupplierInvoice');
   return {
     backingData,
@@ -43,7 +43,11 @@ export const SupplierInvoicesPage = ({
   navigation,
   dispatch: reduxDispatch,
 }) => {
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(routeName, {}, initializer);
+  const initialState = { page: routeName };
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
+    initialState,
+    stateInitialiser
+  );
 
   const {
     data,

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -8,10 +8,9 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { UIDatabase } from '../database';
-import { MODAL_KEYS, newSortDataBy } from '../utilities';
+import { MODAL_KEYS } from '../utilities';
 import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
-import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
+import { getItemLayout } from './dataTableUtilities';
 import { gotoSupplierInvoice, createSupplierInvoice } from '../navigation/actions';
 
 import { PageButton, SearchBar, DataTablePageView } from '../widgets';
@@ -21,22 +20,6 @@ import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTabl
 import { buttonStrings, modalStrings } from '../localization';
 import { newPageStyles } from '../globalStyles';
 
-const stateInitialiser = () => {
-  const backingData = UIDatabase.objects('SupplierInvoice');
-  return {
-    backingData,
-    data: newSortDataBy(backingData.slice(), 'serialNumber', false),
-    keyExtractor: recordKeyExtractor,
-    dataState: new Map(),
-    searchTerm: '',
-    filterDataKeys: ['otherParty.name'],
-    sortBy: 'serialNumber',
-    isAscending: false,
-    modalKey: '',
-    hasSelection: false,
-  };
-};
-
 export const SupplierInvoicesPage = ({
   currentUser,
   routeName,
@@ -44,10 +27,7 @@ export const SupplierInvoicesPage = ({
   dispatch: reduxDispatch,
 }) => {
   const initialState = { page: routeName };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    initialState,
-    stateInitialiser
-  );
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
 
   const {
     data,

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -15,36 +15,12 @@ import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 import { DataTablePageView, PageButton, PageInfo, ToggleBar, SearchBar } from '../widgets';
 
-import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
+import { getItemLayout } from './dataTableUtilities';
 
 import { usePageReducer, useRecordListener } from '../hooks';
 
 import globalStyles, { newPageStyles } from '../globalStyles';
 import { buttonStrings, modalStrings, programStrings } from '../localization';
-
-const stateInitialiser = requisition => {
-  const { program, items: backingData } = requisition;
-  const showAll = !program;
-
-  return {
-    pageObject: requisition,
-    backingData,
-    data: showAll
-      ? backingData.sorted('item.name').slice()
-      : backingData.filter(item => item.isLessThanThresholdMOS),
-    keyExtractor: recordKeyExtractor,
-    dataState: new Map(),
-    currentFocusedRowKey: null,
-    searchTerm: '',
-    filterDataKeys: ['item.name'],
-    sortBy: 'itemName',
-    isAscending: true,
-    modalKey: '',
-    hasSelection: false,
-    showAll,
-    modalValue: null,
-  };
-};
 
 /**
  * Renders a mSupply mobile page with a supplier requisition loaded for editing
@@ -65,10 +41,7 @@ const stateInitialiser = requisition => {
  */
 export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, routeName }) => {
   const initialState = { page: routeName, pageObject: requisition };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    initialState,
-    stateInitialiser
-  );
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
 
   const {
     data,

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -64,11 +64,10 @@ const stateInitialiser = requisition => {
  * @prop {String} routeName The current route name for the top of the navigation stack.
  */
 export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, routeName }) => {
+  const initialState = { page: routeName, pageObject: requisition };
   const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    routeName,
-    {},
-    stateInitialiser,
-    requisition
+    initialState,
+    stateInitialiser
   );
 
   const {

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -64,7 +64,8 @@ export const SupplierRequisitionsPage = ({
   dispatch: reduxDispatch,
   navigation,
 }) => {
-  const [state, dispatch, debouncedDispatch] = usePageReducer(routeName, {}, initialiseState);
+  const initialState = { page: routeName };
+  const [state, dispatch, debouncedDispatch] = usePageReducer(initialState, initialiseState);
 
   const {
     data,

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -15,30 +15,13 @@ import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTabl
 
 import { UIDatabase } from '../database';
 import Settings from '../settings/MobileAppSettings';
-import { MODAL_KEYS, getAllPrograms, newSortDataBy } from '../utilities';
+import { MODAL_KEYS, getAllPrograms } from '../utilities';
 import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
 import { createSupplierRequisition, gotoSupplierRequisition } from '../navigation/actions';
 import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
 
 import globalStyles, { newPageStyles } from '../globalStyles';
 import { buttonStrings, modalStrings } from '../localization';
-
-const initialiseState = () => {
-  const backingData = UIDatabase.objects('RequestRequisition');
-  const data = newSortDataBy(backingData.slice(), 'serialNumber', false);
-  return {
-    backingData,
-    data,
-    keyExtractor: recordKeyExtractor,
-    dataState: new Map(),
-    searchTerm: '',
-    filterDataKeys: ['serialNumber', 'otherStoreName.name'],
-    sortBy: 'serialNumber',
-    isAscending: false,
-    modalKey: '',
-    hasSelection: false,
-  };
-};
 
 /**
  * Renders a mSupply mobile page with a list of supplier requisitions.
@@ -65,7 +48,8 @@ export const SupplierRequisitionsPage = ({
   navigation,
 }) => {
   const initialState = { page: routeName };
-  const [state, dispatch, debouncedDispatch] = usePageReducer(initialState, initialiseState);
+
+  const [state, dispatch, debouncedDispatch] = usePageReducer(initialState);
 
   const {
     data,

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -1,0 +1,216 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import { UIDatabase } from '../../database';
+import Settings from '../../settings/MobileAppSettings';
+
+import { newSortDataBy, getAllPrograms } from '../../utilities';
+import { recordKeyExtractor } from './utilities';
+
+const customerInvoiceInitialiser = pageObject => ({
+  pageObject,
+  backingData: pageObject.items,
+  data: pageObject.items.sorted('item.name').slice(),
+  keyExtractor: recordKeyExtractor,
+  dataState: new Map(),
+  searchTerm: '',
+  filterDataKeys: ['item.name'],
+  sortBy: 'itemName',
+  isAscending: true,
+  modalKey: '',
+  modalValue: null,
+  hasSelection: false,
+});
+
+const customerInvoicesInitialiser = () => {
+  const backingData = UIDatabase.objects('CustomerInvoice');
+  return {
+    backingData,
+    data: newSortDataBy(backingData.slice(), 'serialNumber', false),
+    keyExtractor: recordKeyExtractor,
+    dataState: new Map(),
+    searchTerm: '',
+    filterDataKeys: ['otherParty.name'],
+    sortBy: 'serialNumber',
+    isAscending: false,
+    modalKey: '',
+    hasSelection: false,
+  };
+};
+
+const customerRequisitionInitialiser = pageObject => ({
+  pageObject,
+  backingData: pageObject.items,
+  data: pageObject.items.sorted('item.name').slice(),
+  keyExtractor: recordKeyExtractor,
+  dataState: new Map(),
+  searchTerm: '',
+  filterDataKeys: ['item.name', 'item.code'],
+  sortBy: 'itemName',
+  isAscending: true,
+  modalKey: '',
+});
+
+const customerRequisitionsInitialiser = () => {
+  const backingData = UIDatabase.objects('ResponseRequisition');
+  const data = newSortDataBy(backingData.slice(), 'serialNumber', false);
+  return {
+    backingData,
+    data,
+    keyExtractor: recordKeyExtractor,
+    searchTerm: '',
+    filterDataKeys: ['serialNumber', 'otherStoreName.name'],
+    sortBy: 'serialNumber',
+    isAscending: false,
+  };
+};
+
+const stocktakesInitialiser = () => {
+  const backingData = UIDatabase.objects('Stocktake');
+  return {
+    backingData,
+    data: backingData
+      .filtered('status != $0', 'finalised')
+      .sorted('createdDate', true)
+      .slice(),
+    keyExtractor: recordKeyExtractor,
+    dataState: new Map(),
+    searchTerm: '',
+    filterDataKeys: ['name'],
+    sortBy: 'createdDate',
+    isAscending: false,
+    modalKey: '',
+    hasSelection: false,
+    usingPrograms: getAllPrograms(Settings, UIDatabase).length > 0,
+  };
+};
+
+const stocktakeManagerInitialiser = pageObject => {
+  const backingData = UIDatabase.objects('Item');
+  return {
+    pageObject,
+    backingData,
+    data: backingData.sorted('name').slice(),
+    keyExtractor: recordKeyExtractor,
+    dataState: new Map(),
+    searchTerm: '',
+    filterDataKeys: ['name', 'code'],
+    name: pageObject ? pageObject.name : '',
+    sortBy: 'name',
+    isAscending: true,
+    hasSelection: false,
+    allSelected: false,
+    showAll: true,
+  };
+};
+
+const stocktakeEditorInitialiser = pageObject => ({
+  pageObject,
+  backingData: pageObject.items,
+  data: pageObject.items.sorted('item.name').slice(),
+  keyExtractor: recordKeyExtractor,
+  dataState: new Map(),
+  searchTerm: '',
+  filterDataKeys: ['item.name'],
+  sortBy: 'itemName',
+  isAscending: true,
+  modalKey: '',
+  modalValue: null,
+});
+
+const supplierInvoiceInitialiser = pageObject => {
+  const backingData = pageObject.getTransactionBatches(UIDatabase);
+  return {
+    pageObject,
+    backingData,
+    data: backingData.sorted('itemName').slice(),
+    keyExtractor: recordKeyExtractor,
+    dataState: new Map(),
+    searchTerm: '',
+    filterDataKeys: ['itemName'],
+    sortBy: 'itemName',
+    isAscending: true,
+    modalKey: '',
+    modalValue: null,
+    hasSelection: false,
+  };
+};
+
+const supplierInvoicesInitialiser = () => {
+  const backingData = UIDatabase.objects('SupplierInvoice');
+  return {
+    backingData,
+    data: newSortDataBy(backingData.slice(), 'serialNumber', false),
+    keyExtractor: recordKeyExtractor,
+    dataState: new Map(),
+    searchTerm: '',
+    filterDataKeys: ['otherParty.name'],
+    sortBy: 'serialNumber',
+    isAscending: false,
+    modalKey: '',
+    hasSelection: false,
+  };
+};
+
+const supplierRequisitionInitialiser = requisition => {
+  const { program, items: backingData } = requisition;
+  const showAll = !program;
+
+  return {
+    pageObject: requisition,
+    backingData,
+    data: showAll
+      ? backingData.sorted('item.name').slice()
+      : backingData.filter(item => item.isLessThanThresholdMOS),
+    keyExtractor: recordKeyExtractor,
+    dataState: new Map(),
+    currentFocusedRowKey: null,
+    searchTerm: '',
+    filterDataKeys: ['item.name'],
+    sortBy: 'itemName',
+    isAscending: true,
+    modalKey: '',
+    hasSelection: false,
+    showAll,
+    modalValue: null,
+  };
+};
+
+const supplierRequisitionsInitialiser = () => {
+  const backingData = UIDatabase.objects('RequestRequisition');
+  const data = newSortDataBy(backingData.slice(), 'serialNumber', false);
+  return {
+    backingData,
+    data,
+    keyExtractor: recordKeyExtractor,
+    dataState: new Map(),
+    searchTerm: '',
+    filterDataKeys: ['serialNumber', 'otherStoreName.name'],
+    sortBy: 'serialNumber',
+    isAscending: false,
+    modalKey: '',
+    hasSelection: false,
+  };
+};
+
+const getPageInitialiser = page => {
+  const pageToInitialiser = {
+    customerInvoice: customerInvoiceInitialiser,
+    customerInvoices: customerInvoicesInitialiser,
+    customerRequisition: customerRequisitionInitialiser,
+    customerRequisitions: customerRequisitionsInitialiser,
+    stocktakeEditor: stocktakeEditorInitialiser,
+    stocktakeManager: stocktakeManagerInitialiser,
+    stocktakes: stocktakesInitialiser,
+    supplierInvoice: supplierInvoiceInitialiser,
+    supplierInvoices: supplierInvoicesInitialiser,
+    supplierRequisition: supplierRequisitionInitialiser,
+    supplierRequisitions: supplierRequisitionsInitialiser,
+  };
+
+  return pageToInitialiser[page];
+};
+
+export default getPageInitialiser;

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -102,6 +102,18 @@ const stocktakesInitialiser = () => {
   };
 };
 
+const stocktakeBatchInitialiser = pageObject => ({
+  pageObject,
+  backingData: pageObject.batches,
+  data: pageObject.batches.slice(),
+  keyExtractor: recordKeyExtractor,
+  dataState: new Map(),
+  sortBy: 'itemName',
+  isAscending: true,
+  modalKey: '',
+  modalValue: null,
+});
+
 const stocktakeManagerInitialiser = pageObject => {
   const backingData = UIDatabase.objects('Item');
   return {
@@ -216,6 +228,8 @@ const pageInitialisers = {
   customerRequisition: customerRequisitionInitialiser,
   customerRequisitions: customerRequisitionsInitialiser,
   stock: stockInitialiser,
+  stocktakeBatchEditModal: stocktakeBatchInitialiser,
+  stocktakeBatchEditModalWithReasons: stocktakeBatchInitialiser,
   stocktakeEditor: stocktakeEditorInitialiser,
   stocktakeManager: stocktakeManagerInitialiser,
   stocktakes: stocktakesInitialiser,

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -67,6 +67,21 @@ const customerRequisitionsInitialiser = () => {
   };
 };
 
+const stockInitialiser = () => {
+  const backingData = UIDatabase.objects('Item').sorted('name');
+  return {
+    backingData,
+    data: backingData.slice(),
+    keyExtractor: recordKeyExtractor,
+    dataState: new Map(),
+    searchTerm: '',
+    filterDataKeys: ['name'],
+    sortBy: 'name',
+    isAscending: true,
+    selectedRow: null,
+  };
+};
+
 const stocktakesInitialiser = () => {
   const backingData = UIDatabase.objects('Stocktake');
   return {
@@ -200,6 +215,7 @@ const pageInitialisers = {
   customerInvoices: customerInvoicesInitialiser,
   customerRequisition: customerRequisitionInitialiser,
   customerRequisitions: customerRequisitionsInitialiser,
+  stock: stockInitialiser,
   stocktakeEditor: stocktakeEditorInitialiser,
   stocktakeManager: stocktakeManagerInitialiser,
   stocktakes: stocktakesInitialiser,

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -195,22 +195,20 @@ const supplierRequisitionsInitialiser = () => {
   };
 };
 
-const getPageInitialiser = page => {
-  const pageToInitialiser = {
-    customerInvoice: customerInvoiceInitialiser,
-    customerInvoices: customerInvoicesInitialiser,
-    customerRequisition: customerRequisitionInitialiser,
-    customerRequisitions: customerRequisitionsInitialiser,
-    stocktakeEditor: stocktakeEditorInitialiser,
-    stocktakeManager: stocktakeManagerInitialiser,
-    stocktakes: stocktakesInitialiser,
-    supplierInvoice: supplierInvoiceInitialiser,
-    supplierInvoices: supplierInvoicesInitialiser,
-    supplierRequisition: supplierRequisitionInitialiser,
-    supplierRequisitions: supplierRequisitionsInitialiser,
-  };
-
-  return pageToInitialiser[page];
+const pageInitialisers = {
+  customerInvoice: customerInvoiceInitialiser,
+  customerInvoices: customerInvoicesInitialiser,
+  customerRequisition: customerRequisitionInitialiser,
+  customerRequisitions: customerRequisitionsInitialiser,
+  stocktakeEditor: stocktakeEditorInitialiser,
+  stocktakeManager: stocktakeManagerInitialiser,
+  stocktakes: stocktakesInitialiser,
+  supplierInvoice: supplierInvoiceInitialiser,
+  supplierInvoices: supplierInvoicesInitialiser,
+  supplierRequisition: supplierRequisitionInitialiser,
+  supplierRequisitions: supplierRequisitionsInitialiser,
 };
 
-export default getPageInitialiser;
+const getPageInitialiser = pageToInitialiser => page => pageToInitialiser[page];
+
+export default getPageInitialiser(pageInitialisers);

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -9,10 +9,16 @@ import Settings from '../../settings/MobileAppSettings';
 import { newSortDataBy, getAllPrograms } from '../../utilities';
 import { recordKeyExtractor } from './utilities';
 
-const customerInvoiceInitialiser = pageObject => ({
-  pageObject,
-  backingData: pageObject.items,
-  data: pageObject.items.sorted('item.name').slice(),
+/**
+ * Gets data for initialising a customer invoice page from an associated transaction.
+ *
+ * @param    {Transaction}  transaction
+ * @returns  {object}
+ */
+const customerInvoiceInitialiser = transaction => ({
+  transaction,
+  backingData: transaction.items,
+  data: transaction.items.sorted('item.name').slice(),
   keyExtractor: recordKeyExtractor,
   dataState: new Map(),
   searchTerm: '',
@@ -24,6 +30,11 @@ const customerInvoiceInitialiser = pageObject => ({
   hasSelection: false,
 });
 
+/**
+ * Gets data for initialising a customer invoices page.
+ *
+ * @returns  {object}
+ */
 const customerInvoicesInitialiser = () => {
   const backingData = UIDatabase.objects('CustomerInvoice');
   return {
@@ -40,10 +51,16 @@ const customerInvoicesInitialiser = () => {
   };
 };
 
-const customerRequisitionInitialiser = pageObject => ({
-  pageObject,
-  backingData: pageObject.items,
-  data: pageObject.items.sorted('item.name').slice(),
+/**
+ * Gets data for initialising a customer requisition page from an associated requisition.
+ *
+ * @param    {Requisition}  requisition
+ * @returns  {object}
+ */
+const customerRequisitionInitialiser = requisition => ({
+  requisition,
+  backingData: requisition.items,
+  data: requisition.items.sorted('item.name').slice(),
   keyExtractor: recordKeyExtractor,
   dataState: new Map(),
   searchTerm: '',
@@ -53,6 +70,11 @@ const customerRequisitionInitialiser = pageObject => ({
   modalKey: '',
 });
 
+/**
+ * Gets data for initialising a customer requisitions page.
+ *
+ * @returns  {object}
+ */
 const customerRequisitionsInitialiser = () => {
   const backingData = UIDatabase.objects('ResponseRequisition');
   const data = newSortDataBy(backingData.slice(), 'serialNumber', false);
@@ -67,6 +89,11 @@ const customerRequisitionsInitialiser = () => {
   };
 };
 
+/**
+ * Gets data for initialising a stock page.
+ *
+ * @returns  {object}
+ */
 const stockInitialiser = () => {
   const backingData = UIDatabase.objects('Item').sorted('name');
   return {
@@ -82,6 +109,11 @@ const stockInitialiser = () => {
   };
 };
 
+/**
+ * Gets data for initialising a stocktakes page.
+ *
+ * @returns  {object}
+ */
 const stocktakesInitialiser = () => {
   const backingData = UIDatabase.objects('Stocktake');
   return {
@@ -102,10 +134,16 @@ const stocktakesInitialiser = () => {
   };
 };
 
-const stocktakeBatchInitialiser = pageObject => ({
-  pageObject,
-  backingData: pageObject.batches,
-  data: pageObject.batches.slice(),
+/**
+ * Gets data for initialising a stocktake batch page from an associated stocktake item.
+ *
+ * @param    {StocktakeItem}  stocktakeItem
+ * @returns  {object}
+ */
+const stocktakeBatchInitialiser = stocktakeItem => ({
+  stocktakeItem,
+  backingData: stocktakeItem.batches,
+  data: stocktakeItem.batches.slice(),
   keyExtractor: recordKeyExtractor,
   dataState: new Map(),
   sortBy: 'itemName',
@@ -114,17 +152,23 @@ const stocktakeBatchInitialiser = pageObject => ({
   modalValue: null,
 });
 
-const stocktakeManagerInitialiser = pageObject => {
+/**
+ * Gets data for initialising a manage stocktake page from an associated stocktake item.
+ *
+ * @param    {Stocktake}  stocktake
+ * @returns  {object}
+ */
+const stocktakeManagerInitialiser = stocktake => {
   const backingData = UIDatabase.objects('Item');
   return {
-    pageObject,
+    stocktake,
     backingData,
     data: backingData.sorted('name').slice(),
     keyExtractor: recordKeyExtractor,
     dataState: new Map(),
     searchTerm: '',
     filterDataKeys: ['name', 'code'],
-    name: pageObject ? pageObject.name : '',
+    name: stocktake ? stocktake.name : '',
     sortBy: 'name',
     isAscending: true,
     hasSelection: false,
@@ -133,10 +177,16 @@ const stocktakeManagerInitialiser = pageObject => {
   };
 };
 
-const stocktakeEditorInitialiser = pageObject => ({
-  pageObject,
-  backingData: pageObject.items,
-  data: pageObject.items.sorted('item.name').slice(),
+/**
+ * Gets data for initialising an edit stocktake page from an associated stocktake item.
+ *
+ * @param    {Stocktake}  stocktake
+ * @returns  {object}
+ */
+const stocktakeEditorInitialiser = stocktake => ({
+  stocktake,
+  backingData: stocktake.items,
+  data: stocktake.items.sorted('item.name').slice(),
   keyExtractor: recordKeyExtractor,
   dataState: new Map(),
   searchTerm: '',
@@ -147,10 +197,16 @@ const stocktakeEditorInitialiser = pageObject => ({
   modalValue: null,
 });
 
-const supplierInvoiceInitialiser = pageObject => {
-  const backingData = pageObject.getTransactionBatches(UIDatabase);
+/**
+ * Gets data for initialising a supplier invoice page from an associated transaction item.
+ *
+ * @param    {Transaction}  transaction
+ * @returns  {object}
+ */
+const supplierInvoiceInitialiser = transaction => {
+  const backingData = transaction.getTransactionBatches(UIDatabase);
   return {
-    pageObject,
+    transaction,
     backingData,
     data: backingData.sorted('itemName').slice(),
     keyExtractor: recordKeyExtractor,
@@ -165,6 +221,11 @@ const supplierInvoiceInitialiser = pageObject => {
   };
 };
 
+/**
+ * Gets data for initialising a supplier invoices page.
+ *
+ * @returns  {object}
+ */
 const supplierInvoicesInitialiser = () => {
   const backingData = UIDatabase.objects('SupplierInvoice');
   return {
@@ -181,6 +242,12 @@ const supplierInvoicesInitialiser = () => {
   };
 };
 
+/**
+ * Gets data for initialising a supplier requisition page from an associated requisition.
+ *
+ * @param    {Requisition}  requisition
+ * @returns  {object}
+ */
 const supplierRequisitionInitialiser = requisition => {
   const { program, items: backingData } = requisition;
   const showAll = !program;
@@ -205,6 +272,11 @@ const supplierRequisitionInitialiser = requisition => {
   };
 };
 
+/**
+ * Gets data for initialising a supplier requisitions page.
+ *
+ * @returns  {object}
+ */
 const supplierRequisitionsInitialiser = () => {
   const backingData = UIDatabase.objects('RequestRequisition');
   const data = newSortDataBy(backingData.slice(), 'serialNumber', false);
@@ -239,6 +311,12 @@ const pageInitialisers = {
   supplierRequisitions: supplierRequisitionsInitialiser,
 };
 
+/**
+ * A wrapper for mapping pages to initialisation functions.
+ *
+ * @param    {object}    A mapper from page names to initialisation functions.
+ * @returns  {Function}  A lookup function for retrieving page initialisers.
+ */
 const getPageInitialiser = pageToInitialiser => page => pageToInitialiser[page];
 
 export default getPageInitialiser(pageInitialisers);

--- a/src/pages/dataTableUtilities/index.js
+++ b/src/pages/dataTableUtilities/index.js
@@ -14,5 +14,6 @@ export { recordKeyExtractor, getItemLayout } from './utilities';
 
 import getColumns from './getColumns';
 import getPageInfoColumns from './getPageInfoColumns';
+import getPageInitialiser from './getPageInitialiser';
 
-export { getColumns, getPageInfoColumns };
+export { getColumns, getPageInfoColumns, getPageInitialiser };

--- a/src/widgets/modals/NewStocktakeBatchModal.js
+++ b/src/widgets/modals/NewStocktakeBatchModal.js
@@ -11,7 +11,7 @@ import { View } from 'react-native';
 
 import { MODAL_KEYS } from '../../utilities';
 import { usePageReducer } from '../../hooks';
-import { recordKeyExtractor, getItemLayout } from '../../pages/dataTableUtilities';
+import { getItemLayout } from '../../pages/dataTableUtilities';
 
 import { GenericChoiceList } from '../GenericChoiceList';
 import { PageInfo, DataTablePageView, PageButton } from '..';
@@ -22,18 +22,6 @@ import { newPageStyles } from '../../globalStyles';
 import { UIDatabase } from '../../database';
 import ModalContainer from './ModalContainer';
 import { buttonStrings } from '../../localization/index';
-
-const stateInitialiser = pageObject => ({
-  pageObject,
-  backingData: pageObject.batches,
-  data: pageObject.batches.slice(),
-  keyExtractor: recordKeyExtractor,
-  dataState: new Map(),
-  sortBy: 'itemName',
-  isAscending: true,
-  modalKey: '',
-  modalValue: null,
-});
 
 /**
  * Renders a stateful modal with a stocktake item and it's batches loaded
@@ -54,12 +42,13 @@ const stateInitialiser = pageObject => ({
  */
 export const NewStocktakeBatchModal = ({ stocktakeItem }) => {
   const usingReasons = useMemo(() => UIDatabase.objects('StocktakeReasons').length > 0, []);
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(
-    usingReasons ? 'stocktakeBatchEditModalWithReasons' : 'stocktakeBatchEditModal',
-    {},
-    stateInitialiser,
-    stocktakeItem
-  );
+
+  const initialState = {
+    page: usingReasons ? 'stocktakeBatchEditModalWithReasons' : 'stocktakeBatchEditModal',
+    pageObject: stocktakeItem,
+  };
+
+  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
 
   const {
     pageObject,


### PR DESCRIPTION
Fixes #1249.

## Change summary

Simplifies page logic by moving initialisation logic into a dedicated file and updating the `usePageReducer` hook signature to more closely resemble the standard React `useReducer` hook. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] All pages still work and don't crash!

### Related areas to think about

Updated initialisation naming to UK English 🇬🇧 style (both US and UK were being used in different contexts). If people prefer US 🇺🇸 naming, can update with a quick find/replace.
