### PR TITLE
#1294 sorting performance

### DIFF
--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -131,25 +131,6 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
     [data, dataState]
   );
 
-  const renderButtons = () => {
-    const { verticalContainer, topButton } = globalStyles;
-    return (
-      <View style={verticalContainer}>
-        <PageButton
-          style={{ ...topButton, marginLeft: 0 }}
-          text={buttonStrings.new_item}
-          onPress={onNewRow}
-          isDisabled={isFinalised}
-        />
-        <PageButton
-          text={buttonStrings.add_master_list_items}
-          onPress={onAddMasterList}
-          isDisabled={isFinalised}
-        />
-      </View>
-    );
-  };
-
   const renderHeader = useCallback(
     () => (
       <DataTableHeaderRow
@@ -163,6 +144,7 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
     [sortBy, isAscending]
   );
 
+  const { verticalContainer, topButton } = globalStyles;
   const {
     newPageTopSectionContainer,
     newPageTopLeftSectionContainer,
@@ -176,7 +158,21 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
           {renderPageInfo()}
           <SearchBar onChangeText={onFilterData} style={searchBar} value={searchTerm} />
         </View>
-        <View style={newPageTopRightSectionContainer}>{renderButtons()}</View>
+        <View style={newPageTopRightSectionContainer}>
+          <View style={verticalContainer}>
+            <PageButton
+              style={{ ...topButton, marginLeft: 0 }}
+              text={buttonStrings.new_item}
+              onPress={onNewRow}
+              isDisabled={isFinalised}
+            />
+            <PageButton
+              text={buttonStrings.add_master_list_items}
+              onPress={onAddMasterList}
+              isDisabled={isFinalised}
+            />
+          </View>
+        </View>
       </View>
       <DataTable
         data={data}

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -13,7 +13,7 @@ import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
 import { getItemLayout } from './dataTableUtilities';
 import { gotoCustomerInvoice, createCustomerInvoice } from '../navigation/actions';
 
-import { PageButton, SearchBar, DataTablePageView } from '../widgets';
+import { PageButton, SearchBar, DataTablePageView, ToggleBar } from '../widgets';
 import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
@@ -39,6 +39,7 @@ export const CustomerInvoicesPage = ({
     searchTerm,
     columns,
     PageActions,
+    showFinalised,
   } = state;
 
   // Listen to changes from sync and navigation events re-focusing this screen,
@@ -52,6 +53,7 @@ export const CustomerInvoicesPage = ({
   const onNewInvoice = () => dispatch(PageActions.openModal(MODAL_KEYS.SELECT_CUSTOMER));
   const onConfirmDelete = () => dispatch(PageActions.deleteTransactions());
   const onCancelDelete = () => dispatch(PageActions.deselectAll());
+  const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
 
   const onNavigateToInvoice = useCallback(
     invoice => reduxDispatch(gotoCustomerInvoice(invoice)),
@@ -119,6 +121,18 @@ export const CustomerInvoicesPage = ({
     <PageButton text={buttonStrings.new_invoice} onPress={onNewInvoice} />
   );
 
+  const PastCurrentToggleBar = useCallback(
+    () => (
+      <ToggleBar
+        toggles={[
+          { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
+          { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
+        ]}
+      />
+    ),
+    [showFinalised]
+  );
+
   const {
     newPageTopSectionContainer,
     newPageTopLeftSectionContainer,
@@ -128,6 +142,7 @@ export const CustomerInvoicesPage = ({
     <DataTablePageView>
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
+          <PastCurrentToggleBar />
           <SearchBar onChangeText={onFilterData} value={searchTerm} />
         </View>
         <View style={newPageTopRightSectionContainer}>

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -4,7 +4,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
@@ -65,6 +65,14 @@ export const CustomerInvoicesPage = ({
     onCloseModal();
   };
 
+  const toggles = useMemo(
+    () => [
+      { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
+      { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
+    ],
+    [showFinalised]
+  );
+
   const getAction = (colKey, propName) => {
     switch (colKey) {
       case 'remove':
@@ -117,22 +125,6 @@ export const CustomerInvoicesPage = ({
     [sortBy, isAscending]
   );
 
-  const NewInvoiceButton = () => (
-    <PageButton text={buttonStrings.new_invoice} onPress={onNewInvoice} />
-  );
-
-  const PastCurrentToggleBar = useCallback(
-    () => (
-      <ToggleBar
-        toggles={[
-          { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
-          { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
-        ]}
-      />
-    ),
-    [showFinalised]
-  );
-
   const {
     newPageTopSectionContainer,
     newPageTopLeftSectionContainer,
@@ -142,11 +134,11 @@ export const CustomerInvoicesPage = ({
     <DataTablePageView>
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
-          <PastCurrentToggleBar />
+          <ToggleBar toggles={toggles} />
           <SearchBar onChangeText={onFilterData} value={searchTerm} />
         </View>
         <View style={newPageTopRightSectionContainer}>
-          <NewInvoiceButton />
+          <PageButton text={buttonStrings.new_invoice} onPress={onNewInvoice} />
         </View>
       </View>
       <DataTable

--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -136,37 +136,6 @@ export const CustomerRequisitionPage = ({ requisition, runWithLoadingIndicator, 
     [sortBy, isAscending]
   );
 
-  const UseSuggestedQuantitiesButton = () => (
-    <View>
-      <PageButton
-        style={globalStyles.topButton}
-        text={buttonStrings.use_suggested_quantities}
-        onPress={onSetSuppliedToSuggested}
-        isDisabled={isFinalised}
-      />
-    </View>
-  );
-
-  const UseRequestedQuantitiesButton = () => (
-    <PageButton
-      style={globalStyles.topButton}
-      text={buttonStrings.use_requested_quantities}
-      onPress={onSetSuppliedToRequested}
-      isDisabled={requisition.isFinalised}
-    />
-  );
-
-  const PageButtons = useCallback(() => {
-    const { verticalContainer } = globalStyles;
-
-    return (
-      <View style={verticalContainer}>
-        <UseRequestedQuantitiesButton />
-        <UseSuggestedQuantitiesButton />
-      </View>
-    );
-  }, []);
-
   const {
     newPageTopSectionContainer,
     newPageTopLeftSectionContainer,
@@ -180,7 +149,18 @@ export const CustomerRequisitionPage = ({ requisition, runWithLoadingIndicator, 
           <SearchBar onChangeText={onFilterData} value={searchTerm} />
         </View>
         <View style={newPageTopRightSectionContainer}>
-          <PageButtons />
+          <PageButton
+            style={globalStyles.topButton}
+            text={buttonStrings.use_requested_quantities}
+            onPress={onSetSuppliedToRequested}
+            isDisabled={requisition.isFinalised}
+          />
+          <PageButton
+            style={globalStyles.topButton}
+            text={buttonStrings.use_suggested_quantities}
+            onPress={onSetSuppliedToSuggested}
+            isDisabled={isFinalised}
+          />
         </View>
       </View>
       <DataTable

--- a/src/pages/CustomerRequisitionsPage.js
+++ b/src/pages/CustomerRequisitionsPage.js
@@ -9,7 +9,7 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { SearchBar, DataTablePageView } from '../widgets';
+import { SearchBar, DataTablePageView, ToggleBar } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
 import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
@@ -17,6 +17,7 @@ import { gotoCustomerRequisition } from '../navigation/actions';
 import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
 
 import { newPageStyles } from '../globalStyles';
+import { buttonStrings } from '../localization';
 
 /**
  * Renders a mSupply mobile page with a list of Customer requisitions.
@@ -40,7 +41,16 @@ export const CustomerRequisitionsPage = ({ routeName, dispatch: reduxDispatch, n
   const initialState = { page: routeName };
   const [state, dispatch, debouncedDispatch] = usePageReducer(initialState);
 
-  const { data, sortBy, isAscending, searchTerm, PageActions, columns, keyExtractor } = state;
+  const {
+    data,
+    sortBy,
+    isAscending,
+    searchTerm,
+    PageActions,
+    columns,
+    keyExtractor,
+    showFinalised,
+  } = state;
 
   const refreshCallback = () => dispatch(PageActions.refreshData(), []);
   // Custom hook to refresh data on this page when becoming the head of the stack again.
@@ -49,7 +59,8 @@ export const CustomerRequisitionsPage = ({ routeName, dispatch: reduxDispatch, n
   useSyncListener(refreshCallback, 'Requisition');
 
   const onPressRow = useCallback(rowData => reduxDispatch(gotoCustomerRequisition(rowData)), []);
-  const onSearchFiltering = value => dispatch(PageActions.filterData(value));
+  const onFilterData = value => dispatch(PageActions.filterData(value));
+  const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
 
   const renderRow = useCallback(
     listItem => {
@@ -82,11 +93,26 @@ export const CustomerRequisitionsPage = ({ routeName, dispatch: reduxDispatch, n
     [sortBy, isAscending]
   );
 
-  const { newPageTopSectionContainer } = newPageStyles;
+  const PastCurrentToggleBar = useCallback(
+    () => (
+      <ToggleBar
+        toggles={[
+          { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
+          { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
+        ]}
+      />
+    ),
+    [showFinalised]
+  );
+
+  const { newPageTopSectionContainer, newPageTopLeftSectionContainer } = newPageStyles;
   return (
     <DataTablePageView>
       <View style={newPageTopSectionContainer}>
-        <SearchBar onChangeText={onSearchFiltering} value={searchTerm} />
+        <View style={newPageTopLeftSectionContainer}>
+          <PastCurrentToggleBar />
+          <SearchBar onChangeText={onFilterData} value={searchTerm} />
+        </View>
       </View>
       <DataTable
         data={data}

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -169,18 +169,6 @@ export const StocktakeEditPage = ({
     [sortBy, isAscending]
   );
 
-  const PageButtons = useCallback(() => {
-    const ManageStocktake = (
-      <PageButton
-        text={buttonStrings.manage_stocktake}
-        onPress={onManageStocktake}
-        isDisabled={isFinalised}
-      />
-    );
-
-    return <View style={newPageTopRightSectionContainer}>{program ? null : ManageStocktake}</View>;
-  }, [program]);
-
   const {
     newPageTopSectionContainer,
     newPageTopLeftSectionContainer,
@@ -193,7 +181,15 @@ export const StocktakeEditPage = ({
           {renderPageInfo()}
           <SearchBar onChangeText={onFilterData} value={searchTerm} />
         </View>
-        <PageButtons />
+        <View style={newPageTopRightSectionContainer}>
+          {!program && (
+            <PageButton
+              text={buttonStrings.manage_stocktake}
+              onPress={onManageStocktake}
+              isDisabled={isFinalised}
+            />
+          )}
+        </View>
       </View>
       <DataTable
         data={data}

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -5,7 +5,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
@@ -105,15 +105,11 @@ export const StocktakeManagePage = ({
     [sortBy, isAscending]
   );
 
-  const Toggle = useCallback(
-    () => (
-      <ToggleBar
-        toggles={[
-          { text: buttonStrings.hide_stockouts, onPress: onHideStock, isOn: !showAll },
-          { text: buttonStrings.all_items_selected, onPress: onSelectAll, isOn: allSelected },
-        ]}
-      />
-    ),
+  const toggles = useMemo(
+    () => [
+      { text: buttonStrings.hide_stockouts, onPress: onHideStock, isOn: !showAll },
+      { text: buttonStrings.all_items_selected, onPress: onSelectAll, isOn: allSelected },
+    ],
     [showAll, allSelected]
   );
 
@@ -130,7 +126,7 @@ export const StocktakeManagePage = ({
         </View>
 
         <View style={newPageTopRightSectionContainer}>
-          <Toggle />
+          <ToggleBar toggles={toggles} />
         </View>
       </View>
 

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -5,7 +5,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
@@ -18,7 +18,7 @@ import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
 import { buttonStrings, modalStrings } from '../localization';
-import globalStyles, { newPageStyles } from '../globalStyles';
+import { newPageStyles } from '../globalStyles';
 
 import {
   gotoStocktakeManagePage,
@@ -118,24 +118,11 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     [sortBy, isAscending]
   );
 
-  const PageButtons = useCallback(() => {
-    const { verticalContainer, topButton } = globalStyles;
-    return (
-      <View style={verticalContainer}>
-        <PageButton style={topButton} text={buttonStrings.new_stocktake} onPress={onNewStocktake} />
-      </View>
-    );
-  }, []);
-
-  const PastCurrentToggleBar = useCallback(
-    () => (
-      <ToggleBar
-        toggles={[
-          { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
-          { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
-        ]}
-      />
-    ),
+  const toggles = useMemo(
+    () => [
+      { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
+      { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
+    ],
     [showFinalised]
   );
 
@@ -148,11 +135,11 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     <DataTablePageView>
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
-          <PastCurrentToggleBar />
+          <ToggleBar toggles={toggles} />
           <SearchBar onChangeText={onFilterData} value={searchTerm} />
         </View>
         <View style={newPageTopRightSectionContainer}>
-          <PageButtons />
+          <PageButton text={buttonStrings.new_stocktake} onPress={onNewStocktake} />
         </View>
       </View>
       <DataTable

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -18,7 +18,7 @@ import { PageButton, PageInfo, SearchBar, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
 import { buttonStrings, modalStrings } from '../localization';
-import globalStyles, { newPageStyles } from '../globalStyles';
+import { newPageStyles } from '../globalStyles';
 
 export const SupplierInvoicePage = ({ routeName, transaction }) => {
   const initialState = { page: routeName, pageObject: transaction };
@@ -112,20 +112,6 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
     [data, dataState]
   );
 
-  const PageButtons = useCallback(() => {
-    const { verticalContainer, topButton } = globalStyles;
-    return (
-      <View style={verticalContainer}>
-        <PageButton
-          style={topButton}
-          text={buttonStrings.new_item}
-          onPress={onAddRow}
-          isDisabled={isFinalised}
-        />
-      </View>
-    );
-  }, []);
-
   const renderHeader = useCallback(
     () => (
       <DataTableHeaderRow
@@ -152,7 +138,7 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
           <SearchBar onChangeText={onFilterData} value={searchTerm} />
         </View>
         <View style={newPageTopRightSectionContainer}>
-          <PageButtons />
+          <PageButton text={buttonStrings.new_item} onPress={onAddRow} isDisabled={isFinalised} />
         </View>
       </View>
       <DataTable

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -4,7 +4,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
@@ -118,19 +118,11 @@ export const SupplierInvoicesPage = ({
     [sortBy, isAscending]
   );
 
-  const NewInvoiceButton = () => (
-    <PageButton text={buttonStrings.new_invoice} onPress={onNewInvoice} />
-  );
-
-  const PastCurrentToggleBar = useCallback(
-    () => (
-      <ToggleBar
-        toggles={[
-          { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
-          { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
-        ]}
-      />
-    ),
+  const toggles = useMemo(
+    () => [
+      { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
+      { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
+    ],
     [showFinalised]
   );
 
@@ -143,11 +135,11 @@ export const SupplierInvoicesPage = ({
     <DataTablePageView>
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
-          <PastCurrentToggleBar />
+          <ToggleBar toggles={toggles} />
           <SearchBar onChangeText={onFilterData} value={searchTerm} />
         </View>
         <View style={newPageTopRightSectionContainer}>
-          <NewInvoiceButton />
+          <PageButton text={buttonStrings.new_invoice} onPress={onNewInvoice} />
         </View>
       </View>
       <DataTable

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -13,7 +13,7 @@ import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
 import { getItemLayout } from './dataTableUtilities';
 import { gotoSupplierInvoice, createSupplierInvoice } from '../navigation/actions';
 
-import { PageButton, SearchBar, DataTablePageView } from '../widgets';
+import { PageButton, SearchBar, DataTablePageView, ToggleBar } from '../widgets';
 import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
@@ -40,6 +40,7 @@ export const SupplierInvoicesPage = ({
     searchTerm,
     columns,
     PageActions,
+    showFinalised,
   } = state;
 
   // Listen to changes from sync and navigation events re-focusing this screen,
@@ -53,6 +54,7 @@ export const SupplierInvoicesPage = ({
   const onNewInvoice = () => dispatch(PageActions.openModal(MODAL_KEYS.SELECT_SUPPLIER));
   const onConfirmDelete = () => dispatch(PageActions.deleteTransactions());
   const onCancelDelete = () => dispatch(PageActions.deselectAll());
+  const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
 
   const onNavigateToInvoice = useCallback(
     invoice => reduxDispatch(gotoSupplierInvoice(invoice)),
@@ -120,6 +122,18 @@ export const SupplierInvoicesPage = ({
     <PageButton text={buttonStrings.new_invoice} onPress={onNewInvoice} />
   );
 
+  const PastCurrentToggleBar = useCallback(
+    () => (
+      <ToggleBar
+        toggles={[
+          { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
+          { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
+        ]}
+      />
+    ),
+    [showFinalised]
+  );
+
   const {
     newPageTopSectionContainer,
     newPageTopLeftSectionContainer,
@@ -129,6 +143,7 @@ export const SupplierInvoicesPage = ({
     <DataTablePageView>
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
+          <PastCurrentToggleBar />
           <SearchBar onChangeText={onFilterData} value={searchTerm} />
         </View>
         <View style={newPageTopRightSectionContainer}>

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -5,7 +5,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
@@ -157,58 +157,44 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
     [sortBy, isAscending]
   );
 
-  const AddMasterListItemsButton = useCallback(
-    () => (
-      <PageButton
-        style={globalStyles.leftButton}
-        text={buttonStrings.add_master_list_items}
-        onPress={onAddFromMasterList}
-        isDisabled={isFinalised}
-      />
-    ),
-    []
+  const AddMasterListItemsButton = () => (
+    <PageButton
+      style={globalStyles.leftButton}
+      text={buttonStrings.add_master_list_items}
+      onPress={onAddFromMasterList}
+      isDisabled={isFinalised}
+    />
   );
 
-  const AddNewItemButton = useCallback(
-    () => (
-      <PageButton
-        style={globalStyles.topButton}
-        text={buttonStrings.new_item}
-        onPress={onSelectItem}
-        isDisabled={isFinalised}
-      />
-    ),
-    []
+  const AddNewItemButton = () => (
+    <PageButton
+      style={globalStyles.topButton}
+      text={buttonStrings.new_item}
+      onPress={onSelectItem}
+      isDisabled={isFinalised}
+    />
   );
 
-  const CreateAutomaticOrderButton = useCallback(
-    () => (
-      <PageButton
-        style={{ ...globalStyles.leftButton, marginLeft: 5 }}
-        text={buttonStrings.create_automatic_order}
-        onPress={onCreateAutomaticOrder}
-        isDisabled={isFinalised}
-      />
-    ),
-    []
+  const CreateAutomaticOrderButton = () => (
+    <PageButton
+      style={{ ...globalStyles.leftButton, marginLeft: 5 }}
+      text={buttonStrings.create_automatic_order}
+      onPress={onCreateAutomaticOrder}
+      isDisabled={isFinalised}
+    />
   );
 
-  const UseSuggestedQuantitiesButton = useCallback(
-    () => (
-      <View>
-        <PageButton
-          style={globalStyles.topButton}
-          text={buttonStrings.use_suggested_quantities}
-          onPress={onSetRequestedToSuggested}
-          isDisabled={isFinalised}
-        />
-      </View>
-    ),
-    []
+  const UseSuggestedQuantitiesButton = () => (
+    <PageButton
+      style={globalStyles.topButton}
+      text={buttonStrings.use_suggested_quantities}
+      onPress={onSetRequestedToSuggested}
+      isDisabled={isFinalised}
+    />
   );
 
-  const ThresholdMOSToggle = useCallback(() => {
-    const toggleProps = [
+  const toggles = useMemo(
+    () => [
       {
         text: programStrings.hide_over_stocked,
         isOn: !showAll,
@@ -219,26 +205,22 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
         isOn: showAll,
         onPress: onShowOverStocked,
       },
-    ];
-    return <ToggleBar toggles={toggleProps} />;
-  }, [showAll]);
+    ],
+    [showAll]
+  );
 
-  const ViewRegimenDataButton = useCallback(
-    () => (
-      <View>
-        <PageButton
-          style={globalStyles.topButton}
-          text={buttonStrings.view_regimen_data}
-          onPress={onViewRegimenData}
-        />
-      </View>
-    ),
-    []
+  const ThresholdMOSToggle = () => <ToggleBar toggles={toggles} />;
+
+  const ViewRegimenDataButton = () => (
+    <PageButton
+      style={globalStyles.topButton}
+      text={buttonStrings.view_regimen_data}
+      onPress={onViewRegimenData}
+    />
   );
 
   const GeneralButtons = useCallback(() => {
     const { verticalContainer } = globalStyles;
-
     return (
       <>
         <View style={verticalContainer}>
@@ -251,7 +233,7 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
         </View>
       </>
     );
-  }, []);
+  }, [isFinalised]);
 
   const ProgramButtons = useCallback(() => {
     const { verticalContainer, horizontalContainer } = globalStyles;
@@ -262,13 +244,11 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
             <UseSuggestedQuantitiesButton />
             <ViewRegimenDataButton />
           </View>
-          <View style={verticalContainer}>
-            <ThresholdMOSToggle />
-          </View>
+          <ThresholdMOSToggle />
         </View>
       </>
     );
-  }, [showAll]);
+  }, [showAll, isFinalised]);
 
   const {
     newPageTopSectionContainer,

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
 import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
-import { PageButton, SearchBar, DataTablePageView } from '../widgets';
+import { PageButton, SearchBar, DataTablePageView, ToggleBar } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
 import { UIDatabase } from '../database';
@@ -61,6 +61,7 @@ export const SupplierRequisitionsPage = ({
     searchTerm,
     PageActions,
     columns,
+    showFinalised,
   } = state;
 
   // Custom hook to refresh data on this page when becoming the head of the stack again.
@@ -79,6 +80,7 @@ export const SupplierRequisitionsPage = ({
   const onSearchFiltering = value => dispatch(PageActions.filterData(value));
   const onNewRequisition = () => dispatch(PageActions.openModal(NEW_REQUISITON));
   const onCloseModal = () => dispatch(PageActions.closeModal());
+  const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
 
   const onCreateRequisition = otherStoreName => {
     onCloseModal();
@@ -157,6 +159,18 @@ export const SupplierRequisitionsPage = ({
     );
   }, []);
 
+  const PastCurrentToggleBar = useCallback(
+    () => (
+      <ToggleBar
+        toggles={[
+          { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
+          { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
+        ]}
+      />
+    ),
+    [showFinalised]
+  );
+
   const {
     newPageTopSectionContainer,
     newPageTopLeftSectionContainer,
@@ -166,6 +180,7 @@ export const SupplierRequisitionsPage = ({
     <DataTablePageView>
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
+          <PastCurrentToggleBar />
           <SearchBar onChangeText={onSearchFiltering} value={searchTerm} />
         </View>
         <View style={newPageTopRightSectionContainer}>

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -20,7 +20,7 @@ import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
 import { createSupplierRequisition, gotoSupplierRequisition } from '../navigation/actions';
 import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
 
-import globalStyles, { newPageStyles } from '../globalStyles';
+import { newPageStyles } from '../globalStyles';
 import { buttonStrings, modalStrings } from '../localization';
 
 /**
@@ -146,28 +146,11 @@ export const SupplierRequisitionsPage = ({
     [sortBy, isAscending]
   );
 
-  const PageButtons = useCallback(() => {
-    const { verticalContainer, topButton } = globalStyles;
-    return (
-      <View style={verticalContainer}>
-        <PageButton
-          style={topButton}
-          text={buttonStrings.new_requisition}
-          onPress={onNewRequisition}
-        />
-      </View>
-    );
-  }, []);
-
-  const PastCurrentToggleBar = useCallback(
-    () => (
-      <ToggleBar
-        toggles={[
-          { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
-          { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
-        ]}
-      />
-    ),
+  const toggles = useMemo(
+    () => [
+      { text: buttonStrings.current, onPress: onToggleShowFinalised, isOn: !showFinalised },
+      { text: buttonStrings.past, onPress: onToggleShowFinalised, isOn: showFinalised },
+    ],
     [showFinalised]
   );
 
@@ -180,11 +163,11 @@ export const SupplierRequisitionsPage = ({
     <DataTablePageView>
       <View style={newPageTopSectionContainer}>
         <View style={newPageTopLeftSectionContainer}>
-          <PastCurrentToggleBar />
+          <ToggleBar toggles={toggles} />
           <SearchBar onChangeText={onSearchFiltering} value={searchTerm} />
         </View>
         <View style={newPageTopRightSectionContainer}>
-          <PageButtons />
+          <PageButton text={buttonStrings.new_requisition} onPress={onNewRequisition} />
         </View>
       </View>
       <DataTable
@@ -203,7 +186,6 @@ export const SupplierRequisitionsPage = ({
         confirmText={modalStrings.remove}
       />
       <DataTablePageModal
-        fullScreen={false}
         isOpen={!!modalKey}
         modalKey={modalKey}
         onClose={onCloseModal}

--- a/src/pages/dataTableUtilities/actions/constants.js
+++ b/src/pages/dataTableUtilities/actions/constants.js
@@ -16,6 +16,7 @@ export const ACTIONS = {
   SHOW_FINALISED: 'showFinalised',
   SHOW_NOT_FINALISED: 'showNotFinalised',
   REFRESH_DATA_WITH_FINALISED_TOGGLE: 'refreshDataWithFinalisedToggle',
+  FILTER_DATA_WITH_FINALISED_TOGGLE: 'filterDataWithFinalisedToggle',
 
   // pageAction constants
   OPEN_MODAL: 'openModal',

--- a/src/pages/dataTableUtilities/actions/constants.js
+++ b/src/pages/dataTableUtilities/actions/constants.js
@@ -15,6 +15,7 @@ export const ACTIONS = {
   HIDE_STOCK_OUT: 'hideStockOut',
   SHOW_FINALISED: 'showFinalised',
   SHOW_NOT_FINALISED: 'showNotFinalised',
+  REFRESH_DATA_WITH_FINALISED_TOGGLE: 'refreshDataWithFinalisedToggle',
 
   // pageAction constants
   OPEN_MODAL: 'openModal',

--- a/src/pages/dataTableUtilities/actions/constants.js
+++ b/src/pages/dataTableUtilities/actions/constants.js
@@ -17,6 +17,7 @@ export const ACTIONS = {
   SHOW_NOT_FINALISED: 'showNotFinalised',
   REFRESH_DATA_WITH_FINALISED_TOGGLE: 'refreshDataWithFinalisedToggle',
   FILTER_DATA_WITH_FINALISED_TOGGLE: 'filterDataWithFinalisedToggle',
+  FILTER_DATA_WITH_OVER_STOCK_TOGGLE: 'filterDataWithOverStockToggle',
 
   // pageAction constants
   OPEN_MODAL: 'openModal',

--- a/src/pages/dataTableUtilities/actions/getPageActions.js
+++ b/src/pages/dataTableUtilities/actions/getPageActions.js
@@ -14,6 +14,7 @@ import {
   TableActionsLookup,
   refreshDataWithFinalisedToggle,
   filterDataWithFinalisedToggle,
+  filterDataWithOverStockToggle,
 } from './tableActions';
 import { PageActionsLookup } from './pageActions';
 
@@ -78,6 +79,11 @@ const supplierRequisitions = {
   filterData: filterDataWithFinalisedToggle,
 };
 
+const supplierRequisitionWithProgram = {
+  ...BasePageActions,
+  filterData: filterDataWithOverStockToggle,
+};
+
 /**
  * If actions need to be overriden for a particular routeName,
  * adding them here will pass that new set of actions to the
@@ -91,6 +97,7 @@ const NON_DEFAULT_PAGE_ACTIONS = {
   supplierInvoices,
   supplierRequisitions,
   stocktakes,
+  supplierRequisitionWithProgram,
 };
 
 /**

--- a/src/pages/dataTableUtilities/actions/getPageActions.js
+++ b/src/pages/dataTableUtilities/actions/getPageActions.js
@@ -10,7 +10,11 @@ import {
   editStocktakeBatchCountedQuantityWithReason,
 } from './cellActions';
 import { RowActionsLookup } from './rowActions';
-import { TableActionsLookup, refreshDataWithFinalisedToggle } from './tableActions';
+import {
+  TableActionsLookup,
+  refreshDataWithFinalisedToggle,
+  filterDataWithFinalisedToggle,
+} from './tableActions';
 import { PageActionsLookup } from './pageActions';
 
 /**
@@ -47,26 +51,31 @@ const stocktakeBatchEditModalWithReasons = {
 const stocktakes = {
   ...BasePageActions,
   refreshData: refreshDataWithFinalisedToggle,
+  filterData: filterDataWithFinalisedToggle,
 };
 
 const customerInvoices = {
   ...BasePageActions,
   refreshData: refreshDataWithFinalisedToggle,
+  filterData: filterDataWithFinalisedToggle,
 };
 
 const customerRequisitions = {
   ...BasePageActions,
   refreshData: refreshDataWithFinalisedToggle,
+  filterData: filterDataWithFinalisedToggle,
 };
 
 const supplierInvoices = {
   ...BasePageActions,
   refreshData: refreshDataWithFinalisedToggle,
+  filterData: filterDataWithFinalisedToggle,
 };
 
 const supplierRequisitions = {
   ...BasePageActions,
   refreshData: refreshDataWithFinalisedToggle,
+  filterData: filterDataWithFinalisedToggle,
 };
 
 /**

--- a/src/pages/dataTableUtilities/actions/getPageActions.js
+++ b/src/pages/dataTableUtilities/actions/getPageActions.js
@@ -10,7 +10,7 @@ import {
   editStocktakeBatchCountedQuantityWithReason,
 } from './cellActions';
 import { RowActionsLookup } from './rowActions';
-import { TableActionsLookup } from './tableActions';
+import { TableActionsLookup, refreshDataWithFinalisedToggle } from './tableActions';
 import { PageActionsLookup } from './pageActions';
 
 /**
@@ -34,9 +34,6 @@ const BasePageActions = {
   ...PageActionsLookup,
 };
 
-/**
- * Actions for `stocktakeEditPage` when reasons are defined.
- */
 const stocktakeEditorWithReasons = {
   ...BasePageActions,
   editCountedQuantity: editCountedQuantityWithReason,
@@ -47,6 +44,31 @@ const stocktakeBatchEditModalWithReasons = {
   editStocktakeBatchCountedQuantity: editStocktakeBatchCountedQuantityWithReason,
 };
 
+const stocktakes = {
+  ...BasePageActions,
+  refreshData: refreshDataWithFinalisedToggle,
+};
+
+const customerInvoices = {
+  ...BasePageActions,
+  refreshData: refreshDataWithFinalisedToggle,
+};
+
+const customerRequisitions = {
+  ...BasePageActions,
+  refreshData: refreshDataWithFinalisedToggle,
+};
+
+const supplierInvoices = {
+  ...BasePageActions,
+  refreshData: refreshDataWithFinalisedToggle,
+};
+
+const supplierRequisitions = {
+  ...BasePageActions,
+  refreshData: refreshDataWithFinalisedToggle,
+};
+
 /**
  * If actions need to be overriden for a particular routeName,
  * adding them here will pass that new set of actions to the
@@ -55,6 +77,11 @@ const stocktakeBatchEditModalWithReasons = {
 const NON_DEFAULT_PAGE_ACTIONS = {
   stocktakeEditorWithReasons,
   stocktakeBatchEditModalWithReasons,
+  customerInvoices,
+  customerRequisitions,
+  supplierInvoices,
+  supplierRequisitions,
+  stocktakes,
 };
 
 /**

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -279,3 +279,20 @@ export const TableActionsLookup = {
   addTransactionItem,
   addStocktakeBatch,
 };
+
+/**
+ * =====================================================================
+ *
+ *                             Overrides
+ *
+ * Below are actions which are overrides of base actions.
+ *
+ * Example: editCountedQuantityWithReason overrides editCountedQuantity
+ * for a stocktakeEditPage when reasons are defined.
+ *
+ * =====================================================================
+ */
+
+export const refreshDataWithFinalisedToggle = () => ({
+  type: ACTIONS.REFRESH_DATA_WITH_FINALISED_TOGGLE,
+});

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -296,3 +296,8 @@ export const TableActionsLookup = {
 export const refreshDataWithFinalisedToggle = () => ({
   type: ACTIONS.REFRESH_DATA_WITH_FINALISED_TOGGLE,
 });
+
+export const filterDataWithFinalisedToggle = searchTerm => ({
+  type: ACTIONS.FILTER_DATA_WITH_FINALISED_TOGGLE,
+  payload: { searchTerm },
+});

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -73,16 +73,6 @@ export const showFinalised = () => ({ type: ACTIONS.SHOW_FINALISED });
 export const showNotFinalised = () => ({ type: ACTIONS.SHOW_NOT_FINALISED });
 
 /**
- * Wrapper around showFinalised/showNotFinalised to toggle between. Determines the
- * correct action to dispatch.
- *
- * @param {Bool} showFinalised Indicator wheter finalised rows are currently displayed.
- */
-export const toggleShowFinalised = showingFinalised => {
-  if (showingFinalised) return showNotFinalised();
-  return showFinalised();
-};
-/**
  * Shows all items, regardless of current stock on hand, toggles
  * showAll to true and removes the current search filtering. Sort is
  * kept stable.
@@ -95,6 +85,17 @@ export const showOverStocked = () => refreshData();
  * kept stable.
  */
 export const showStockOut = () => refreshData();
+
+/**
+ * Wrapper around showFinalised/showNotFinalised to toggle between. Determines the
+ * correct action to dispatch.
+ *
+ * @param {Bool} showFinalised Indicator wheter finalised rows are currently displayed.
+ */
+export const toggleShowFinalised = showingFinalised => {
+  if (showingFinalised) return showNotFinalised();
+  return showFinalised();
+};
 
 /**
  * Wrapper around hideStockout and showStockout. Determines which
@@ -299,5 +300,10 @@ export const refreshDataWithFinalisedToggle = () => ({
 
 export const filterDataWithFinalisedToggle = searchTerm => ({
   type: ACTIONS.FILTER_DATA_WITH_FINALISED_TOGGLE,
+  payload: { searchTerm },
+});
+
+export const filterDataWithOverStockToggle = searchTerm => ({
+  type: ACTIONS.FILTER_DATA_WITH_OVER_STOCK_TOGGLE,
   payload: { searchTerm },
 });

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -38,6 +38,7 @@ const customerInvoiceInitialiser = transaction => {
 
 /**
  * Gets data for initialising a customer invoices page.
+ * Invoices shown initially are unfinalised and sorted by serial number.
  *
  * @returns  {object}
  */
@@ -128,6 +129,7 @@ const stockInitialiser = () => {
 
 /**
  * Gets data for initialising a stocktakes page.
+ * Initial data is unfinalised stocktakes, sorted by creation date.
  *
  * @returns  {object}
  */
@@ -253,15 +255,19 @@ const supplierInvoiceInitialiser = transaction => {
 
 /**
  * Gets data for initialising a supplier invoices page.
+ * Data is initially unfinalised and sorted by serial number.
  *
  * @returns  {object}
  */
 const supplierInvoicesInitialiser = () => {
   const backingData = UIDatabase.objects('SupplierInvoice');
+
   const filteredData = backingData.filtered('status != $0', 'finalised').slice();
+  const sortedData = newSortDataBy(filteredData, 'serialNumber', false);
+
   return {
     backingData,
-    data: newSortDataBy(filteredData, 'serialNumber', false),
+    data: sortedData,
     keyExtractor: recordKeyExtractor,
     dataState: new Map(),
     searchTerm: '',
@@ -329,6 +335,7 @@ const supplierRequisitionWithProgramInitialiser = requisition => {
 
 /**
  * Gets data for initialising a supplier requisitions page.
+ * Initial data are unfinalised requisitions, sorted by serial number.
  *
  * @returns  {object}
  */

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -258,15 +258,12 @@ const supplierInvoicesInitialiser = () => {
  */
 const supplierRequisitionInitialiser = requisition => {
   const { items: backingData } = requisition;
-  const filteredData = backingData
-    .filtered('status != $0', 'finalised')
-    .sorted('item.name')
-    .slice();
+  const sortedData = backingData.sorted('item.name').slice();
 
   return {
     pageObject: requisition,
     backingData,
-    data: filteredData,
+    data: sortedData,
     keyExtractor: recordKeyExtractor,
     dataState: new Map(),
     searchTerm: '',

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -37,14 +37,10 @@ const customerInvoiceInitialiser = transaction => ({
  */
 const customerInvoicesInitialiser = () => {
   const backingData = UIDatabase.objects('CustomerInvoice');
-  // const data = backingData.filtered('status != $0', 'finalised');
+  const filteredData = backingData.filtered('status != $0', 'finalised').slice();
   return {
     backingData,
-    data: newSortDataBy(
-      backingData.filtered('status != $0', 'finalised').slice(),
-      'serialNumber',
-      false
-    ),
+    data: newSortDataBy(filteredData, 'serialNumber', false),
     keyExtractor: recordKeyExtractor,
     dataState: new Map(),
     searchTerm: '',

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -81,7 +81,7 @@ export const refreshDataWithFinalisedToggle = state => {
 export const showFinalised = state => {
   const { backingData } = state;
 
-  const newData = backingData.filtered('status == $0', 'finalised');
+  const newData = backingData.filtered('status == $0', 'finalised').slice();
 
   return { ...state, data: newData, showFinalised: true };
 };
@@ -93,7 +93,7 @@ export const showFinalised = state => {
 export const showNotFinalised = state => {
   const { backingData } = state;
 
-  const newData = backingData.filtered('status != $0', 'finalised');
+  const newData = backingData.filtered('status != $0', 'finalised').slice();
 
   return { ...state, data: newData, showFinalised: false };
 };

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -34,9 +34,7 @@ export const filterData = (state, action) => {
   const { payload } = action;
   const { searchTerm } = payload;
 
-  const queryString = filterDataKeys
-    .map(filterTerm => `${filterTerm} CONTAINS[c]  $0`)
-    .join(' OR ');
+  const queryString = filterDataKeys.map(filterTerm => `${filterTerm} CONTAINS[c] $0`).join(' OR ');
 
   const filteredData = backingData.filtered(queryString, searchTerm).slice();
 
@@ -55,9 +53,23 @@ export const filterData = (state, action) => {
 export const refreshData = state => {
   const { backingData, sortBy, isAscending } = state;
 
-  const newData = sortBy
-    ? newSortDataBy(backingData.slice(), sortBy, isAscending)
-    : backingData.slice();
+  const backingDataArray = backingData.slice();
+  const newData = sortBy ? newSortDataBy(backingDataArray, sortBy, isAscending) : backingDataArray;
+
+  return { ...state, data: newData, searchTerm: '', showAll: true };
+};
+
+/**
+ * Override for refreshData for pages which use a finalised toggle,
+ * which will display either finalised records, or unfinalised.
+ */
+export const refreshDataWithFinalisedToggle = state => {
+  const { backingData, sortBy, isAscending, showFinalised } = state;
+
+  const finalisedCondition = showFinalised ? '==' : '!=';
+  const filteredData = backingData.filtered(`status ${finalisedCondition} $0`, 'finalised');
+
+  const newData = sortBy ? newSortDataBy(filteredData.slice(), sortBy, isAscending) : filteredData;
 
   return { ...state, data: newData, searchTerm: '', showAll: true };
 };

--- a/src/widgets/PageButton.js
+++ b/src/widgets/PageButton.js
@@ -12,7 +12,7 @@ import { Button } from 'react-native-ui-components';
 import globalStyles from '../globalStyles';
 
 // A generic button for use on pages
-export function PageButton(props) {
+export function PageButtonComponent(props) {
   const { style, textStyle, isDisabled, ...buttonProps } = props;
 
   const defaultButtonStyle = [globalStyles.button];
@@ -29,10 +29,15 @@ export function PageButton(props) {
   );
 }
 
+const propsAreEqual = ({ isDisabled: prevIsDisabled }, { isDisabled: nextIsDisabled }) =>
+  prevIsDisabled === nextIsDisabled;
+
+export const PageButton = React.memo(PageButtonComponent, propsAreEqual);
+
 export default PageButton;
 
 /* eslint-disable react/forbid-prop-types, react/require-default-props */
-PageButton.propTypes = {
+PageButtonComponent.propTypes = {
   style: ViewPropTypes.style,
   textStyle: Text.propTypes.style,
   onPress: PropTypes.func,

--- a/src/widgets/ToggleBar/ToggleBar.js
+++ b/src/widgets/ToggleBar/ToggleBar.js
@@ -31,7 +31,7 @@ import globalStyles from '../../globalStyles';
  *
  */
 
-export const ToggleBar = props => {
+export const ToggleBarComponent = props => {
   const {
     style,
     toggleOffStyle,
@@ -77,9 +77,11 @@ export const ToggleBar = props => {
   );
 };
 
+export const ToggleBar = React.memo(ToggleBarComponent);
+
 export default ToggleBar;
 
-ToggleBar.propTypes = {
+ToggleBarComponent.propTypes = {
   style: ViewPropTypes.style,
   // eslint-disable-next-line react/require-default-props, react/forbid-prop-types
   toggles: PropTypes.array,
@@ -89,7 +91,7 @@ ToggleBar.propTypes = {
   textOnStyle: Text.propTypes.style,
 };
 
-ToggleBar.defaultProps = {
+ToggleBarComponent.defaultProps = {
   style: globalStyles.toggleBar,
   toggleOffStyle: globalStyles.toggleOption,
   toggleOnStyle: globalStyles.toggleOptionSelected,

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -102,7 +102,9 @@ export const DataTablePageModal = ({
           <ByProgramModal
             onConfirm={onSelect}
             database={UIDatabase}
-            transactionType={MODAL_KEYS.PROGRAM_STOCKTAKE ? 'stocktake' : 'requisition'}
+            transactionType={
+              modalKey === MODAL_KEYS.PROGRAM_STOCKTAKE ? 'stocktake' : 'requisition'
+            }
             settings={Settings}
           />
         );


### PR DESCRIPTION
Fixes #1294  & Fixes #1300 

## Change summary

- Adds a Past/Current toggle, the same as in `StocktakesPage` to all plural pages
- Fixed filtering on a program requisition page regaarding show/hide over stocked
- Little fix of `ByProgramModal` to correctly open the right one
- Adjustments to init methods

## Testing

See #1043 

### Related areas to think about

N/A
