### PR TITLE
#1463 Editable when finalised

### DIFF
--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -113,6 +113,7 @@ export const StocktakeBatchModal = ({ stocktakeItem }) => {
           dispatch={dispatch}
           getAction={getAction}
           rowIndex={index}
+          isFinalised={isFinalised}
         />
       );
     },


### PR DESCRIPTION
Fixes #1463

## Change summary

- Adds a prop to `DataTableRow` to disable it correctly

## Testing

- [ ] Batches can't be edited on a finalised stocktake

### Related areas to think about

N/A
