### PR TITLE
#1403 months stock modal title

### DIFF
--- a/src/utilities/getModalTitle.js
+++ b/src/utilities/getModalTitle.js
@@ -15,6 +15,7 @@ export const MODAL_KEYS = {
   SELECT_MONTH: 'selectMonth',
   SELECT_CUSTOMER: 'selectCustomer',
   SELECT_SUPPLIER: 'selectSupplier',
+  SELECT_LANGUAGE: 'selectLanguage',
   PROGRAM_REQUISITION: 'programRequisition',
   PROGRAM_STOCKTAKE: 'programStocktake',
   VIEW_REGIMEN_DATA: 'viewRegimenData',
@@ -28,6 +29,8 @@ export const getModalTitle = modalKey => {
   switch (modalKey) {
     default:
       return '';
+    case MODAL_KEYS.SELECT_LANGUAGE:
+      return modalStrings.select_a_language;
     case MODAL_KEYS.SELECT_MONTH:
       return modalStrings.select_the_number_of_months_stock_required;
     case MODAL_KEYS.STOCKTAKE_NAME_EDIT:

--- a/src/utilities/getModalTitle.js
+++ b/src/utilities/getModalTitle.js
@@ -28,6 +28,8 @@ export const getModalTitle = modalKey => {
   switch (modalKey) {
     default:
       return '';
+    case MODAL_KEYS.SELECT_MONTH:
+      return modalStrings.select_the_number_of_months_stock_required;
     case MODAL_KEYS.STOCKTAKE_NAME_EDIT:
       return modalStrings.edit_the_stocktake_name;
     case MODAL_KEYS.STOCKTAKE_COMMENT_EDIT:

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -17,6 +17,7 @@ import { GenericChoiceList, Flag } from '..';
 import ModalContainer from './ModalContainer';
 
 import { LANGUAGE_NAMES, LANGUAGE_CHOICE, authStrings, navStrings } from '../../localization';
+import { getModalTitle, MODAL_KEYS } from '../../utilities/index';
 
 export class LoginModal extends React.Component {
   constructor(props) {
@@ -217,7 +218,11 @@ export class LoginModal extends React.Component {
             </Icon.Button>
             <Text style={globalStyles.authWindowButtonText}>v{appVersion}</Text>
           </View>
-          <ModalContainer isVisible={isLanguageModalOpen} onClose={this.onCloseModal}>
+          <ModalContainer
+            isVisible={isLanguageModalOpen}
+            onClose={this.onCloseModal}
+            title={getModalTitle(MODAL_KEYS.SELECT_LANGUAGE)}
+          >
             <GenericChoiceList
               data={LANGUAGE_CHOICE}
               keyToDisplay="name"


### PR DESCRIPTION
Fixes #1403 

## Change summary

- Adds a modal title to both select months of stock modal and language modal (I realised this was missing one also while working on issue)

## Testing

- [ ] The modal opened when changing months of stock in a supplier requisition has a title
- [ ] The modal opened when changing language in the login page has a title

### Related areas to think about

N/A
