### PR TITLE
#1398 rename unsafe lifecycle methods

### DIFF
--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -23,6 +23,7 @@ export class MenuPage extends React.Component {
     this.databaseListenerId = null;
   }
 
+  // eslint-disable-next-line camelcase, react/sort-comp
   UNSAFE_componentWillMount() {
     const { database } = this.props;
 

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -23,7 +23,7 @@ export class MenuPage extends React.Component {
     this.databaseListenerId = null;
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { database } = this.props;
 
     this.databaseListenerId = database.addListener(

--- a/src/widgets/Spinner.js
+++ b/src/widgets/Spinner.js
@@ -20,6 +20,7 @@ export class Spinner extends React.Component {
     this.startSpinning();
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.isSpinning) this.startSpinning();
     else this.stopSpinning();
@@ -63,6 +64,7 @@ export class Spinner extends React.Component {
 export default Spinner;
 
 Spinner.propTypes = {
+  // eslint-disable-next-line react/no-unused-prop-types
   isSpinning: PropTypes.bool,
   color: PropTypes.string,
 };

--- a/src/widgets/Spinner.js
+++ b/src/widgets/Spinner.js
@@ -20,7 +20,7 @@ export class Spinner extends React.Component {
     this.startSpinning();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.isSpinning) this.startSpinning();
     else this.stopSpinning();
   }

--- a/src/widgets/modals/BottomModal.js
+++ b/src/widgets/modals/BottomModal.js
@@ -12,6 +12,7 @@ import Modal from 'react-native-modalbox';
 import { DARKER_GREY } from '../../globalStyles/index';
 
 export class BottomModal extends React.Component {
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { isOpen } = this.props;
     const { isOpen: willOpen } = nextProps;

--- a/src/widgets/modals/BottomModal.js
+++ b/src/widgets/modals/BottomModal.js
@@ -12,7 +12,7 @@ import Modal from 'react-native-modalbox';
 import { DARKER_GREY } from '../../globalStyles/index';
 
 export class BottomModal extends React.Component {
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { isOpen } = this.props;
     const { isOpen: willOpen } = nextProps;
 

--- a/src/widgets/modals/DemoUserModal.js
+++ b/src/widgets/modals/DemoUserModal.js
@@ -33,6 +33,7 @@ export class DemoUserModal extends React.Component {
     this.errorTimeoutId = null;
   }
 
+  // eslint-disable-next-line camelcase, react/sort-comp
   UNSAFE_componentWillUpdate() {
     if (this.errorTimeoutId) clearTimeout(this.errorTimeoutId);
   }

--- a/src/widgets/modals/DemoUserModal.js
+++ b/src/widgets/modals/DemoUserModal.js
@@ -33,7 +33,7 @@ export class DemoUserModal extends React.Component {
     this.errorTimeoutId = null;
   }
 
-  componentWillUpdate() {
+  UNSAFE_componentWillUpdate() {
     if (this.errorTimeoutId) clearTimeout(this.errorTimeoutId);
   }
 

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -36,6 +36,7 @@ export class LoginModal extends React.Component {
     this.errorTimeoutId = null;
   }
 
+  // eslint-disable-next-line camelcase, react/sort-comp
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { authStatus } = this.state;
 
@@ -47,6 +48,7 @@ export class LoginModal extends React.Component {
     }
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillUpdate() {
     if (this.errorTimeoutId) clearTimeout(this.errorTimeoutId);
   }

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -36,7 +36,7 @@ export class LoginModal extends React.Component {
     this.errorTimeoutId = null;
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { authStatus } = this.state;
 
     if (authStatus === 'authenticated' && !nextProps.isAuthenticated) {
@@ -47,7 +47,7 @@ export class LoginModal extends React.Component {
     }
   }
 
-  componentWillUpdate() {
+  UNSAFE_componentWillUpdate() {
     if (this.errorTimeoutId) clearTimeout(this.errorTimeoutId);
   }
 


### PR DESCRIPTION
Fixes #1398.

## Change summary

- Used `react-codemod` script to update unsafe lifecycle methods.
  - Updated pages: `MenuPage`.
  - Updated widgets: `Spinner`
  - Update modals: `BottomModal`, `DemoUserModal`, `LoginModal`.
- Disabled eslint rules `camelcase` and `react/sort-comp` where needed.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Use the `LoginModal`. No errors occur.
- [ ] Use the `DemoUserModal` (not sure how to enable this?). No errors occur.
- [ ] Navigate to `MenuPage`. No errors occur.
- [ ] Use the `BottomModal` (e.g. navigate to `StockPage`, click an item). No errors occur.
- [ ] Use the `Spinner` widget (e.g. create a new stocktake). No errors occur.

### Related areas to think about

N/A.
