### PR TITLE
#1399 Sortable status column

### DIFF
--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -38,8 +38,8 @@ const PAGE_COLUMNS = {
   customerInvoices: [
     COLUMN_NAMES.INVOICE_NUMBER,
     COLUMN_NAMES.CUSTOMER,
-    COLUMN_NAMES.STATUS,
     COLUMN_NAMES.ENTRY_DATE,
+    COLUMN_NAMES.STATUS,
     COLUMN_NAMES.COMMENT,
     COLUMN_NAMES.REMOVE,
   ],
@@ -53,8 +53,8 @@ const PAGE_COLUMNS = {
   supplierInvoices: [
     COLUMN_NAMES.INVOICE_NUMBER,
     COLUMN_NAMES.SUPPLIER,
-    COLUMN_NAMES.STATUS,
     COLUMN_NAMES.ENTRY_DATE,
+    COLUMN_NAMES.STATUS,
     COLUMN_NAMES.COMMENT,
     COLUMN_NAMES.REMOVE,
   ],
@@ -232,7 +232,7 @@ const COLUMNS = () => ({
     type: COLUMN_TYPES.STRING,
     key: COLUMN_KEYS.STATUS,
     title: tableStrings.status,
-    sortable: true,
+    sortable: false,
     editable: false,
   },
   [COLUMN_NAMES.QUESTION]: {


### PR DESCRIPTION
Fixes #1399 

## Change summary

- Removed sortable status of status column
- Reordered a couple of pages columns to make all of the sortable columns at the end. Also makes it more consistent on all pages where entry date is before status

## Testing

- [ ] All status columns on all plural pages are not sortable

### Related areas to think about

N/A
