### PR TITLE
#1471 stocktake line editing

### DIFF
--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -26,6 +26,7 @@ import {
   OpenModal,
 } from '../icons';
 import TextInputCell from './TextInputCell';
+import TextInputCellWithState from './TextInputCellWithState';
 
 import { formatStatus } from '../../utilities';
 
@@ -94,12 +95,13 @@ const DataTableRow = React.memo(
               // Use the placeholder 'Not counted' when a stocktake item or batch
               // has not been counted yet.
               let placeholder = '';
+              let Component = TextInputCell;
               if (columnKey === COLUMN_NAMES.COUNTED_TOTAL_QUANTITY) {
                 placeholder = rowData.hasBeenCounted ? '' : tableStrings.not_counted;
+                Component = TextInputCellWithState;
               }
-
               return (
-                <TextInputCell
+                <Component
                   key={columnKey}
                   value={rowData[columnKey]}
                   rowKey={rowKey}

--- a/src/widgets/DataTable/TextInputCellWithState.js
+++ b/src/widgets/DataTable/TextInputCellWithState.js
@@ -1,0 +1,135 @@
+/* eslint-disable react/forbid-prop-types */
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { View, TextInput } from 'react-native';
+
+import Cell from './Cell';
+import RefContext from './RefContext';
+
+import { getAdjustedStyle } from './utilities';
+
+const TextInputCellWithState = React.memo(
+  ({
+    value,
+    rowKey,
+    columnKey,
+    isDisabled,
+    placeholderColour,
+    editAction,
+    dispatch,
+    isLastCell,
+    width,
+    debug,
+    keyboardType,
+    placeholder,
+    viewStyle,
+    rowIndex,
+    textInputStyle,
+    cellTextStyle,
+    underlineColor,
+  }) => {
+    if (debug) console.log(`- TextInputCellWithState: ${value}`);
+
+    const [internalValue, setInternalValue] = useState({ initialValue: value, newValue: value });
+
+    const { initialValue, newValue } = internalValue;
+
+    if (initialValue !== value) setInternalValue({ initialValue: value, newValue: value });
+
+    const usingPlaceholder = placeholder && !internalValue;
+
+    const { focusNextCell, getRefIndex, getCellRef } = React.useContext(RefContext);
+    const refIndex = getRefIndex(rowIndex, columnKey);
+
+    const focusNext = () => focusNextCell(refIndex);
+
+    // On editing, set the internal state of this component.
+    const onEdit = updatedValue => setInternalValue({ ...internalValue, newValue: updatedValue });
+
+    // When editing has been completed, submit the final result.
+    const onEnd = ({ nativeEvent }) => {
+      const { text = '' } = nativeEvent || {};
+      dispatch(editAction(text, rowKey, columnKey));
+    };
+
+    // Render a plain Cell if disabled.
+    if (isDisabled) {
+      return (
+        <Cell
+          key={columnKey}
+          viewStyle={viewStyle}
+          textStyle={cellTextStyle}
+          value={value}
+          width={width}
+          isLastCell={isLastCell}
+        />
+      );
+    }
+
+    const internalViewStyle = getAdjustedStyle(viewStyle, width, isLastCell);
+    const internalTextStyle = getAdjustedStyle(textInputStyle, width);
+
+    // Render a Cell with a textInput.
+    return (
+      <View style={internalViewStyle}>
+        <TextInput
+          ref={getCellRef(refIndex)}
+          placeholder={placeholder}
+          style={internalTextStyle}
+          value={usingPlaceholder ? '' : String(newValue)}
+          placeholderTextColor={placeholderColour}
+          onChangeText={onEdit}
+          onSubmitEditing={focusNext}
+          onEndEditing={onEnd}
+          underlineColorAndroid={underlineColor}
+          keyboardType={keyboardType}
+          blurOnSubmit={false}
+        />
+      </View>
+    );
+  }
+);
+
+TextInputCellWithState.propTypes = {
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  rowKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  columnKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  isDisabled: PropTypes.bool,
+  placeholderColour: PropTypes.string,
+  editAction: PropTypes.func.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  cellTextStyle: PropTypes.object,
+  viewStyle: PropTypes.object,
+  width: PropTypes.number,
+  textInputStyle: PropTypes.object,
+  isLastCell: PropTypes.bool,
+  debug: PropTypes.bool,
+  placeholder: PropTypes.string,
+  rowIndex: PropTypes.number.isRequired,
+  underlineColor: PropTypes.string,
+  keyboardType: PropTypes.oneOf([
+    'default',
+    'number-pad',
+    'decimal-pad',
+    'numeric',
+    'email-address',
+    'phone-pad',
+  ]),
+};
+
+TextInputCellWithState.defaultProps = {
+  value: '',
+  isDisabled: false,
+  viewStyle: {},
+  cellTextStyle: {},
+  textInputStyle: {},
+  isLastCell: false,
+  width: 0,
+  debug: false,
+  keyboardType: 'numeric',
+  placeholder: '',
+  placeholderColour: '#CDCDCD',
+  underlineColor: '#CDCDCD',
+};
+
+export default TextInputCellWithState;

--- a/src/widgets/DataTable/TouchableCell.js
+++ b/src/widgets/DataTable/TouchableCell.js
@@ -1,8 +1,8 @@
 /* eslint-disable react/prop-types */
 /* eslint-disable react/forbid-prop-types */
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { Text, TouchableOpacity, TouchableOpacityPropTypes } from 'react-native';
+import { Text, TouchableOpacity, Keyboard, TouchableOpacityPropTypes } from 'react-native';
 
 import TouchableNoFeedback from './TouchableNoFeedback';
 
@@ -45,7 +45,10 @@ const TouchableCell = React.memo(
   }) => {
     if (debug) console.log(`- TouchableCell: ${rowKey},${columnKey}`);
 
-    const onPress = () => dispatch(onPressAction(rowKey, columnKey));
+    const onPress = useCallback(() => {
+      Keyboard.dismiss();
+      dispatch(onPressAction(rowKey, columnKey));
+    }, [onPressAction, rowKey, columnKey]);
 
     const internalContainerStyle = getAdjustedStyle(containerStyle, width, isLastCell);
     const Container = isDisabled ? TouchableNoFeedback : TouchableComponent || TouchableOpacity;

--- a/src/widgets/DataTable/index.js
+++ b/src/widgets/DataTable/index.js
@@ -9,6 +9,7 @@ import DataTable from './DataTable';
 import DataTableHeaderRow from './DataTableHeaderRow';
 import DataTableRow from './DataTableRow';
 import TouchableNoFeedback from './TouchableNoFeedback';
+import TextInputCellWithState from './TextInputCellWithState';
 
 export {
   DataTable,
@@ -22,4 +23,5 @@ export {
   HeaderCell,
   DataTableRow,
   TouchableNoFeedback,
+  TextInputCellWithState,
 };


### PR DESCRIPTION
Fixes #1471 

## Change summary

- Adds a new stateful Cell for editing stocktakes

## Testing

- [ ] Editing any `Stocktake` `Counted Quantity` cell does not change any values until losing focus [i.e. difference column does not change as you type]

### Related areas to think about

This isn't a perfect fix - there are still inconsistencies when opening/closing the modal, clicking finalised etc etc. I don't like this fix but it will do for now, I think
