### PR TITLE
#1410 scrolling item details

### DIFF
--- a/src/pages/StockPage.js
+++ b/src/pages/StockPage.js
@@ -89,7 +89,7 @@ export const StockPage = ({ routeName }) => {
 
   const { pageTopSectionContainer } = globalStyles;
   return (
-    <DataTablePageView>
+    <DataTablePageView captureUncaughtGestures={false}>
       <View style={pageTopSectionContainer}>
         <SearchBar
           onChangeText={onFilterData}

--- a/src/widgets/DataTablePageView.js
+++ b/src/widgets/DataTablePageView.js
@@ -19,7 +19,11 @@ const dismiss = () => Keyboard.dismiss();
  * to this level.
  */
 export const DataTablePageView = React.memo(({ children, captureUncaughtGestures }) => {
+  // Use a Fragment over TouchableWithoutFeedback so no gesture events are caught.
+  // Frament over a view as TouchableWithoutFeedback does not have implicit styling, a View does.
   const Container = captureUncaughtGestures ? TouchableWithoutFeedback : Fragment;
+
+  // Fragements can only have key or children props
   const containerProps = captureUncaughtGestures ? { onPress: dismiss } : {};
 
   return (

--- a/src/widgets/DataTablePageView.js
+++ b/src/widgets/DataTablePageView.js
@@ -3,7 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { View, Keyboard, TouchableWithoutFeedback } from 'react-native';
 
@@ -18,19 +18,26 @@ const dismiss = () => Keyboard.dismiss();
  * Touchable, dismissing the keyboard when an event propogates
  * to this level.
  */
-export const DataTablePageView = props => {
-  const { children } = props;
+export const DataTablePageView = React.memo(({ children, captureUncaughtGestures }) => {
+  const Container = captureUncaughtGestures ? TouchableWithoutFeedback : Fragment;
+  const containerProps = captureUncaughtGestures ? { onPress: dismiss } : {};
+
   return (
-    <TouchableWithoutFeedback onPress={dismiss}>
+    <Container {...containerProps}>
       <View style={pageContentContainer}>
         <View style={container}>{children}</View>
       </View>
-    </TouchableWithoutFeedback>
+    </Container>
   );
+});
+
+DataTablePageView.defaultProps = {
+  captureUncaughtGestures: true,
 };
 
 DataTablePageView.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+  captureUncaughtGestures: PropTypes.bool,
 };
 
 export default DataTablePageView;


### PR DESCRIPTION
Fixes #1410

## Change summary

- Add a prop to disable/enable gesture handling of `DataTablePageView`
- Disabled gesture handling in `DataTablePageView`

## Testing

- [ ] Have an item with 5+ batches. Go to Stock Page, the `ItemDetails` popup is scrollable.
- [ ] Regression check: When the keyboard is open on a (non-stocktake) `DataTable` page, tap somewhere that does not handle an event i.e. the blueish error - the keyboard should close

### Related areas to think about

N/A
