### PR TITLE
#1337 StocktakeManagePage title

### DIFF
--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -37,7 +37,7 @@ export const gotoStocktakeManagePage = ({ stocktake, stocktakeName }) =>
   NavigationActions.navigate({
     routeName: 'stocktakeManager',
     params: {
-      title: stocktake ? stocktakeName : navStrings.new_stocktake,
+      title: stocktake ? navStrings.manage_stocktake : navStrings.new_stocktake,
       stocktakeName,
       stocktake,
     },


### PR DESCRIPTION
Fixes #1337 

## Change summary

- Just updated the title on `StocktakeMangagePage`

## Testing

- [ ] The title of `StocktakeManagePage` for an existing stock take is `Manage Stocktake`
- [ ] The title of `StocktakeManagePage` for a new stock take is `Manage Stocktake`

### Related areas to think about

N/A
