### PR TITLE
#1467 Footer to DataTable

### DIFF
--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -6,7 +6,13 @@
 
 import PropTypes from 'prop-types';
 import React, { useMemo, useRef, useCallback } from 'react';
-import { StyleSheet, VirtualizedList, VirtualizedListPropTypes, Keyboard } from 'react-native';
+import {
+  StyleSheet,
+  VirtualizedList,
+  VirtualizedListPropTypes,
+  Keyboard,
+  View,
+} from 'react-native';
 import RefContext from './RefContext';
 
 /**
@@ -31,91 +37,96 @@ import RefContext from './RefContext';
  * @param {Object} data         Array of data objects.
  * @param {Object} columns      Array of column objects.
  */
-const DataTable = React.memo(({ renderRow, renderHeader, style, data, columns, ...otherProps }) => {
-  // Reference to the virtualized list for scroll operations.
-  const virtualizedListRef = useRef();
+const DataTable = React.memo(
+  ({ renderRow, renderHeader, style, data, columns, footerHeight, ...otherProps }) => {
+    // Reference to the virtualized list for scroll operations.
+    const virtualizedListRef = useRef();
 
-  // Array of column keys for determining ref indicies.
-  const editableColumnKeys = useMemo(
-    () =>
-      columns.reduce((columnKeys, column) => {
-        const { editable } = column;
-        if (editable) return [...columnKeys, column.key];
-        return columnKeys;
-      }, []),
-    [columns]
-  );
-  const numberOfEditableColumns = editableColumnKeys.length;
-  const numberOfRows = data.length;
-  const numberOfEditableCells = numberOfEditableColumns * numberOfRows;
+    // Array of column keys for determining ref indicies.
+    const editableColumnKeys = useMemo(
+      () =>
+        columns.reduce((columnKeys, column) => {
+          const { editable } = column;
+          if (editable) return [...columnKeys, column.key];
+          return columnKeys;
+        }, []),
+      [columns]
+    );
+    const numberOfEditableColumns = editableColumnKeys.length;
+    const numberOfRows = data.length;
+    const numberOfEditableCells = numberOfEditableColumns * numberOfRows;
 
-  // Array for each editable cell. Needs to be stable, but updates shouldn't cause re-renders.
-  const cellRefs = useRef(Array.from({ length: numberOfEditableCells }));
+    // Array for each editable cell. Needs to be stable, but updates shouldn't cause re-renders.
+    const cellRefs = useRef(Array.from({ length: numberOfEditableCells }));
 
-  // Passes a cell it's ref index.
-  const getRefIndex = (rowIndex, columnKey) => {
-    const columnIndex = editableColumnKeys.findIndex(key => columnKey === key);
+    // Passes a cell it's ref index.
+    const getRefIndex = (rowIndex, columnKey) => {
+      const columnIndex = editableColumnKeys.findIndex(key => columnKey === key);
 
-    return rowIndex * numberOfEditableColumns + columnIndex;
-  };
+      return rowIndex * numberOfEditableColumns + columnIndex;
+    };
 
-  // Callback for an editable cell. Lazily creating refs.
-  const getCellRef = refIndex => {
-    if (cellRefs.current[refIndex]) return cellRefs.current[refIndex];
+    // Callback for an editable cell. Lazily creating refs.
+    const getCellRef = refIndex => {
+      if (cellRefs.current[refIndex]) return cellRefs.current[refIndex];
 
-    const newRef = React.createRef();
-    cellRefs.current[refIndex] = newRef;
+      const newRef = React.createRef();
+      cellRefs.current[refIndex] = newRef;
 
-    return newRef;
-  };
+      return newRef;
+    };
 
-  // Focuses the next editable cell in the list. On the last row, dismiss the keyboard.
-  const focusNextCell = refIndex => {
-    const lastRefIndex = numberOfEditableCells - 1;
-    if (refIndex === lastRefIndex) return Keyboard.dismiss();
+    // Focuses the next editable cell in the list. On the last row, dismiss the keyboard.
+    const focusNextCell = refIndex => {
+      const lastRefIndex = numberOfEditableCells - 1;
+      if (refIndex === lastRefIndex) return Keyboard.dismiss();
 
-    const nextCellRef = (refIndex + 1) % numberOfEditableCells;
-    const cellRef = getCellRef(nextCellRef);
+      const nextCellRef = (refIndex + 1) % numberOfEditableCells;
+      const cellRef = getCellRef(nextCellRef);
 
-    return cellRef.current.focus();
-  };
+      return cellRef.current.focus();
+    };
 
-  // Adjusts the passed row to the top of the list.
-  const adjustToTop = useCallback(rowIndex => {
-    virtualizedListRef.current.scrollToIndex({ index: rowIndex });
-  }, []);
+    // Adjusts the passed row to the top of the list.
+    const adjustToTop = useCallback(rowIndex => {
+      virtualizedListRef.current.scrollToIndex({ index: rowIndex });
+    }, []);
 
-  // Contexts values. Functions passed to rows and editable cells to control focus/scrolling.
-  const contextValue = useMemo(
-    () => ({
-      getRefIndex,
-      getCellRef,
-      focusNextCell,
-      adjustToTop,
-    }),
-    [numberOfEditableCells]
-  );
+    // Contexts values. Functions passed to rows and editable cells to control focus/scrolling.
+    const contextValue = useMemo(
+      () => ({
+        getRefIndex,
+        getCellRef,
+        focusNextCell,
+        adjustToTop,
+      }),
+      [numberOfEditableCells]
+    );
 
-  const renderItem = useCallback(
-    rowItem => renderRow(rowItem, focusNextCell, getCellRef, adjustToTop),
-    [renderRow]
-  );
+    const renderItem = useCallback(
+      rowItem => renderRow(rowItem, focusNextCell, getCellRef, adjustToTop),
+      [renderRow]
+    );
 
-  return (
-    <RefContext.Provider value={contextValue}>
-      {renderHeader && renderHeader()}
-      <VirtualizedList
-        ref={virtualizedListRef}
-        keyboardDismissMode="none"
-        data={data}
-        keyboardShouldPersistTaps="always"
-        style={style}
-        renderItem={renderItem}
-        {...otherProps}
-      />
-    </RefContext.Provider>
-  );
-});
+    const footer = useCallback(() => <View style={{ height: footerHeight }} />, [footerHeight]);
+
+    return (
+      <RefContext.Provider value={contextValue}>
+        {renderHeader && renderHeader()}
+        <VirtualizedList
+          ref={virtualizedListRef}
+          keyboardDismissMode="none"
+          data={data}
+          keyboardShouldPersistTaps="always"
+          style={style}
+          ListFooterComponent={footer}
+          renderItem={renderItem}
+          {...otherProps}
+        />
+      </RefContext.Provider>
+    );
+  }
+);
 
 const defaultStyles = StyleSheet.create({
   virtualizedList: {
@@ -133,11 +144,13 @@ DataTable.propTypes = {
   removeClippedSubviews: PropTypes.bool,
   windowSize: PropTypes.number,
   style: PropTypes.object,
+  footerHeight: PropTypes.number,
   columns: PropTypes.array,
 };
 
 DataTable.defaultProps = {
   renderHeader: null,
+  footerHeight: 200,
   style: defaultStyles.virtualizedList,
   getItem: (items, index) => items[index],
   getItemCount: items => items.length,


### PR DESCRIPTION
Fixes #1467 

# NOTE: The physical devices I have tested on do not have a problem with the last row in the first place. I have no idea if this fixes it :)

## Change summary

- Adds a footer to `DataTable`

## Testing

- [ ] With a stocktake with >19 lines, editing the last row is possible (not covered by the keyboard)

### Related areas to think about

N/A
