### PR TITLE
#1350 disable autocorrect for server url

### DIFF
--- a/src/pages/FirstUsePage.js
+++ b/src/pages/FirstUsePage.js
@@ -115,6 +115,7 @@ export class FirstUsePage extends React.Component {
               editable={status !== 'initialising'}
               returnKeyType="next"
               selectTextOnFocus
+              autoCorrect={false}
               onChangeText={text => this.setState({ serverURL: text, status: 'uninitialised' })}
               onSubmitEditing={() => {
                 if (this.siteNameInputRef) this.siteNameInputRef.focus();


### PR DESCRIPTION
Fixes #1350.

## Change summary

Disables autocorrect for primary server URL. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Primary server URL does not autocorrect (in particularly, does not autocapitalise).

### Related areas to think about

N/A.
