### PR TITLE
#1446 cells use dispatch not callbacks

### DIFF
--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -70,10 +70,10 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
   const onConfirmDelete = () => dispatch(PageActions.deleteTransactions());
   const onCancelDelete = () => dispatch(PageActions.deselectAll());
   const onCloseModal = () => dispatch(PageActions.closeModal());
-  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
-  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
-  const onEditTotalQuantity = (newValue, rowKey, columnKey) =>
-    dispatch(PageActions.editTotalQuantity(newValue, rowKey, columnKey));
+  const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
+  const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
+  const onEditTotalQuantity = (newValue, rowKey) =>
+    dispatch(PageActions.editTotalQuantity(newValue, rowKey));
 
   const onAddMasterList = () =>
     runWithLoadingIndicator(() => dispatch(PageActions.addMasterListItems('Transaction')));

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -7,7 +7,7 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { MODAL_KEYS } from '../utilities';
+import { MODAL_KEYS, debounce } from '../utilities';
 import { useRecordListener, usePageReducer } from '../hooks';
 import { getItemLayout } from './dataTableUtilities';
 
@@ -37,7 +37,7 @@ import globalStyles from '../globalStyles';
  */
 export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, routeName }) => {
   const initialState = { page: routeName, pageObject: transaction };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
+  const [state, dispatch] = usePageReducer(initialState);
 
   const {
     data,
@@ -77,6 +77,11 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
 
   const onAddMasterList = () =>
     runWithLoadingIndicator(() => dispatch(PageActions.addMasterListItems('Transaction')));
+
+  const onSortColumn = useCallback(
+    debounce(columnKey => dispatch(PageActions.sortData(columnKey)), 250, true),
+    []
+  );
 
   const pageInfoColumns = useCallback(getPageInfoColumns(pageObject, dispatch, PageActions), [
     comment,
@@ -133,8 +138,7 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
     () => (
       <DataTableHeaderRow
         columns={columns}
-        dispatch={instantDebouncedDispatch}
-        sortAction={PageActions.sortData}
+        onPress={onSortColumn}
         isAscending={isAscending}
         sortBy={sortBy}
       />

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -70,6 +70,10 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
   const onConfirmDelete = () => dispatch(PageActions.deleteTransactions());
   const onCancelDelete = () => dispatch(PageActions.deselectAll());
   const onCloseModal = () => dispatch(PageActions.closeModal());
+  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
+  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
+  const onEditTotalQuantity = (newValue, rowKey, columnKey) =>
+    dispatch(PageActions.editTotalQuantity(newValue, rowKey, columnKey));
 
   const onAddMasterList = () =>
     runWithLoadingIndicator(() => dispatch(PageActions.addMasterListItems('Transaction')));
@@ -80,13 +84,13 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
     isFinalised,
   ]);
 
-  const getAction = useCallback((colKey, propName) => {
+  const getCallback = useCallback((colKey, propName) => {
     switch (colKey) {
       case 'totalQuantity':
-        return PageActions.editTotalQuantity;
+        return onEditTotalQuantity;
       case 'remove':
-        if (propName === 'onCheckAction') return PageActions.selectRow;
-        return PageActions.deselectRow;
+        if (propName === 'onCheck') return onCheck;
+        return onUncheck;
       default:
         return null;
     }
@@ -117,8 +121,7 @@ export const CustomerInvoicePage = ({ transaction, runWithLoadingIndicator, rout
           rowKey={rowKey}
           columns={columns}
           isFinalised={isFinalised}
-          dispatch={dispatch}
-          getAction={getAction}
+          getCallback={getCallback}
           rowIndex={index}
         />
       );

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -54,8 +54,8 @@ export const CustomerInvoicesPage = ({
   const onConfirmDelete = () => dispatch(PageActions.deleteTransactions());
   const onCancelDelete = () => dispatch(PageActions.deselectAll());
   const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
-  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
-  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
+  const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
+  const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
 
   const onNavigateToInvoice = useCallback(
     invoice => reduxDispatch(gotoCustomerInvoice(invoice)),

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -8,7 +8,7 @@ import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { MODAL_KEYS } from '../utilities';
+import { MODAL_KEYS, debounce } from '../utilities';
 import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
 import { getItemLayout } from './dataTableUtilities';
 import { gotoCustomerInvoice, createCustomerInvoice } from '../navigation/actions';
@@ -27,7 +27,7 @@ export const CustomerInvoicesPage = ({
   dispatch: reduxDispatch,
 }) => {
   const initialState = { page: routeName };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
+  const [state, dispatch] = usePageReducer(initialState);
   const {
     data,
     dataState,
@@ -57,6 +57,10 @@ export const CustomerInvoicesPage = ({
   const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
   const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
 
+  const onSortColumn = useCallback(
+    debounce(columnKey => dispatch(PageActions.sortData(columnKey)), 250, true),
+    []
+  );
   const onNavigateToInvoice = useCallback(
     invoice => reduxDispatch(gotoCustomerInvoice(invoice)),
     []
@@ -117,8 +121,7 @@ export const CustomerInvoicesPage = ({
     () => (
       <DataTableHeaderRow
         columns={columns}
-        dispatch={instantDebouncedDispatch}
-        sortAction={PageActions.sortData}
+        onPress={onSortColumn}
         isAscending={isAscending}
         sortBy={sortBy}
       />

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -54,6 +54,8 @@ export const CustomerInvoicesPage = ({
   const onConfirmDelete = () => dispatch(PageActions.deleteTransactions());
   const onCancelDelete = () => dispatch(PageActions.deselectAll());
   const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
+  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
+  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
 
   const onNavigateToInvoice = useCallback(
     invoice => reduxDispatch(gotoCustomerInvoice(invoice)),
@@ -73,11 +75,11 @@ export const CustomerInvoicesPage = ({
     [showFinalised]
   );
 
-  const getAction = useCallback((colKey, propName) => {
+  const getCallback = useCallback((colKey, propName) => {
     switch (colKey) {
       case 'remove':
-        if (propName === 'onCheckAction') return PageActions.selectRow;
-        return PageActions.deselectRow;
+        if (propName === 'onCheck') return onCheck;
+        return onUncheck;
       default:
         return null;
     }
@@ -102,8 +104,7 @@ export const CustomerInvoicesPage = ({
           rowState={dataState.get(rowKey)}
           rowKey={rowKey}
           columns={columns}
-          dispatch={dispatch}
-          getAction={getAction}
+          getCallback={getCallback}
           rowIndex={index}
           onPress={onNavigateToInvoice}
         />

--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -7,7 +7,7 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { MODAL_KEYS } from '../utilities';
+import { MODAL_KEYS, debounce } from '../utilities';
 
 import { DataTablePageModal } from '../widgets/modals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
@@ -39,7 +39,7 @@ import { buttonStrings } from '../localization';
  */
 export const CustomerRequisitionPage = ({ requisition, runWithLoadingIndicator, routeName }) => {
   const initialState = { page: routeName, pageObject: requisition };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
+  const [state, dispatch] = usePageReducer(initialState);
 
   const {
     data,
@@ -72,7 +72,10 @@ export const CustomerRequisitionPage = ({ requisition, runWithLoadingIndicator, 
     runWithLoadingIndicator(() => dispatch(PageActions.setSuppliedToRequested()));
   const onSetSuppliedToSuggested = () =>
     runWithLoadingIndicator(() => dispatch(PageActions.setSuppliedToSuggested()));
-
+  const onSortColumn = useCallback(
+    debounce(columnKey => dispatch(PageActions.sortData(columnKey)), 250, true),
+    []
+  );
   const pageInfoColumns = useCallback(getPageInfoColumns(pageObject, dispatch, PageActions), [
     comment,
     isFinalised,
@@ -120,8 +123,7 @@ export const CustomerRequisitionPage = ({ requisition, runWithLoadingIndicator, 
     () => (
       <DataTableHeaderRow
         columns={columns}
-        dispatch={instantDebouncedDispatch}
-        sortAction={PageActions.sortData}
+        onPress={onSortColumn}
         isAscending={isAscending}
         sortBy={sortBy}
       />

--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -66,7 +66,8 @@ export const CustomerRequisitionPage = ({ requisition, runWithLoadingIndicator, 
   const onAddItem = value => dispatch(PageActions.addRequisitionItem(value));
   const onEditComment = value => dispatch(PageActions.editComment(value, 'Requisition'));
   const onFilterData = value => dispatch(PageActions.filterData(value));
-
+  const onEditSuppliedQuantity = (newValue, rowKey, columnKey) =>
+    dispatch(PageActions.editSuppliedQuantity(newValue, rowKey, columnKey));
   const onSetSuppliedToRequested = () =>
     runWithLoadingIndicator(() => dispatch(PageActions.setSuppliedToRequested()));
   const onSetSuppliedToSuggested = () =>
@@ -77,10 +78,10 @@ export const CustomerRequisitionPage = ({ requisition, runWithLoadingIndicator, 
     isFinalised,
   ]);
 
-  const getAction = useCallback(colKey => {
+  const getCallback = useCallback(colKey => {
     switch (colKey) {
       case 'suppliedQuantity':
-        return PageActions.editSuppliedQuantity;
+        return onEditSuppliedQuantity;
       default:
         return null;
     }
@@ -107,8 +108,7 @@ export const CustomerRequisitionPage = ({ requisition, runWithLoadingIndicator, 
           rowKey={rowKey}
           columns={columns}
           isFinalised={isFinalised}
-          dispatch={dispatch}
-          getAction={getAction}
+          getCallback={getCallback}
           rowIndex={index}
         />
       );

--- a/src/pages/CustomerRequisitionsPage.js
+++ b/src/pages/CustomerRequisitionsPage.js
@@ -69,7 +69,6 @@ export const CustomerRequisitionsPage = ({ routeName, dispatch: reduxDispatch, n
           rowData={data[index]}
           rowKey={rowKey}
           columns={columns}
-          dispatch={dispatch}
           onPress={onPressRow}
           rowIndex={index}
         />

--- a/src/pages/CustomerRequisitionsPage.js
+++ b/src/pages/CustomerRequisitionsPage.js
@@ -16,6 +16,7 @@ import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
 
 import globalStyles from '../globalStyles';
 import { buttonStrings } from '../localization';
+import { debounce } from '../utilities/index';
 
 /**
  * Renders a mSupply mobile page with a list of Customer requisitions.
@@ -37,7 +38,7 @@ import { buttonStrings } from '../localization';
  */
 export const CustomerRequisitionsPage = ({ routeName, dispatch: reduxDispatch, navigation }) => {
   const initialState = { page: routeName };
-  const [state, dispatch, debouncedDispatch] = usePageReducer(initialState);
+  const [state, dispatch] = usePageReducer(initialState);
 
   const {
     data,
@@ -60,6 +61,11 @@ export const CustomerRequisitionsPage = ({ routeName, dispatch: reduxDispatch, n
   const onFilterData = value => dispatch(PageActions.filterData(value));
   const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
 
+  const onSortColumn = useCallback(
+    debounce(columnKey => dispatch(PageActions.sortData(columnKey)), 250, true),
+    []
+  );
+
   const renderRow = useCallback(
     listItem => {
       const { item, index } = listItem;
@@ -81,8 +87,7 @@ export const CustomerRequisitionsPage = ({ routeName, dispatch: reduxDispatch, n
     () => (
       <DataTableHeaderRow
         columns={columns}
-        dispatch={debouncedDispatch}
-        sortAction={PageActions.sortData}
+        onPress={onSortColumn}
         isAscending={isAscending}
         sortBy={sortBy}
       />

--- a/src/pages/StockPage.js
+++ b/src/pages/StockPage.js
@@ -67,8 +67,6 @@ export const StockPage = ({ routeName }) => {
           rowState={dataState.get(rowKey)}
           rowKey={rowKey}
           columns={columns}
-          isFinalised={false}
-          dispatch={dispatch}
           rowIndex={index}
           onPress={onSelectRow}
         />

--- a/src/pages/StockPage.js
+++ b/src/pages/StockPage.js
@@ -17,6 +17,7 @@ import { usePageReducer, useSyncListener } from '../hooks';
 import { DataTablePageView, SearchBar } from '../widgets';
 
 import { ItemDetails } from '../widgets/modals/ItemDetails';
+import { debounce } from '../utilities/index';
 
 /**
  * Renders a mSupply mobile page with Items and their stock levels.
@@ -35,7 +36,7 @@ import { ItemDetails } from '../widgets/modals/ItemDetails';
  */
 export const StockPage = ({ routeName }) => {
   const initialState = { page: routeName };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
+  const [state, dispatch] = usePageReducer(initialState);
 
   const {
     data,
@@ -56,6 +57,11 @@ export const StockPage = ({ routeName }) => {
   const onSelectRow = useCallback(({ id }) => dispatch(PageActions.selectOneRow(id)), []);
   const onDeselectRow = () => dispatch(PageActions.deselectRow(selectedRow.id));
   const onFilterData = value => dispatch(PageActions.filterData(value));
+
+  const onSortColumn = useCallback(
+    debounce(columnKey => dispatch(PageActions.sortData(columnKey)), 250, true),
+    []
+  );
 
   const renderRow = useCallback(
     listItem => {
@@ -78,8 +84,7 @@ export const StockPage = ({ routeName }) => {
   const renderHeader = () => (
     <DataTableHeaderRow
       columns={columns}
-      dispatch={instantDebouncedDispatch}
-      sortAction={PageActions.sortData}
+      onPress={onSortColumn}
       isAscending={isAscending}
       sortBy={sortBy}
     />

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -91,8 +91,8 @@ export const StocktakeEditPage = ({
   const onApplyReason = ({ item }) => dispatch(PageActions.applyReason(item));
   const onConfirmBatchEdit = () => dispatch(PageActions.closeAndRefresh());
   const onManageStocktake = () => reduxDispatch(gotoStocktakeManagePage(name, stocktake));
-  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
-  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
+  const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
+  const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
   const onEditCountedQuantity = (newValue, rowKey, columnKey) =>
     dispatch(PageActions.editCountedQuantity(newValue, rowKey, columnKey));
   const onResetStocktake = () =>

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -82,13 +82,19 @@ export const StocktakeEditPage = ({
 
   const onEditName = value => dispatch(PageActions.editPageObjectName(value, 'Stocktake'));
   const onFilterData = value => dispatch(PageActions.filterData(value));
-  const onEditBatch = rowKey => PageActions.openModal(MODAL_KEYS.EDIT_STOCKTAKE_BATCH, rowKey);
-  const onEditReason = rowKey => PageActions.openModal(MODAL_KEYS.STOCKTAKE_REASON, rowKey);
+  const onEditBatch = rowKey =>
+    dispatch(PageActions.openModal(MODAL_KEYS.EDIT_STOCKTAKE_BATCH, rowKey));
+  const onEditReason = rowKey =>
+    dispatch(PageActions.openModal(MODAL_KEYS.STOCKTAKE_REASON, rowKey));
   const onEditComment = value => dispatch(PageActions.editComment(value, 'Stocktake'));
   const onCloseModal = () => dispatch(PageActions.closeModal());
   const onApplyReason = ({ item }) => dispatch(PageActions.applyReason(item));
   const onConfirmBatchEdit = () => dispatch(PageActions.closeAndRefresh());
   const onManageStocktake = () => reduxDispatch(gotoStocktakeManagePage(name, stocktake));
+  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
+  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
+  const onEditCountedQuantity = (newValue, rowKey, columnKey) =>
+    dispatch(PageActions.editCountedQuantity(newValue, rowKey, columnKey));
   const onResetStocktake = () =>
     runWithLoadingIndicator(() => dispatch(PageActions.resetStocktake()));
 
@@ -98,15 +104,15 @@ export const StocktakeEditPage = ({
     name,
   ]);
 
-  const getAction = useCallback((colKey, propName) => {
+  const getCallback = useCallback((colKey, propName) => {
     switch (colKey) {
       case 'countedTotalQuantity':
-        return PageActions.editCountedQuantity;
+        return onEditCountedQuantity;
       case 'batch':
         return onEditBatch;
       case 'remove':
-        if (propName === 'onCheckAction') return PageActions.selectRow;
-        return PageActions.deselectRow;
+        if (propName === 'onCheck') return onCheck;
+        return onUncheck;
       case 'reasonTitle':
         return onEditReason;
       default:
@@ -143,8 +149,7 @@ export const StocktakeEditPage = ({
           rowKey={rowKey}
           columns={columns}
           isFinalised={isFinalised}
-          dispatch={dispatch}
-          getAction={getAction}
+          getCallback={getCallback}
           rowIndex={index}
         />
       );

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -8,7 +8,7 @@ import React, { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { MODAL_KEYS } from '../utilities';
+import { MODAL_KEYS, debounce } from '../utilities';
 import { usePageReducer } from '../hooks/usePageReducer';
 import { getItemLayout } from './dataTableUtilities';
 
@@ -50,7 +50,7 @@ export const StocktakeEditPage = ({
   navigation,
 }) => {
   const initialState = { page: routeName, pageObject: stocktake };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
+  const [state, dispatch] = usePageReducer(initialState);
 
   const {
     pageObject,
@@ -97,6 +97,11 @@ export const StocktakeEditPage = ({
     dispatch(PageActions.editCountedQuantity(newValue, rowKey, columnKey));
   const onResetStocktake = () =>
     runWithLoadingIndicator(() => dispatch(PageActions.resetStocktake()));
+
+  const onSortColumn = useCallback(
+    debounce(columnKey => dispatch(PageActions.sortData(columnKey)), 250, true),
+    []
+  );
 
   const pageInfoColumns = useCallback(getPageInfoColumns(pageObject, dispatch, PageActions), [
     comment,
@@ -161,8 +166,7 @@ export const StocktakeEditPage = ({
     () => (
       <DataTableHeaderRow
         columns={columns}
-        dispatch={instantDebouncedDispatch}
-        sortAction={PageActions.sortData}
+        onPress={onSortColumn}
         isAscending={isAscending}
         sortBy={sortBy}
       />

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -48,8 +48,8 @@ export const StocktakeManagePage = ({
     if (stocktake) dispatch(PageActions.selectItems(stocktake.itemsInStocktake));
   }, []);
 
-  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
-  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
+  const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
+  const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
 
   const getCallback = useCallback((colKey, propName) => {
     switch (colKey) {

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -48,11 +48,14 @@ export const StocktakeManagePage = ({
     if (stocktake) dispatch(PageActions.selectItems(stocktake.itemsInStocktake));
   }, []);
 
-  const getAction = useCallback((colKey, propName) => {
+  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
+  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
+
+  const getCallback = useCallback((colKey, propName) => {
     switch (colKey) {
       case 'selected':
-        if (propName === 'onCheckAction') return PageActions.selectRow;
-        return PageActions.deselectRow;
+        if (propName === 'onCheck') return onCheck;
+        return onUncheck;
       default:
         return null;
     }
@@ -81,8 +84,7 @@ export const StocktakeManagePage = ({
           rowState={dataState.get(rowKey)}
           rowKey={rowKey}
           columns={columns}
-          dispatch={dispatch}
-          getAction={getAction}
+          getCallback={getCallback}
           rowIndex={index}
         />
       );

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -17,6 +17,7 @@ import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTabl
 
 import { buttonStrings, modalStrings } from '../localization';
 import globalStyles from '../globalStyles';
+import { debounce } from '../utilities/index';
 
 export const StocktakeManagePage = ({
   routeName,
@@ -25,7 +26,7 @@ export const StocktakeManagePage = ({
   runWithLoadingIndicator,
 }) => {
   const initialState = { page: routeName, pageObject: stocktake };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
+  const [state, dispatch] = usePageReducer(initialState);
 
   const {
     data,
@@ -50,6 +51,11 @@ export const StocktakeManagePage = ({
 
   const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
   const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
+
+  const onSortColumn = useCallback(
+    debounce(columnKey => dispatch(PageActions.sortData(columnKey)), 250, true),
+    []
+  );
 
   const getCallback = useCallback((colKey, propName) => {
     switch (colKey) {
@@ -96,8 +102,7 @@ export const StocktakeManagePage = ({
     () => (
       <DataTableHeaderRow
         columns={columns}
-        dispatch={instantDebouncedDispatch}
-        sortAction={PageActions.sortData}
+        onPress={onSortColumn}
         isAscending={isAscending}
         sortBy={sortBy}
       />

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -55,17 +55,19 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
   const onConfirmDelete = () => dispatch(PageActions.deleteStocktakes());
   const onCloseModal = () => dispatch(PageActions.closeModal());
   const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
+  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
+  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
 
   const onNewStocktake = () => {
     if (usingPrograms) return dispatch(PageActions.openModal(MODAL_KEYS.PROGRAM_STOCKTAKE));
     return reduxDispatch(gotoStocktakeManagePage(''));
   };
 
-  const getAction = useCallback((colKey, propName) => {
+  const getCallback = useCallback((colKey, propName) => {
     switch (colKey) {
       case 'remove':
-        if (propName === 'onCheckAction') return PageActions.selectRow;
-        return PageActions.deselectRow;
+        if (propName === 'onCheck') return onCheck;
+        return onUncheck;
       default:
         return null;
     }
@@ -93,8 +95,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
           rowState={dataState.get(rowKey)}
           rowKey={rowKey}
           columns={columns}
-          dispatch={dispatch}
-          getAction={getAction}
+          getCallback={getCallback}
           onPress={onRowPress}
           rowIndex={index}
         />

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -55,8 +55,8 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
   const onConfirmDelete = () => dispatch(PageActions.deleteStocktakes());
   const onCloseModal = () => dispatch(PageActions.closeModal());
   const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
-  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
-  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
+  const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
+  const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
 
   const onNewStocktake = () => {
     if (usingPrograms) return dispatch(PageActions.openModal(MODAL_KEYS.PROGRAM_STOCKTAKE));

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -7,7 +7,7 @@ import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { MODAL_KEYS } from '../utilities';
+import { MODAL_KEYS, debounce } from '../utilities';
 import { usePageReducer, useSyncListener, useNavigationFocus } from '../hooks';
 import { getItemLayout } from './dataTableUtilities';
 
@@ -26,7 +26,7 @@ import {
 
 export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch, navigation }) => {
   const initialState = { page: routeName };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
+  const [state, dispatch] = usePageReducer(initialState);
 
   const {
     data,
@@ -57,6 +57,11 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
   const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
   const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
   const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
+
+  const onSortColumn = useCallback(
+    debounce(columnKey => dispatch(PageActions.sortData(columnKey)), 250, true),
+    []
+  );
 
   const onNewStocktake = () => {
     if (usingPrograms) return dispatch(PageActions.openModal(MODAL_KEYS.PROGRAM_STOCKTAKE));
@@ -108,8 +113,7 @@ export const StocktakesPage = ({ routeName, currentUser, dispatch: reduxDispatch
     () => (
       <DataTableHeaderRow
         columns={columns}
-        dispatch={instantDebouncedDispatch}
-        sortAction={PageActions.sortData}
+        onPress={onSortColumn}
         isAscending={isAscending}
         sortBy={sortBy}
       />

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -7,7 +7,7 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { MODAL_KEYS } from '../utilities';
+import { MODAL_KEYS, debounce } from '../utilities';
 import { usePageReducer, useRecordListener } from '../hooks';
 import { getItemLayout } from './dataTableUtilities';
 
@@ -20,7 +20,7 @@ import globalStyles from '../globalStyles';
 
 export const SupplierInvoicePage = ({ routeName, transaction }) => {
   const initialState = { page: routeName, pageObject: transaction };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
+  const [state, dispatch] = usePageReducer(initialState);
 
   const {
     pageObject,
@@ -59,6 +59,10 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
   const onEditTotalQuantity = (newValue, rowKey) =>
     dispatch(PageActions.editTotalQuantity(newValue, rowKey));
 
+  const onSortColumn = useCallback(
+    debounce(columnKey => dispatch(PageActions.sortData(columnKey)), 250, true),
+    []
+  );
   const pageInfoColumns = useCallback(getPageInfoColumns(pageObject, dispatch, PageActions), [
     comment,
     theirRef,
@@ -115,8 +119,7 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
     () => (
       <DataTableHeaderRow
         columns={columns}
-        dispatch={instantDebouncedDispatch}
-        sortAction={PageActions.sortData}
+        onPress={onSortColumn}
         isAscending={isAscending}
         sortBy={sortBy}
       />

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -52,6 +52,12 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
   const onCancelDelete = () => dispatch(PageActions.deselectAll());
   const onConfirmDelete = () => dispatch(PageActions.deleteTransactionBatches());
   const onCloseModal = () => dispatch(PageActions.closeModal());
+  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
+  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
+  const onEditDate = (date, rowKey, columnKey) =>
+    dispatch(PageActions.editTransactionBatchExpiryDate(date, rowKey, columnKey));
+  const onEditTotalQuantity = (newValue, rowKey, columnKey) =>
+    dispatch(PageActions.editTotalQuantity(newValue, rowKey, columnKey));
 
   const pageInfoColumns = useCallback(getPageInfoColumns(pageObject, dispatch, PageActions), [
     comment,
@@ -59,15 +65,15 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
     isFinalised,
   ]);
 
-  const getAction = useCallback((columnKey, propName) => {
+  const getCallback = useCallback((columnKey, propName) => {
     switch (columnKey) {
       case 'totalQuantity':
-        return PageActions.editTotalQuantity;
+        return onEditTotalQuantity;
       case 'expiryDate':
-        return PageActions.editTransactionBatchExpiryDate;
+        return onEditDate;
       case 'remove':
-        if (propName === 'onCheckAction') return PageActions.selectRow;
-        return PageActions.deselectRow;
+        if (propName === 'onCheck') return onCheck;
+        return onUncheck;
       default:
         return null;
     }
@@ -97,8 +103,7 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
           rowKey={rowKey}
           columns={columns}
           isFinalised={isFinalised}
-          dispatch={dispatch}
-          getAction={getAction}
+          getCallback={getCallback}
           rowIndex={index}
         />
       );

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -52,12 +52,12 @@ export const SupplierInvoicePage = ({ routeName, transaction }) => {
   const onCancelDelete = () => dispatch(PageActions.deselectAll());
   const onConfirmDelete = () => dispatch(PageActions.deleteTransactionBatches());
   const onCloseModal = () => dispatch(PageActions.closeModal());
-  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
-  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
-  const onEditDate = (date, rowKey, columnKey) =>
-    dispatch(PageActions.editTransactionBatchExpiryDate(date, rowKey, columnKey));
-  const onEditTotalQuantity = (newValue, rowKey, columnKey) =>
-    dispatch(PageActions.editTotalQuantity(newValue, rowKey, columnKey));
+  const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
+  const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
+  const onEditDate = (date, rowKey) =>
+    dispatch(PageActions.editTransactionBatchExpiryDate(date, rowKey));
+  const onEditTotalQuantity = (newValue, rowKey) =>
+    dispatch(PageActions.editTotalQuantity(newValue, rowKey));
 
   const pageInfoColumns = useCallback(getPageInfoColumns(pageObject, dispatch, PageActions), [
     comment,

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -54,6 +54,8 @@ export const SupplierInvoicesPage = ({
   const onConfirmDelete = () => dispatch(PageActions.deleteTransactions());
   const onCancelDelete = () => dispatch(PageActions.deselectAll());
   const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
+  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
+  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
 
   const onNavigateToInvoice = useCallback(
     invoice => reduxDispatch(gotoSupplierInvoice(invoice)),
@@ -65,11 +67,11 @@ export const SupplierInvoicesPage = ({
     onCloseModal();
   };
 
-  const getAction = useCallback((colKey, propName) => {
+  const getCallback = useCallback((colKey, propName) => {
     switch (colKey) {
       case 'remove':
-        if (propName === 'onCheckAction') return PageActions.selectRow;
-        return PageActions.deselectRow;
+        if (propName === 'onCheck') return onCheck;
+        return onUncheck;
       default:
         return null;
     }
@@ -94,8 +96,7 @@ export const SupplierInvoicesPage = ({
           rowState={dataState.get(rowKey)}
           rowKey={rowKey}
           columns={columns}
-          dispatch={dispatch}
-          getAction={getAction}
+          getCallback={getCallback}
           rowIndex={index}
           onPress={onNavigateToInvoice}
         />

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -7,7 +7,7 @@ import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { MODAL_KEYS } from '../utilities';
+import { MODAL_KEYS, debounce } from '../utilities';
 import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
 import { getItemLayout } from './dataTableUtilities';
 import { gotoSupplierInvoice, createSupplierInvoice } from '../navigation/actions';
@@ -26,7 +26,7 @@ export const SupplierInvoicesPage = ({
   dispatch: reduxDispatch,
 }) => {
   const initialState = { page: routeName };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
+  const [state, dispatch] = usePageReducer(initialState);
 
   const {
     data,
@@ -62,6 +62,10 @@ export const SupplierInvoicesPage = ({
     []
   );
 
+  const onSortColumn = useCallback(
+    debounce(columnKey => dispatch(PageActions.sortData(columnKey)), 250, true),
+    []
+  );
   const onCreateInvoice = otherParty => {
     reduxDispatch(createSupplierInvoice(otherParty, currentUser));
     onCloseModal();
@@ -109,8 +113,7 @@ export const SupplierInvoicesPage = ({
     () => (
       <DataTableHeaderRow
         columns={columns}
-        dispatch={instantDebouncedDispatch}
-        sortAction={PageActions.sortData}
+        onPress={onSortColumn}
         isAscending={isAscending}
         sortBy={sortBy}
       />

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -54,8 +54,8 @@ export const SupplierInvoicesPage = ({
   const onConfirmDelete = () => dispatch(PageActions.deleteTransactions());
   const onCancelDelete = () => dispatch(PageActions.deselectAll());
   const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
-  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
-  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
+  const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
+  const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
 
   const onNavigateToInvoice = useCallback(
     invoice => reduxDispatch(gotoSupplierInvoice(invoice)),

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -86,6 +86,11 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
   const onAddFromMasterList = () =>
     runWithLoadingIndicator(() => dispatch(PageActions.addMasterListItems('Requisition')));
 
+  const onEditRequiredQuantity = (newValue, rowKey, columnKey) =>
+    dispatch(PageActions.editRequisitionItemRequiredQuantity(newValue, rowKey, columnKey));
+  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
+  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
+
   const pageInfoColumns = useCallback(getPageInfoColumns(pageObject, dispatch, PageActions), [
     comment,
     theirRef,
@@ -93,13 +98,13 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
     daysToSupply,
   ]);
 
-  const getAction = useCallback((colKey, propName) => {
+  const getCallback = useCallback((colKey, propName) => {
     switch (colKey) {
       case 'requiredQuantity':
-        return PageActions.editRequisitionItemRequiredQuantity;
+        return onEditRequiredQuantity;
       case 'remove':
-        if (propName === 'onCheckAction') return PageActions.selectRow;
-        return PageActions.deselectRow;
+        if (propName === 'onCheck') return onCheck;
+        return onUncheck;
       default:
         return null;
     }
@@ -130,8 +135,7 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
           rowKey={rowKey}
           columns={columns}
           isFinalised={isFinalised}
-          dispatch={dispatch}
-          getAction={getAction}
+          getCallback={getCallback}
           rowIndex={index}
         />
       );

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -86,10 +86,10 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
   const onAddFromMasterList = () =>
     runWithLoadingIndicator(() => dispatch(PageActions.addMasterListItems('Requisition')));
 
-  const onEditRequiredQuantity = (newValue, rowKey, columnKey) =>
-    dispatch(PageActions.editRequisitionItemRequiredQuantity(newValue, rowKey, columnKey));
-  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
-  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
+  const onEditRequiredQuantity = (newValue, rowKey) =>
+    dispatch(PageActions.editRequisitionItemRequiredQuantity(newValue, rowKey));
+  const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
+  const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
 
   const pageInfoColumns = useCallback(getPageInfoColumns(pageObject, dispatch, PageActions), [
     comment,

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -7,8 +7,7 @@ import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
-import { MODAL_KEYS } from '../utilities';
-
+import { MODAL_KEYS, debounce } from '../utilities';
 import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 import { DataTablePageView, PageButton, PageInfo, ToggleBar, SearchBar } from '../widgets';
@@ -39,7 +38,7 @@ import { buttonStrings, modalStrings, programStrings } from '../localization';
  */
 export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, routeName }) => {
   const initialState = { page: routeName, pageObject: requisition };
-  const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
+  const [state, dispatch] = usePageReducer(initialState);
 
   const {
     data,
@@ -77,6 +76,7 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
 
   const onFilterData = value => dispatch(PageActions.filterData(value));
   const onHideOverStocked = () => dispatch(PageActions.hideOverStocked());
+
   const onShowOverStocked = () =>
     runWithLoadingIndicator(() => dispatch(PageActions.showOverStocked()));
   const onSetRequestedToSuggested = () =>
@@ -86,6 +86,10 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
   const onAddFromMasterList = () =>
     runWithLoadingIndicator(() => dispatch(PageActions.addMasterListItems('Requisition')));
 
+  const onSortColumn = useCallback(
+    debounce(columnKey => dispatch(PageActions.sortData(columnKey)), 250, true),
+    []
+  );
   const onEditRequiredQuantity = (newValue, rowKey) =>
     dispatch(PageActions.editRequisitionItemRequiredQuantity(newValue, rowKey));
   const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
@@ -147,8 +151,7 @@ export const SupplierRequisitionPage = ({ requisition, runWithLoadingIndicator, 
     () => (
       <DataTableHeaderRow
         columns={columns}
-        dispatch={instantDebouncedDispatch}
-        sortAction={PageActions.sortData}
+        onPress={onSortColumn}
         isAscending={isAscending}
         sortBy={sortBy}
       />

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -79,6 +79,8 @@ export const SupplierRequisitionsPage = ({
   const onNewRequisition = () => dispatch(PageActions.openModal(NEW_REQUISITON));
   const onCloseModal = () => dispatch(PageActions.closeModal());
   const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
+  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
+  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
 
   const onCreateRequisition = otherStoreName => {
     onCloseModal();
@@ -90,11 +92,11 @@ export const SupplierRequisitionsPage = ({
     reduxDispatch(createSupplierRequisition({ ...requisitionParameters, currentUser }));
   };
 
-  const getAction = useCallback((colKey, propName) => {
+  const getCallback = useCallback((colKey, propName) => {
     switch (colKey) {
       case 'remove':
-        if (propName === 'onCheckAction') return PageActions.selectRow;
-        return PageActions.deselectRow;
+        if (propName === 'onCheck') return onCheck;
+        return onUncheck;
       default:
         return null;
     }
@@ -121,8 +123,7 @@ export const SupplierRequisitionsPage = ({
           rowState={dataState.get(rowKey)}
           rowKey={rowKey}
           columns={columns}
-          dispatch={dispatch}
-          getAction={getAction}
+          getCallback={getCallback}
           onPress={onPressRow}
           rowIndex={index}
         />

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -13,7 +13,7 @@ import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTabl
 
 import { UIDatabase } from '../database';
 import Settings from '../settings/MobileAppSettings';
-import { MODAL_KEYS, getAllPrograms } from '../utilities';
+import { MODAL_KEYS, debounce, getAllPrograms } from '../utilities';
 import { usePageReducer, useNavigationFocus, useSyncListener } from '../hooks';
 import { createSupplierRequisition, gotoSupplierRequisition } from '../navigation/actions';
 import { getItemLayout, recordKeyExtractor } from './dataTableUtilities';
@@ -47,7 +47,7 @@ export const SupplierRequisitionsPage = ({
 }) => {
   const initialState = { page: routeName };
 
-  const [state, dispatch, debouncedDispatch] = usePageReducer(initialState);
+  const [state, dispatch] = usePageReducer(initialState);
 
   const {
     data,
@@ -81,6 +81,11 @@ export const SupplierRequisitionsPage = ({
   const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
   const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
   const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
+
+  const onSortColumn = useCallback(
+    debounce(columnKey => dispatch(PageActions.sortData(columnKey)), 250, true),
+    []
+  );
 
   const onCreateRequisition = otherStoreName => {
     onCloseModal();
@@ -136,8 +141,7 @@ export const SupplierRequisitionsPage = ({
     () => (
       <DataTableHeaderRow
         columns={columns}
-        dispatch={debouncedDispatch}
-        sortAction={PageActions.sortData}
+        onPress={onSortColumn}
         isAscending={isAscending}
         sortBy={sortBy}
       />

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -79,8 +79,8 @@ export const SupplierRequisitionsPage = ({
   const onNewRequisition = () => dispatch(PageActions.openModal(NEW_REQUISITON));
   const onCloseModal = () => dispatch(PageActions.closeModal());
   const onToggleShowFinalised = () => dispatch(PageActions.toggleShowFinalised(showFinalised));
-  const onCheck = (rowKey, columnKey) => dispatch(PageActions.selectRow(rowKey, columnKey));
-  const onUncheck = (rowKey, columnKey) => dispatch(PageActions.deselectRow(rowKey, columnKey));
+  const onCheck = rowKey => dispatch(PageActions.selectRow(rowKey));
+  const onUncheck = rowKey => dispatch(PageActions.deselectRow(rowKey));
 
   const onCreateRequisition = otherStoreName => {
     onCloseModal();

--- a/src/widgets/DataTable/CheckableCell.js
+++ b/src/widgets/DataTable/CheckableCell.js
@@ -18,11 +18,8 @@ import TouchableCell from './TouchableCell';
  *                                                  checked and disabled
  * @param {React.element} DisabledUncheckedComponent  Component to render when cell is
  *                                                    checked and disabled
- * @param {func} onCheckAction Action creator for handling checking of this cell.
- *                          `(rowKey, columnKey) => {...}`
- * @param {func} onUncheckAction Action creator for handling unchecking of this cell.
- *                          `(rowKey, columnKey) => {...}`
- * @param {func} dispatch Reducer dispatch callback for handling actions
+ * @param {func} onCheck Callback when this cell is checked.
+ * @param {func} onUncheck Callback when this cell is unchecked.
  * @param {Object} containerStyle Style object for the containing Touchable component
  */
 
@@ -36,9 +33,8 @@ const CheckableCell = React.memo(
     UncheckedComponent,
     DisabledCheckedComponent,
     DisabledUncheckedComponent,
-    onCheckAction,
-    onUncheckAction,
-    dispatch,
+    onCheck,
+    onUncheck,
     containerStyle,
     width,
     isLastCell,
@@ -46,7 +42,7 @@ const CheckableCell = React.memo(
   }) => {
     if (debug) console.log(`- CheckableCell: ${rowKey},${columnKey}`);
 
-    const onPressAction = isChecked ? onUncheckAction : onCheckAction;
+    const onPressAction = isChecked ? onUncheck : onCheck;
 
     const renderCheck = isChecked
       ? (isDisabled && DisabledCheckedComponent) || CheckedComponent
@@ -57,8 +53,7 @@ const CheckableCell = React.memo(
         renderChildren={renderCheck}
         rowKey={rowKey}
         columnKey={columnKey}
-        onPressAction={onPressAction}
-        dispatch={dispatch}
+        onPress={onPressAction}
         containerStyle={containerStyle}
         width={width}
         isLastCell={isLastCell}
@@ -81,9 +76,8 @@ CheckableCell.propTypes = {
   UncheckedComponent: PropTypes.func.isRequired,
   DisabledCheckedComponent: PropTypes.func,
   DisabledUncheckedComponent: PropTypes.func,
-  onCheckAction: PropTypes.func.isRequired,
-  onUncheckAction: PropTypes.func.isRequired,
-  dispatch: PropTypes.func.isRequired,
+  onCheck: PropTypes.func.isRequired,
+  onUncheck: PropTypes.func.isRequired,
   containerStyle: PropTypes.object,
   width: PropTypes.number,
   isLastCell: PropTypes.bool,

--- a/src/widgets/DataTable/DataTableHeaderRow.js
+++ b/src/widgets/DataTable/DataTableHeaderRow.js
@@ -22,7 +22,7 @@ import { dataTableStyles } from '../../globalStyles';
  *
  *
  */
-const DataTableHeaderRow = React.memo(({ columns, sortBy, isAscending, dispatch, sortAction }) => {
+const DataTableHeaderRow = React.memo(({ columns, sortBy, isAscending, onPress }) => {
   const { headerRow, headerCells, cellText } = dataTableStyles;
   return (
     <HeaderRow
@@ -41,8 +41,7 @@ const DataTableHeaderRow = React.memo(({ columns, sortBy, isAscending, dispatch,
               SortDescComponent={SortDescIcon}
               SortNeutralComponent={SortNeutralIcon}
               columnKey={key}
-              onPressAction={sortable ? sortAction : null}
-              dispatch={dispatch}
+              onPress={sortable ? onPress : null}
               sortDirection={directionForThisColumn}
               sortable={sortable}
               width={width}
@@ -61,15 +60,13 @@ DataTableHeaderRow.propTypes = {
   columns: PropTypes.arrayOf(PropTypes.object),
   sortBy: PropTypes.string,
   isAscending: PropTypes.bool.isRequired,
-  dispatch: PropTypes.func,
-  sortAction: PropTypes.func,
+  onPress: PropTypes.func,
 };
 
 DataTableHeaderRow.defaultProps = {
   columns: [],
   sortBy: '',
-  dispatch: null,
-  sortAction: null,
+  onPress: null,
 };
 
 export default DataTableHeaderRow;

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -44,14 +44,13 @@ import { generalStrings, tableStrings } from '../../localization/index';
  * @param {String} rowKey      Unique key for a row
  * @param {Array}  columns     Array of column objects, see: columns.js
  * @param {Bool}   isFinalised Boolean indicating if the DataTable page is finalised.
- * @param {Func}   dispatch    Dispatch function for containing reducer.
  * @param {Func}   rowIndex    index of this row.
  * @param {Func}   onPress     On press callback for the row itself.
- * @param {Func}   getAction   Function to return an action for a cell
- *                             (colKey, propName) => actionObject
+ * @param {Func}   getCallback Function to return a cells callback
+ *                             (colKey, propName) => callback
  */
 const DataTableRow = React.memo(
-  ({ rowData, rowState, rowKey, columns, isFinalised, dispatch, getAction, onPress, rowIndex }) => {
+  ({ rowData, rowState, rowKey, columns, isFinalised, getCallback, onPress, rowIndex }) => {
     const {
       cellText,
       cellContainer,
@@ -104,9 +103,8 @@ const DataTableRow = React.memo(
                   value={rowData[columnKey]}
                   rowKey={rowKey}
                   columnKey={columnKey}
-                  editAction={getAction(columnKey)}
+                  onChangeText={getCallback(columnKey)}
                   isDisabled={isDisabled}
-                  dispatch={dispatch}
                   width={width}
                   viewStyle={cellContainer[cellAlignment]}
                   textViewStyle={editableCellTextView}
@@ -127,9 +125,8 @@ const DataTableRow = React.memo(
                   value={rowData[columnKey]}
                   rowKey={rowKey}
                   columnKey={columnKey}
-                  editAction={getAction(columnKey)}
+                  onEndEditing={getCallback(columnKey)}
                   isDisabled={isDisabled}
-                  dispatch={dispatch}
                   width={width}
                   isLastCell={isLastCell}
                   rowIndex={rowIndex}
@@ -148,9 +145,8 @@ const DataTableRow = React.memo(
                   UncheckedComponent={UncheckedComponent}
                   DisabledCheckedComponent={DisabledCheckedComponent}
                   DisabledUncheckedComponent={DisabledUncheckedComponent}
-                  onCheckAction={getAction(columnKey, 'onCheckAction')}
-                  onUncheckAction={getAction(columnKey, 'onUncheckAction')}
-                  dispatch={dispatch}
+                  onCheck={getCallback(columnKey, 'onCheck')}
+                  onUncheck={getCallback(columnKey, 'onUncheck')}
                   containerStyle={touchableCellContainer}
                   width={width}
                   isLastCell={isLastCell}
@@ -212,8 +208,7 @@ const DataTableRow = React.memo(
                   renderChildren={OpenModal}
                   rowKey={rowKey}
                   columnKey={columnKey}
-                  onPressAction={getAction(columnKey)}
-                  dispatch={dispatch}
+                  onPress={getCallback(columnKey)}
                   width={width}
                   isLastCell={isLastCell}
                   containerStyle={iconCell}
@@ -225,8 +220,7 @@ const DataTableRow = React.memo(
                 <DropDownCell
                   key={columnKey}
                   isDisabled={isFinalised}
-                  dispatch={dispatch}
-                  onPressAction={getAction(columnKey)}
+                  onPress={getCallback(columnKey)}
                   rowKey={rowKey}
                   columnKey={columnKey}
                   value={rowData[columnKey]}
@@ -269,7 +263,7 @@ const DataTableRow = React.memo(
 
 DataTableRow.defaultProps = {
   isFinalised: false,
-  getAction: null,
+  getCallback: null,
   onPress: null,
   rowState: null,
 };
@@ -280,9 +274,8 @@ DataTableRow.propTypes = {
   rowState: PropTypes.object,
   rowKey: PropTypes.string.isRequired,
   columns: PropTypes.array.isRequired,
-  dispatch: PropTypes.func.isRequired,
   isFinalised: PropTypes.bool,
-  getAction: PropTypes.func,
+  getCallback: PropTypes.func,
   rowIndex: PropTypes.number.isRequired,
 };
 

--- a/src/widgets/DataTable/HeaderCell.js
+++ b/src/widgets/DataTable/HeaderCell.js
@@ -30,8 +30,7 @@ const HeaderCell = React.memo(
     SortAscComponent,
     SortDescComponent,
     SortNeutralComponent,
-    onPressAction,
-    dispatch,
+    onPress,
     sortable,
     containerStyle,
     textStyle,
@@ -39,9 +38,7 @@ const HeaderCell = React.memo(
     isLastCell,
     ...otherProps
   }) => {
-    const onPress = () => {
-      dispatch(onPressAction(columnKey));
-    };
+    const onPressCell = () => onPress(columnKey);
 
     const Icon = () => {
       switch (sortDirection) {
@@ -57,12 +54,12 @@ const HeaderCell = React.memo(
       }
     };
 
-    const Container = onPressAction ? TouchableOpacity : View;
+    const Container = onPress ? TouchableOpacity : View;
 
     const internalContainerStyle = getAdjustedStyle(containerStyle, width, isLastCell);
 
     return (
-      <Container style={internalContainerStyle} onPress={onPress} {...otherProps}>
+      <Container style={internalContainerStyle} onPress={onPressCell} {...otherProps}>
         <Text style={textStyle}>{title}</Text>
         {sortable && <Icon />}
       </Container>

--- a/src/widgets/DataTable/TextInputCell.js
+++ b/src/widgets/DataTable/TextInputCell.js
@@ -17,7 +17,6 @@ import { getAdjustedStyle } from './utilities';
  * @param {string|number} columnKey  Unique key associated to column cell is in
  * @param {bool} isDisabled          If `true` will render a plain Cell element with no interaction
  * @param {String} placeholderColour Placholder text colour
- * @param {func}  dispatch           Reducer dispatch callback for handling actions
  * @param {Object}  viewStyle        Style object for the wrapping View component
  * @param {Object}  textStyle        Style object for the inner Text component
  * @param {Object}  textInputStyle   Style object for TextInput component.
@@ -28,8 +27,7 @@ import { getAdjustedStyle } from './utilities';
  * @param {Object} cellTextStyle     text style for the disabled Cell component.
  * @param {Bool}  isLastCell         Indicator if this cell is last in a row,
  *                                   removing the borderRight,
- * @param {func}  editAction         Action creator for handling editing of this cell.
- *                                   `(newValue, rowKey, columnKey) => {...}`
+ * @param {Func}  onChangeText       Callback for the onChangeText event.
  * @param {String} underlineColor    Underline colour of TextInput on Android.
  */
 const TextInputCell = React.memo(
@@ -39,8 +37,7 @@ const TextInputCell = React.memo(
     columnKey,
     isDisabled,
     placeholderColour,
-    editAction,
-    dispatch,
+    onChangeText,
     isLastCell,
     width,
     debug,
@@ -59,7 +56,7 @@ const TextInputCell = React.memo(
     const { focusNextCell, getRefIndex, getCellRef } = React.useContext(RefContext);
     const refIndex = getRefIndex(rowIndex, columnKey);
 
-    const onEdit = newValue => dispatch(editAction(newValue, rowKey, columnKey));
+    const onEdit = newValue => onChangeText(newValue, rowKey, columnKey);
     const focusNext = () => focusNextCell(refIndex);
 
     // Render a plain Cell if disabled.
@@ -105,8 +102,7 @@ TextInputCell.propTypes = {
   columnKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   isDisabled: PropTypes.bool,
   placeholderColour: PropTypes.string,
-  editAction: PropTypes.func.isRequired,
-  dispatch: PropTypes.func.isRequired,
+  onChangeText: PropTypes.func.isRequired,
   cellTextStyle: PropTypes.object,
   viewStyle: PropTypes.object,
   width: PropTypes.number,

--- a/src/widgets/DataTable/TouchableCell.js
+++ b/src/widgets/DataTable/TouchableCell.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 /* eslint-disable react/forbid-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -14,9 +13,7 @@ import { getAdjustedStyle } from './utilities';
  * @param {string|number} value The value to render in cell
  * @param {string|number} rowKey Unique key associated to row cell is in
  * @param {string|number} columnKey Unique key associated to column cell is in
- * @param {func} onPressAction Action creator for handling focusing of this cell.
- *                          `(rowKey, columnKey) => {...}`
- * @param {func} dispatch Reducer dispatch callback for handling actions
+ * @param {func} onPress Callback when this cell is touched.
  * @param {func} renderChildren Reducer dispatch callback for handling actions
  * @param {func} TouchableComponent Override containing element of TouchableCell
  * Additional props spread into TouchableComponent
@@ -31,8 +28,7 @@ const TouchableCell = React.memo(
     value,
     rowKey,
     columnKey,
-    onPressAction,
-    dispatch,
+    onPress,
     renderChildren,
     TouchableComponent,
     containerStyle,
@@ -45,14 +41,14 @@ const TouchableCell = React.memo(
   }) => {
     if (debug) console.log(`- TouchableCell: ${rowKey},${columnKey}`);
 
-    const onPress = () => dispatch(onPressAction(rowKey, columnKey));
+    const onPressCell = () => onPress(rowKey, columnKey);
 
     const internalContainerStyle = getAdjustedStyle(containerStyle, width, isLastCell);
     const Container = isDisabled ? TouchableNoFeedback : TouchableComponent || TouchableOpacity;
     const content = renderChildren ? renderChildren(value) : <Text style={textStyle}>{value}</Text>;
 
     return (
-      <Container style={internalContainerStyle} onPress={onPress} {...otherProps}>
+      <Container style={internalContainerStyle} onPress={onPressCell} {...otherProps}>
         {content}
       </Container>
     );
@@ -64,8 +60,7 @@ TouchableCell.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   rowKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   columnKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  onPressAction: PropTypes.func.isRequired,
-  dispatch: PropTypes.func.isRequired,
+  onPress: PropTypes.func.isRequired,
   renderChildren: PropTypes.func.isRequired,
   TouchableComponent: PropTypes.node,
   containerStyle: PropTypes.object,

--- a/src/widgets/DropDownCell.js
+++ b/src/widgets/DropDownCell.js
@@ -21,8 +21,7 @@ const {
  * value is passed.
  *
  * @param {Bool}    isDisabled      Indicator whether this cell is disabled.
- * @param {Func}    dispatch        Dispatching function to containing reducer.
- * @param {Func}    onPressAction   Action creator when pressed.
+ * @param {Func}    onPress         Callback function for the onPress event.
  * @param {String}  rowKey          Key for this cells row.
  * @param {String}  columnKey       Key for this cells column.
  * @param {String}  value           Text value for this cell.
@@ -32,18 +31,7 @@ const {
  * @param {Bool}    debug           Indicator whether logging should occur for this cell.
  */
 const DropDownCell = React.memo(
-  ({
-    isDisabled,
-    dispatch,
-    onPressAction,
-    rowKey,
-    columnKey,
-    value,
-    isLastCell,
-    width,
-    placeholder,
-    debug,
-  }) => {
+  ({ isDisabled, onPress, rowKey, columnKey, value, isLastCell, width, placeholder, debug }) => {
     const internalFontStyle = value ? dropDownFont : dropDownPlaceholderFont;
 
     const TouchableChild = () => (
@@ -63,13 +51,12 @@ const DropDownCell = React.memo(
 
     return (
       <TouchableCell
-        dispatch={dispatch}
         rowKey={rowKey}
         columnKey={columnKey}
         value={value}
         debug={debug}
         isLastCell={isLastCell}
-        onPressAction={onPressAction}
+        onPress={onPress}
         isDisabled={!value || isDisabled}
         width={width}
         renderChildren={TouchableChild}
@@ -88,8 +75,7 @@ DropDownCell.defaultProps = {
   debug: false,
 };
 DropDownCell.propTypes = {
-  dispatch: PropTypes.func.isRequired,
-  onPressAction: PropTypes.func.isRequired,
+  onPress: PropTypes.func.isRequired,
   rowKey: PropTypes.string.isRequired,
   columnKey: PropTypes.string.isRequired,
   width: PropTypes.number.isRequired,

--- a/src/widgets/ExpiryDateInput.js
+++ b/src/widgets/ExpiryDateInput.js
@@ -32,19 +32,12 @@ import RefContext from './DataTable/RefContext';
  * @param {string|number} value The value to render in cell
  * @param {string|number} rowKey Unique key associated to row cell is in
  * @param {string|number} columnKey Unique key associated to column cell is in
- * @param {bool} disabled If `true` will render a plain Cell element with no interaction
- * @param {bool} isFocused If `false` will TouchableOpacity that dispatches a focusAction
- *                         when pressed. When `true` will render a TextInput with focus
-
- * @param {func}  dispatch Reducer dispatch callback for handling actions
+ * @param {bool} isDisabled If `true` will render a plain Cell element with no interaction
  * @param {Number}  width Optional flex property to inject into styles.
- * @param {Bool}  isLastCell Indicator for if this cell is the last
- *                                   in a row. Removing the borderRight if true.
+ * @param {Bool}  isLastCell Indicator if this cell is the last in a row.
+ * @param {Func} onEndEditing Callback for onEndEditing event.
  * @param {String}  placeholder String to display when the cell is empty.
- * @param {func} editAction Action creator for handling editing of this cell.
- *                          `(newValue, rowKey, columnKey) => {...}`
  * @param {String} underlineColor    Underline colour of TextInput on Android.
- *
  */
 
 const { expiryBatchView, expiryBatchText, expiryBatchPlaceholderText } = dataTableStyles;
@@ -56,8 +49,7 @@ export const ExpiryDateInput = React.memo(
     columnKey,
     isDisabled,
     placeholderColour,
-    editAction,
-    dispatch,
+    onEndEditing,
     isLastCell,
     width,
     debug,
@@ -81,7 +73,7 @@ export const ExpiryDateInput = React.memo(
     // to the underlying model are not committed until a valid date is entered.
     const finishEditingExpiryDate = () => {
       finaliseExpiryDate();
-      dispatch(editAction(parseExpiryDate(expiryDate), rowKey, columnKey));
+      onEndEditing(parseExpiryDate(expiryDate), rowKey, columnKey);
     };
 
     const onSubmit = () => {
@@ -135,8 +127,7 @@ ExpiryDateInput.propTypes = {
   rowKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   columnKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   isDisabled: PropTypes.bool,
-  editAction: PropTypes.func.isRequired,
-  dispatch: PropTypes.func.isRequired,
+  onEndEditing: PropTypes.func.isRequired,
   width: PropTypes.number,
   isLastCell: PropTypes.bool,
   debug: PropTypes.bool,

--- a/src/widgets/modals/RegimenDataModal.js
+++ b/src/widgets/modals/RegimenDataModal.js
@@ -71,13 +71,13 @@ export const RegimenDataModal = ({ requisition }) => {
     });
   }, [customData]);
 
-  const getAction = columnKey => {
+  const getCallback = columnKey => {
     switch (columnKey) {
       default:
       case 'comment':
-        return actions.updateComment;
+        return (value, rowKey) => dispatch(actions.updateComment(value, rowKey));
       case 'value':
-        return actions.updateValue;
+        return (value, rowKey) => dispatch(actions.updateValue(value, rowKey));
     }
   };
 
@@ -90,8 +90,7 @@ export const RegimenDataModal = ({ requisition }) => {
         rowKey={rowKey}
         columns={columns}
         isFinalised={isFinalised}
-        dispatch={dispatch}
-        getAction={getAction}
+        getCallback={getCallback}
         rowIndex={index}
       />
     );

--- a/src/widgets/modals/RegimenDataModal.js
+++ b/src/widgets/modals/RegimenDataModal.js
@@ -71,13 +71,16 @@ export const RegimenDataModal = ({ requisition }) => {
     });
   }, [customData]);
 
+  const updateComment = (value, rowKey) => dispatch(actions.updateComment(value, rowKey));
+  const updateValue = (value, rowKey) => dispatch(actions.updateValue(value, rowKey));
+
   const getCallback = columnKey => {
     switch (columnKey) {
       default:
       case 'comment':
-        return (value, rowKey) => dispatch(actions.updateComment(value, rowKey));
+        return updateComment;
       case 'value':
-        return (value, rowKey) => dispatch(actions.updateValue(value, rowKey));
+        return updateValue;
     }
   };
 

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -81,8 +81,8 @@ export const StocktakeBatchModal = ({ stocktakeItem }) => {
   const onCloseModal = () => dispatch(PageActions.closeModal());
   const onApplyReason = ({ item }) => dispatch(PageActions.applyReason(item));
   const onAddBatch = () => dispatch(PageActions.addStocktakeBatch());
-  const onEditBatch = rowKey =>
-    dispatch(PageActions.openModal(MODAL_KEYS.EDIT_STOCKTAKE_BATCH, rowKey));
+  const onEditBatch = (value, rowKey, columnKey) =>
+    dispatch(PageActions.editStocktakeBatchName(value, rowKey, columnKey));
   const onEditReason = rowKey =>
     dispatch(PageActions.openModal(MODAL_KEYS.STOCKTAKE_REASON, rowKey));
   const onEditCountedQuantity = (newValue, rowKey, columnKey) =>

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -78,27 +78,34 @@ export const StocktakeBatchModal = ({ stocktakeItem }) => {
       ? UIDatabase.objects('PositiveAdjustmentReason')
       : UIDatabase.objects('NegativeAdjustmentReason');
 
-  const onEditReason = rowKey => PageActions.openModal(MODAL_KEYS.STOCKTAKE_REASON, rowKey);
   const onCloseModal = () => dispatch(PageActions.closeModal());
   const onApplyReason = ({ item }) => dispatch(PageActions.applyReason(item));
   const onAddBatch = () => dispatch(PageActions.addStocktakeBatch());
+  const onEditBatch = rowKey =>
+    dispatch(PageActions.openModal(MODAL_KEYS.EDIT_STOCKTAKE_BATCH, rowKey));
+  const onEditReason = rowKey =>
+    dispatch(PageActions.openModal(MODAL_KEYS.STOCKTAKE_REASON, rowKey));
+  const onEditCountedQuantity = (newValue, rowKey, columnKey) =>
+    dispatch(PageActions.editStocktakeBatchCountedQuantity(newValue, rowKey, columnKey));
+  const onEditDate = (date, rowKey, columnKey) =>
+    dispatch(PageActions.editTransactionBatchExpiryDate(date, rowKey, columnKey));
 
   const toggles = useCallback(getPageInfoColumns(pageObject, dispatch, PageActions), []);
 
-  const getAction = colKey => {
+  const getCallback = useCallback(colKey => {
     switch (colKey) {
-      case 'batch':
-        return PageActions.editStocktakeBatchName;
       case 'countedTotalQuantity':
-        return PageActions.editStocktakeBatchCountedQuantity;
+        return onEditCountedQuantity;
+      case 'batch':
+        return onEditBatch;
       case 'expiryDate':
-        return PageActions.editStocktakeBatchExpiryDate;
+        return onEditDate;
       case 'reasonTitle':
         return onEditReason;
       default:
         return null;
     }
-  };
+  }, []);
 
   const renderRow = useCallback(
     listItem => {
@@ -110,8 +117,7 @@ export const StocktakeBatchModal = ({ stocktakeItem }) => {
           rowState={dataState.get(rowKey)}
           rowKey={rowKey}
           columns={columns}
-          dispatch={dispatch}
-          getAction={getAction}
+          getCallback={getCallback}
           rowIndex={index}
         />
       );


### PR DESCRIPTION
Fixes #1446 

## Change summary

This does exactly as described in the issue. Looks like a lot but it it just changing `dispatch` + `action` prop to be a combined callback.

## Testing

*The way of invocation has been changed, but no actual logic. As long as the following columns can be used, then this does what it should - if the cell isn't hooked up correctly, it will just throw an error and crash the app. The following is a list of all effected cells*

- [ ] Customer invoice page
    - [ ] Quantity column
    - [ ] remove column
- [ ] Customer invoices page
    - [ ] remove column
- [ ] Supplier invoice page
    - [ ] quantity column
    - [ ] expiry date
    - [ ] remove column
- [ ] supplier invoices page
    - [ ] remove column
- [ ] customer requisition page
    - [ ] supplied this invoice column
- [ ] supplier requisition page
    - [ ] requested quantity column
    - [ ] remove column
    - [ ] Regimen data columns
- [ ] supplier requisitions page
    - [ ] remove column
- [ ] stocktakes page
    - [ ] remove column
- [ ] stocktake manage page
    - [ ] select column
- [ ] stocktake editor page
    - [ ] counted quantity column
    - [ ] reason column
    - [ ] batches column
    - [ ] stocktake batch: quantity
    - [ ] stocktake batch: batch name
    - [ ] stocktake batch: reason
    - [ ] stocktake batch: expiry

### Related areas to think about

N/A
