### PR TITLE
Fix incorrect ByProgramModal thresholdMOS

### DIFF
--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -41,9 +41,9 @@ const modalProps = ({ dispatch, program, orderType }) => ({
     onSelect: value => dispatch(selectOrderType(value)),
     renderRightText: item => {
       const { maxMOS, maxOPP, threshMOS } = getLocalizedStrings();
-      const { maxOrdersPerPeriod: maxOrders, maxMOS: itemMOS } = item;
-      const mosText = `${maxMOS}: ${item.maxMOS}`;
-      const thresholdText = `${threshMOS}: ${itemMOS}`;
+      const { maxOrdersPerPeriod: maxOrders, maxMOS: itemMOS, thresholdMOS: itemThreshMOS } = item;
+      const mosText = `${maxMOS}: ${itemMOS}`;
+      const thresholdText = `${threshMOS}: ${itemThreshMOS}`;
       const maxOrdersText = `${maxOPP}: ${maxOrders}`;
       return `${mosText} - ${thresholdText} - ${maxOrdersText}`;
     },


### PR DESCRIPTION
Fixes #1317.

Not sure if correct branch, let me know if should be PRed into `develop` or another branch.

## Change summary

Small variable assignment fix.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a new program-based requisition for an order type with differing `Max MOS` and `Threshold MOS`. The `byProgramModal` correctly displays the threshold MOS.

### Related areas to think about

None that I'm aware of. 