### PR TITLE
#1405 Multiline Cell component

### DIFF
--- a/src/widgets/DataTable/Cell.js
+++ b/src/widgets/DataTable/Cell.js
@@ -16,18 +16,20 @@ import { getAdjustedStyle } from './utilities';
  * @param {Number}        maxLiens   Maximum number of lines for the Text component
  *                                   in a row. Removing the borderRight if true.
  */
-const Cell = React.memo(({ value, textStyle, viewStyle, width, isLastCell, maxLines, debug }) => {
-  if (debug) console.log(`- Cell: ${value}`);
-  const internalViewStyle = getAdjustedStyle(viewStyle, width, isLastCell);
+const Cell = React.memo(
+  ({ value, textStyle, viewStyle, width, isLastCell, numberOfLines, debug }) => {
+    if (debug) console.log(`- Cell: ${value}`);
+    const internalViewStyle = getAdjustedStyle(viewStyle, width, isLastCell);
 
-  return (
-    <View style={internalViewStyle}>
-      <Text ellipsizeMode="tail" numberOfLines={maxLines} style={textStyle}>
-        {value}
-      </Text>
-    </View>
-  );
-});
+    return (
+      <View style={internalViewStyle}>
+        <Text ellipsizeMode="tail" numberOfLines={numberOfLines} style={textStyle}>
+          {value}
+        </Text>
+      </View>
+    );
+  }
+);
 
 Cell.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -35,7 +37,7 @@ Cell.propTypes = {
   viewStyle: PropTypes.object,
   width: PropTypes.number,
   isLastCell: PropTypes.bool,
-  maxLines: PropTypes.number,
+  numberOfLines: PropTypes.number,
   debug: PropTypes.bool,
 };
 
@@ -45,7 +47,7 @@ Cell.defaultProps = {
   viewStyle: {},
   width: 0,
   isLastCell: false,
-  maxLines: 2,
+  numberOfLines: 2,
   debug: false,
 };
 

--- a/src/widgets/DataTable/Cell.js
+++ b/src/widgets/DataTable/Cell.js
@@ -13,15 +13,16 @@ import { getAdjustedStyle } from './utilities';
  * @param {Object}        textStyle  Style object for the inner Text
  * @param {Number}        width      optional flex property to inject into styles.
  * @param {Bool}          isLastCell Indicator for if this cell is the last
+ * @param {Number}        maxLiens   Maximum number of lines for the Text component
  *                                   in a row. Removing the borderRight if true.
  */
-const Cell = React.memo(({ value, textStyle, viewStyle, width, isLastCell, debug }) => {
+const Cell = React.memo(({ value, textStyle, viewStyle, width, isLastCell, maxLines, debug }) => {
   if (debug) console.log(`- Cell: ${value}`);
   const internalViewStyle = getAdjustedStyle(viewStyle, width, isLastCell);
 
   return (
     <View style={internalViewStyle}>
-      <Text ellipsizeMode="tail" numberOfLines={1} style={textStyle}>
+      <Text ellipsizeMode="tail" numberOfLines={maxLines} style={textStyle}>
         {value}
       </Text>
     </View>
@@ -34,6 +35,7 @@ Cell.propTypes = {
   viewStyle: PropTypes.object,
   width: PropTypes.number,
   isLastCell: PropTypes.bool,
+  maxLines: PropTypes.number,
   debug: PropTypes.bool,
 };
 
@@ -43,6 +45,7 @@ Cell.defaultProps = {
   viewStyle: {},
   width: 0,
   isLastCell: false,
+  maxLines: 2,
   debug: false,
 };
 


### PR DESCRIPTION
Fixes #1405 

## Change summary

- Adds a `maxLines` prop to `Cell`, default of 2

<img width="1324" alt="image" src="https://user-images.githubusercontent.com/35858975/67139469-10679a80-f2ad-11e9-89dc-49b7e19b9580.png">

<img width="1233" alt="image" src="https://user-images.githubusercontent.com/35858975/67139479-30975980-f2ad-11e9-9aa1-5118538e82ff.png">


## Testing

- [ ] Have an `ItemLine`/`Supplier`/`Customer` with a really long name and look at the name in the `DataTable`, should look all good over two lines

### Related areas to think about

N/A

have updated PR for `react-native-data-table`: https://github.com/sussol/react-native-data-table/pull/57
