### PR TITLE
#1288 Keyboard dismissal on last cell

### DIFF
--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { useMemo, useRef, useCallback } from 'react';
-import { StyleSheet, VirtualizedList, VirtualizedListPropTypes } from 'react-native';
+import { StyleSheet, VirtualizedList, VirtualizedListPropTypes, Keyboard } from 'react-native';
 import RefContext from './RefContext';
 
 /**
@@ -69,11 +69,13 @@ const DataTable = React.memo(({ renderRow, renderHeader, style, data, columns, .
     return newRef;
   };
 
-  // Focuses the next editable cell in the list. Back to the top on last row.
+  // Focuses the next editable cell in the list. On the last row, dismiss the keyboard.
   const focusNextCell = refIndex => {
+    if (refIndex + 1 === numberOfEditableCells) return Keyboard.dismiss();
+
     const cellRef = getCellRef((refIndex + 1) % numberOfEditableCells);
 
-    cellRef.current.focus();
+    return cellRef.current.focus();
   };
 
   // Adjusts the passed row to the top of the list.

--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -71,9 +71,11 @@ const DataTable = React.memo(({ renderRow, renderHeader, style, data, columns, .
 
   // Focuses the next editable cell in the list. On the last row, dismiss the keyboard.
   const focusNextCell = refIndex => {
-    if (refIndex + 1 === numberOfEditableCells) return Keyboard.dismiss();
+    const lastRefIndex = numberOfEditableCells - 1;
+    if (refIndex === lastRefIndex) return Keyboard.dismiss();
 
-    const cellRef = getCellRef((refIndex + 1) % numberOfEditableCells);
+    const nextCellRef = (refIndex + 1) % numberOfEditableCells;
+    const cellRef = getCellRef(nextCellRef);
 
     return cellRef.current.focus();
   };


### PR DESCRIPTION
Fixes #1288 

## Change summary

- When you get to the end of the list of items in a table, dismiss the keyboard on submitting

## Testing

See #1043 

### Related areas to think about

N/A