### PR TITLE
#1573 ByProgramModal when no programs

### DIFF
--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -166,7 +166,7 @@ export const Stocktakes = ({
 };
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-  const usingPrograms = () => getAllPrograms(Settings, UIDatabase).length > 0;
+  const usingPrograms = getAllPrograms(Settings, UIDatabase).length > 0;
   const onNewProgramStocktake = () =>
     dispatch(PageActions.openModal(MODAL_KEYS.PROGRAM_STOCKTAKE, ROUTES.STOCKTAKES));
   const onNewStocktake = () => dispatch(gotoStocktakeManagePage(''));

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -181,7 +181,7 @@ export const SupplierRequisitions = ({
 };
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-  const usingPrograms = () => getAllPrograms(Settings, UIDatabase).length > 0;
+  const usingPrograms = getAllPrograms(Settings, UIDatabase).length > 0;
   const newRequisitionModalKey = usingPrograms
     ? MODAL_KEYS.PROGRAM_REQUISITION
     : MODAL_KEYS.SELECT_INTERNAL_SUPPLIER;


### PR DESCRIPTION
Fixes #1573 

## Change summary

- The condition variable was accidentally declared as a function for some reason 🤷‍♂ 

## Testing

With no programs defined:
- [ ] Clicking `New Requisition` on `SupplierRequisitionsPage` does not open the `ByProgramModal`
- [ ] Clicking `New Stocktake` on `StocktakesPage` does not open the `ByProgramModal`

### Related areas to think about

N/A
