### PR TITLE
#1518 Corrected select all state

### DIFF
--- a/src/pages/dataTableUtilities/reducer/rowReducers.js
+++ b/src/pages/dataTableUtilities/reducer/rowReducers.js
@@ -82,13 +82,13 @@ export const deselectAll = state => {
  * Toggles selection of all rows between selected/false
  */
 export const toggleSelectAll = state => {
-  const { data, keyExtractor, dataState, allSelected } = state;
+  const { keyExtractor, dataState, allSelected, backingData } = state;
 
   const newDataState = new Map(dataState);
 
   const newSelectionState = !allSelected;
 
-  data.forEach(item => {
+  backingData.forEach(item => {
     const rowKey = keyExtractor(item);
     newDataState.set(rowKey, { ...newDataState.get(rowKey), isSelected: newSelectionState });
   });


### PR DESCRIPTION
Fixes #1518 

## Change summary

- When selecting all, all items are actually selected. This is the behaviour I would expect.


## Testing

- [ ] Filter `StocktakeManage` page to a sub set of items and pres all items selected. All items should be selected (after removing the filter)

### Related areas to think about

I think we are looking to change this page anyway (Or at least I would like to!), but probably not before the next version?
