### PR TITLE
#1341 update period toInfoString formatting

### DIFF
--- a/src/database/DataTypes/Period.js
+++ b/src/database/DataTypes/Period.js
@@ -38,11 +38,11 @@ export class Period extends Realm.Object {
   }
 
   toInfoString() {
-    return `${this.name} -- ${this}`;
+    return `${this.name} (${this})`;
   }
 
   toString() {
-    return `${this.startDate.toLocaleDateString()} - ${this.endDate.toLocaleDateString()} `;
+    return `${this.startDate.toLocaleDateString()} - ${this.endDate.toLocaleDateString()}`;
   }
 }
 


### PR DESCRIPTION
Fixes #1341.

## Change summary

A small UX change. Feedback welcome if you prefer the existing formatting.

![#1341-update-period-field](https://user-images.githubusercontent.com/43223637/66624524-ff83ad00-ec4c-11e9-8208-9d2c8f02ee41.png)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] New program requisitions display period info strings with dates in parentheses (see screenshot above).

### Related areas to think about

N/A.
