### PR TITLE
#1479 Strange ordering when adding rows

### DIFF
--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -174,20 +174,12 @@ export const toggleStockOut = state => {
  *
  * Also removes the current sorting and filter.
  */
-export const addRecord = (state, action) => {
-  const { data, searchTerm, backingData } = state;
-  const { payload } = action;
-  const { record } = payload;
-
-  // New records are added to index 0 of the table and all filtering and
-  // sorting are removed. To keep the table consistent while adding items,
-  // if there is a search term, the table is currently being filtered so
-  // fetch all the rows again. Otherwise, just use the current data state.
-  const newData = searchTerm ? backingData.slice(1, backingData.length - 1) : data;
+export const addRecord = state => {
+  const { backingData } = state;
 
   return {
     ...state,
-    data: [record, ...newData],
+    data: backingData.sorted('id', true).slice(),
     modalKey: '',
     sortBy: '',
     searchTerm: '',

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -175,13 +175,13 @@ export const toggleStockOut = state => {
  * Also removes the current sorting and filter.
  */
 export const addRecord = (state, action) => {
-  const { backingData } = state;
+  const { data } = state;
   const { payload } = action;
   const { record } = payload;
 
   return {
     ...state,
-    data: [record, ...backingData.slice(0, backingData.length - 1)],
+    data: [record, ...data],
     modalKey: '',
     sortBy: '',
     searchTerm: '',

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -175,13 +175,19 @@ export const toggleStockOut = state => {
  * Also removes the current sorting and filter.
  */
 export const addRecord = (state, action) => {
-  const { data } = state;
+  const { data, searchTerm, backingData } = state;
   const { payload } = action;
   const { record } = payload;
 
+  // New records are added to index 0 of the table and all filtering and
+  // sorting are removed. To keep the table consistent while adding items,
+  // if there is a search term, the table is currently being filtered so
+  // fetch all the rows again. Otherwise, just use the current data state.
+  const newData = searchTerm ? backingData.slice(1, backingData.length - 1) : data;
+
   return {
     ...state,
-    data: [record, ...data],
+    data: [record, ...newData],
     modalKey: '',
     sortBy: '',
     searchTerm: '',


### PR DESCRIPTION
Fixes #1479 

## Change summary

- Just changes the way state is mutated. I'm 90%, but not 100% there is no edge case where this would not cause a problem, so putting it into develop rather than master as a patch so we can have time to play

## Testing

Not really a check list of testing, more of a story sorry 🤷‍♂ 

*This PR just changes the way state is held, such that when adding a new row to a table, the row is added to the top of the table, and the remaining rows do not change order, but the current filtering and sorting is removed (as it is possibly not correct anymore).*

Create a list of a few items in a supplier invoice. Easiest to number the quantities `1,2,3` etc. Add an item. It should be added to the head and the order of the remaining rows should be stable when adding more items - whether there is a filtering term or sorting.

This applies to adding of all rows `supplier invoice`, `customer invoice` and `supplier requisition`. All the logic is shared, so testing one page is sufficient.

Try to break the app, by using some funky ordering or workflow of sorting/filtering/adding/editing/removing etc

- [ ] App doesn't break

### Related areas to think about

N/A
