### PR TITLE
#1580 Badges crash on navigating

### DIFF
--- a/src/hooks/useNavigationFocus.js
+++ b/src/hooks/useNavigationFocus.js
@@ -34,9 +34,8 @@ export const useNavigationFocus = (navigation, willFocusCallback, willBlurCallba
   };
 
   const unSubscribe = () => {
-    if (!willFocusSub.current || !willBlurSub.current) return;
-    willFocusSub.current.remove();
-    willBlurSub.current.remove();
+    if (willFocusSub.current) willFocusSub.current.remove();
+    if (willBlurSub.current) willBlurSub.current.remove();
   };
 
   // On-mount/On-unmount effect, subscribing/unsubscribing to navigation events given the callbacks.

--- a/src/hooks/usePopover.js
+++ b/src/hooks/usePopover.js
@@ -1,15 +1,18 @@
 import React, { useState, useCallback, useRef } from 'react';
+import { useNavigationFocus } from './useNavigationFocus';
 
 /**
  * Hook which manages popover position over a DOM element.
  * Pass a ref created by React.createRef. Receive callbacks,
  */
-export const usePopover = () => {
+export const usePopover = navigation => {
   const [visibilityState, setVisibilityState] = useState(false);
   const ref = useRef(React.createRef());
 
   const showPopover = useCallback(() => setVisibilityState(true), []);
   const closePopover = useCallback(() => setVisibilityState(false), []);
+
+  useNavigationFocus(navigation, null, closePopover);
 
   return [ref, visibilityState, showPopover, closePopover];
 };

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -49,7 +49,7 @@ export const CustomerInvoices = ({
 }) => {
   // Listen to changes from sync and navigation events re-focusing this screen,
   // such that any side effects that occur trigger a reconcilitation of data.
-  useNavigationFocus(refreshData, navigation);
+  useNavigationFocus(navigation, refreshData);
   useSyncListener(refreshData, ['Transaction']);
 
   const onNavigateToInvoice = useCallback(invoice => dispatch(gotoCustomerInvoice(invoice)), []);

--- a/src/pages/CustomerRequisitionsPage.js
+++ b/src/pages/CustomerRequisitionsPage.js
@@ -50,7 +50,7 @@ export const CustomerRequisitions = ({
   onSortColumn,
 }) => {
   // Custom hook to refresh data on this page when becoming the head of the stack again.
-  useNavigationFocus(refreshData, navigation);
+  useNavigationFocus(navigation, refreshData);
   useSyncListener(refreshData, 'Requisition');
 
   const onPressRow = useCallback(rowData => dispatch(gotoCustomerRequisition(rowData)), []);

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -152,26 +152,32 @@ const Menu = ({
     [isInAdminMode, isAdmin]
   );
 
-  const ModuleLayout = useCallback(() => (
-    <View style={styles.moduleTopRow}>
-      <View style={moduleRow}>
+  const ModuleLayout = useCallback(
+    () => (
+      <View style={styles.moduleTopRow}>
+        <View style={moduleRow}>
+          <CustomerSection />
+          <SupplierSection />
+        </View>
+        <View style={moduleRow}>
+          <StockSection />
+          <ModulesSection />
+        </View>
+      </View>
+    ),
+    []
+  );
+
+  const OriginalLayout = useCallback(
+    () => (
+      <View style={styles.originalTopRow}>
         <CustomerSection />
         <SupplierSection />
-      </View>
-      <View style={moduleRow}>
         <StockSection />
-        <ModulesSection />
       </View>
-    </View>
-  ));
-
-  const OriginalLayout = useCallback(() => (
-    <View style={styles.originalTopRow}>
-      <CustomerSection />
-      <SupplierSection />
-      <StockSection />
-    </View>
-  ));
+    ),
+    []
+  );
 
   return (
     <View style={{ ...appBackground }}>
@@ -233,7 +239,10 @@ const mapStateToProps = state => {
   return { usingDispensary, usingModules: usingDispensary, isAdmin: currentUser?.isAdmin };
 };
 
-export const MenuPage = connect(mapStateToProps, mapDispatchToProps)(Menu);
+export const MenuPage = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Menu);
 
 Menu.defaultProps = {
   isInAdminMode: false,

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -73,7 +73,7 @@ export const StocktakeEdit = ({
   // Listen to the stocktake become the top of the stack or being finalised,
   // as these events are side-effects. Refreshing makes the state consistent again.
   useRecordListener(refreshData, pageObject, 'Stocktake');
-  useNavigationFocus(refreshData, navigation);
+  useNavigationFocus(navigation, refreshData);
 
   // If the Stocktake is outdated, force a reset of the stocktake on mount.
   useEffect(() => {

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -57,7 +57,7 @@ export const Stocktakes = ({
 }) => {
   // Listen to sync & navigation changing stocktake data - refresh if there are any.
   useSyncListener(refreshData, ['Stocktake']);
-  useNavigationFocus(refreshData, navigation);
+  useNavigationFocus(navigation, refreshData);
 
   const onRowPress = useCallback(stocktake => dispatch(gotoStocktakeEditPage(stocktake)), []);
 

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -49,7 +49,7 @@ export const SupplierInvoices = ({
 }) => {
   // Listen to changes from sync and navigation events re-focusing this screen,
   // such that any side effects that occur trigger a reconcilitation of data.
-  useNavigationFocus(refreshData, navigation);
+  useNavigationFocus(navigation, refreshData);
   useSyncListener(refreshData, ['Transaction']);
 
   const onNewInvoice = () =>

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -63,7 +63,7 @@ export const SupplierRequisitions = ({
   onNewRequisition,
 }) => {
   // Custom hook to refresh data on this page when becoming the head of the stack again.
-  useNavigationFocus(refreshData, navigation);
+  useNavigationFocus(navigation, refreshData);
   useSyncListener(refreshData, 'Requisition');
 
   const onPressRow = useCallback(rowData => dispatch(gotoSupplierRequisition(rowData)), []);

--- a/src/widgets/Badge.js
+++ b/src/widgets/Badge.js
@@ -1,8 +1,5 @@
+/* eslint-disable react/prop-types */
 /* eslint-disable react/require-default-props */
-/* Taken from https://github.com/react-native-training/react-native-elements
- * since we only need badge component. Tweaked the component class since we do not
- * need extra logic present in the code.
- */
 
 import React from 'react';
 
@@ -10,10 +7,10 @@ import PropTypes from 'prop-types';
 import { StyleSheet, Dimensions, Text, View, TouchableOpacity, ViewPropTypes } from 'react-native';
 import { SUSSOL_ORANGE } from '../globalStyles/index';
 
-const Badge = props => {
+const BadgeComponent = (props, ref) => {
   const {
-    containerStyle,
-    textStyle,
+    containerStyle = localStyles.badgeStyle,
+    textStyle = localStyles.textStyle,
     badgeStyle,
     onPress,
     Component = onPress ? TouchableOpacity : View,
@@ -22,26 +19,13 @@ const Badge = props => {
   } = props;
 
   return (
-    <View style={containerStyle}>
-      <Component {...attributes} style={badgeStyle} onPress={onPress}>
-        <Text style={textStyle}>{value}</Text>
-      </Component>
-    </View>
+    <Component {...attributes} ref={ref} style={containerStyle} onPress={onPress}>
+      <Text style={textStyle}>{value}</Text>
+    </Component>
   );
 };
 
-Badge.propTypes = {
-  containerStyle: ViewPropTypes.style,
-  badgeStyle: ViewPropTypes.style,
-  textStyle: Text.propTypes.style,
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  onPress: PropTypes.func,
-  Component: PropTypes.elementType,
-};
-
-Badge.defaultProps = {
-  containerStyle: {},
-  textStyle: { fontSize: 16, color: '#FFF', paddingHorizontal: 4, fontWeight: 'bold' },
+const localStyles = StyleSheet.create({
   badgeStyle: {
     alignSelf: 'center',
     width: Dimensions.get('window').width / 25,
@@ -53,6 +37,18 @@ Badge.defaultProps = {
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: '#fff',
   },
+  textStyle: { fontSize: 16, color: '#FFF', paddingHorizontal: 4, fontWeight: 'bold' },
+});
+
+const Badge = React.forwardRef(BadgeComponent);
+
+Badge.propTypes = {
+  containerStyle: ViewPropTypes.style,
+  badgeStyle: ViewPropTypes.style,
+  textStyle: Text.propTypes.style,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  onPress: PropTypes.func,
+  Component: PropTypes.elementType,
 };
 
 export default Badge;

--- a/src/widgets/InfoBadge.js
+++ b/src/widgets/InfoBadge.js
@@ -1,8 +1,10 @@
 /* eslint-disable react/forbid-prop-types */
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { View, TouchableHighlight, Text } from 'react-native';
+
+import { View, Text } from 'react-native';
 import Popover from 'react-native-popover-view';
+import { withNavigation } from 'react-navigation';
 
 import { getBadgeData } from '../utilities/getBadgeData';
 import { usePopover } from '../hooks';
@@ -13,7 +15,7 @@ import { SUSSOL_ORANGE } from '../globalStyles';
 
 const animationConfig = { duration: 150 };
 
-export const InfoBadge = ({
+const InfoBadgeComponent = ({
   popoverBackgroundStyle,
   children,
   mainWrapperStyle,
@@ -22,9 +24,10 @@ export const InfoBadge = ({
   arrowStyle,
   popoverStyle,
   badgeTextStyle,
-  touchableContainerStyle,
+
+  navigation,
 }) => {
-  const [ref, visible, show, close] = usePopover();
+  const [ref, visible, show, close] = usePopover(navigation);
 
   // Get total of all the count variables in the info array. We want to show it on the badge
   const info = getBadgeData(routeName);
@@ -48,9 +51,7 @@ export const InfoBadge = ({
       {children}
       {pendingCount !== 0 && (
         <View style={mainWrapperStyle}>
-          <TouchableHighlight ref={ref} style={touchableContainerStyle} onPress={show}>
-            <Badge value={unfinalisedCountText} />
-          </TouchableHighlight>
+          <Badge ref={ref} value={unfinalisedCountText} onPress={show} />
           <Popover
             isVisible={visible}
             fromView={ref.current}
@@ -61,7 +62,7 @@ export const InfoBadge = ({
             placement={popoverPosition}
             animationConfig={animationConfig}
           >
-            <View>{info.map(popoverText)}</View>
+            {info.map(popoverText)}
           </Popover>
         </View>
       )}
@@ -69,9 +70,10 @@ export const InfoBadge = ({
   );
 };
 
-export default InfoBadge;
+export const InfoBadge = withNavigation(InfoBadgeComponent);
+export default withNavigation(InfoBadgeComponent);
 
-InfoBadge.propTypes = {
+InfoBadgeComponent.propTypes = {
   routeName: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,
   mainWrapperStyle: PropTypes.object,
@@ -80,10 +82,10 @@ InfoBadge.propTypes = {
   arrowStyle: PropTypes.object,
   popoverStyle: PropTypes.object,
   badgeTextStyle: PropTypes.object,
-  touchableContainerStyle: PropTypes.object,
+  navigation: PropTypes.object.isRequired,
 };
 
-InfoBadge.defaultProps = {
+InfoBadgeComponent.defaultProps = {
   arrowStyle: { backgroundColor: SUSSOL_ORANGE },
   popoverStyle: { padding: 10, backgroundColor: SUSSOL_ORANGE },
   badgeTextStyle: { color: '#FFF', fontSize: 14, fontWeight: 'bold' },
@@ -92,11 +94,7 @@ InfoBadge.defaultProps = {
     top: 0,
     right: 8,
   },
-  touchableContainerStyle: {
-    borderRadius: 15,
-    backgroundColor: '#FFF',
-    borderColor: '#FFF',
-  },
+
   popoverPosition: 'auto',
   popoverBackgroundStyle: { backgroundColor: 'transparent' },
 };


### PR DESCRIPTION
Fixes #1580 

## Change summary

- Turns out it was because of the badge being unmounted and the ref being reset. Which is what the changes in `MenuPage` were from. So the popover was trying to reference a null pointer.
- When this was fixed, there was an issue that the popover would not dissapear after navigating away. So this is where the change to `usePopover` using `useNavigationFocus` and the addition of `willBlur` in `useNavigationFocus` comes from.

## Testing

- [ ] When clicking pressing a badge to open a popover, and tapping a button to navigate, the app does not crash!
- [ ] When clicking pressing a badge to open a popover, and tapping a button to navigate, the popover is not visible
- [ ] When clicking pressing a badge to open a popover, and tapping a button to navigate, when returning to the previous page (menu page) the popover is closed.

### Related areas to think about

You could also fork/pr into this repo to add a simple line here:  https://github.com/SteffeyDev/react-native-popover-view/blob/6b2c0dea3529f5dd821d6dd98394a45a096d79f2/src/Utility.js#L32-L36

`if (!ref) return false` to 'fix' this 

TIL: `defaultProps` and `propTypes` are not compatible with `forwardRef`
