### PR TITLE
#1406 Handle long text in ByProgramModal

### DIFF
--- a/src/localization/programStrings.js
+++ b/src/localization/programStrings.js
@@ -57,7 +57,7 @@ export const programStrings = new LocalizedStrings({
     not_applicable: 'Pas applicable',
     hide_over_stocked: 'Masquer les produits surstocké',
     show_over_stocked: 'Afficher les produits surstocké',
-    program_order: 'Commande par programme',
+    program_order: 'Commande par\nprogramme',
     general_stocktake: 'Inventaire général',
     general_order: 'Commande Générale',
     program_stocktake: 'Inventaire par\n programme',

--- a/src/widgets/Step.js
+++ b/src/widgets/Step.js
@@ -157,7 +157,7 @@ const localStyles = StyleSheet.create({
     alignItems: 'center',
     minHeight: '10%',
   },
-  textContainerStyle: { minWidth: '30%', justifyContent: 'center' },
-  iconContainerStyle: { minWidth: '5%' },
+  textContainerStyle: { width: '30%', justifyContent: 'center' },
+  iconContainerStyle: { width: '5%' },
   textStyle: { color: 'white' },
 });


### PR DESCRIPTION
Fixes #1406 

## Change summary

- Adjust styles to use the correct property
- Gave program order french string a `\n` to have it fit more nicelyer


## Testing

- [ ] Program modal with very long supplier/program/order type names are handled correctly
- [ ] program order side of toggle in program modal when in french looks fine

### Related areas to think about

N/A
