### PR TITLE
#1519 usage dates

### DIFF
--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -78,19 +78,15 @@ export class Item extends Realm.Object {
   }
 
   /**
-   * Get the date the item was added, defined as date of he earliest added batch associated
-   * with this item, or undefined if no batches exist.
-   *
+   * Get the date the item was added, defined as date of the earliest added batch associated
+   * with this item.
    * @return  {Date}
    */
   get addedDate() {
-    if (this.batches.length === 0) return undefined;
-    let itemAddedDate = new Date();
-    this.batches.forEach(batch => {
-      const batchAddedDate = batch.addedDate;
-      itemAddedDate = batchAddedDate < itemAddedDate ? batchAddedDate : itemAddedDate;
-    });
-    return itemAddedDate;
+    return this.batches.reduce(
+      (acc, { addedDate }) => (acc > addedDate ? addedDate : acc),
+      new Date()
+    );
   }
 
   /**

--- a/src/database/DataTypes/ItemBatch.js
+++ b/src/database/DataTypes/ItemBatch.js
@@ -35,16 +35,14 @@ export class ItemBatch extends Realm.Object {
   /**
    * Get the date this batch was added, equivalent to the confirm date
    * of the earliest transaction batch this batch is associated with.
-   *
    * @return  {Date}
    */
   get addedDate() {
-    if (this.transactionBatches.length === 0) return new Date();
-    const transactionBatches = this.transactionBatches.slice();
-    const sortedTransactionBatches = transactionBatches.sort(
-      (a, b) => a.transaction.confirmDate < b.transaction.confirmDate
+    return (
+      this.transactionBatches
+        .filtered('transaction.type == $0 && transaction.status != $1', 'supplier_invoice', 'new')
+        .sorted('transaction.confirmDate', false)[0]?.transaction?.confirmDate ?? new Date()
     );
-    return sortedTransactionBatches[0].transaction.confirmDate;
   }
 
   /**


### PR DESCRIPTION
Fixes #1519 

## Change summary

- Changes `Item.addedDate` and `ItemBatch.addedDate` methods so that the added date is the earliest confirm date, of all incoming `TransactionBatch` records.

I tried to mimic the previous behaviour while just fixing the bug between `null` and dates.

I understand that we use the earliest date for the added date. I don't fully understand why we would use this in the usage calculation. It seems to be trying to account for using large amounts when an item is 'added'. If so, should this look for the earliest confirmed, incoming batch, with stock? Currently this logic would only account for the first ever incoming batch.

I'm missing a little bit of knowledge here I think!

## Testing

*Internal, hard to test change..*
- [ ] `Item.addedDate` returns the date of the earliest confirmed transaction batch..
- [ ] `ItemBatch.addedDate` returns the date of the earliest confirmed transaction batch..

### Related areas to think about

Related PR: #1520 
