### PR TITLE
#1409 emergency order types

### DIFF
--- a/src/database/DataTypes/PeriodSchedule.js
+++ b/src/database/DataTypes/PeriodSchedule.js
@@ -22,10 +22,12 @@ export class PeriodSchedule extends Realm.Object {
    * @param {object}      orderType  The maxOrdersPerPeriod of the orderType
    */
   getPeriodsForOrderType(program, orderType) {
-    if (orderType.isEmergency) return this.periods.slice();
-    return this.periods.filter(
-      period => period.requisitionsForOrderType(program, orderType) < orderType.maxOrdersPerPeriod
-    );
+    const { isEmergency } = orderType || {};
+
+    const periodsFilter = period =>
+      period.requisitionsForOrderType(program, orderType) < orderType.maxOrdersPerPeriod;
+
+    return isEmergency ? this.periods.slice() : this.periods.filter(periodsFilter);
   }
 
   /**

--- a/src/database/DataTypes/PeriodSchedule.js
+++ b/src/database/DataTypes/PeriodSchedule.js
@@ -24,10 +24,10 @@ export class PeriodSchedule extends Realm.Object {
   getPeriodsForOrderType(program, orderType) {
     const { isEmergency } = orderType || {};
 
-    const periodsFilter = period =>
+    const filterValidPeriods = period =>
       period.requisitionsForOrderType(program, orderType) < orderType.maxOrdersPerPeriod;
 
-    return isEmergency ? this.periods.slice() : this.periods.filter(periodsFilter);
+    return isEmergency ? this.periods.slice() : this.periods.filter(filterValidPeriods);
   }
 
   /**

--- a/src/database/DataTypes/PeriodSchedule.js
+++ b/src/database/DataTypes/PeriodSchedule.js
@@ -17,14 +17,15 @@ export class PeriodSchedule extends Realm.Object {
    * Finds the related periods for this periodSchedule, which
    * are available to use for the given orderType -- they have
    * less related requisitions to than orderType.maxOrdersPerPeriod.
+   * If the ordertype is an emergency order type, return all periods.
    * @param {MasterList}  program    The related program
    * @param {object}      orderType  The maxOrdersPerPeriod of the orderType
    */
   getPeriodsForOrderType(program, orderType) {
-    const periods = this.periods.filter(
+    if (orderType.isEmergency) return this.periods.slice();
+    return this.periods.filter(
       period => period.requisitionsForOrderType(program, orderType) < orderType.maxOrdersPerPeriod
     );
-    return periods;
   }
 
   /**

--- a/src/localization/programStrings.js
+++ b/src/localization/programStrings.js
@@ -62,6 +62,7 @@ export const programStrings = new LocalizedStrings({
     general_stocktake: 'Inventaire général',
     general_order: 'Commande Générale',
     program_stocktake: 'Inventaire par\n programme',
+    emergency_orders: 'Urgence commandes',
   },
   gil: {
     select_a_program: 'Select a program',

--- a/src/localization/programStrings.js
+++ b/src/localization/programStrings.js
@@ -33,6 +33,7 @@ export const programStrings = new LocalizedStrings({
     general_stocktake: 'General stocktake',
     program_stocktake: 'Program stocktake',
     general_order: 'General order',
+    emergency_orders: 'Emergency orders',
   },
   fr: {
     select_a_program: 'Sélectionnez un programme',

--- a/src/localization/programStrings.js
+++ b/src/localization/programStrings.js
@@ -62,7 +62,7 @@ export const programStrings = new LocalizedStrings({
     general_stocktake: 'Inventaire général',
     general_order: 'Commande Générale',
     program_stocktake: 'Inventaire par\n programme',
-    emergency_orders: 'Urgence commandes',
+    emergency_orders: ' Commandes urgence',
   },
   gil: {
     select_a_program: 'Select a program',

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -41,10 +41,19 @@ const modalProps = ({ dispatch, program, orderType }) => ({
     onSelect: value => dispatch(selectOrderType(value)),
     renderRightText: item => {
       const { maxMOS, maxOPP, threshMOS } = getLocalizedStrings();
-      const { maxOrdersPerPeriod: maxOrders, maxMOS: itemMOS, thresholdMOS: itemThreshMOS } = item;
+      const {
+        maxOrdersPerPeriod: maxOrders,
+        maxMOS: itemMOS,
+        thresholdMOS: itemThreshMOS,
+        isEmergency,
+      } = item;
+
       const mosText = `${maxMOS}: ${itemMOS}`;
       const thresholdText = `${threshMOS}: ${itemThreshMOS}`;
-      const maxOrdersText = `${maxOPP}: ${maxOrders}`;
+      const maxOrdersText = isEmergency
+        ? programStrings.emergency_orders
+        : `${maxOPP}: ${maxOrders}`;
+
       return `${mosText} - ${thresholdText} - ${maxOrdersText}`;
     },
   },
@@ -52,9 +61,15 @@ const modalProps = ({ dispatch, program, orderType }) => ({
     onSelect: value => dispatch(selectPeriod(value)),
     renderRightText: item => {
       const { requisitions } = getLocalizedStrings();
-      const { maxOrdersPerPeriod } = orderType;
+      const { maxOrdersPerPeriod, isEmergency } = orderType;
+
       const requisitionsInPeriod = item.requisitionsForOrderType(program, orderType);
-      const periodText = `${requisitionsInPeriod}/${maxOrdersPerPeriod} ${requisitions}`;
+      const requisitionsCount = `${requisitionsInPeriod}/${maxOrdersPerPeriod} ${requisitions}`;
+
+      const periodText = isEmergency
+        ? `${requisitionsInPeriod} ${programStrings.emergency_orders}`
+        : requisitionsCount;
+
       return `${item} - ${periodText}`;
     },
   },


### PR DESCRIPTION
Fixes #1409 

## Change summary

- Add a change to the method which returns the periods for a program and order type for emergency order types
- Add possible french translation and some changes to strings for emergency orders

## Testing

- [ ] Can create infinitely many program requisitions for an emergency order type

### Related areas to think about

N/A
