### PR TITLE
#1464 Add update to stocktake manager navigation to replace

### DIFF
--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -34,15 +34,25 @@ import { getCurrentRouteName } from './selectors';
  *
  * @param {Object} requisition The requisition to pass to the next screen.
  */
-export const gotoStocktakeManagePage = (stocktakeName, stocktake) =>
-  NavigationActions.navigate({
+export const gotoStocktakeManagePage = (stocktakeName, stocktake) => (dispatch, getState) => {
+  const { nav } = getState();
+
+  const currentRouteName = getCurrentRouteName(nav);
+
+  const navigationActionCreator =
+    currentRouteName === 'stocktakes' ? NavigationActions.navigate : StackActions.replace;
+
+  const navigationParameters = {
     routeName: 'stocktakeManager',
     params: {
       title: stocktake ? navStrings.manage_stocktake : navStrings.new_stocktake,
       stocktakeName,
       stocktake,
     },
-  });
+  };
+
+  dispatch(navigationActionCreator(navigationParameters));
+};
 
 /**
  * Navigate to the StocktakeEditPage.
@@ -61,7 +71,9 @@ export const gotoStocktakeEditPage = stocktake => (dispatch, getState) => {
   // replace the current page as the user is coming from StocktakeManagePage.
   const navigationActionCreator =
     currentRouteName === 'stocktakes' ? NavigationActions.navigate : StackActions.replace;
-
+  console.log(navigationActionCreator({ routeName: '?' }));
+  console.log(Object.keys(nav));
+  nav.routes.forEach(route => console.log(route.routeName));
   const navigationParameters = {
     routeName: usesReasons ? 'stocktakeEditorWithReasons' : 'stocktakeEditor',
     params: { title: navStrings.stocktake, stocktake },

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -71,9 +71,7 @@ export const gotoStocktakeEditPage = stocktake => (dispatch, getState) => {
   // replace the current page as the user is coming from StocktakeManagePage.
   const navigationActionCreator =
     currentRouteName === 'stocktakes' ? NavigationActions.navigate : StackActions.replace;
-  console.log(navigationActionCreator({ routeName: '?' }));
-  console.log(Object.keys(nav));
-  nav.routes.forEach(route => console.log(route.routeName));
+
   const navigationParameters = {
     routeName: usesReasons ? 'stocktakeEditorWithReasons' : 'stocktakeEditor',
     params: { title: navStrings.stocktake, stocktake },


### PR DESCRIPTION
Fixes #1464

## Change summary

- Updates navigation to `StocktakeManagePage` such that when navigating from the `StocktakeEditPage`, `StocktakeEditPage` is replaced, so that stack stays valid

## Testing

- [ ] When navigating to and from `StocktakeManagePage`->`StocktakeEditPage`, multiple `StocktakeEditPage`s are not added to the navigation stack

### Related areas to think about

N/A
