### PR TITLE
#1212 Make Master list Multiselectable

### DIFF
--- a/src/database/DataTypes/MasterList.js
+++ b/src/database/DataTypes/MasterList.js
@@ -71,6 +71,10 @@ export class MasterList extends Realm.Object {
 
     return foundStoreTag && storeTags[foundStoreTag];
   }
+
+  toString() {
+    return this.name;
+  }
 }
 
 MasterList.schema = {

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -210,23 +210,26 @@ export class Requisition extends Realm.Object {
   /**
    * Add all items from the mobile store master list to this requisition.
    *
-   * @param  {Realm}  database
-   * @param  {Name}   thisStore
+   * @param  {Realm}            database
+   * @param  {Array.<string>}   selected masterlists from multiselect
+   * @param  {Name}             thisStore
    */
-  addItemsFromMasterList(database, thisStore) {
+  addItemsFromMasterList(database, selected, thisStore) {
     if (this.isFinalised) {
       throw new Error('Cannot add items to a finalised requisition');
     }
-
-    thisStore.masterLists.forEach(masterList => {
-      const itemsToAdd = complement(masterList.items, this.items, item => item.itemId);
-      itemsToAdd.forEach(masterListItem => {
-        if (!masterListItem.item.crossReferenceItem) {
-          // Do not add cross reference items as causes unwanted duplicates.
-          createRecord(database, 'RequisitionItem', this, masterListItem.item);
-        }
+    // Filter through masterList ids that are on multiselect list
+    thisStore.masterLists
+      .filter(item => selected.indexOf(item.id) !== -1)
+      .forEach(masterList => {
+        const itemsToAdd = complement(masterList.items, this.items, item => item.itemId);
+        itemsToAdd.forEach(masterListItem => {
+          if (!masterListItem.item.crossReferenceItem) {
+            // Do not add cross reference items as causes unwanted duplicates.
+            createRecord(database, 'RequisitionItem', this, masterListItem.item);
+          }
+        });
       });
-    });
   }
 
   /**

--- a/src/localization/modalStrings.js
+++ b/src/localization/modalStrings.js
@@ -47,12 +47,14 @@ export const modalStrings = new LocalizedStrings({
     select_the_number_of_months_stock_required: 'Select the number of months stock required',
     start_typing_to_select_customer: 'Start typing to select customer',
     start_typing_to_select_supplier: 'Start typing to select supplier',
+    start_typing_to_select_master_list: 'Start typing to select master list',
     stock_quantity_greater_then_zero: 'Stock quantity must be greater then zero before finalising',
     stocktake_no_counted_items: "Can't finalise a stocktake with no counted items",
     stocktake_invalid_stock:
       'Stock on hand for these item(s) have changed since this stocktake was last opened (through customer invoice, supplier invoice or another stocktake), both "Snapshot Quantity" and "Actual Quantity" will be reset',
     select_a_reason: 'Select a reason',
     confirm_password: 'Please confirm your user password',
+    select_master_lists: 'Select master list',
   },
   fr: {
     add_at_least_one_item_before_finalising:

--- a/src/localization/modalStrings.js
+++ b/src/localization/modalStrings.js
@@ -55,6 +55,7 @@ export const modalStrings = new LocalizedStrings({
     select_a_reason: 'Select a reason',
     confirm_password: 'Please confirm your user password',
     select_master_lists: 'Select master list',
+    no_masterlist_available: 'Sorry, no master list available.',
   },
   fr: {
     add_at_least_one_item_before_finalising:

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -47,6 +47,25 @@ const SYNC_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 const AUTHENTICATION_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 
 class MSupplyMobileAppContainer extends React.Component {
+  handleBackEvent = debounce(
+    () => {
+      const { dispatch } = this.props;
+      const { confirmFinalise, syncModalIsOpen } = this.state;
+      // If finalise or sync modals are open, close them rather than navigating.
+      if (confirmFinalise || syncModalIsOpen) {
+        this.setState({ confirmFinalise: false, syncModalIsOpen: false });
+        return true;
+      }
+      // If we are on base screen (e.g. home), back button should close app as we can't go back.
+      if (!this.getCanNavigateBack()) BackHandler.exitApp();
+      else dispatch(NavigationActions.back());
+
+      return true;
+    },
+    400,
+    true
+  );
+
   constructor(props, ...otherArgs) {
     super(props, ...otherArgs);
 
@@ -107,25 +126,6 @@ class MSupplyMobileAppContainer extends React.Component {
 
     return route.routeName;
   }
-
-  handleBackEvent = debounce(
-    () => {
-      const { dispatch } = this.props;
-      const { confirmFinalise, syncModalIsOpen } = this.state;
-      // If finalise or sync modals are open, close them rather than navigating.
-      if (confirmFinalise || syncModalIsOpen) {
-        this.setState({ confirmFinalise: false, syncModalIsOpen: false });
-        return true;
-      }
-      // If we are on base screen (e.g. home), back button should close app as we can't go back.
-      if (!this.getCanNavigateBack()) BackHandler.exitApp();
-      else dispatch(NavigationActions.back());
-
-      return true;
-    },
-    400,
-    true
-  );
 
   runWithLoadingIndicator = async functionToRun => {
     UIDatabase.isLoading = true;

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 
 import { MODAL_KEYS } from '../utilities';
 import { useRecordListener } from '../hooks';
-import { getItemLayout, getPageDispatchers, PageActions } from './dataTableUtilities';
+import { getItemLayout, getPageDispatchers } from './dataTableUtilities';
 import { ROUTES } from '../navigation/constants';
 
 import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
@@ -35,7 +35,6 @@ import globalStyles from '../globalStyles';
  * { isSelected, isFocused, isDisabled }
  */
 export const CustomerInvoice = ({
-  runWithLoadingIndicator,
   dispatch,
   data,
   dataState,
@@ -51,6 +50,7 @@ export const CustomerInvoice = ({
   getPageInfoColumns,
   refreshData,
   onSelectNewItem,
+  onAddMasterList,
   onEditComment,
   onEditTheirRef,
   onFilterData,
@@ -62,6 +62,7 @@ export const CustomerInvoice = ({
   onSortColumn,
   onEditTotalQuantity,
   onAddTransactionItem,
+  onApplyMasterLists,
   route,
 }) => {
   const { isFinalised, comment, theirRef } = pageObject;
@@ -69,9 +70,6 @@ export const CustomerInvoice = ({
   // Listen for this invoice being finalised which will prune items and cause side effects
   // outside of the reducer. Reconcile differences when triggered.
   useRecordListener(refreshData, pageObject, 'Transaction');
-
-  const onAddMasterList = () =>
-    runWithLoadingIndicator(() => dispatch(PageActions.addMasterListItems('Transaction', route)));
 
   const pageInfoColumns = useCallback(getPageInfoColumns(pageObject, dispatch, route), [
     comment,
@@ -99,6 +97,8 @@ export const CustomerInvoice = ({
         return onEditComment;
       case MODAL_KEYS.THEIR_REF_EDIT:
         return onEditTheirRef;
+      case MODAL_KEYS.SELECT_MASTER_LISTS:
+        return onApplyMasterLists;
       default:
         return null;
     }
@@ -161,6 +161,7 @@ export const CustomerInvoice = ({
             <PageButton
               text={buttonStrings.add_master_list_items}
               onPress={onAddMasterList}
+              onSelect={onApplyMasterLists}
               isDisabled={isFinalised}
             />
           </View>
@@ -204,17 +205,13 @@ const mapStateToProps = state => {
   return customerInvoice;
 };
 
-export const CustomerInvoicePage = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(CustomerInvoice);
+export const CustomerInvoicePage = connect(mapStateToProps, mapDispatchToProps)(CustomerInvoice);
 
 CustomerInvoice.defaultProps = {
   modalValue: null,
 };
 
 CustomerInvoice.propTypes = {
-  runWithLoadingIndicator: PropTypes.func.isRequired,
   dispatch: PropTypes.func.isRequired,
   data: PropTypes.array.isRequired,
   dataState: PropTypes.object.isRequired,
@@ -230,6 +227,7 @@ CustomerInvoice.propTypes = {
   getPageInfoColumns: PropTypes.func.isRequired,
   refreshData: PropTypes.func.isRequired,
   onSelectNewItem: PropTypes.func.isRequired,
+  onAddMasterList: PropTypes.func.isRequired,
   onEditComment: PropTypes.func.isRequired,
   onEditTheirRef: PropTypes.func.isRequired,
   onFilterData: PropTypes.func.isRequired,
@@ -241,5 +239,6 @@ CustomerInvoice.propTypes = {
   onSortColumn: PropTypes.func.isRequired,
   onEditTotalQuantity: PropTypes.func.isRequired,
   onAddTransactionItem: PropTypes.func.isRequired,
+  onApplyMasterLists: PropTypes.func.isRequired,
   route: PropTypes.string.isRequired,
 };

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -69,6 +69,8 @@ const SupplierRequisition = ({
   onEditRequiredQuantity,
   onAddRequisitionItem,
   onSetRequestedToSuggested,
+  onAddMasterList,
+  onApplyMasterLists,
   route,
 }) => {
   // Listen for changes to this pages requisition. Refreshing data on side effects i.e. finalizing.
@@ -78,9 +80,6 @@ const SupplierRequisition = ({
 
   const createAutomaticOrder = () => dispatch(PageActions.createAutomaticOrder(route));
   const onCreateAutomaticOrder = () => runWithLoadingIndicator(createAutomaticOrder);
-
-  const addFromMasterlist = () => dispatch(PageActions.addMasterListItems('Requisition', route));
-  const onAddFromMasterList = () => runWithLoadingIndicator(addFromMasterlist);
 
   const pageInfoColumns = useMemo(() => getPageInfoColumns(pageObject, dispatch, route), [
     comment,
@@ -109,6 +108,8 @@ const SupplierRequisition = ({
         return onEditMonth;
       case MODAL_KEYS.REQUISITION_COMMENT_EDIT:
         return onEditComment;
+      case MODAL_KEYS.SELECT_MASTER_LISTS:
+        return onApplyMasterLists;
       default:
         return null;
     }
@@ -150,7 +151,8 @@ const SupplierRequisition = ({
     <PageButton
       style={globalStyles.leftButton}
       text={buttonStrings.add_master_list_items}
-      onPress={onAddFromMasterList}
+      onPress={onAddMasterList}
+      onSelect={onApplyMasterLists}
       isDisabled={isFinalised}
     />
   );
@@ -336,5 +338,7 @@ SupplierRequisition.propTypes = {
   onEditRequiredQuantity: PropTypes.func.isRequired,
   onAddRequisitionItem: PropTypes.func.isRequired,
   onSetRequestedToSuggested: PropTypes.func.isRequired,
+  onAddMasterList: PropTypes.func.isRequired,
+  onApplyMasterLists: PropTypes.func.isRequired,
   route: PropTypes.string.isRequired,
 };

--- a/src/pages/dataTableUtilities/actions/pageActions.js
+++ b/src/pages/dataTableUtilities/actions/pageActions.js
@@ -60,7 +60,6 @@ export const openModal = (modalKey, value, route) => {
     case MODAL_KEYS.EDIT_STOCKTAKE_BATCH:
     case MODAL_KEYS.ENFORCE_STOCKTAKE_REASON:
       return { type: ACTIONS.OPEN_MODAL, payload: { modalKey, rowKey: value, route } };
-
     case MODAL_KEYS.MONTHS_SELECT:
     case MODAL_KEYS.PROGRAM_REQUISITION:
     case MODAL_KEYS.PROGRAM_STOCKTAKE:
@@ -75,6 +74,7 @@ export const openModal = (modalKey, value, route) => {
     case MODAL_KEYS.TRANSACTION_COMMENT_EDIT:
     case MODAL_KEYS.REQUISITION_COMMENT_EDIT:
     case MODAL_KEYS.THEIR_REF_EDIT:
+    case MODAL_KEYS.SELECT_MASTER_LISTS:
     default:
       return { type: ACTIONS.OPEN_MODAL, payload: { modalKey, route: route || value } };
   }

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -101,7 +101,8 @@ export const toggleStockOut = route => ({
  *
  * @param {String} objectType Type of object to add items for.
  */
-export const addMasterListItems = (objectType, route) => (dispatch, getState) => {
+export const addMasterListItems = (selected, route) => (dispatch, getState) => {
+  let objectType = '';
   const pageObject = pageObjectSelector(getState());
 
   const thisStore = UIDatabase.objects('Name').filtered(
@@ -109,12 +110,27 @@ export const addMasterListItems = (objectType, route) => (dispatch, getState) =>
     Settings.get(SETTINGS_KEYS.THIS_STORE_NAME_ID)
   )[0];
 
-  UIDatabase.write(() => {
-    pageObject.addItemsFromMasterList(UIDatabase, thisStore);
-    UIDatabase.save(objectType, pageObject);
-  });
+  switch (route) {
+    case 'supplierRequisition':
+      objectType = 'Requisition';
+      break;
+    case 'customerInvoice':
+      objectType = 'Transaction';
+      break;
+    default:
+      objectType = '';
+  }
+
+  console.log(`objectType ${objectType}`);
+  if (objectType) {
+    UIDatabase.write(() => {
+      pageObject.addItemsFromMasterList(UIDatabase, selected, thisStore);
+      UIDatabase.save(objectType, pageObject);
+    });
+  }
 
   dispatch(refreshData(route));
+  dispatch(closeModal(route));
 };
 
 /**
@@ -241,6 +257,11 @@ export const refreshDataWithFinalisedToggle = route => ({
 export const filterDataWithFinalisedToggle = (searchTerm, route) => ({
   type: ACTIONS.FILTER_DATA_WITH_FINALISED_TOGGLE,
   payload: { searchTerm, route },
+});
+
+export const applyMasterLists = (selectedMasterLists, route) => ({
+  type: ACTIONS.APPLY_MASTER_LISTS,
+  payload: { selectedMasterLists, route },
 });
 
 export const filterDataWithOverStockToggle = (searchTerm, route) => ({

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -121,7 +121,6 @@ export const addMasterListItems = (selected, route) => (dispatch, getState) => {
       objectType = '';
   }
 
-  console.log(`objectType ${objectType}`);
   if (objectType) {
     UIDatabase.write(() => {
       pageObject.addItemsFromMasterList(UIDatabase, selected, thisStore);

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -101,8 +101,7 @@ export const toggleStockOut = route => ({
  *
  * @param {String} objectType Type of object to add items for.
  */
-export const addMasterListItems = (selected, route) => (dispatch, getState) => {
-  let objectType = '';
+export const addMasterListItems = (selected, objectType, route) => (dispatch, getState) => {
   const pageObject = pageObjectSelector(getState());
 
   const thisStore = UIDatabase.objects('Name').filtered(
@@ -110,23 +109,10 @@ export const addMasterListItems = (selected, route) => (dispatch, getState) => {
     Settings.get(SETTINGS_KEYS.THIS_STORE_NAME_ID)
   )[0];
 
-  switch (route) {
-    case 'supplierRequisition':
-      objectType = 'Requisition';
-      break;
-    case 'customerInvoice':
-      objectType = 'Transaction';
-      break;
-    default:
-      objectType = '';
-  }
-
-  if (objectType) {
-    UIDatabase.write(() => {
-      pageObject.addItemsFromMasterList(UIDatabase, selected, thisStore);
-      UIDatabase.save(objectType, pageObject);
-    });
-  }
+  UIDatabase.write(() => {
+    pageObject.addItemsFromMasterList(UIDatabase, selected, thisStore);
+    UIDatabase.save(objectType, pageObject);
+  });
 
   dispatch(refreshData(route));
   dispatch(closeModal(route));

--- a/src/pages/dataTableUtilities/getPageDispatchers.js
+++ b/src/pages/dataTableUtilities/getPageDispatchers.js
@@ -58,6 +58,11 @@ export const getPageDispatchers = (dispatch, props, dataType, route) => {
     onAddRequisitionItem: item => dispatch(BasePageActions.addItem(item, 'RequisitionItem', route)),
     onSelectNewItem: () => dispatch(BasePageActions.openModal(MODAL_KEYS.SELECT_ITEM, route)),
 
+    // Master list
+    onAddMasterList: () =>
+      dispatch(BasePageActions.openModal(MODAL_KEYS.SELECT_MASTER_LISTS, route)),
+    onApplyMasterLists: selected => dispatch(BasePageActions.addMasterListItems(selected, route)),
+
     // Navigation
     onManageStocktake: name => dispatch(gotoStocktakeManagePage(name, pageObject, route)),
 

--- a/src/pages/dataTableUtilities/getPageDispatchers.js
+++ b/src/pages/dataTableUtilities/getPageDispatchers.js
@@ -61,7 +61,8 @@ export const getPageDispatchers = (dispatch, props, dataType, route) => {
     // Master list
     onAddMasterList: () =>
       dispatch(BasePageActions.openModal(MODAL_KEYS.SELECT_MASTER_LISTS, route)),
-    onApplyMasterLists: selected => dispatch(BasePageActions.addMasterListItems(selected, route)),
+    onApplyMasterLists: selected =>
+      dispatch(BasePageActions.addMasterListItems(selected, pageObject, route)),
 
     // Navigation
     onManageStocktake: name => dispatch(gotoStocktakeManagePage(name, pageObject, route)),

--- a/src/pages/dataTableUtilities/reducer/pageReducers.js
+++ b/src/pages/dataTableUtilities/reducer/pageReducers.js
@@ -4,6 +4,9 @@
  */
 
 import { MODAL_KEYS, formatErrorItemNames } from '../../../utilities';
+import { UIDatabase } from '../../../database/index';
+import { SETTINGS_KEYS } from '../../../settings';
+import Settings from '../../../settings/MobileAppSettings';
 
 /**
  * Edits the name field in the current stores state.
@@ -83,6 +86,28 @@ export const openModal = (state, action) => {
       const { monthsToSupply } = pageObject;
 
       return { ...state, modalKey, modalValue: monthsToSupply };
+    }
+
+    case MODAL_KEYS.SELECT_MASTER_LISTS: {
+      let masterLists = [];
+      const { pageObject } = state;
+      const { route } = payload;
+
+      switch (route) {
+        case 'supplierRequisition':
+          masterLists = UIDatabase.objects('Name').filtered(
+            'id == $0',
+            Settings.get(SETTINGS_KEYS.THIS_STORE_NAME_ID)
+          )[0].masterLists;
+          break;
+        case 'customerInvoice':
+          masterLists = pageObject.otherParty.masterLists;
+          break;
+        default:
+          masterLists = [];
+      }
+
+      return { ...state, modalKey, modalValue: masterLists };
     }
 
     default: {

--- a/src/utilities/getModalTitle.js
+++ b/src/utilities/getModalTitle.js
@@ -27,6 +27,7 @@ export const MODAL_KEYS = {
   STOCKTAKE_OUTDATED_ITEM: 'stocktakeOutdatedItems',
   STOCKTAKE_REASON: 'stocktakeReason',
   ENFORCE_STOCKTAKE_REASON: 'enforceStocktakeReason',
+  SELECT_MASTER_LISTS: 'selectMasterList',
 };
 
 export const getModalTitle = modalKey => {
@@ -64,5 +65,7 @@ export const getModalTitle = modalKey => {
       return authStrings.warning_sync_edit;
     case MODAL_KEYS.CONFIRM_USER_PASSWORD:
       return modalStrings.confirm_password;
+    case MODAL_KEYS.SELECT_MASTER_LISTS:
+      return modalStrings.select_master_lists;
   }
 };

--- a/src/widgets/MultiSelectList.js
+++ b/src/widgets/MultiSelectList.js
@@ -6,7 +6,7 @@
 import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { SearchBar } from 'react-native-ui-components';
-import { Dimensions, FlatList, StyleSheet, View } from 'react-native';
+import { Dimensions, FlatList, StyleSheet, View, Text } from 'react-native';
 import { complement } from 'set-manipulator';
 import globalStyles, { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../globalStyles';
 import { generalStrings, buttonStrings } from '../localization';
@@ -37,6 +37,7 @@ const MultiSelectList = ({
   showCheckIcon,
   placeholderText,
   onConfirmSelections,
+  emptyMessage,
 }) => {
   const [queryText, setQueryText] = useState('');
   const [selected, setSelected] = useState([]);
@@ -97,8 +98,8 @@ const MultiSelectList = ({
   const renderItem = useCallback(data => (
     <ResultRow
       data={data}
-      onPress={() => onSelect(data)}
-      isSelected={() => isSelected(data)}
+      onPress={onSelect}
+      isSelected={isSelected}
       renderLeftText={renderLeftText}
       renderRightText={renderRightText}
       showCheckIcon={showCheckIcon}
@@ -110,12 +111,19 @@ const MultiSelectList = ({
    *
    * @prop  {object}     data   Single item data.
    */
-  const onSelect = data =>
+  const onSelect = useCallback(data =>
     setSelected(prevState =>
       prevState.indexOf(data.item.id) === -1
         ? [...prevState, data.item.id]
         : prevState.filter(i => i !== data.item.id)
-    );
+    )
+  );
+
+  const EmptyComponent = useCallback(({ title }) => (
+    <View style={localStyles.emptyContainer}>
+      <Text style={localStyles.emptyText}>{title}</Text>
+    </View>
+  ));
 
   /**
    * Check if the single item is selected or not
@@ -124,7 +132,7 @@ const MultiSelectList = ({
    *
    * @returns {bool}    selected state of the item
    */
-  const isSelected = data => !(selected.indexOf(data.item.id) === -1);
+  const isSelected = useCallback(data => !(selected.indexOf(data.item.id) === -1));
 
   const data = getData();
 
@@ -135,21 +143,20 @@ const MultiSelectList = ({
         autoCorrect={false}
         autoFocus
         color="white"
-        onChange={text => setQueryText(text)}
+        onChange={setQueryText}
         placeholder={placeholderText}
         placeholderTextColor="white"
         style={[localStyles.text, localStyles.searchBar]}
       />
-      {data.length > 0 && (
-        <FlatList
-          data={data}
-          keyExtractor={item => item.id || item.name}
-          renderItem={renderItem}
-          keyboardShouldPersistTaps="always"
-          style={localStyles.resultList}
-          extraData={selected}
-        />
-      )}
+      <FlatList
+        data={data}
+        keyExtractor={item => item.id || item.name}
+        renderItem={renderItem}
+        keyboardShouldPersistTaps="always"
+        style={localStyles.resultList}
+        extraData={selected}
+        ListEmptyComponent={<EmptyComponent title={emptyMessage} />}
+      />
       <View style={localStyles.contentContainer}>
         <View style={[localStyles.buttonContainer]}>
           <OnePressButton
@@ -178,6 +185,7 @@ MultiSelectList.propTypes = {
   renderRightText: PropTypes.func,
   primaryFilterProperty: PropTypes.string,
   secondaryFilterProperty: PropTypes.string,
+  emptyMessage: PropTypes.string,
   onConfirmSelections: PropTypes.func,
   showCheckIcon: PropTypes.bool,
 };
@@ -190,6 +198,15 @@ MultiSelectList.defaultProps = {
 const localStyles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  emptyContainer: {
+    flex: 1,
+    alignItems: 'flex-start',
+  },
+  emptyText: {
+    fontSize: 20,
+    fontFamily: APP_FONT_FAMILY,
+    padding: 15,
   },
   buttonContainer: {
     position: 'absolute',

--- a/src/widgets/MultiSelectList.js
+++ b/src/widgets/MultiSelectList.js
@@ -134,6 +134,8 @@ const MultiSelectList = ({
    */
   const isSelected = useCallback(data => !(selected.indexOf(data.item.id) === -1));
 
+  const onDoneSelected = useCallback(() => onConfirmSelections(selected));
+
   const data = getData();
 
   return (
@@ -163,7 +165,7 @@ const MultiSelectList = ({
             style={[globalStyles.button, localStyles.confirmButton]}
             textStyle={[globalStyles.buttonText, localStyles.confirmButtonText]}
             text={buttonStrings.done}
-            onPress={() => onConfirmSelections(selected)}
+            onPress={onDoneSelected}
           />
         </View>
       </View>

--- a/src/widgets/MultiSelectList.js
+++ b/src/widgets/MultiSelectList.js
@@ -158,7 +158,7 @@ const MultiSelectList = ({
         ListEmptyComponent={<EmptyComponent title={emptyMessage} />}
       />
       <View style={localStyles.contentContainer}>
-        <View style={[localStyles.buttonContainer]}>
+        <View style={localStyles.buttonContainer}>
           <OnePressButton
             style={[globalStyles.button, localStyles.confirmButton]}
             textStyle={[globalStyles.buttonText, localStyles.confirmButtonText]}

--- a/src/widgets/MultiSelectList.js
+++ b/src/widgets/MultiSelectList.js
@@ -11,7 +11,7 @@ import { complement } from 'set-manipulator';
 import globalStyles, { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../globalStyles';
 import { generalStrings, buttonStrings } from '../localization';
 import { OnePressButton } from '.';
-import { ResultRow } from './ResultRow';
+import ResultRow from './ResultRow';
 
 /**
  * A search bar that autocompletes from the options passed in, and allows any of

--- a/src/widgets/ResultRow.js
+++ b/src/widgets/ResultRow.js
@@ -1,0 +1,110 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2016
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Text, TouchableOpacity, StyleSheet } from 'react-native';
+import Icon from 'react-native-vector-icons/Ionicons';
+import { APP_FONT_FAMILY, SUSSOL_ORANGE, BACKGROUND_COLOR, GREY } from '../globalStyles';
+
+const ResultRow = props => {
+  const { data, renderLeftText, renderRightText, onPress, isSelected, showCheckIcon } = props;
+  const selected = isSelected(data);
+
+  return (
+    <TouchableOpacity
+      style={[localStyles.resultRow, selected && localStyles.selected]}
+      onPress={() => onPress(data)}
+    >
+      {showCheckIcon && selected ? (
+        <Icon name="md-checkbox" style={localStyles.checkIcon} />
+      ) : (
+        <Icon name="md-square-outline" style={[localStyles.checkIcon, { color: GREY }]} />
+      )}
+      <Text
+        style={[
+          localStyles.text,
+          localStyles.itemText,
+          selected && localStyles.selectedText,
+          {
+            flex: 5,
+            justifyContent: 'flex-start',
+            alignItems: 'stretch',
+          },
+        ]}
+      >
+        {renderLeftText ? renderLeftText(data.item) : data.item.toString()}
+      </Text>
+      {renderRightText && (
+        <Text
+          style={[
+            localStyles.text,
+            localStyles.itemText,
+            selected && localStyles.selectedText,
+            {
+              justifyContent: 'flex-end',
+              textAlign: 'right',
+            },
+          ]}
+        >
+          {renderRightText(data.item)}
+        </Text>
+      )}
+    </TouchableOpacity>
+  );
+};
+
+ResultRow.propTypes = {
+  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
+  renderLeftText: PropTypes.func,
+  renderRightText: PropTypes.func,
+  onPress: PropTypes.func,
+  isSelected: PropTypes.func,
+  showCheckIcon: PropTypes.bool,
+};
+
+ResultRow.defaultProps = {
+  renderLeftText: null,
+  renderRightText: null,
+  onPress: null,
+  isSelected: false,
+  showCheckIcon: false,
+};
+
+const localStyles = StyleSheet.create({
+  text: {
+    fontSize: 20,
+    fontFamily: APP_FONT_FAMILY,
+  },
+  itemText: {
+    flex: 1,
+    flexDirection: 'row',
+    marginHorizontal: 10,
+    marginVertical: 10,
+  },
+  resultRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    borderColor: BACKGROUND_COLOR,
+    borderTopWidth: 0.5,
+    borderBottomWidth: 0.5,
+  },
+  selectedText: { color: 'white' },
+  selected: {
+    backgroundColor: SUSSOL_ORANGE,
+    borderColor: 'white',
+    borderTopWidth: 0.5,
+    borderBottomWidth: 0.5,
+  },
+  checkIcon: {
+    fontSize: 28,
+    color: 'white',
+    padding: 10,
+    marginRight: 0,
+  },
+});
+
+export { ResultRow };

--- a/src/widgets/ResultRow.js
+++ b/src/widgets/ResultRow.js
@@ -9,52 +9,53 @@ import { Text, TouchableOpacity, StyleSheet } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
 import { APP_FONT_FAMILY, SUSSOL_ORANGE, BACKGROUND_COLOR, GREY } from '../globalStyles';
 
-const ResultRow = props => {
-  const { data, renderLeftText, renderRightText, onPress, isSelected, showCheckIcon } = props;
-  const selected = isSelected(data);
+const ResultRow = React.memo(
+  ({ data, renderLeftText, renderRightText, onPress, isSelected, showCheckIcon }) => {
+    const selected = isSelected(data);
 
-  return (
-    <TouchableOpacity
-      style={[localStyles.resultRow, selected && localStyles.selected]}
-      onPress={() => onPress(data)}
-    >
-      {showCheckIcon && selected ? (
-        <Icon name="md-checkbox" style={localStyles.checkIcon} />
-      ) : (
-        <Icon name="md-square-outline" style={[localStyles.checkIcon, { color: GREY }]} />
-      )}
-      <Text
-        style={[
-          localStyles.text,
-          localStyles.itemText,
-          selected && localStyles.selectedText,
-          {
-            flex: 5,
-            justifyContent: 'flex-start',
-            alignItems: 'stretch',
-          },
-        ]}
+    return (
+      <TouchableOpacity
+        style={[localStyles.resultRow, selected && localStyles.selected]}
+        onPress={() => onPress(data)}
       >
-        {renderLeftText ? renderLeftText(data.item) : data.item.toString()}
-      </Text>
-      {renderRightText && (
+        {showCheckIcon && selected ? (
+          <Icon name="md-checkbox" style={localStyles.checkIcon} />
+        ) : (
+          <Icon name="md-square-outline" style={[localStyles.checkIcon, { color: GREY }]} />
+        )}
         <Text
           style={[
             localStyles.text,
             localStyles.itemText,
             selected && localStyles.selectedText,
             {
-              justifyContent: 'flex-end',
-              textAlign: 'right',
+              flex: 5,
+              justifyContent: 'flex-start',
+              alignItems: 'stretch',
             },
           ]}
         >
-          {renderRightText(data.item)}
+          {renderLeftText ? renderLeftText(data.item) : data.item.toString()}
         </Text>
-      )}
-    </TouchableOpacity>
-  );
-};
+        {renderRightText && (
+          <Text
+            style={[
+              localStyles.text,
+              localStyles.itemText,
+              selected && localStyles.selectedText,
+              {
+                justifyContent: 'flex-end',
+                textAlign: 'right',
+              },
+            ]}
+          >
+            {renderRightText(data.item)}
+          </Text>
+        )}
+      </TouchableOpacity>
+    );
+  }
+);
 
 ResultRow.propTypes = {
   data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
@@ -107,4 +108,4 @@ const localStyles = StyleSheet.create({
   },
 });
 
-export { ResultRow };
+export default ResultRow;

--- a/src/widgets/ResultRow.js
+++ b/src/widgets/ResultRow.js
@@ -3,7 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2016
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Text, TouchableOpacity, StyleSheet } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
@@ -12,11 +12,12 @@ import { APP_FONT_FAMILY, SUSSOL_ORANGE, BACKGROUND_COLOR, GREY } from '../globa
 const ResultRow = React.memo(
   ({ data, renderLeftText, renderRightText, onPress, isSelected, showCheckIcon }) => {
     const selected = isSelected(data);
+    const rowPressed = useCallback(() => onPress(data));
 
     return (
       <TouchableOpacity
         style={[localStyles.resultRow, selected && localStyles.selected]}
-        onPress={() => onPress(data)}
+        onPress={rowPressed}
       >
         {showCheckIcon && selected ? (
           <Icon name="md-checkbox" style={localStyles.checkIcon} />

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -6,6 +6,8 @@
 export { Button, ProgressBar } from 'react-native-ui-components';
 
 export { AutocompleteSelector } from './AutocompleteSelector';
+// eslint-disable-next-line import/no-cycle
+export { MultiSelectList } from './MultiSelectList';
 export { FinaliseButton } from './FinaliseButton';
 export { GenericChoiceList } from './GenericChoiceList';
 export { IconCell } from './IconCell';
@@ -39,7 +41,6 @@ export {
   Expand,
   ConfirmIcon,
   LockIcon,
-  SettingsIcon,
 } from './icons';
 export {
   KiribatiFlag,

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -14,6 +14,7 @@ import { getModalTitle, MODAL_KEYS } from '../../utilities/getModalTitle';
 
 import ModalContainer from './ModalContainer';
 import { AutocompleteSelector } from '../AutocompleteSelector';
+import { MultiSelectList } from '../MultiSelectList';
 import { TextEditor } from '../TextEditor';
 import { ByProgramModal } from './ByProgramModal';
 import { ToggleSelector } from '../ToggleSelector';
@@ -168,6 +169,17 @@ const DataTablePageModalComponent = ({
           />
         );
       }
+      case MODAL_KEYS.SELECT_MASTER_LISTS:
+        return (
+          <MultiSelectList
+            options={currentValue}
+            isOpen={isOpen}
+            placeholderText={modalStrings.start_typing_to_select_master_list}
+            queryString="name BEGINSWITH[c] $0"
+            sortByString="name"
+            onConfirmSelections={onSelect}
+          />
+        );
       default:
         return null;
     }

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -178,6 +178,7 @@ const DataTablePageModalComponent = ({
             queryString="name BEGINSWITH[c] $0"
             sortByString="name"
             onConfirmSelections={onSelect}
+            emptyMessage={modalStrings.no_masterlist_available}
           />
         );
       default:


### PR DESCRIPTION
Fixes #1212

## Change summary

- CustomerInvoice and SupplierRequisition may have multiple MasterLists.
- Previously `add from masterlist` button added all items from all the masterlists combined.
- We want a feature to be able to Select one or more Master list of our choosing and have only the items in the masterlists show up in the invoices.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Click `Add from masterlist` button on any CustomerInvoice or SupplierRequisition.
- [ ] Select one or more masterlists from the list of options.
- [ ] See if the items from the masterlist show up in the invoice. 
- [ ] The items should be there and according to the masterlist selected. There may not be overlap or duplications.

