### PR TITLE
#1575 toast when no masterlist

### DIFF
--- a/src/localization/modalStrings.js
+++ b/src/localization/modalStrings.js
@@ -55,7 +55,8 @@ export const modalStrings = new LocalizedStrings({
     select_a_reason: 'Select a reason',
     confirm_password: 'Please confirm your user password',
     select_master_lists: 'Select master list',
-    no_masterlist_available: 'Sorry, no master list available.',
+    customer_no_masterlist_available: 'This customer has no master lists!',
+    supplier_no_masterlist_available: 'Your store has no master lists!',
   },
   fr: {
     add_at_least_one_item_before_finalising:

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -6,7 +6,7 @@
 
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { View } from 'react-native';
+import { View, ToastAndroid } from 'react-native';
 import { connect } from 'react-redux';
 
 import { MODAL_KEYS } from '../utilities';
@@ -50,7 +50,6 @@ export const CustomerInvoice = ({
   getPageInfoColumns,
   refreshData,
   onSelectNewItem,
-  onAddMasterList,
   onEditComment,
   onEditTheirRef,
   onFilterData,
@@ -62,6 +61,7 @@ export const CustomerInvoice = ({
   onSortColumn,
   onEditTotalQuantity,
   onAddTransactionItem,
+  onAddMasterList,
   onApplyMasterLists,
   route,
 }) => {
@@ -160,7 +160,6 @@ export const CustomerInvoice = ({
             <PageButton
               text={buttonStrings.add_master_list_items}
               onPress={onAddMasterList}
-              onSelect={onApplyMasterLists}
               isDisabled={isFinalised}
             />
           </View>
@@ -195,8 +194,18 @@ export const CustomerInvoice = ({
   );
 };
 
-const mapDispatchToProps = (dispatch, ownProps) =>
-  getPageDispatchers(dispatch, ownProps, 'Transaction', ROUTES.CUSTOMER_INVOICE);
+const mapDispatchToProps = (dispatch, ownProps) => {
+  const { transaction } = ownProps || {};
+  const { otherParty } = transaction;
+  const hasMasterLists = otherParty.masterLists.length > 0;
+
+  const noMasterLists = () =>
+    ToastAndroid.show(modalStrings.customer_no_masterlist_available, ToastAndroid.LONG);
+  return {
+    ...getPageDispatchers(dispatch, ownProps, 'Transaction', ROUTES.CUSTOMER_INVOICE),
+    [hasMasterLists ? null : 'onAddMasterList']: noMasterLists,
+  };
+};
 
 const mapStateToProps = state => {
   const { pages } = state;

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { View } from 'react-native';
+import { View, ToastAndroid } from 'react-native';
 import { connect } from 'react-redux';
 
 import { MODAL_KEYS } from '../utilities';
@@ -22,6 +22,8 @@ import { useRecordListener } from '../hooks';
 
 import globalStyles from '../globalStyles';
 import { buttonStrings, modalStrings, programStrings } from '../localization';
+import { UIDatabase } from '../database/index';
+import { SETTINGS_KEYS } from '../settings/index';
 
 /**
  * Renders a mSupply mobile page with a supplier requisition loaded for editing
@@ -286,8 +288,19 @@ const SupplierRequisition = ({
   );
 };
 
-const mapDispatchToProps = (dispatch, ownProps) =>
-  getPageDispatchers(dispatch, ownProps, 'Requisition', ROUTES.SUPPLIER_REQUISITION);
+const mapDispatchToProps = (dispatch, ownProps) => {
+  const thisStoreID = UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_NAME_ID);
+  const thisStore = UIDatabase.get('Name', thisStoreID);
+  const hasMasterLists = thisStore?.masterLists?.length > 0;
+
+  const noMasterLists = () =>
+    ToastAndroid.show(modalStrings.supplier_no_masterlist_available, ToastAndroid.LONG);
+
+  return {
+    ...getPageDispatchers(dispatch, ownProps, 'Requisition', ROUTES.SUPPLIER_REQUISITION),
+    [hasMasterLists ? null : 'onAddMasterList']: noMasterLists,
+  };
+};
 
 const mapStateToProps = state => {
   const { pages } = state;

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -244,11 +244,6 @@ export const filterDataWithFinalisedToggle = (searchTerm, route) => ({
   payload: { searchTerm, route },
 });
 
-export const applyMasterLists = (selectedMasterLists, route) => ({
-  type: ACTIONS.APPLY_MASTER_LISTS,
-  payload: { selectedMasterLists, route },
-});
-
 export const filterDataWithOverStockToggle = (searchTerm, route) => ({
   type: ACTIONS.FILTER_DATA_WITH_OVER_STOCK_TOGGLE,
   payload: { searchTerm, route },

--- a/src/widgets/MultiSelectList.js
+++ b/src/widgets/MultiSelectList.js
@@ -7,7 +7,7 @@
 import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { FlatList, StyleSheet, View, Text } from 'react-native';
+import { FlatList, StyleSheet, View } from 'react-native';
 import globalStyles, { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../globalStyles';
 import { generalStrings, buttonStrings } from '../localization';
 import { OnePressButton, SearchBar } from '.';
@@ -28,7 +28,6 @@ const MultiSelectList = ({
   showCheckIcon,
   placeholderText,
   onConfirmSelections,
-  emptyMessage,
 }) => {
   const [queryText, setQueryText] = useState('');
   const [selected, setSelected] = useState([]);
@@ -55,7 +54,6 @@ const MultiSelectList = ({
 
   const filterArrayData = () => {
     const regexFilter = RegExp(queryText, 'i');
-
     return options.filter(
       optionItem =>
         regexFilter.test(optionItem[primaryFilterProperty]) ||
@@ -85,15 +83,6 @@ const MultiSelectList = ({
     [data, onSelect, renderLeftText, renderRightText, showCheckIcon]
   );
 
-  const EmptyComponent = useCallback(
-    ({ title }) => (
-      <View style={localStyles.emptyContainer}>
-        <Text style={localStyles.emptyText}>{title}</Text>
-      </View>
-    ),
-    []
-  );
-
   return (
     <View style={localStyles.container}>
       <SearchBar
@@ -109,9 +98,7 @@ const MultiSelectList = ({
         keyboardShouldPersistTaps="always"
         style={localStyles.resultList}
         extraData={selected}
-        ListEmptyComponent={<EmptyComponent title={emptyMessage} />}
       />
-
       <View style={localStyles.buttonContainer}>
         <OnePressButton
           style={localStyles.confirmButton}
@@ -137,7 +124,6 @@ MultiSelectList.propTypes = {
   renderRightText: PropTypes.func,
   primaryFilterProperty: PropTypes.string,
   secondaryFilterProperty: PropTypes.string,
-  emptyMessage: PropTypes.string,
   onConfirmSelections: PropTypes.func,
   showCheckIcon: PropTypes.bool,
 };
@@ -149,8 +135,6 @@ MultiSelectList.defaultProps = {
 
 const localStyles = StyleSheet.create({
   container: { flex: 1 },
-  emptyContainer: { flex: 1, alignItems: 'flex-start' },
-  emptyText: { fontSize: 20, fontFamily: APP_FONT_FAMILY, padding: 15 },
   buttonContainer: { alignItems: 'flex-end' },
   resultList: { marginHorizontal: 5, backgroundColor: 'white' },
   confirmButton: { ...globalStyles.button, backgroundColor: SUSSOL_ORANGE },


### PR DESCRIPTION
### NOTE: Branched FROM #1578 

Fixes #1575 

## Change summary

- Adds a toast when there are no master lists

## Testing

**This PR is concerned with when there are no master lists. For Customer invoices, this is when the CUSTOMER has no master lists. For a Supplier requisition, this is when YOUR STORE has no master lists**
- [ ] When pressing `Add from master list` on `CustomerInvoicePage` a toast appears
- [ ] When pressing `Add from master list` on `SupplierRequisitionPage` a toast appears

### Related areas to think about

We need to make a custom toast. I think we should make it come from the top the full width and height of the navigation bar and bright orange (not joking) I think it would be obvious for users and also would look good.

@alainsussol can you tell me french for these pretty please:
- "This customer has no master lists!"
- "Your store has no master lists!" 
