### PR TITLE
#1356 fix french program stocktake

### DIFF
--- a/src/localization/programStrings.js
+++ b/src/localization/programStrings.js
@@ -60,7 +60,7 @@ export const programStrings = new LocalizedStrings({
     program_order: 'Commande par programme',
     general_stocktake: 'Inventaire général',
     general_order: 'Commande Générale',
-    program_stocktake: 'Inventaire général',
+    program_stocktake: 'Inventaire par\n programme',
   },
   gil: {
     select_a_program: 'Select a program',


### PR DESCRIPTION
Fixes #1356.

## Change summary

Fixes incorrect French localisation for program stocktakes. Whitespace added to ensure correct centering (adding formatting to localisation strings seems hacky, but seems to be consistent with the way mobile currently handles this).

![#1356-fix-french-program-stocktake-2](https://user-images.githubusercontent.com/43223637/66963442-2ff59c00-f0d0-11e9-9d80-e0fcc87af82c.png)


## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Login as a French user and create a new stocktake with programs enabled. The toggle for program stocktake should read `"Inventaire par programme`".

### Related areas to think about

N/A.
