### PR TITLE
#1505 Months lead time crash

### DIFF
--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -193,7 +193,7 @@ export const createSupplierRequisition = ({
 
   // Months lead time has an effect on daysToSupply for a requisition.
   const monthsLeadTime = parsedCustomData.monthsLeadTime
-    ? Number(customData.monthsLeadTime.data)
+    ? Number(parsedCustomData.monthsLeadTime.data)
     : 0;
 
   // Create the requisition. If a program was supplied, add items from that


### PR DESCRIPTION
Fixes #1505 

## Change summary

- Uses the correct variable

## Testing

*Setup: Have a program ready. Have `monthsLeadTime` set to a value in `[store]custom_data`
- [ ] When creating a program requisition, the app doesn't crash.

### Related areas to think about

N/A
