### PR TITLE
#1327 OnPress Crash

### DIFF
--- a/src/widgets/DataTable/TouchableNoFeedback.js
+++ b/src/widgets/DataTable/TouchableNoFeedback.js
@@ -17,7 +17,7 @@ import PropTypes from 'prop-types';
 const onPressNoOp = () => {};
 
 const TouchableNoFeedback = ({ children, style, ...touchableProps }) => (
-  <TouchableWithoutFeedback onPress={onPressNoOp} {...touchableProps}>
+  <TouchableWithoutFeedback {...touchableProps} onPress={onPressNoOp}>
     <View style={style}>{children}</View>
   </TouchableWithoutFeedback>
 );


### PR DESCRIPTION
Fixes #1327, #1340.

## Change summary

- Correctly overrides `onPress` for `TouchableNoFeedbacl` to be a no op onPress

## Testing

- [ ] Clicking a row in for example `CustomerRequisitionPage` doesn't throw an error

### Related areas to think about

Not getting a crash on pressing `Use Suggested Quantities` button
