### PR TITLE
#1425 Stocktake navigation

### DIFF
--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -34,7 +34,7 @@ import { getCurrentRouteName } from './selectors';
  *
  * @param {Object} requisition The requisition to pass to the next screen.
  */
-export const gotoStocktakeManagePage = ({ stocktake, stocktakeName }) =>
+export const gotoStocktakeManagePage = (stocktakeName, stocktake) =>
   NavigationActions.navigate({
     routeName: 'stocktakeManager',
     params: {
@@ -219,9 +219,9 @@ export const createStocktake = ({ currentUser, stocktakeName, program, itemIds }
 
   // If creating a Stocktake with a program or with a list of itemIds, navigate to
   // the StocktakeEditPage. Otherwise, navigate to the StocktakeManagePage.
-  const nextAction = program || itemIds ? gotoStocktakeEditPage : gotoStocktakeManagePage;
-
-  dispatch(nextAction(stocktake));
+  return program || itemIds
+    ? dispatch(gotoStocktakeEditPage(stocktake))
+    : dispatch(gotoStocktakeManagePage(stocktakeName, stocktake));
 };
 
 /**

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -51,13 +51,14 @@ export const gotoStocktakeManagePage = ({ stocktake, stocktakeName }) =>
  */
 export const gotoStocktakeEditPage = stocktake => (dispatch, getState) => {
   const { nav } = getState();
-
   const currentRouteName = getCurrentRouteName(nav);
 
   const hasNegativeAdjustmentReasons = UIDatabase.objects('NegativeAdjustmentReason').length > 0;
   const hasPositiveAdjustmentReasons = UIDatabase.objects('PositiveAdjustmentReason').length > 0;
   const usesReasons = hasNegativeAdjustmentReasons && hasPositiveAdjustmentReasons;
 
+  // If navigating from the stocktakesPage, go straight to the StocktakeEditPage. Otherwise,
+  // replace the current page as the user is coming from StocktakeManagePage.
   const navigationActionCreator =
     currentRouteName === 'stocktakes' ? NavigationActions.navigate : StackActions.replace;
 
@@ -216,6 +217,8 @@ export const createStocktake = ({ currentUser, stocktakeName, program, itemIds }
     else if (itemIds) stocktake.setItemsByID(UIDatabase, itemIds);
   });
 
+  // If creating a Stocktake with a program or with a list of itemIds, navigate to
+  // the StocktakeEditPage. Otherwise, navigate to the StocktakeManagePage.
   const nextAction = program || itemIds ? gotoStocktakeEditPage : gotoStocktakeManagePage;
 
   dispatch(nextAction(stocktake));

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/forbid-prop-types */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
@@ -66,7 +67,7 @@ export const StocktakeEditPage = ({
     getPageInfoColumns,
   } = state;
 
-  const { isFinalised, comment, program } = pageObject;
+  const { isFinalised, comment, program, name } = pageObject;
 
   // Listen to the stocktake become the top of the stack or being finalised,
   // as these events are side-effects. Refreshing makes the state consistent again.
@@ -87,16 +88,14 @@ export const StocktakeEditPage = ({
   const onCloseModal = () => dispatch(PageActions.closeModal());
   const onApplyReason = ({ item }) => dispatch(PageActions.applyReason(item));
   const onConfirmBatchEdit = () => dispatch(PageActions.closeAndRefresh());
-
+  const onManageStocktake = () => reduxDispatch(gotoStocktakeManagePage(name, stocktake));
   const onResetStocktake = () =>
     runWithLoadingIndicator(() => dispatch(PageActions.resetStocktake()));
-  const onManageStocktake = () =>
-    reduxDispatch(gotoStocktakeManagePage({ stocktake, stocktakeName: stocktake.name }));
 
   const pageInfoColumns = useCallback(getPageInfoColumns(pageObject, dispatch, PageActions), [
     comment,
     isFinalised,
-    pageObject.name,
+    name,
   ]);
 
   const getAction = useCallback((colKey, propName) => {
@@ -210,7 +209,6 @@ export const StocktakeEditPage = ({
   );
 };
 
-/* eslint-disable react/forbid-prop-types */
 StocktakeEditPage.propTypes = {
   runWithLoadingIndicator: PropTypes.func.isRequired,
   stocktake: PropTypes.object.isRequired,

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -58,7 +58,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
 
   const onNewStocktake = () => {
     if (usingPrograms) return dispatch(PageActions.openModal(MODAL_KEYS.PROGRAM_STOCKTAKE));
-    return reduxDispatch(gotoStocktakeManagePage({ stocktakeName: '' }));
+    return reduxDispatch(gotoStocktakeManagePage(''));
   };
 
   const getAction = useCallback((colKey, propName) => {


### PR DESCRIPTION
Fixes #1425 

## Change summary

- Changes a couple of navigation actions to fix the bug as per the issue
    - When creating a `Stocktake`, 3 invocations
        - Creating a program stocktake: create and go to `StocktakeEditPage`
        - Creating a normal stocktake with programs defined - create and go to StocktakeManagePage
        - Creating a normal stocktake with no programs defined: Already on `StocktakeManagePage`, with a list of items selected - go to `StocktakeEditPage`
    - When navigating to `StocktakeEditPage`, two invocations
        - Navigating from `StocktakesPage` [When creating a program stocktake]
        - Navigating from `StocktakeManagePage` [all others]. Don't want to navigate back to `StocktakeManagePage` from `StocktakeEditPage`, so pop and push the stack

## Testing

- [ ] Creating a program stocktake
    - [ ] After creating a program stocktake - navigates to `StocktakeEditPage`
    - [ ] From `StocktakeEditPage`, pressing back goes to `StocktakesPage`
- [ ] Creating a general stocktake [from `ByProgramModal`]
    - [ ] Navigates to `StocktakeManagePage` on creation [name should be set]
    - [ ] Selecting items and confirming navigates to `StocktakeEditPage`
    - [ ] Navigating back from `StocktakeEditPage` goes to `StocktakesPage`
- [ ] Creating a stocktake [with no programs defined]
    - [ ] Navigates to `StocktakeManagePage`  [no stocktake created yet]
    - [ ] Adding items and confirming navigates to `StocktakeEditPage`
    - [ ] Navigating back from `StocktakeEditPage` navigates to `StocktakesPage`

### Related areas to think about

N/A
