### PR TITLE
#1267 Missing StocktakesPage toggle

### DIFF
--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -16,7 +16,7 @@ import { MODAL_KEYS, getAllPrograms } from '../utilities';
 import { usePageReducer, useSyncListener, useNavigationFocus } from '../hooks';
 import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
 
-import { PageButton, DataTablePageView, SearchBar } from '../widgets';
+import { PageButton, DataTablePageView, SearchBar, ToggleBar } from '../widgets';
 import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
@@ -148,6 +148,23 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     );
   }, []);
 
+  const renderToggleBar = () => (
+    <ToggleBar
+      toggles={[
+        {
+          text: buttonStrings.current,
+          onPress: () => {},
+          isOn: true,
+        },
+        {
+          text: buttonStrings.past,
+          onPress: () => {},
+          isOn: !false,
+        },
+      ]}
+    />
+  );
+
   const {
     newPageTopSectionContainer,
     newPageTopLeftSectionContainer,
@@ -157,6 +174,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     <DataTablePageView>
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
+          {renderToggleBar()}
           <SearchBar onChangeText={onFilterData} value={searchTerm} />
         </View>
         <View style={newPageTopRightSectionContainer}>

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -82,6 +82,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
   const onCancelDelete = () => dispatch(PageActions.deselectAll());
   const onConfirmDelete = () => dispatch(PageActions.deleteStocktakes());
   const onCloseModal = () => dispatch(PageActions.closeModal());
+  const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
 
   const onNewStocktake = () => {
     if (usingPrograms) return dispatch(PageActions.openModal(MODAL_KEYS.PROGRAM_STOCKTAKE));
@@ -152,21 +153,16 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     );
   }, []);
 
-  const renderToggleBar = () => (
-    <ToggleBar
-      toggles={[
-        {
-          text: buttonStrings.current,
-          onPress: () => dispatch(PageActions.showNotFinalised()),
-          isOn: !showFinalised,
-        },
-        {
-          text: buttonStrings.past,
-          onPress: () => dispatch(PageActions.showFinalised()),
-          isOn: showFinalised,
-        },
-      ]}
-    />
+  const renderToggleBar = useCallback(
+    () => (
+      <ToggleBar
+        toggles={[
+          { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
+          { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
+        ]}
+      />
+    ),
+    [showFinalised]
   );
 
   const {

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -153,7 +153,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     );
   }, []);
 
-  const renderToggleBar = useCallback(
+  const PastCurrentToggleBar = useCallback(
     () => (
       <ToggleBar
         toggles={[
@@ -174,7 +174,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     <DataTablePageView>
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
-          {renderToggleBar()}
+          <PastCurrentToggleBar />
           <SearchBar onChangeText={onFilterData} value={searchTerm} />
         </View>
         <View style={newPageTopRightSectionContainer}>

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -33,7 +33,10 @@ const stateInitialiser = () => {
   const backingData = UIDatabase.objects('Stocktake');
   return {
     backingData,
-    data: backingData.sorted('createdDate', true).slice(),
+    data: backingData
+      .filtered('status != $0', 'finalised')
+      .sorted('createdDate', true)
+      .slice(),
     keyExtractor: recordKeyExtractor,
     dataState: new Map(),
     searchTerm: '',
@@ -65,6 +68,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     keyExtractor,
     columns,
     PageActions,
+    showFinalised,
   } = state;
 
   const refreshCallback = useCallback(() => dispatch(PageActions.refreshData()), []);
@@ -153,13 +157,13 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
       toggles={[
         {
           text: buttonStrings.current,
-          onPress: () => {},
-          isOn: true,
+          onPress: () => dispatch(PageActions.showNotFinalised()),
+          isOn: !showFinalised,
         },
         {
           text: buttonStrings.past,
-          onPress: () => {},
-          isOn: !false,
+          onPress: () => dispatch(PageActions.showFinalised()),
+          isOn: showFinalised,
         },
       ]}
     />

--- a/src/pages/dataTableUtilities/actions/constants.js
+++ b/src/pages/dataTableUtilities/actions/constants.js
@@ -28,13 +28,13 @@ export const ACTIONS = {
   EDIT_REQUIRED_QUANTITY: 'editRequiredQuantity',
   EDIT_EXPIRY_DATE: 'editExpiryDate',
   ENFORCE_REASON: 'enforceReasonChoice',
-  SELECT_ONE_ROW: 'selectOneRow',
 
   // cellAction constants
   FOCUS_CELL: 'focusCell',
   FOCUS_NEXT: 'focusNext',
   SELECT_ROW: 'selectRow',
   SELECT_ALL: 'selectAll',
+  SELECT_ONE_ROW: 'selectOneRow',
   SELECT_ROWS: 'selectRows',
   DESELECT_ROW: 'deselectRow',
   DESELECT_ALL: 'deselectAll',

--- a/src/pages/dataTableUtilities/actions/constants.js
+++ b/src/pages/dataTableUtilities/actions/constants.js
@@ -13,6 +13,8 @@ export const ACTIONS = {
   ADD_RECORD: 'addRecord',
   HIDE_OVER_STOCKED: 'hideOverStocked',
   HIDE_STOCK_OUT: 'hideStockOut',
+  SHOW_FINALISED: 'showFinalised',
+  SHOW_NOT_FINALISED: 'showNotFinalised',
 
   // pageAction constants
   OPEN_MODAL: 'openModal',

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -73,6 +73,16 @@ export const showFinalised = () => ({ type: ACTIONS.SHOW_FINALISED });
 export const showNotFinalised = () => ({ type: ACTIONS.SHOW_NOT_FINALISED });
 
 /**
+ * Wrapper around showFinalised/showNotFinalised to toggle between. Determines the
+ * correct action to dispatch.
+ *
+ * @param {Bool} showFinalised Indicator wheter finalised rows are currently displayed.
+ */
+export const toggleShowFinalised = showingFinalised => {
+  if (showingFinalised) return showNotFinalised();
+  return showFinalised();
+};
+/**
  * Shows all items, regardless of current stock on hand, toggles
  * showAll to true and removes the current search filtering. Sort is
  * kept stable.
@@ -252,6 +262,7 @@ export const TableActionsLookup = {
   hideOverStocked,
   showNotFinalised,
   showFinalised,
+  toggleShowFinalised,
   hideStockOut,
   showOverStocked,
   showStockOut,

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -63,6 +63,16 @@ export const hideOverStocked = () => ({ type: ACTIONS.HIDE_OVER_STOCKED });
 export const hideStockOut = () => ({ type: ACTIONS.HIDE_STOCK_OUT });
 
 /**
+ * Hides all rows which have a status of finalised.
+ */
+export const showFinalised = () => ({ type: ACTIONS.SHOW_FINALISED });
+
+/**
+ * Shows all rows which do not have the status of finalised.
+ */
+export const showNotFinalised = () => ({ type: ACTIONS.SHOW_NOT_FINALISED });
+
+/**
  * Shows all items, regardless of current stock on hand, toggles
  * showAll to true and removes the current search filtering. Sort is
  * kept stable.
@@ -240,6 +250,8 @@ export const TableActionsLookup = {
   filterData,
   refreshData,
   hideOverStocked,
+  showNotFinalised,
+  showFinalised,
   hideStockOut,
   showOverStocked,
   showStockOut,

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -63,6 +63,30 @@ export const refreshData = state => {
 };
 
 /**
+ * Filters `backingData` by status, setting `data` as all elements whose
+ * status is finalised.
+ */
+export const showFinalised = state => {
+  const { backingData } = state;
+
+  const newData = backingData.filtered('status == $0', 'finalised');
+
+  return { ...state, data: newData, showFinalised: true };
+};
+
+/**
+ * Filters `backingData` by status, setting `data` as all elements whose
+ * status is not finalised.
+ */
+export const showNotFinalised = state => {
+  const { backingData } = state;
+
+  const newData = backingData.filtered('status != $0', 'finalised');
+
+  return { ...state, data: newData, showFinalised: false };
+};
+
+/**
  * Filters backingData by the elements isLessThanThresholdMOS field.
  */
 export const hideOverStocked = state => {
@@ -106,6 +130,8 @@ export const addRecord = (state, action) => {
 
 export const TableReducerLookup = {
   hideStockOut,
+  showNotFinalised,
+  showFinalised,
   addRecord,
   hideOverStocked,
   refreshData,


### PR DESCRIPTION
Fixes #1267 

## Change summary

- Adds back the toggle I forgot about

## Testing

See #1043 

### Related areas to think about

Conflicts with #1266 

Note that this messes up the back navigation a little bit. When navigating back `refreshData` is called which will just display everything. This needs to change with changes made in #1266 such that the state is re-init, rather than `refreshData`