### PR TITLE
#xxxx row debug prop default to false

### DIFF
--- a/src/widgets/DataTable/Row.js
+++ b/src/widgets/DataTable/Row.js
@@ -76,7 +76,7 @@ Row.defaultProps = {
   rowState: null,
   style: {},
   onPress: null,
-  debug: true,
+  debug: false,
 };
 
 export default Row;


### PR DESCRIPTION
Fixes nothing, just a dev tweak. I believe it can be a performance issue if it gets into a release APK though.

## Change summary

Develop is logging stuff to metro bundler
![image](https://user-images.githubusercontent.com/7684221/68633779-fd688300-0557-11ea-8775-1dd2eb8b82da.png)

## Testing

Run develop branch. See no more console logs in the metro bundler terminal output

### Related areas to think about
