### PR TITLE
#1275 MonthsToSupply Pageinfo switcheroo

### DIFF
--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -4,9 +4,7 @@
  * Sustainable Solutions (NZ) Ltd. 2016
  */
 import { pageInfoStrings, programStrings, tableStrings } from '../../localization';
-import { formatDate } from '../../utilities';
-
-import { MODAL_KEYS } from '../../utilities/getModalTitle';
+import { MODAL_KEYS, formatDate } from '../../utilities';
 
 /**
  * PageInfo rows/columns for use with the PageInfo component.
@@ -32,11 +30,11 @@ const PER_PAGE_INFO_COLUMNS = {
   supplierInvoice: [['entryDate', 'confirmDate'], ['otherParty', 'theirRef', 'transactionComment']],
   supplierRequisition: [
     ['entryDate', 'enteredBy'],
-    ['otherParty', 'monthsToSupply', 'requisitionComment'],
+    ['otherParty', 'editableMonthsToSupply', 'requisitionComment'],
   ],
   supplierRequisitionWithProgram: [
     ['program', 'orderType', 'entryDate', 'enteredBy'],
-    ['period', 'otherParty', 'editableMonthsToSupply', 'requisitionComment'],
+    ['period', 'otherParty', 'monthsToSupply', 'requisitionComment'],
   ],
   stocktakeEditor: [['stocktakeName', 'stocktakeComment']],
   stocktakeEditorWithReasons: [['stocktakeName', 'stocktakeComment']],


### PR DESCRIPTION
Fixes #1275 

## Change summary

- Switches the `pageInfo` used in `SupplierRequisition` and `SupplierRequisitionWithPrograms` such that a non-program requisition months to supply is editable, where as a program requisition is not (it is set by the max MOS of the order type chosen on creation)

## Testing

See #1043 

### Related areas to think about

Defining constants for page info isn't overkill right?
