### PR TITLE
#879 Localise 'Pushing changes to Server'

### DIFF
--- a/src/localization/authStrings.js
+++ b/src/localization/authStrings.js
@@ -15,7 +15,6 @@ export const authStrings = new LocalizedStrings({
     email: 'E-mail Address',
     warning_sync_edit:
       'WARNING:\nThis will effect syncing for this store.\nMake sure you know what you doing!',
-    pushing_changes_text: 'Pushing changes to the server',
   },
   fr: {
     logging_in: 'Connexion en cours',

--- a/src/localization/authStrings.js
+++ b/src/localization/authStrings.js
@@ -15,6 +15,7 @@ export const authStrings = new LocalizedStrings({
     email: 'E-mail Address',
     warning_sync_edit:
       'WARNING:\nThis will effect syncing for this store.\nMake sure you know what you doing!',
+    pushing_changes_text: 'Pushing changes to the server',
   },
   fr: {
     logging_in: 'Connexion en cours',

--- a/src/localization/syncStrings.js
+++ b/src/localization/syncStrings.js
@@ -18,6 +18,9 @@ export const syncStrings = new LocalizedStrings({
     all_records_updated: 'All records updated.',
     loading_change_count: 'Loading change count...',
     last_successful_sync: 'Last successful sync',
+    initialising: 'Initialising...',
+    pulling_changes: 'Pulling changes from the server',
+    pushing_changes: 'Pushing changes to the server',
   },
   fr: {
     last_sync: 'Dernier SYNC',

--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -9,7 +9,7 @@ import DeviceInfo from 'react-native-device-info';
 
 import { Client as BugsnagClient } from 'bugsnag-react-native';
 
-import { authStrings } from '../localization/authStrings';
+import { syncStrings } from '../localization/syncStrings';
 
 import {
   incrementSyncProgress,
@@ -137,7 +137,7 @@ export class Synchroniser {
    */
   initialise = async (serverURL, syncSiteName, syncSitePassword) => {
     this.setIsSyncing(true);
-    this.setProgressMessage('Initialising...');
+    this.setProgressMessage(syncStrings.initializing);
     this.syncQueue.disable(); // Stop sync queue listening to database changes.
 
     // Check if the |serverURL| passed in is the same as that which has been used during
@@ -246,7 +246,7 @@ export class Synchroniser {
    * @return  {Promise}  Resolves if successful, or bubbles up any errors thrown.
    */
   push = async () => {
-    this.setProgressMessage(authStrings.pushing_changes_text);
+    this.setProgressMessage(syncStrings.pushing_changes);
     this.setProgress(0);
     this.setTotal(this.syncQueue.length);
     while (this.syncQueue.length > 0) {
@@ -313,7 +313,7 @@ export class Synchroniser {
     let total = waitingRecordCount;
     let progress = 0;
 
-    this.setProgressMessage('Pulling changes from the server');
+    this.setProgressMessage(syncStrings.pulling_changes);
     this.setProgress(progress);
     this.setTotal(total);
 

--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -9,6 +9,8 @@ import DeviceInfo from 'react-native-device-info';
 
 import { Client as BugsnagClient } from 'bugsnag-react-native';
 
+import { authStrings } from '../localization/authStrings';
+
 import {
   incrementSyncProgress,
   setSyncProgress,
@@ -244,7 +246,7 @@ export class Synchroniser {
    * @return  {Promise}  Resolves if successful, or bubbles up any errors thrown.
    */
   push = async () => {
-    this.setProgressMessage('Pushing changes to the server');
+    this.setProgressMessage(authStrings.pushing_changes_text);
     this.setProgress(0);
     this.setTotal(this.syncQueue.length);
     while (this.syncQueue.length > 0) {

--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -137,7 +137,7 @@ export class Synchroniser {
    */
   initialise = async (serverURL, syncSiteName, syncSitePassword) => {
     this.setIsSyncing(true);
-    this.setProgressMessage(syncStrings.initializing);
+    this.setProgressMessage(syncStrings.initialising);
     this.syncQueue.disable(); // Stop sync queue listening to database changes.
 
     // Check if the |serverURL| passed in is the same as that which has been used during


### PR DESCRIPTION
Fixes #879 

## Change summary

'Pushing changes to server' was hard-coded, now it's properly declared in authStrings.js. Anyway, for other languages rather than English, this is still the default message.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Initialise page
- [ ] Connect to the server
- [ ] Check messages: `Initialising ...` and ` Pulling changes from the server`

Then:
- [ ] Go to Log in page
- [ ] Select a language 
- [ ] Create/Edit/Delete records to push changes to the server
- [ ] Perform a Manual Sync
- [ ] Check the message: `Pushing changes to server`

 Repeat this process with all languages.

### Related areas to think about

This solution is related with issue [#484](https://github.com/openmsupply/mobile/issues/484)
