### PR TITLE
#1324 SearchBar not dismissing details on StockPage

### DIFF
--- a/src/widgets/SearchBar.js
+++ b/src/widgets/SearchBar.js
@@ -106,8 +106,8 @@ const propsAreEqual = (
   { value: nextValue, onFocusOrBlur: nextOnFocusOrBlur }
 ) => {
   const valuesAreEqual = prevValue === nextValue;
-  const onFocusOrBlueAreEqual = prevOnFocusOrBlur === nextOnFocusOrBlur;
-  return valuesAreEqual && onFocusOrBlueAreEqual;
+  const onFocusOrBlurAreEqual = prevOnFocusOrBlur === nextOnFocusOrBlur;
+  return valuesAreEqual && onFocusOrBlurAreEqual;
 };
 
 export const SearchBar = React.memo(SearchBarComponent, propsAreEqual);

--- a/src/widgets/SearchBar.js
+++ b/src/widgets/SearchBar.js
@@ -98,9 +98,17 @@ export const SearchBarComponent = ({
 };
 
 /**
- * Only re-render this component when the value prop changes.
+ * Only re-render this component when the value or onFocusOrBlur
+ * props change.
  */
-const propsAreEqual = ({ value: prevValue }, { value: nextValue }) => prevValue === nextValue;
+const propsAreEqual = (
+  { value: prevValue, onFocusOrBlur: prevOnFocusOrBlur },
+  { value: nextValue, onFocusOrBlur: nextOnFocusOrBlur }
+) => {
+  const valuesAreEqual = prevValue === nextValue;
+  const onFocusOrBlueAreEqual = prevOnFocusOrBlur === nextOnFocusOrBlur;
+  return valuesAreEqual && onFocusOrBlueAreEqual;
+};
 
 export const SearchBar = React.memo(SearchBarComponent, propsAreEqual);
 


### PR DESCRIPTION
Fixes #1324 

## Change summary

-  Updated memoization, closure wasn't updating

## Testing

- [ ] When the item details popup is open, focusing the `SearchBar` dismisses the item details

### Related areas to think about

N/A