### PR TITLE
#1277 Expiry date column key

### DIFF
--- a/src/pages/dataTableUtilities/constants.js
+++ b/src/pages/dataTableUtilities/constants.js
@@ -5,13 +5,13 @@
 
 export const COLUMN_TYPES = {
   CHECKABLE: 'checkable',
-  DATE_EDITABLE: 'editableDate',
+  EDITABLE_EXPIRY_DATE: 'editableExpiryDate',
   DATE: 'date',
   DROP_DOWN: 'dropdown',
   ICON: 'icon',
-  NUMERIC_EDITABLE: 'editableNumeric',
+  EDITABLE_NUMERIC: 'editableNumeric',
   NUMERIC: 'numeric',
-  STRING_EDITABLE: 'editableString',
+  EDITABLE_STRING: 'editableString',
   STRING: 'string',
 };
 
@@ -63,7 +63,7 @@ export const COLUMN_NAMES = {
   EDITABLE_VALUE: 'editableValue',
   EDITABLE_TOTAL_QUANTITY: 'editableTotalQuantity',
   ENTRY_DATE: 'entryDate',
-  EXPIRY_DATE: 'expiryDate',
+  EDITABLE_EXPIRY_DATE: 'editableExpiryDate',
   INVOICE_NUMBER: 'invoiceNumber',
   ITEM_CODE: 'itemCode',
   ITEM_NAME: 'itemName',

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -47,7 +47,7 @@ const PAGE_COLUMNS = {
     COLUMN_NAMES.ITEM_CODE,
     COLUMN_NAMES.ITEM_NAME,
     COLUMN_NAMES.EDITABLE_TOTAL_QUANTITY,
-    COLUMN_NAMES.EXPIRY_DATE,
+    COLUMN_NAMES.EDITABLE_EXPIRY_DATE,
     COLUMN_NAMES.REMOVE,
   ],
   supplierInvoices: [
@@ -129,14 +129,14 @@ const PAGE_COLUMNS = {
   ],
   stocktakeBatchEditModal: [
     COLUMN_NAMES.BATCH_NAME,
-    COLUMN_NAMES.EXPIRY_DATE,
+    COLUMN_NAMES.EDITABLE_EXPIRY_DATE,
     COLUMN_NAMES.SNAPSHOT_TOTAL_QUANTITY,
     COLUMN_NAMES.COUNTED_TOTAL_QUANTITY,
     COLUMN_NAMES.DIFFERENCE,
   ],
   stocktakeBatchEditModalWithReasons: [
     COLUMN_NAMES.BATCH_NAME,
-    COLUMN_NAMES.EXPIRY_DATE,
+    COLUMN_NAMES.EDITABLE_EXPIRY_DATE,
     COLUMN_NAMES.SNAPSHOT_TOTAL_QUANTITY,
     COLUMN_NAMES.COUNTED_TOTAL_QUANTITY,
     COLUMN_NAMES.DIFFERENCE,
@@ -247,14 +247,14 @@ const COLUMNS = () => ({
   // EDITABLE STRING COLUMNS
 
   [COLUMN_NAMES.BATCH_NAME]: {
-    type: COLUMN_TYPES.STRING_EDITABLE,
+    type: COLUMN_TYPES.EDITABLE_STRING,
     key: COLUMN_KEYS.BATCH,
     title: tableStrings.batch_name,
     alignText: 'center',
     editable: true,
   },
   [COLUMN_NAMES.EDITABLE_COMMENT]: {
-    type: COLUMN_TYPES.STRING_EDITABLE,
+    type: COLUMN_TYPES.EDITABLE_STRING,
     key: COLUMN_KEYS.COMMENT,
     title: tableStrings.comment,
     textAlign: 'right',
@@ -262,7 +262,7 @@ const COLUMNS = () => ({
     editable: true,
   },
   [COLUMN_NAMES.EDITABLE_VALUE]: {
-    type: COLUMN_TYPES.STRING_EDITABLE,
+    type: COLUMN_TYPES.EDITABLE_STRING,
     key: COLUMN_KEYS.VALUE,
     title: 'value',
     textAlign: 'right',
@@ -364,7 +364,7 @@ const COLUMNS = () => ({
   // EDITABLE NUMERIC COLUMNS
 
   [COLUMN_NAMES.EDITABLE_REQUIRED_QUANTITY]: {
-    type: COLUMN_TYPES.NUMERIC_EDITABLE,
+    type: COLUMN_TYPES.EDITABLE_NUMERIC,
     key: COLUMN_KEYS.REQUIRED_QUANTITY,
     title: tableStrings.required_quantity,
     alignText: 'right',
@@ -372,7 +372,7 @@ const COLUMNS = () => ({
     editable: true,
   },
   [COLUMN_NAMES.COUNTED_TOTAL_QUANTITY]: {
-    type: COLUMN_TYPES.NUMERIC_EDITABLE,
+    type: COLUMN_TYPES.EDITABLE_NUMERIC,
     key: COLUMN_KEYS.COUNTED_TOTAL_QUANTITY,
     title: tableStrings.actual_quantity,
     alignText: 'right',
@@ -380,7 +380,7 @@ const COLUMNS = () => ({
     editable: true,
   },
   [COLUMN_NAMES.EDITABLE_TOTAL_QUANTITY]: {
-    type: COLUMN_TYPES.NUMERIC_EDITABLE,
+    type: COLUMN_TYPES.EDITABLE_NUMERIC,
     key: COLUMN_KEYS.TOTAL_QUANTITY,
     title: tableStrings.quantity,
     alignText: 'right',
@@ -388,7 +388,7 @@ const COLUMNS = () => ({
     editable: true,
   },
   [COLUMN_NAMES.SUPPLIED_QUANTITY]: {
-    type: COLUMN_TYPES.NUMERIC_EDITABLE,
+    type: COLUMN_TYPES.EDITABLE_NUMERIC,
     key: COLUMN_KEYS.SUPPLIED_QUANTITY,
     title: tableStrings.supply_quantity,
     alignText: 'right',
@@ -415,8 +415,8 @@ const COLUMNS = () => ({
   },
 
   // EDITABLE DATE COLUMNS
-  [COLUMN_NAMES.EXPIRY_DATE]: {
-    type: COLUMN_TYPES.DATE,
+  [COLUMN_NAMES.EDITABLE_EXPIRY_DATE]: {
+    type: COLUMN_TYPES.EDITABLE_EXPIRY_DATE,
     key: COLUMN_KEYS.EXPIRY_DATE,
     title: tableStrings.batch_expiry,
     alignText: 'center',

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -87,8 +87,8 @@ const DataTableRow = React.memo(
           const cellAlignment = alignText || 'left';
 
           switch (type) {
-            case COLUMN_TYPES.STRING_EDITABLE:
-            case COLUMN_TYPES.NUMERIC_EDITABLE:
+            case COLUMN_TYPES.EDITABLE_STRING:
+            case COLUMN_TYPES.EDITABLE_NUMERIC:
               return (
                 <TextInputCell
                   key={columnKey}
@@ -112,7 +112,7 @@ const DataTableRow = React.memo(
                 />
               );
 
-            case COLUMN_TYPES.DATE_EDITABLE:
+            case COLUMN_TYPES.EXPIRY_DATE_EDITABLE:
               return (
                 <NewExpiryDateInput
                   key={columnKey}

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -103,7 +103,7 @@ const DataTableRow = React.memo(
                   textViewStyle={editableCellTextView}
                   isLastCell={isLastCell}
                   keyboardType={
-                    type === COLUMN_TYPES.NUMERIC ? COLUMN_TYPES.NUMERIC_EDITABLE : 'default'
+                    type === COLUMN_TYPES.NUMERIC ? COLUMN_TYPES.EDITABLE_NUMERIC : 'default'
                   }
                   textInputStyle={cellText[cellAlignment]}
                   textStyle={editableCellUnfocused[cellAlignment]}


### PR DESCRIPTION
Fixes #1277 

## Change summary

- Column type of expiry date was `editableExpiryDate` but `DataTableRow` was trying to render `EDITABLE_DATE` - corrected this
- Also changed types to be in the form `EDITABLE_XX` from `XX_EDITABLE` just to match the actual scalar value `editableXXX` cause I was getting confused

## Testing

See #1043 

### Related areas to think about

N/A
