### PR TITLE
#1343 stocktake updates

### DIFF
--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -158,7 +158,7 @@ export class Stocktake extends Realm.Object {
    * @return  {boolean}
    */
   get hasSomeCountedItems() {
-    return this.items.some(item => item.hasCountedBatches);
+    return this.items.some(item => item.hasBeenCounted);
   }
 
   /**
@@ -257,7 +257,7 @@ export class Stocktake extends Realm.Object {
     // Prune any stocktake item that has not had a quantity change.
     database.delete(
       'StocktakeItem',
-      this.items.filter(stocktakeItem => !stocktakeItem.hasCountedBatches)
+      this.items.filter(stocktakeItem => !stocktakeItem.hasBeenCounted)
     );
 
     // Get every batch associated with this stocktake.

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -39,12 +39,13 @@ export class StocktakeBatch extends Realm.Object {
   }
 
   /**
-   * Get total quantity in batch.
+   * Get the total countedQuantity for this batch. If nothing has been
+   * counted, return 0.
    *
    * @return  {number}
    */
   get countedTotalQuantity() {
-    if (this.countedNumberOfPacks === null) return this.snapshotTotalQuantity;
+    if (this.countedNumberOfPacks === null) return 0;
     return this.countedNumberOfPacks * this.packSize;
   }
 

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -77,7 +77,7 @@ export class StocktakeItem extends Realm.Object {
    *
    * @return  {boolean}
    */
-  get hasCountedBatches() {
+  get hasBeenCounted() {
     // Return true if any batches of this stocktake item have adjustments.
     return this.batches.some(
       stocktakeBatch => stocktakeBatch.isValid() && stocktakeBatch.hasBeenCounted

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -65,7 +65,7 @@ export const StocktakeManagePage = ({
 
   const onConfirmStocktake = () => {
     runWithLoadingIndicator(() => {
-      const itemIds = Array.from(dataState.keys()).filter(id => id);
+      const itemIds = Array.from(dataState.keys()).filter(id => dataState.get(id).isSelected && id);
       if (stocktake) return reduxDispatch(updateStocktake(stocktake, itemIds, name));
       return reduxDispatch(createStocktake({ stocktakeName: name, itemIds }));
     });
@@ -138,7 +138,7 @@ export const StocktakeManagePage = ({
       />
 
       <BottomTextEditor
-        isOpen={hasSelection}
+        isOpen
         buttonText={stocktake ? modalStrings.confirm : modalStrings.create}
         value={name}
         placeholder={modalStrings.give_your_stocktake_a_name}

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -29,7 +29,8 @@ import TextInputCell from './TextInputCell';
 
 import { formatStatus } from '../../utilities';
 
-import { COLUMN_TYPES } from '../../pages/dataTableUtilities';
+import { COLUMN_TYPES, COLUMN_NAMES } from '../../pages/dataTableUtilities';
+import { tableStrings } from '../../localization/index';
 
 /**
  * Wrapper component for a mSupply DataTable page row.
@@ -88,7 +89,15 @@ const DataTableRow = React.memo(
 
           switch (type) {
             case COLUMN_TYPES.EDITABLE_STRING:
-            case COLUMN_TYPES.EDITABLE_NUMERIC:
+            case COLUMN_TYPES.EDITABLE_NUMERIC: {
+              // Special condition for stocktake counted total quantity cells.
+              // Use the placeholder 'Not counted' when a stocktake item or batch
+              // has not been counted yet.
+              let placeholder = '';
+              if (columnKey === COLUMN_NAMES.COUNTED_TOTAL_QUANTITY) {
+                placeholder = rowData.hasBeenCounted ? '' : tableStrings.not_counted;
+              }
+
               return (
                 <TextInputCell
                   key={columnKey}
@@ -102,16 +111,15 @@ const DataTableRow = React.memo(
                   viewStyle={cellContainer[cellAlignment]}
                   textViewStyle={editableCellTextView}
                   isLastCell={isLastCell}
-                  keyboardType={
-                    type === COLUMN_TYPES.NUMERIC ? COLUMN_TYPES.EDITABLE_NUMERIC : 'default'
-                  }
+                  keyboardType={type === COLUMN_TYPES.EDITABLE_NUMERIC ? 'numeric' : 'default'}
                   textInputStyle={cellText[cellAlignment]}
                   textStyle={editableCellUnfocused[cellAlignment]}
                   cellTextStyle={editableCellText}
                   rowIndex={rowIndex}
+                  placeholder={placeholder}
                 />
               );
-
+            }
             case COLUMN_TYPES.EDITABLE_EXPIRY_DATE:
               return (
                 <ExpiryDateInput


### PR DESCRIPTION
Fixes #1343 

## Change summary

- Correctly using placeholders and not counted state for rows in a stocktake
- Made the bottom modal thing in `StocktakeManagePage`  always open
- Corrected logic for remove items from a `Stocktake`
- Corrected logic for the keyboard type for editable cells

## Testing

- [ ] When editing a cell that should be numeric, the numeric keyboard is opened
- [ ] When adding an item to a stocktake, initial state is to be NOT COUNTED
- [ ] When changing a value in a stocktake row, the state is the value entered
- [ ] Can remove items from a `Stocktake`
- [ ] When finalising a `Stocktake`, `Not Counted` rows are pruned

### Related areas to think about
`DataTableRow` getting pretty messy at this point. Could refactor soon!
