### PR TITLE
#1586 Utility method: pay

### DIFF
--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -112,6 +112,10 @@ export class Transaction extends Realm.Object {
     return this.type === 'supplier_invoice';
   }
 
+  get isPrescription() {
+    return this.mode === 'dispensary' && this.type === 'customer_invoice';
+  }
+
   /**
    * Get if transaction is an external supplier invoice.
    *

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -185,15 +185,18 @@ const createCustomerCredit = (database, user, patient, total) => {
   return customerCredit;
 };
 
-const createCustomerCreditLine = (database, payment, total) => {
+const createCustomerCreditLine = (database, customerCredit, total) => {
   const receiptLine = database.create('TransactionBatch', {
     id: generateUUID(),
     total,
-    transaction: payment,
+    transaction: customerCredit,
     type: 'cash_in',
     note: 'credit',
   });
 
+  customerCredit.outstanding += total;
+
+  database.save('Transaction', customerCredit);
   database.save('TransactionBatch', receiptLine);
   return receiptLine;
 };

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -6,6 +6,34 @@ import { UIDatabase } from '../../../database/index';
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
+/**
+ * Helper method to pay off a prescription. Given a cash amount
+ * a script and a patient, all receipts, credits and cash in
+ * transactions will be created and the script will be finalised.
+ *
+ * Paying a script has three paths: underpay, exactpay and overpay.
+ * All payments create a Receipt with a ReceiptLine.
+ *
+ * An underpayment creates a CustomerCreditLine and a ReceiptLine
+ * for each source of credit (CustomerCredit) that credit was used from.
+ * For example if a Patient has overpaid the last two prescriptions, then
+ * there would be two sources of credit. If both sources were used to pay
+ * off a script, a CustomerCreditLine is added to each CustomerCredit for
+ * the amount used. A CustomerCredit can have many CustomerCreditLines If
+ * only a fraction of credit is used at a time.
+ *
+ * An overpayment creates a CashIn Transaction to the value of the
+ * amount overpaid.
+ *
+ * When using credit, credit must not become negative.
+ * A script must be paid off in full, no partial payments.
+ * Any amount overpaid must be gained in credit.
+ *
+ * @param {Name} patient       A Name that is a patient
+ * @param {Transaction} script A Transaction that is a prescription
+ * @param {Number} cashAmount  The cash amount being paid for the script.
+ */
+
 export const pay = (currentUser, patient, script, cashAmount) => {
   if (!patient.isPatient) throw new Error('Patient is not a patient');
 

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -27,7 +27,7 @@ export const pay = (currentUser, patient, script, cashAmount) => {
   if (creditAmount > availableCredit) throw new Error('Not enough credit');
 
   // Create a Receipt and ReceiptLine for every payment path.
-  const receipt = createRecord(UIDatabase, 'Receipt', patient);
+  const receipt = createRecord(UIDatabase, 'Receipt', currentUser, patient, cashAmount);
   createRecord(UIDatabase, 'ReceiptLine', script, null, cashAmount);
 
   // When using credit, create a CustomerCreditLine and ReceiptLine for each
@@ -41,7 +41,7 @@ export const pay = (currentUser, patient, script, cashAmount) => {
 
       if (creditFromCustomerCredit >= 0) return false;
 
-      const amountToTake = Math.min(creditFromCustomerCredit, creditToAllocate);
+      const amountToTake = Math.min(Math.abs(creditFromCustomerCredit), creditToAllocate);
 
       createRecord(UIDatabase, 'CustomerCreditLine', customerCredit, amountToTake);
       createRecord(UIDatabase, 'ReceiptLine', receipt, customerCredit, -amountToTake);
@@ -51,6 +51,7 @@ export const pay = (currentUser, patient, script, cashAmount) => {
       return !creditToAllocate;
     });
   }
+
   if (usingCredit && creditToAllocate > 0) throw new Error('Credit not fully allocated');
 
   if (usingOverpayment) createRecord(UIDatabase, 'CashIn', currentUser, patient, overpayAmount);

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -1,0 +1,60 @@
+import { createRecord } from '../../../database/utilities/index';
+import { UIDatabase } from '../../../database/index';
+
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+export const pay = (currentUser, patient, script, cashAmount) => {
+  if (!patient.isPatient) throw new Error('Patient is not a patient');
+
+  if (!script.isPrescription) throw new Error('Script is not a script');
+  if (!(script.items.length > 0)) throw new Error('Script is empty');
+  if (script.isFinalised) throw new Error('Script is finalised');
+
+  if (cashAmount < 0) throw new Error('Cash amount is negative');
+
+  const { total } = script;
+  const { availableCredit } = patient;
+
+  // Determine if this is an under, exact or over payment
+  const creditAmount = total - cashAmount;
+  const overpayAmount = cashAmount - total;
+  const usingCredit = creditAmount > 0;
+  const usingOverpayment = overpayAmount > 0;
+
+  if (creditAmount > availableCredit) throw new Error('Not enough credit');
+
+  // Create a Receipt and ReceiptLine for every payment path.
+  const receipt = createRecord(UIDatabase, 'Receipt', patient);
+  createRecord(UIDatabase, 'ReceiptLine', script, null, cashAmount);
+
+  // When using credit, create a CustomerCreditLine and ReceiptLine for each
+  // source of credit being used.
+  let creditToAllocate = creditAmount;
+  if (usingCredit) {
+    // Iterate over all the patients CustomerCredits, taking credit
+    // from each with available credit, until all has been allocated.
+    patient.customerCredits.some(customerCredit => {
+      const creditFromCustomerCredit = customerCredit.outstanding;
+
+      if (creditFromCustomerCredit >= 0) return false;
+
+      const amountToTake = Math.min(creditFromCustomerCredit, creditToAllocate);
+
+      createRecord(UIDatabase, 'CustomerCreditLine', customerCredit, amountToTake);
+      createRecord(UIDatabase, 'ReceiptLine', receipt, customerCredit, -amountToTake);
+
+      creditToAllocate -= amountToTake;
+
+      return !creditToAllocate;
+    });
+  }
+  if (usingCredit && creditToAllocate > 0) throw new Error('Credit not fully allocated');
+
+  if (usingOverpayment) createRecord(UIDatabase, 'CashIn', currentUser, patient, overpayAmount);
+
+  // Ensure the script is finalised once paid.
+  script.finalise(UIDatabase);
+};


### PR DESCRIPTION
## BRANCHED FROM: #1588 

Fixes #1586 

## Change summary

- utility method to pay a prescription off - adding credit for overpayments or using credit for underpayments
- Still not setting exactly all the fields that should be - for example time should probably be set
- Excessive errors is mainly for development - can be cut down possibly a bit later

## Testing

N/A

### Related areas to think about

N/A
