### PR TITLE
#1480 update dev scripts

### DIFF
--- a/dev_scripts/clean.sh
+++ b/dev_scripts/clean.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# mSupply Mobile
+# Sustainable Solutions (NZ) Ltd. 2019.
+#
+# Clean up react native caches.
+
+TMPDIR_PACKAGER=$TMPDIR/react-native-packager-*
+TMPDIR_METRO=$TMPDIR/metro-bundler-*
+
+echo "Cleaning up temporary files..."
+rm -rf $TMPDIR_PACKAGER $TMPDIR_METRO
+echo "Cleaning up watchman files..."
+npx watchman watch-del-all
+echo "Reinstalling node modules..."
+rm -rf node_modules/ &&
+    yarn cache clean &&
+    yarn install

--- a/dev_scripts/deploy.sh
+++ b/dev_scripts/deploy.sh
@@ -6,7 +6,7 @@
 # Deploy mobile app.
 
 APK_DIR="android/app/build/outputs/apk/release"
-APK_VERSION="mSupplyMobile-2_3_6-universal-release"
+APK_VERSION="mSupplyMobile-3_0_2-universal-release"
 PACKAGE="com.msupplymobile"
 
 echo "Rooting device..."
@@ -14,4 +14,4 @@ adb root > /dev/null
 echo "Uninstalling mSupply mobile..."
 adb uninstall $PACKAGE > /dev/null
 echo "Installing latest .apk build..."
-adb install "${APK_DIR}/${APK_VERSION}.apk" > /dev/null
+adb install $APK_DIR/$APK_VERSION.apk > /dev/null

--- a/dev_scripts/keygen.sh
+++ b/dev_scripts/keygen.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# mSupply Mobile
+# Sustainable Solutions (NZ) Ltd. 2019.
+#
+# Generate debug signing key.
+
+KEYDIR=./android/app
+KEYSTORE=$KEYDIR/debug.keystore
+STOREPASS=android
+ALIAS=androiddebugkey
+KEYPASS=android
+KEYALG=RSA
+KEYSIZE=2048
+VALIDITY=10000
+
+keytool -genkey \
+ -keystore $KEYSTORE \
+ -storepass $STOREPASS \
+ -alias $ALIAS \
+ -keypass $KEYPASS \
+ -keyalg $KEYALG \
+ -keysize $KEYSIZE \
+ -validity $VALIDITY 

--- a/dev_scripts/upload.sh
+++ b/dev_scripts/upload.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# mSupply Mobile
+# Sustainable Solutions (NZ) Ltd. 2019.
+#
+# Upload source maps to bugsnag server.
+
+BUGSNAG_URL=https://upload.bugsnag.com/react-native-source-map
+BUGSNAG_KEY=16a680e189b1e5f03f28665870f1401f
+APP_VERSION=3.0.2
+
+PLATFORM=android
+DEV=false
+ENTRY_FILE=index.js
+PROJECT_ROOT=$(pwd)
+BUNDLE_OUTPUT=android-release.bundle
+SOURCEMAP_OUTPUT=android-release.bundle.map
+
+echo "Building source map..."
+react-native bundle \
+	     --platform $PLATFORM \
+	     --dev $DEV \
+	     --entry-file $ENTRY_FILE \
+	     --bundle-output $BUNDLE_OUTPUT \
+	     --sourcemap-output $SOURCEMAP_OUTPUT
+echo "Uploading source map..."
+curl $BUGSNAG_URL \
+   -F apiKey=$BUGSNAG_KEY \
+   -F appVersion=$APP_VERSION \
+   -F dev=$DEV \
+   -F platform=$PLATFORM \
+   -F sourceMap=@$SOURCEMAP_OUTPUT \
+   -F bundle=@$BUNDLE_OUTPUT \
+   -F projectRoot=$PROJECT_ROOT

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "uninstall": "./dev_scripts/uninstall.sh",
     "clean-mac-cache": "./dev_scripts/clean.sh",
     "keygen": "./dev_scripts/keygen.sh",
+    "upload-bugsnag": "./dev_scripts/upload.sh"
   },
   "jest": {
     "preset": "react-native"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "deploy": "./dev_scripts/deploy.sh",
     "export": "./dev_scripts/export.sh",
     "uninstall": "./dev_scripts/uninstall.sh",
-    "clean-mac-cache": "rm -rf $TMPDIR/react-native-packager-* && rm -rf $TMPDIR/metro-bundler-* && watchman watch-del-all && rm -rf node_modules/ && yarn cache clean && yarn install"
+    "clean-mac-cache": "./dev_scripts/clean.sh",
   },
   "jest": {
     "preset": "react-native"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "export": "./dev_scripts/export.sh",
     "uninstall": "./dev_scripts/uninstall.sh",
     "clean-mac-cache": "./dev_scripts/clean.sh",
+    "keygen": "./dev_scripts/keygen.sh",
   },
   "jest": {
     "preset": "react-native"


### PR DESCRIPTION
Fixes #1480

## Change summary

Just clean up and adding a few useful scripts.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] `yarn clean-mac-cache` works as expected.
- [ ] `yarn deploy` works for current release 3.0.2.
- [ ] `yarn keygen` generates a debug signing key (try running `react-native run-android` before and after).
- [ ] `yarn upload-bugsnag` correctly bundles and uploads the source map to the bugsnag server (try examining a new error before and after).

### Related areas to think about

May be worth committed the debug key to the repo, although it may still be useful to have the ability to generate keys for testing some functionality (e.g. hardware IDs etc.)
