### PR TITLE
#1564 payments schema additions

### DIFF
--- a/src/database/DataTypes/InsurancePolicy.js
+++ b/src/database/DataTypes/InsurancePolicy.js
@@ -7,7 +7,6 @@ InsurancePolicy.schema = {
   primaryKey: 'id',
   properties: {
     id: 'string',
-    patient: 'string',
     policyNumberFamily: 'string',
     policyNumberPerson: 'string',
     type: 'string',
@@ -15,6 +14,7 @@ InsurancePolicy.schema = {
     expiryDate: 'date',
     enteredBy: { type: 'User', optional: false },
     insuranceProvider: { type: 'InsuranceProvider', optional: false },
+    patient: { type: 'InsuranceProvider', optional: false },
   },
 };
 

--- a/src/database/DataTypes/InsurancePolicy.js
+++ b/src/database/DataTypes/InsurancePolicy.js
@@ -13,6 +13,7 @@ InsurancePolicy.schema = {
     discountRate: 'float',
     expiryDate: 'date',
     enteredBy: { type: 'User', optional: false },
+    patient: { type: 'Name', optional: false },
     insuranceProvider: { type: 'InsuranceProvider', optional: false },
     patient: { type: 'Name', optional: false },
   },

--- a/src/database/DataTypes/InsurancePolicy.js
+++ b/src/database/DataTypes/InsurancePolicy.js
@@ -14,7 +14,7 @@ InsurancePolicy.schema = {
     expiryDate: 'date',
     enteredBy: { type: 'User', optional: false },
     insuranceProvider: { type: 'InsuranceProvider', optional: false },
-    patient: { type: 'InsuranceProvider', optional: false },
+    patient: { type: 'Name', optional: false },
   },
 };
 

--- a/src/database/DataTypes/InsurancePolicy.js
+++ b/src/database/DataTypes/InsurancePolicy.js
@@ -1,0 +1,21 @@
+import Realm from 'realm';
+
+export class InsurancePolicy extends Realm.Object {}
+
+InsurancePolicy.schema = {
+  name: 'InsurancePolicy',
+  primaryKey: 'id',
+  properties: {
+    id: 'string',
+    patient: 'string',
+    policyNumberFamily: 'string',
+    policyNumberPerson: 'string',
+    type: 'string',
+    discountRate: 'float',
+    expiryDate: 'date',
+    enteredBy: { type: 'User', optional: false },
+    insuranceProvider: { type: 'InsuranceProvider', optional: false },
+  },
+};
+
+export default InsurancePolicy;

--- a/src/database/DataTypes/InsuranceProvider.js
+++ b/src/database/DataTypes/InsuranceProvider.js
@@ -1,0 +1,17 @@
+import Realm from 'realm';
+
+export class InsuranceProvider extends Realm.Object {}
+
+InsuranceProvider.schema = {
+  name: 'InsuranceProvider',
+  primaryKey: 'id',
+  properties: {
+    id: 'string',
+    name: 'string',
+    comment: 'string?',
+    validityDays: 'int',
+    isActive: 'bool',
+  },
+};
+
+export default InsuranceProvider;

--- a/src/database/DataTypes/InsuranceProvider.js
+++ b/src/database/DataTypes/InsuranceProvider.js
@@ -11,6 +11,11 @@ InsuranceProvider.schema = {
     comment: 'string?',
     validityDays: 'int',
     isActive: 'bool',
+    policies: {
+      type: 'linkingObjects',
+      objectType: 'InsurancePolicy',
+      property: 'insuranceProvider',
+    },
   },
 };
 

--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -123,7 +123,7 @@ Name.schema = {
     isSupplier: { type: 'bool', default: false },
     isManufacturer: { type: 'bool', default: false },
     isPatient: { type: 'bool', default: false },
-    policies: { type: 'linkingObjects', objectType: 'Name', property: 'patient' },
+    policies: { type: 'linkingObjects', objectType: 'InsurancePolicy', property: 'patient' },
   },
 };
 

--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -123,6 +123,7 @@ Name.schema = {
     isSupplier: { type: 'bool', default: false },
     isManufacturer: { type: 'bool', default: false },
     isPatient: { type: 'bool', default: false },
+    policies: { type: 'linkingObjects', objectType: 'Name', property: 'patient' },
   },
 };
 

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -245,7 +245,8 @@ export class StocktakeBatch extends Realm.Object {
         database,
         'TransactionBatch',
         transactionItem,
-        this.itemBatch
+        this.itemBatch,
+        isAddition
       );
 
       // Apply difference from stocktake to actual stock on hand levels. Whether stock is increased

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -463,6 +463,9 @@ Transaction.schema = {
     mode: { type: 'string', default: 'store' },
     prescriber: { type: 'Prescriber', optional: true },
     linkedRequisition: { type: 'Requisition', optional: true },
+    total: { type: 'float', optional: true },
+    outstanding: { type: 'float', optional: true },
+    insurancePolicy: { type: 'InsurancePolicy', optional: true },
   },
 };
 

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -81,7 +81,7 @@ export class Transaction extends Realm.Object {
    * @return  {boolean}
    */
   get isIncoming() {
-    return this.type === 'supplier_invoice';
+    return this.type === 'supplier_invoice' || this.type === 'customer_credit';
   }
 
   /**

--- a/src/database/DataTypes/TransactionBatch.js
+++ b/src/database/DataTypes/TransactionBatch.js
@@ -155,6 +155,9 @@ TransactionBatch.schema = {
     sellPrice: 'double',
     donor: { type: 'Name', optional: true },
     sortIndex: { type: 'int', optional: true },
+    total: { type: 'float', optional: true },
+    type: { type: 'string', optional: true },
+    linkedTransaction: { type: 'Transaction', optional: true },
   },
 };
 

--- a/src/database/DataTypes/index.js
+++ b/src/database/DataTypes/index.js
@@ -14,6 +14,8 @@ export class TransactionCategory extends Realm.Object {}
 export class User extends Realm.Object {}
 
 export { Item } from './Item';
+export { InsurancePolicy } from './InsurancePolicy';
+export { InsuranceProvider } from './InsuranceProvider';
 export { ItemBatch } from './ItemBatch';
 export { ItemStoreJoin } from './ItemStoreJoin';
 export { MasterList } from './MasterList';

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -16,6 +16,9 @@ const translateToCoreDatabaseType = type => {
     case 'CustomerInvoice':
     case 'Prescription':
     case 'SupplierInvoice':
+    case 'Receipt':
+    case 'CustomerCredit':
+    case 'Payment':
       return 'Transaction';
     case 'Customer':
     case 'Supplier':
@@ -29,6 +32,10 @@ const translateToCoreDatabaseType = type => {
     case 'NegativeAdjustmentReason':
     case 'PositiveAdjustmentReason':
       return 'Options';
+    case 'Policy':
+      return 'InsurancePolicy';
+    case 'Provider':
+      return 'InsuranceProvider';
     default:
       return type;
   }
@@ -116,6 +123,20 @@ class UIDatabase {
           'store',
           'inventory_adjustment'
         );
+      case 'Receipt':
+        return results.filtered('type == $0', 'receipt');
+      case 'Payment':
+        return results.filtered('type == $0', 'payment');
+      case 'CustomerCredit':
+        return results.filtered('type == $0', 'customer_credit');
+      case 'Policy':
+        return results.filtered(
+          'insuranceProvider.isActive == $0 && expiryDate > $1',
+          true,
+          new Date()
+        );
+      case 'Provider':
+        return results.filtered('isActive == $0', true);
       case 'Customer':
         return results.filtered(
           'isVisible == true AND isCustomer == true AND id != $0',

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -34,6 +34,8 @@ import {
   User,
   Unit,
   Prescriber,
+  InsurancePolicy,
+  InsuranceProvider,
 } from './DataTypes';
 
 Address.schema = {
@@ -154,8 +156,10 @@ export const schema = {
     User,
     Unit,
     Prescriber,
+    InsurancePolicy,
+    InsuranceProvider,
   ],
-  schemaVersion: 10,
+  schemaVersion: 11,
 };
 
 export default schema;

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -37,6 +37,105 @@ export const getNumberSequence = (database, sequenceKey) => {
   return sequenceResults[0];
 };
 
+const createReceipt = (database, user, patient, total) => {
+  const currentDate = new Date();
+  const { CUSTOMER_INVOICE_NUMBER } = NUMBER_SEQUENCE_KEYS;
+  const receipt = database.create('Transaction', {
+    id: generateUUID(),
+    serialNumber: getNextNumber(database, CUSTOMER_INVOICE_NUMBER),
+    entryDate: currentDate,
+    confirmDate: currentDate,
+    type: 'receipt',
+    status: 'finalised',
+    comment: '',
+    otherParty: patient,
+    enteredBy: user,
+    total,
+  });
+
+  database.save('Transaction', receipt);
+  return receipt;
+};
+
+const createReceiptLine = (database, receipt, linkedTransaction, total) => {
+  const receiptLine = database.create('TransactionBatch', {
+    id: generateUUID(),
+    total,
+    transaction: receipt,
+    linkedTransaction,
+    type: 'cash_in',
+  });
+
+  database.save('TransactionBatch', receiptLine);
+  return receiptLine;
+};
+
+const createPayment = (database, user, patient, total) => {
+  const currentDate = new Date();
+  const { CUSTOMER_INVOICE_NUMBER } = NUMBER_SEQUENCE_KEYS;
+  const payment = database.create('Transaction', {
+    id: generateUUID(),
+    serialNumber: getNextNumber(database, CUSTOMER_INVOICE_NUMBER),
+    entryDate: currentDate,
+    confirmDate: currentDate,
+    type: 'payment',
+    status: 'finalised',
+    comment: '',
+    otherParty: patient,
+    enteredBy: user,
+    total,
+  });
+
+  database.save('Transaction', payment);
+  return payment;
+};
+
+const createPaymentLine = (database, payment, linkedTransaction, total) => {
+  const receiptLine = database.create('TransactionBatch', {
+    id: generateUUID(),
+    total,
+    transaction: payment,
+    linkedTransaction,
+    type: 'cash_out',
+  });
+
+  database.save('TransactionBatch', receiptLine);
+  return receiptLine;
+};
+
+const createCustomerCredit = (database, user, patient, total) => {
+  const currentDate = new Date();
+  const { CUSTOMER_INVOICE_NUMBER } = NUMBER_SEQUENCE_KEYS;
+  const customerCredit = database.create('Transaction', {
+    id: generateUUID(),
+    serialNumber: getNextNumber(database, CUSTOMER_INVOICE_NUMBER),
+    entryDate: currentDate,
+    confirmDate: currentDate,
+    type: 'customer_credit',
+    status: 'finalised',
+    comment: '',
+    otherParty: patient,
+    enteredBy: user,
+    total,
+  });
+
+  database.save('Transaction', customerCredit);
+  return customerCredit;
+};
+
+const createCustomerCreditLine = (database, payment, total) => {
+  const receiptLine = database.create('TransactionBatch', {
+    id: generateUUID(),
+    total,
+    transaction: payment,
+    type: 'cash_in',
+    note: 'credit',
+  });
+
+  database.save('TransactionBatch', receiptLine);
+  return receiptLine;
+};
+
 /**
  * Create a customer invoice associated with a given customer.
  *
@@ -337,15 +436,16 @@ const createSupplierInvoice = (database, supplier, user) => {
 };
 
 /**
- * Create a new transaction batch.
- *
+ * Create a new transaction batch. When creating a TransactionBatch, this is coming from either
+ * a) an external supplier or b) some adjustment during a stocktake. These must be stock ins.
  * @param   {Realm}             database
  * @param   {TransactionItem}   transactionItem  Batch item.
  * @param   {ItemBatch}         itemBatch        Item batch to associate with transaction batch.
  * @return  {TransactionBatch}
  */
-const createTransactionBatch = (database, transactionItem, itemBatch) => {
+const createTransactionBatch = (database, transactionItem, itemBatch, isAddition = true) => {
   const { item, batch, expiryDate, packSize, costPrice, sellPrice, donor } = itemBatch;
+  const { transaction } = transactionItem || {};
 
   const transactionBatch = database.create('TransactionBatch', {
     id: generateUUID(),
@@ -359,8 +459,9 @@ const createTransactionBatch = (database, transactionItem, itemBatch) => {
     costPrice,
     sellPrice,
     donor,
-    transaction: transactionItem.transaction,
-    sortIndex: transactionItem.transaction ? transactionItem.transaction.numberOfBatches : 0,
+    transaction,
+    sortIndex: transaction?.numberOfBatches || 0,
+    type: isAddition ? 'stock_in' : 'stock_out',
   });
 
   transactionItem.addBatch(transactionBatch);
@@ -432,6 +533,18 @@ export const createRecord = (database, type, ...args) => {
       return createTransactionItem(database, ...args);
     case 'TransactionBatch':
       return createTransactionBatch(database, ...args);
+    case 'Receipt':
+      return createReceipt(database, ...args);
+    case 'ReceiptLine':
+      return createReceiptLine(database, ...args);
+    case 'Payment':
+      return createPayment(database, ...args);
+    case 'PaymentLine':
+      return createPaymentLine(database, ...args);
+    case 'CustomerCredit':
+      return createCustomerCredit(database, ...args);
+    case 'CustomerCreditLine':
+      return createCustomerCreditLine(database, ...args);
     default:
       throw new Error(`Cannot create a record with unsupported type: ${type}`);
   }

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -671,6 +671,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         sortIndex: parseNumber(record.line_number),
         expiryDate: parseDate(record.expiry_date),
         batch: record.batch,
+        type: record.type,
       };
       const transactionBatch = database.update(recordType, internalRecord);
       transaction.addBatchIfUnique(database, transactionBatch);

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -13,7 +13,6 @@ import {
   SEQUENCE_KEYS,
   STATUSES,
   SYNC_TYPES,
-  TRANSACTION_BATCH_TYPES,
   TRANSACTION_TYPES,
 } from './syncTranslators';
 import { CHANGE_TYPES } from '../database';
@@ -220,7 +219,7 @@ const generateSyncData = (settings, recordType, record) => {
         item_name: record.itemName,
         is_from_inventory_adjustment: transaction.isInventoryAdjustment,
         donor_id: record.donor && record.donor.id,
-        type: TRANSACTION_BATCH_TYPES.translate(transaction.type, INTERNAL_TO_EXTERNAL),
+        type: record.type,
       };
     }
     default:

--- a/src/sync/syncTranslators.js
+++ b/src/sync/syncTranslators.js
@@ -81,18 +81,12 @@ export const TRANSACTION_TYPES = new SyncTranslator({
   supplier_invoice: 'si',
   supplier_credit: 'sc',
   inventory_adjustment: 'in',
-  prescription: 'pi', // Following types provided for sync purposes, not actually used by mobile.
-  build: 'bu',
-  repack: 'sr',
+  prescription: 'pi',
   receipt: 'rc',
   payment: 'ps',
-});
-
-export const TRANSACTION_BATCH_TYPES = new SyncTranslator({
-  customer_invoice: 'stock_out',
-  customer_credit: 'stock_in',
-  supplier_invoice: 'stock_in',
-  supplier_credit: 'stock_out',
+  // Following types provided for sync purposes, not actually used by mobile.
+  build: 'bu',
+  repack: 'sr',
 });
 
 export const NAME_TYPES = new SyncTranslator({


### PR DESCRIPTION
Fixes #1564 

## Change summary

- Adds, as per the issue, change to the schema for payments
- Bumps schema


- Have left out a couple of `InsuranceNameJoin` fields i.e. `isActive` where they can be derived easily (I think this just is `insuranceProvider.isActive` and renamed a couple things.
- `InsuranceNameJoin.enteredById` I think is for a `User` not a `Name`? It is never set in desktop/not used and isn't a foreign key 🤷‍♂ 

## Testing

N/A

### Related areas to think about

N/A
