### PR TITLE
#1565 transaction types

### DIFF
--- a/src/database/DataTypes/InsurancePolicy.js
+++ b/src/database/DataTypes/InsurancePolicy.js
@@ -7,13 +7,13 @@ InsurancePolicy.schema = {
   primaryKey: 'id',
   properties: {
     id: 'string',
-    patient: 'string',
     policyNumberFamily: 'string',
     policyNumberPerson: 'string',
     type: 'string',
     discountRate: 'float',
     expiryDate: 'date',
     enteredBy: { type: 'User', optional: false },
+    patient: { type: 'Name', optional: false },
     insuranceProvider: { type: 'InsuranceProvider', optional: false },
   },
 };

--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -123,6 +123,7 @@ Name.schema = {
     isSupplier: { type: 'bool', default: false },
     isManufacturer: { type: 'bool', default: false },
     isPatient: { type: 'bool', default: false },
+    policies: { type: 'linkingObjects', objectType: 'InsurancePolicy', property: 'patient' },
   },
 };
 

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -245,7 +245,8 @@ export class StocktakeBatch extends Realm.Object {
         database,
         'TransactionBatch',
         transactionItem,
-        this.itemBatch
+        this.itemBatch,
+        isAddition
       );
 
       // Apply difference from stocktake to actual stock on hand levels. Whether stock is increased

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -81,7 +81,7 @@ export class Transaction extends Realm.Object {
    * @return  {boolean}
    */
   get isIncoming() {
-    return this.type === 'supplier_invoice';
+    return this.type === 'supplier_invoice' || this.type === 'customer_credit';
   }
 
   /**

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -16,6 +16,9 @@ const translateToCoreDatabaseType = type => {
     case 'CustomerInvoice':
     case 'Prescription':
     case 'SupplierInvoice':
+    case 'Receipt':
+    case 'CustomerCredit':
+    case 'Payment':
       return 'Transaction';
     case 'Customer':
     case 'Supplier':
@@ -29,6 +32,10 @@ const translateToCoreDatabaseType = type => {
     case 'NegativeAdjustmentReason':
     case 'PositiveAdjustmentReason':
       return 'Options';
+    case 'Policy':
+      return 'InsurancePolicy';
+    case 'Provider':
+      return 'InsuranceProvider';
     default:
       return type;
   }
@@ -116,6 +123,20 @@ class UIDatabase {
           'store',
           'inventory_adjustment'
         );
+      case 'Receipt':
+        return results.filtered('type == $0', 'receipt');
+      case 'Payment':
+        return results.filtered('type == $0', 'payment');
+      case 'CustomerCredit':
+        return results.filtered('type == $0', 'customer_credit');
+      case 'Policy':
+        return results.filtered(
+          'insuranceProvider.isActive == $0 && expiryDate > $1',
+          true,
+          new Date()
+        );
+      case 'Provider':
+        return results.filtered('isActive == $0', true);
       case 'Customer':
         return results.filtered(
           'isVisible == true AND isCustomer == true AND id != $0',

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -344,7 +344,7 @@ const createSupplierInvoice = (database, supplier, user) => {
  * @param   {ItemBatch}         itemBatch        Item batch to associate with transaction batch.
  * @return  {TransactionBatch}
  */
-const createTransactionBatch = (database, transactionItem, itemBatch) => {
+const createTransactionBatch = (database, transactionItem, itemBatch, isAddition = true) => {
   const { item, batch, expiryDate, packSize, costPrice, sellPrice, donor } = itemBatch;
   const { transaction } = transactionItem || {};
 
@@ -362,7 +362,7 @@ const createTransactionBatch = (database, transactionItem, itemBatch) => {
     donor,
     transaction,
     sortIndex: transaction?.numberOfBatches || 0,
-    type: 'stock_in',
+    type: isAddition ? 'stock_in' : 'stock_out',
   });
 
   transactionItem.addBatch(transactionBatch);

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -337,8 +337,8 @@ const createSupplierInvoice = (database, supplier, user) => {
 };
 
 /**
- * Create a new transaction batch.
- *
+ * Create a new transaction batch. When creating a TransactionBatch, this is coming from either
+ * a) an external supplier or b) some adjustment during a stocktake. These must be stock ins.
  * @param   {Realm}             database
  * @param   {TransactionItem}   transactionItem  Batch item.
  * @param   {ItemBatch}         itemBatch        Item batch to associate with transaction batch.
@@ -346,6 +346,7 @@ const createSupplierInvoice = (database, supplier, user) => {
  */
 const createTransactionBatch = (database, transactionItem, itemBatch) => {
   const { item, batch, expiryDate, packSize, costPrice, sellPrice, donor } = itemBatch;
+  const { transaction } = transactionItem || {};
 
   const transactionBatch = database.create('TransactionBatch', {
     id: generateUUID(),
@@ -359,8 +360,9 @@ const createTransactionBatch = (database, transactionItem, itemBatch) => {
     costPrice,
     sellPrice,
     donor,
-    transaction: transactionItem.transaction,
-    sortIndex: transactionItem.transaction ? transactionItem.transaction.numberOfBatches : 0,
+    transaction,
+    sortIndex: transaction?.numberOfBatches || 0,
+    type: 'stock_in',
   });
 
   transactionItem.addBatch(transactionBatch);

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -671,6 +671,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         sortIndex: parseNumber(record.line_number),
         expiryDate: parseDate(record.expiry_date),
         batch: record.batch,
+        type: record.type,
       };
       const transactionBatch = database.update(recordType, internalRecord);
       transaction.addBatchIfUnique(database, transactionBatch);

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -13,7 +13,6 @@ import {
   SEQUENCE_KEYS,
   STATUSES,
   SYNC_TYPES,
-  TRANSACTION_BATCH_TYPES,
   TRANSACTION_TYPES,
 } from './syncTranslators';
 import { CHANGE_TYPES } from '../database';
@@ -220,7 +219,7 @@ const generateSyncData = (settings, recordType, record) => {
         item_name: record.itemName,
         is_from_inventory_adjustment: transaction.isInventoryAdjustment,
         donor_id: record.donor && record.donor.id,
-        type: TRANSACTION_BATCH_TYPES.translate(transaction.type, INTERNAL_TO_EXTERNAL),
+        type: record.type,
       };
     }
     default:

--- a/src/sync/syncTranslators.js
+++ b/src/sync/syncTranslators.js
@@ -81,18 +81,12 @@ export const TRANSACTION_TYPES = new SyncTranslator({
   supplier_invoice: 'si',
   supplier_credit: 'sc',
   inventory_adjustment: 'in',
-  prescription: 'pi', // Following types provided for sync purposes, not actually used by mobile.
-  build: 'bu',
-  repack: 'sr',
+  prescription: 'pi',
   receipt: 'rc',
   payment: 'ps',
-});
-
-export const TRANSACTION_BATCH_TYPES = new SyncTranslator({
-  customer_invoice: 'stock_out',
-  customer_credit: 'stock_in',
-  supplier_invoice: 'stock_in',
-  supplier_credit: 'stock_out',
+  // Following types provided for sync purposes, not actually used by mobile.
+  build: 'bu',
+  repack: 'sr',
 });
 
 export const NAME_TYPES = new SyncTranslator({


### PR DESCRIPTION
### BRANCHED FROM #1569 

Fixes #1565 

## Change summary

Minor changes, big impact

- Previously `TransactionBatch` had no type. As we were only really handling `ci`/`si` `Transaction`s, could just use the `Transaction.type` to determine the `type` of a batch (i.e. all si `TransactionBatch` are `stock_in`. Since cc `TransactionBatch` can be either a `stock_in` or a `cash_in`, this assumption is no longer valid, so `type` was added to `TransactionBatch`. This means we can just set this directly on the batch, which means when creating, we need to set it.

Pretty smelly with all the parameters already on this method - I'm going to say that refactoring this can be a part of replacing realm and won't do too much now. See below for info on creating other types for rc/cc

## Testing

N/A

### Related areas to think about

For creation of `TransactionBatch`s for `cc`/`rc` `Transaction`s, going to make new `create` methods, rather than using this same `TransactionBatch` creation method - this will be a bit confusing and against the current deisgn, but better, I think, rather than stuffing in a bunch of `ifs` and additional parameters
