### PR TITLE
#1513 Add code to item select

### DIFF
--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -57,12 +57,11 @@ const DataTablePageModalComponent = ({
         return (
           <AutocompleteSelector
             options={UIDatabase.objects('Item')}
-            queryString="name BEGINSWITH[c] $0 OR code BEGINSWITH[c] $0"
-            queryStringSecondary="name CONTAINS[c] $0"
+            queryString="name CONTAINS[c] $0 OR code BEGINSWITH[c] $0"
             sortByString="name"
             onSelect={onSelect}
-            renderLeftText={item => `${item.name}`}
-            renderRightText={item => `${item.totalQuantity}`}
+            renderLeftText={({ code, name }) => `${code} - ${name}`}
+            renderRightText={({ totalQuantity }) => `${totalQuantity}`}
           />
         );
       case MODAL_KEYS.STOCKTAKE_NAME_EDIT:


### PR DESCRIPTION
Fixes #1513 

## Change summary

- Adds the items code to `ITEM_SELECT` modal

![image](https://user-images.githubusercontent.com/35858975/68354957-aab35380-0172-11ea-899c-97319f35b5e3.png)
#### Note: This hits the limit of characters on both code and name


## Testing

**Info: `ITEM_SELECT` modal is used in `SupplierRequisitionPage` (no programs), `CustomerInvoicePage`, `SupplierInvoicePage`

- [ ] When adding an item, each row displays the items code

### Related areas to think about

N/A