### PR TITLE
#1510 Focus, submit and scrolling

### DIFF
--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -89,7 +89,7 @@ const DataTable = React.memo(
 
     // Adjusts the passed row to the top of the list.
     const adjustToTop = useCallback(rowIndex => {
-      virtualizedListRef.current.scrollToIndex({ index: rowIndex });
+      virtualizedListRef.current.scrollToIndex({ index: Math.max(0, rowIndex - 1) });
     }, []);
 
     // Contexts values. Functions passed to rows and editable cells to control focus/scrolling.


### PR DESCRIPTION
Fixes #1510 

## Change summary

- Just adjusts the index to scroll to leave the last row 

## Testing

- [ ] When submitting a row in a data table, the table is scrolled to leave a row above the currently focused one

### Related areas to think about

N/A
