### PR TITLE
#1475 Focus crash

### DIFF
--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -84,7 +84,7 @@ const DataTable = React.memo(
       const nextCellRef = (refIndex + 1) % numberOfEditableCells;
       const cellRef = getCellRef(nextCellRef);
 
-      return cellRef.current.focus();
+      return cellRef.current && cellRef.current.focus();
     };
 
     // Adjusts the passed row to the top of the list.


### PR DESCRIPTION
Fixes #1475 

## Change summary

- Adds a check that a ref exists before trying to focus

Essentially this occurs in the edge case in a stocktake batch modal window where the table is smaller, and the keyboard covers some rows. When the keyboard covers rows, rows aren't rendered, and therefore dont have a ref to focus. 

I'm not sure of a nother work around. Doesn't occur on a normal table, only on stocktake batch which is smaller as explained above

## Testing
* This is very edge case, I think I would need to show someone how to have it occur*
- [ ] Focusing the next cell never crashes the app

### Related areas to think about

N/A
