### PR TITLE
#1367 fix stocktake difference for uncounted quantities

### DIFF
--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -30,7 +30,7 @@ import TextInputCell from './TextInputCell';
 import { formatStatus } from '../../utilities';
 
 import { COLUMN_TYPES, COLUMN_NAMES } from '../../pages/dataTableUtilities';
-import { tableStrings } from '../../localization/index';
+import { generalStrings, tableStrings } from '../../localization/index';
 
 /**
  * Wrapper component for a mSupply DataTable page row.
@@ -173,10 +173,18 @@ const DataTableRow = React.memo(
             }
 
             case COLUMN_TYPES.NUMERIC: {
+              // Special condition for stocktake difference cells.
+              // Use the placeholder 'Not counted' when a stocktake item or batch
+              // has not been counted yet.
+              const value =
+                columnKey === COLUMN_NAMES.DIFFERENCE && !rowData.hasBeenCounted
+                  ? generalStrings.not_available
+                  : Math.round(rowData[columnKey]);
+
               return (
                 <Cell
                   key={columnKey}
-                  value={Math.round(rowData[columnKey])}
+                  value={value}
                   width={width}
                   viewStyle={cellContainer[cellAlignment]}
                   textStyle={cellText[cellAlignment]}


### PR DESCRIPTION
Fixes #1367.

I think that, as the column is read-only, using the standard style looks good (as opposed to the placeholder style). Feedback appreciated whether you agree or not.

![#1397-fix-uncounted-stock-difference-2](https://user-images.githubusercontent.com/43223637/67168370-79abf280-f400-11e9-901c-2f9e3b0d641e.png)

## Change summary

Figured I'd follow the open-close principle and avoided changing existing `Cell` behaviour.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When stocktake `"Actual quantity"` is `"Not Counted"`, `"Difference`" is `"N/A`".
  - [ ] Create a new stocktake and add an item. `"Difference"` is `"N/A"`.
  - [ ] Edit an existing stocktake and add an item. `"Difference"` is `"N/A`".
  - [ ] Find an existing stocktake with an uncounted item. `"Difference`" is "`N/A`".
- [ ] When stocktake batch `"Actual quantity"` is `"Not Counted"`, `"Difference`" is `"N/A`".
  - [ ] Create a new stocktake and add an item. `"Difference`" for all batches for that item are `"N/A"`.
  - [ ] Edit an existing stocktake and add an item. `"Difference`" for all batches for that item are `"N/A"`.
  - [ ] Find an existing stocktake with an uncounted batch. `"Difference`" is "`N/A`".
- [ ] No other page columns are effected.
  - [ ] Customer invoice columns are not effected.
  - [ ] Customer requisition columns are not effected.
  - [ ] Supplier invoice columns are not effected.
  - [ ] Supplier requisition columns are not effected.
  - [ ] Current stock columns are not effected.
  - [ ] Other stocktake columns are not effected.

### Related areas to think about

Rubber ducking 🦆 .

Think this is a good way of fixing the problem, but introduces the question of how much data manipulation should be handled by `DataTableRow` and how much by `Cell`, `EditableCell`, etc.
IMO, an ideal situation would be to leave `Cell` etc. as dumb as possible, and do all data parsing, validation, manipulation etc. in `DataTableRow`. That seems like a good way to respect SRP and also makes it easy to debug columns as all logic is in one place (might need helper methods etc.).


