### PR TITLE
#1335 Stocktakename cant be updated

### DIFF
--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -254,9 +254,12 @@ export const createSupplierInvoice = (otherParty, currentUser) => dispatch => {
  * @param {Object} stocktake realm Stocktake object
  * @param {Array}  itemIds   Array of item id strings that should be the new
  *                           Items in the stocktake.
+ *  * @param {String} name   Name of the stocktake for updating. Cannot update to remove completely.
  */
-export const updateStocktake = (stocktake, itemIds) => dispatch => {
+export const updateStocktake = (stocktake, itemIds, name = '') => dispatch => {
   UIDatabase.write(() => {
+    if (!name) stocktake.name = name;
+
     stocktake.setItemsByID(UIDatabase, itemIds);
     UIDatabase.save('Stocktake', stocktake);
   });

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -258,7 +258,7 @@ export const createSupplierInvoice = (otherParty, currentUser) => dispatch => {
  */
 export const updateStocktake = (stocktake, itemIds, name = '') => dispatch => {
   UIDatabase.write(() => {
-    if (!name) stocktake.name = name;
+    if (name) stocktake.name = name;
 
     stocktake.setItemsByID(UIDatabase, itemIds);
     UIDatabase.save('Stocktake', stocktake);

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -254,7 +254,7 @@ export const createSupplierInvoice = (otherParty, currentUser) => dispatch => {
  * @param {Object} stocktake realm Stocktake object
  * @param {Array}  itemIds   Array of item id strings that should be the new
  *                           Items in the stocktake.
- *  * @param {String} name   Name of the stocktake for updating. Cannot update to remove completely.
+ * @param {String} name   Name of the stocktake for updating. Cannot update to remove completely.
  */
 export const updateStocktake = (stocktake, itemIds, name = '') => dispatch => {
   UIDatabase.write(() => {

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -79,6 +79,7 @@ export const StocktakeEditPage = ({
     if (stocktake.isOutdated) dispatch(PageActions.openModal(MODAL_KEYS.STOCKTAKE_OUTDATED_ITEM));
   }, []);
 
+  const onEditName = value => dispatch(PageActions.editPageObjectName(value, 'Stocktake'));
   const onFilterData = value => dispatch(PageActions.filterData(value));
   const onEditBatch = rowKey => PageActions.openModal(MODAL_KEYS.EDIT_STOCKTAKE_BATCH, rowKey);
   const onEditReason = rowKey => PageActions.openModal(MODAL_KEYS.STOCKTAKE_REASON, rowKey);
@@ -95,6 +96,7 @@ export const StocktakeEditPage = ({
   const pageInfoColumns = useCallback(getPageInfoColumns(pageObject, dispatch, PageActions), [
     comment,
     isFinalised,
+    pageObject.name,
   ]);
 
   const getAction = useCallback((colKey, propName) => {
@@ -115,6 +117,8 @@ export const StocktakeEditPage = ({
 
   const getModalOnSelect = () => {
     switch (modalKey) {
+      case MODAL_KEYS.STOCKTAKE_NAME_EDIT:
+        return onEditName;
       case MODAL_KEYS.STOCKTAKE_COMMENT_EDIT:
         return onEditComment;
       case MODAL_KEYS.EDIT_STOCKTAKE_BATCH:

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -66,7 +66,7 @@ export const StocktakeManagePage = ({
   const onConfirmStocktake = () => {
     runWithLoadingIndicator(() => {
       const itemIds = Array.from(dataState.keys()).filter(id => id);
-      if (stocktake) return reduxDispatch(updateStocktake(stocktake, itemIds));
+      if (stocktake) return reduxDispatch(updateStocktake(stocktake, itemIds, name));
       return reduxDispatch(createStocktake({ stocktakeName: name, itemIds }));
     });
   };

--- a/src/pages/dataTableUtilities/actions/pageActions.js
+++ b/src/pages/dataTableUtilities/actions/pageActions.js
@@ -79,6 +79,29 @@ export const openModal = (modalKey, value) => {
 };
 
 /**
+ * Edits the `name` field of a pageObject.
+ *
+ * @param {String} value          New name value.
+ * @param {String} pageObjectType PageObject type to edit i.e. Transaction.
+ */
+export const editPageObjectName = (value, pageObjectType) => (dispatch, getState) => {
+  const { pageObject } = getState();
+
+  const { name } = pageObject;
+
+  if (name !== value) {
+    UIDatabase.write(() => {
+      UIDatabase.update(pageObjectType, {
+        ...pageObject,
+        name: value,
+      });
+    });
+  }
+
+  dispatch(closeModal());
+};
+
+/**
  * Edits the `theirRef` field of a pageObject.
  *
  * @param {String} value          New theifRef value.
@@ -166,4 +189,5 @@ export const PageActionsLookup = {
   editMonthsToSupply,
   resetStocktake,
   closeAndRefresh,
+  editPageObjectName,
 };

--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -113,7 +113,7 @@ const PAGE_INFO_ROWS = (pageObject, dispatch, PageActions) => ({
   stocktakeName: {
     title: `${pageInfoStrings.stocktake_name}:`,
     info: pageObject.name,
-    onPress: null,
+    onPress: () => dispatch(PageActions.openModal(MODAL_KEYS.STOCKTAKE_NAME_EDIT)),
     editableType: 'text',
   },
   itemName: {

--- a/src/pages/dataTableUtilities/reducer/pageReducers.js
+++ b/src/pages/dataTableUtilities/reducer/pageReducers.js
@@ -30,6 +30,13 @@ export const openModal = (state, action) => {
       return { ...state, modalKey, modalValue: pageObject };
     }
 
+    case MODAL_KEYS.STOCKTAKE_NAME_EDIT: {
+      const { pageObject } = state;
+      const { name } = pageObject;
+
+      return { ...state, modalKey, modalValue: name };
+    }
+
     case MODAL_KEYS.ENFORCE_STOCKTAKE_REASON:
     case MODAL_KEYS.EDIT_STOCKTAKE_BATCH:
     case MODAL_KEYS.STOCKTAKE_REASON: {

--- a/src/utilities/getModalTitle.js
+++ b/src/utilities/getModalTitle.js
@@ -7,6 +7,7 @@ import { modalStrings, buttonStrings } from '../localization';
 
 export const MODAL_KEYS = {
   STOCKTAKE_COMMENT_EDIT: 'stocktakeCommentEdit',
+  STOCKTAKE_NAME_EDIT: 'stocktakeNameEdit',
   TRANSACTION_COMMENT_EDIT: 'transactionCommentEdit',
   REQUISITION_COMMENT_EDIT: 'requisitionCommentEdit',
   THEIR_REF_EDIT: 'theirRefEdit',
@@ -27,6 +28,8 @@ export const getModalTitle = modalKey => {
   switch (modalKey) {
     default:
       return '';
+    case MODAL_KEYS.STOCKTAKE_NAME_EDIT:
+      return modalStrings.edit_the_stocktake_name;
     case MODAL_KEYS.STOCKTAKE_COMMENT_EDIT:
       return modalStrings.edit_the_stocktake_comment;
     case MODAL_KEYS.REQUISITION_COMMENT_EDIT:

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -65,6 +65,7 @@ const DataTablePageModalComponent = ({
             renderRightText={item => `${item.totalQuantity}`}
           />
         );
+      case MODAL_KEYS.STOCKTAKE_NAME_EDIT:
       case MODAL_KEYS.THEIR_REF_EDIT:
       case MODAL_KEYS.STOCKTAKE_COMMENT_EDIT:
       case MODAL_KEYS.TRANSACTION_COMMENT_EDIT:


### PR DESCRIPTION
Fixes #1335 

## Change summary

- Added updating of name from stocktake manage page via redux
- Added onpress event for the name page info on `StocktakeEditPage`

Note: This does fix the page info problem described in #1343 also, as  it was easier to just do it here

Seems I just completely forgot about this..

## Testing
- [ ] Updating the stocktake name in stocktake manage page correctly updates the name
- [ ] Updating the stocktake name in `StocktakeEditPage` correctly updates the name

### Related areas to think about

N/A
