### PR TITLE
#1309 Broken scrolling

### DIFF
--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -138,7 +138,7 @@ DataTable.defaultProps = {
   getItemCount: items => items.length,
   initialNumToRender: 10,
   removeClippedSubviews: true,
-  windowSize: 2,
+  windowSize: 3,
   columns: [],
 };
 

--- a/src/widgets/DataTable/Row.js
+++ b/src/widgets/DataTable/Row.js
@@ -49,7 +49,7 @@ const Row = React.memo(
     }
 
     const { adjustToTop } = useContext(RefContext);
-    const onPressRow = useCallback(onPress ? () => onPress(rowData) : () => {}, [onPress]);
+    const onPressRow = useCallback(() => onPress(rowData), [onPress]);
     const onFocus = () => adjustToTop(rowIndex);
 
     const Container = onPress ? TouchableOpacity : TouchableNoFeedback;

--- a/src/widgets/DataTable/Row.js
+++ b/src/widgets/DataTable/Row.js
@@ -3,7 +3,9 @@
 import React, { useContext, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
-import { TouchableOpacity, View } from 'react-native';
+import { TouchableOpacity } from 'react-native';
+
+import TouchableNoFeedback from './TouchableNoFeedback';
 
 import RefContext from './RefContext';
 
@@ -47,10 +49,10 @@ const Row = React.memo(
     }
 
     const { adjustToTop } = useContext(RefContext);
-    const onPressRow = useCallback(() => onPress(rowData), []);
+    const onPressRow = useCallback(onPress ? () => onPress(rowData) : () => {}, [onPress]);
     const onFocus = () => adjustToTop(rowIndex);
 
-    const Container = onPress ? TouchableOpacity : View;
+    const Container = onPress ? TouchableOpacity : TouchableNoFeedback;
     return (
       <Container onPress={onPressRow} style={style} onFocus={onFocus}>
         {renderCells(rowData, rowState, rowKey, rowIndex)}

--- a/src/widgets/DataTable/TouchableCell.js
+++ b/src/widgets/DataTable/TouchableCell.js
@@ -2,13 +2,9 @@
 /* eslint-disable react/forbid-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Text,
-  TouchableOpacity,
-  TouchableOpacityPropTypes,
-  TouchableWithoutFeedback,
-  View,
-} from 'react-native';
+import { Text, TouchableOpacity, TouchableOpacityPropTypes } from 'react-native';
+
+import TouchableNoFeedback from './TouchableNoFeedback';
 
 import { getAdjustedStyle } from './utilities';
 
@@ -50,15 +46,6 @@ const TouchableCell = React.memo(
     if (debug) console.log(`- TouchableCell: ${rowKey},${columnKey}`);
 
     const onPress = () => dispatch(onPressAction(rowKey, columnKey));
-
-    // TouchableWithoutFeedback doesn't have a style prop. View doesn't have an onPress
-    // Prop. This hack ensures events don't propogate to the parent, styling stays consistent
-    // and no feedback (i.e. gesture echo) is given to the user.
-    const TouchableNoFeedback = ({ children, style }) => (
-      <TouchableWithoutFeedback onPress={() => {}}>
-        <View style={style}>{children}</View>
-      </TouchableWithoutFeedback>
-    );
 
     const internalContainerStyle = getAdjustedStyle(containerStyle, width, isLastCell);
     const Container = isDisabled ? TouchableNoFeedback : TouchableComponent || TouchableOpacity;

--- a/src/widgets/DataTable/TouchableNoFeedback.js
+++ b/src/widgets/DataTable/TouchableNoFeedback.js
@@ -14,8 +14,10 @@ import PropTypes from 'prop-types';
  * Prop. This hack ensures events don't propogate to the parent, styling stays consistent
  * and no feedback (i.e. gesture echo) is given to the user.
  */
-const TouchableNoFeedback = ({ children, style }) => (
-  <TouchableWithoutFeedback onPress={() => {}}>
+const onPressNoOp = () => {};
+
+const TouchableNoFeedback = ({ children, style, ...touchableProps }) => (
+  <TouchableWithoutFeedback onPress={onPressNoOp} {...touchableProps}>
     <View style={style}>{children}</View>
   </TouchableWithoutFeedback>
 );

--- a/src/widgets/DataTable/TouchableNoFeedback.js
+++ b/src/widgets/DataTable/TouchableNoFeedback.js
@@ -1,0 +1,32 @@
+/* eslint-disable react/forbid-prop-types */
+/* eslint-disable import/prefer-default-export */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View, TouchableWithoutFeedback } from 'react-native';
+import PropTypes from 'prop-types';
+
+/**
+ * TouchableWithoutFeedback doesn't have a style prop. View doesn't have an onPress
+ * Prop. This hack ensures events don't propogate to the parent, styling stays consistent
+ * and no feedback (i.e. gesture echo) is given to the user.
+ */
+const TouchableNoFeedback = ({ children, style }) => (
+  <TouchableWithoutFeedback onPress={() => {}}>
+    <View style={style}>{children}</View>
+  </TouchableWithoutFeedback>
+);
+
+TouchableNoFeedback.defaultProps = {
+  style: null,
+};
+
+TouchableNoFeedback.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+  style: PropTypes.object,
+};
+
+export default TouchableNoFeedback;

--- a/src/widgets/DataTable/index.js
+++ b/src/widgets/DataTable/index.js
@@ -8,6 +8,7 @@ import HeaderCell from './HeaderCell';
 import DataTable from './DataTable';
 import DataTableHeaderRow from './DataTableHeaderRow';
 import DataTableRow from './DataTableRow';
+import TouchableNoFeedback from './TouchableNoFeedback';
 
 export {
   DataTable,
@@ -20,4 +21,5 @@ export {
   HeaderRow,
   HeaderCell,
   DataTableRow,
+  TouchableNoFeedback,
 };


### PR DESCRIPTION
Fixes #1309 

## Change summary

- Add `TouchableNoFeedback` component as it's now used in two places
- Add use of `TouchableNoFeedback` on a row when no `onPress` is used. This captures the event, preventing propgation and allows scrolling

## Testing

See #1043 

### Related areas to think about

N/A
