### PR TITLE
#1344 Incorrect initial state

### DIFF
--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -93,7 +93,9 @@ const customerRequisitionInitialiser = requisition => {
  */
 const customerRequisitionsInitialiser = () => {
   const backingData = UIDatabase.objects('ResponseRequisition');
-  const sortedData = sortDataBy(backingData.slice(), 'serialNumber', false);
+
+  const filteredData = backingData.filtered('status != $0', 'finalised');
+  const sortedData = sortDataBy(filteredData.slice(), 'serialNumber', false);
 
   return {
     backingData,

--- a/src/utilities/sortDataBy.js
+++ b/src/utilities/sortDataBy.js
@@ -48,11 +48,11 @@ export const sortDataBy = (data, sortKey, isAscending = true, sortDataType) => {
       if (isAscending) return [...data.sort((a, b) => Number(a[sortKey]) - Number(b[sortKey]))];
       return [...data.sort((a, b) => Number(b[sortKey]) - Number(a[sortKey]))];
     case 'date':
-      if (isAscending) return [...data.sort((a, b) => new Date(b[sortKey]) - new Date(a[sortKey]))];
-      return [...data.sort((a, b) => new Date(a[sortKey]) - new Date(b[sortKey]))];
+      if (isAscending) return [...data.sort((a, b) => new Date(a[sortKey]) - new Date(b[sortKey]))];
+      return [...data.sort((a, b) => new Date(b[sortKey]) - new Date(a[sortKey]))];
     case 'boolean':
-      if (isAscending) return [...data.sort((a, b) => b[sortKey] - a[sortKey])];
-      return [...data.sort((a, b) => a[sortKey] - b[sortKey])];
+      if (isAscending) return [...data.sort((a, b) => a[sortKey] - b[sortKey])];
+      return [...data.sort((a, b) => b[sortKey] - a[sortKey])];
     default:
       throw new Error(`sortType for the field '${sortKey}' not defined`);
   }


### PR DESCRIPTION
Fixes #1344 

## Change summary

- Updated sorting logic to fix the stocktakes page sorting issues
- Updated initial state of `CustomerRequisitionsPage`

## Testing

- [ ] When navigating to `CustomerRequisitionsPage` with BOTH requisitions created - FINALISED and NOT FINALISED, the toggle is correct
- [ ] When navigating to `StocktakesPage`, using the toggle correctly holds the sorting of the rows

### Related areas to think about

N/A
