### PR TITLE
#1336 Stocktake reason changes

### DIFF
--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -176,11 +176,12 @@ export class StocktakeBatch extends Realm.Object {
    * @param {Realm} database App-wide database interface.
    */
   removeReason(database) {
-    if (!this.option && !this.difference) return;
-    database.write(() => {
-      this.option = null;
-      database.save('StocktakeBatch', this);
-    });
+    if (this.option && this.difference) {
+      database.write(() => {
+        this.option = null;
+        database.save('StocktakeBatch', this);
+      });
+    }
   }
 
   /**

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -137,21 +137,19 @@ export class StocktakeBatch extends Realm.Object {
    * while no difference requires there to be no option applied.
    */
   get validateReason() {
-    const { difference, option, hasPositiveAdjustment, hasNegativeAdjustment } = this;
-
     // Short circuits for simple cases
-    if (!difference && !option) return true;
-    if (difference && !option) return false;
+    if (!this.difference && !this.option) return true;
+    if (this.difference && !this.option) return false;
 
     // Determine the validity of the reason state where there is a difference
     // and the batch already has a option.
-    const { type } = option;
+    const { type } = this.option;
 
     const positiveAdjustmentReason = type === 'positiveInventoryAdjustment';
     const negativeAdjustmentReason = type === 'negativeInventoryAdjustment';
 
-    const correctPositiveReason = positiveAdjustmentReason && hasPositiveAdjustment;
-    const correctNegativeReason = negativeAdjustmentReason && hasNegativeAdjustment;
+    const correctPositiveReason = positiveAdjustmentReason && this.hasPositiveAdjustment;
+    const correctNegativeReason = negativeAdjustmentReason && this.hasNegativeAdjustment;
 
     return correctNegativeReason || correctPositiveReason;
   }
@@ -178,8 +176,7 @@ export class StocktakeBatch extends Realm.Object {
    * @param {Realm} database App-wide database interface.
    */
   removeReason(database) {
-    const { option, difference } = this;
-    if (!option && !difference) return;
+    if (!this.option && !this.difference) return;
     database.write(() => {
       this.option = null;
       database.save('StocktakeBatch', this);
@@ -193,16 +190,14 @@ export class StocktakeBatch extends Realm.Object {
    * @param {Option} newOption New option to apply
    */
   applyReason(database, newOption) {
-    const { difference, hasPositiveAdjustment } = this;
-
     const { type: newOptionType } = newOption || {};
     const isPositiveAdjustmentReason = newOptionType === 'positiveInventoryAdjustment';
 
     database.write(() => {
       // If this batch does not have an adjustment, remove the reason.
-      if (!difference) this.option = null;
+      if (!this.difference) this.option = null;
       // Otherwise if the adjustment type and reason types match, apply the reason.
-      else if (hasPositiveAdjustment === isPositiveAdjustmentReason) this.option = newOption;
+      else if (this.hasPositiveAdjustment === isPositiveAdjustmentReason) this.option = newOption;
       database.save('StocktakeBatch', this);
     });
   }

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -307,9 +307,7 @@ export class StocktakeItem extends Realm.Object {
    * @param {Options} option   Option object to apply.
    */
   applyReason(database, option) {
-    this.batches.forEach(batch => {
-      batch.applyReason(database, option);
-    });
+    this.batches.forEach(batch => batch.applyReason(database, option));
   }
 }
 

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -295,11 +295,7 @@ export class StocktakeItem extends Realm.Object {
    */
   removeReason(database) {
     this.batches.forEach(batch => {
-      const { difference } = this;
-
-      if (difference) return;
-
-      batch.removeReason(database);
+      if (!this.difference) batch.removeReason(database);
     });
   }
 

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -24,7 +24,8 @@ const translateToCoreDatabaseType = type => {
     case 'RequestRequisition':
     case 'ResponseRequisition':
       return 'Requisition';
-    case 'StocktakeReasons':
+    case 'NegativeAdjustmentReason':
+    case 'PositiveAdjustmentReason':
       return 'Options';
     default:
       return type;
@@ -129,8 +130,10 @@ class UIDatabase {
         return results.filtered('type == "request"');
       case 'ResponseRequisition':
         return results.filtered('serialNumber != "-1" AND type == "response"');
-      case 'StocktakeReasons':
-        return results.filtered('type == $0 && isActive == true', 'stocktakeLineAdjustment');
+      case 'NegativeAdjustmentReason':
+        return results.filtered('type == $0 && isActive == true', 'negativeInventoryAdjustment');
+      case 'PositiveAdjustmentReason':
+        return results.filtered('type == $0 && isActive == true', 'positiveInventoryAdjustment');
       default:
         return results;
     }

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -49,7 +49,9 @@ export const gotoStocktakeManagePage = ({ stocktake, stocktakeName }) =>
  * @param {Object} stocktake  The requisition to navigate to.
  */
 export const gotoStocktakeEditPage = stocktake => {
-  const usesReasons = UIDatabase.objects('StocktakeReasons').length > 0;
+  const hasNegativeAdjustmentReasons = UIDatabase.objects('NegativeAdjustmentReason').length > 0;
+  const hasPositiveAdjustmentReasons = UIDatabase.objects('PositiveAdjustmentReason').length > 0;
+  const usesReasons = hasNegativeAdjustmentReasons && hasPositiveAdjustmentReasons;
 
   return NavigationActions.navigate({
     routeName: usesReasons ? 'stocktakeEditorWithReasons' : 'stocktakeEditor',

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -200,6 +200,7 @@ export const enforceReasonChoice = rowKey => (dispatch, getState) => {
   const { data, keyExtractor } = getState();
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
+  if (!objectToEdit) return null;
 
   const { difference } = objectToEdit;
   // If there's no difference, just remove the reason

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -202,12 +202,10 @@ export const enforceReasonChoice = rowKey => (dispatch, getState) => {
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
   const { difference } = objectToEdit;
-
   // If there's no difference, just remove the reason
   if (!difference) return dispatch(removeReason(rowKey));
 
   const { validateReason } = objectToEdit;
-
   if (!validateReason) return dispatch(openModal(MODAL_KEYS.ENFORCE_STOCKTAKE_REASON, rowKey));
 
   return null;

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -179,7 +179,7 @@ export const removeReason = rowKey => (dispatch, getState) => {
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  objectToEdit.applyReason(UIDatabase);
+  objectToEdit.removeReason(UIDatabase);
 
   dispatch(refreshRow(rowKey));
 };
@@ -188,7 +188,10 @@ export const removeReason = rowKey => (dispatch, getState) => {
  * Handles reason logic for a particular object (stocktakeBatch or
  * StocktakeItem) - if there is a difference (between snapshot and
  * countedTotalQuantity) - then a reason should be related to this
- * object. If there is already a reason, do nothing. If there is no
+ * object. For negative adjustments, a negativeInventoryAdjustment
+ * reason should be applied. If positive, a positiveInventoryAdjustment.
+ * A correct reason
+ * If there is already a reason, do nothing. If there is no
  * difference, but a reason has been previously applied, remove it.
  *
  * @param {String} rowKey Key of the row to enforce a reason on
@@ -198,16 +201,16 @@ export const enforceReasonChoice = rowKey => (dispatch, getState) => {
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  const { difference, hasReason } = objectToEdit;
+  const { difference } = objectToEdit;
 
-  // If there is no difference and no reason, do nothing.
-  if (!difference && !hasReason) return;
+  // If there's no difference, just remove the reason
+  if (!difference) return dispatch(removeReason(rowKey));
 
-  // If there is no difference, but a reason, remove it.
-  if (!difference && hasReason) dispatch(removeReason(rowKey));
+  const { validateReason } = objectToEdit;
 
-  // If there is a difference, and no reason, enforce it.
-  if (!hasReason) dispatch(openModal(MODAL_KEYS.ENFORCE_STOCKTAKE_REASON, rowKey));
+  if (!validateReason) return dispatch(openModal(MODAL_KEYS.ENFORCE_STOCKTAKE_REASON, rowKey));
+
+  return null;
 };
 
 /**

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -698,14 +698,12 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       break;
     }
     case 'Options': {
-      if (record.type === 'stocktakeLineAdjustment') {
-        database.update(recordType, {
-          id: record.ID,
-          title: record.title,
-          type: record.type,
-          isActive: parseBoolean(record.isActive),
-        });
-      }
+      database.update(recordType, {
+        id: record.ID,
+        title: record.title,
+        type: record.type,
+        isActive: parseBoolean(record.isActive),
+      });
       break;
     }
     case 'Unit': {

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -135,15 +135,21 @@ const DataTablePageModalComponent = ({
           />
         );
       case MODAL_KEYS.ENFORCE_STOCKTAKE_REASON:
-      case MODAL_KEYS.STOCKTAKE_REASON:
+      case MODAL_KEYS.STOCKTAKE_REASON: {
+        const { difference, reasonTitle } = currentValue;
+        const reasonsSelection =
+          difference > 0
+            ? UIDatabase.objects('PositiveAdjustmentReason')
+            : UIDatabase.objects('NegativeAdjustmentReason');
         return (
           <GenericChoiceList
-            data={UIDatabase.objects('StocktakeReasons')}
-            highlightValue={currentValue.reasonTitle}
+            data={reasonsSelection}
+            highlightValue={reasonTitle}
             keyToDisplay="title"
             onPress={onSelect}
           />
         );
+      }
       default:
         return null;
     }

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -41,7 +41,12 @@ import { buttonStrings } from '../../localization/index';
  *
  */
 export const StocktakeBatchModal = ({ stocktakeItem }) => {
-  const usingReasons = useMemo(() => UIDatabase.objects('StocktakeReasons').length > 0, []);
+  const usingReasons = useMemo(
+    () =>
+      UIDatabase.objects('NegativeAdjustmentReason').length > 0 &&
+      UIDatabase.objects('PositiveAdjustmentReason').length > 0,
+    []
+  );
 
   const initialState = {
     page: usingReasons ? 'stocktakeBatchEditModalWithReasons' : 'stocktakeBatchEditModal',
@@ -64,8 +69,13 @@ export const StocktakeBatchModal = ({ stocktakeItem }) => {
     getPageInfoColumns,
   } = state;
 
-  const { stocktake = {} } = stocktakeItem;
+  const { stocktake = {}, difference } = stocktakeItem;
   const { isFinalised = false } = stocktake;
+
+  const reasonsSelection =
+    difference > 0
+      ? UIDatabase.objects('PositiveAdjustmentReason')
+      : UIDatabase.objects('NegativeAdjustmentReason');
 
   const onEditReason = rowKey => PageActions.openModal(MODAL_KEYS.STOCKTAKE_REASON, rowKey);
   const onCloseModal = () => dispatch(PageActions.closeModal());
@@ -157,7 +167,7 @@ export const StocktakeBatchModal = ({ stocktakeItem }) => {
         onClose={onCloseModal}
       >
         <GenericChoiceList
-          data={UIDatabase.objects('StocktakeReasons')}
+          data={reasonsSelection}
           highlightValue={(modalValue && modalValue.reasonTitle) || ''}
           keyToDisplay="title"
           onPress={onApplyReason}

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -69,8 +69,9 @@ export const StocktakeBatchModal = ({ stocktakeItem }) => {
     getPageInfoColumns,
   } = state;
 
-  const { stocktake = {}, difference } = stocktakeItem;
+  const { stocktake = {} } = stocktakeItem;
   const { isFinalised = false } = stocktake;
+  const { difference = 0 } = modalValue || {};
 
   const reasonsSelection =
     difference > 0


### PR DESCRIPTION
Fixes #1336 

## Change summary

- Makes sync adjustments for options
- changes some logic in `StocktakeItem` and `StocktakeBatch` to aid in the logic for applying reasons
- Changes some logic in the actions for applying reasons



## Testing

**With reasons defined**
- [ ] When changing the counted quantity on a stocktake item, a modal opens with negative reasons
- [ ]  When changing the counted quantity on a stocktake item, a modal opens with positive reasons
- [ ] When changing the quantity to have no difference, reasons are removed from the line (and all batches which have no difference)
- [ ] When applying a reason the reason is applied to each batch with the corresponding difference.

### Related areas to think about

Overall I think this is extremely annoying and it's also pretty unintuitive for a user. I think changing `Stocktakes` to just be a list of batches, like it is in desktop would be a lot better for the overall app. I wonder how users really do stocktakes on mobile and if having it NOT by batch is actually helpful
