### PR TITLE
#1454 add headers to Synchroniser bugsnag

### DIFF
--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -85,13 +85,13 @@ export class Synchroniser {
   };
 
   fetchWrapper = async (url, opts) => {
-    const { body } = opts;
+    const { body, headers } = opts;
 
     const bugsnagNotify = async message => {
       const responseText = await responseClone.text();
       bugsnagClient.notify(new Error(message), report => {
         report.context = 'SYNC ERROR';
-        report.metadata = { error: { url, body, responseText } };
+        report.metadata = { error: { url, headers, body, responseText } };
       });
     };
 


### PR DESCRIPTION
Fixes #1454.

## Change summary

Adds request headers to bugsnag metadata for sync errors.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Headers are included when a sync bug is snagged.

### Related areas to think about

Would also be good to add snagging to user authentication, as we currently don't log auth errors (which cold be considered some of the more visible errors to users).
