### PR TITLE
#484 Localization scripts to json/csv

### DIFF
--- a/src/localization/authStrings.js
+++ b/src/localization/authStrings.js
@@ -7,16 +7,7 @@ import LocalizedStrings from 'react-native-localization';
 import gb from './jsonFiles/gb.json';
 
 export const authStrings = new LocalizedStrings({
-  gb: {
-    logging_in: gb.authStrings.logging_in,
-    login: gb.authStrings.login,
-    password: gb.authStrings.password,
-    repeat_password: gb.authStrings.repeat_password,
-    user_name: gb.authStrings.user_name,
-    email: gb.authStrings.email,
-    invalid_username_or_password: gb.authStrings.invalid_username_or_password,
-    warning_sync_edit: gb.authStrings.warning_sync_edit,
-  },
+  gb: gb.authStrings,
   fr: {
     logging_in: 'Connexion en cours',
     login: 'Se connecter',

--- a/src/localization/authStrings.js
+++ b/src/localization/authStrings.js
@@ -4,18 +4,18 @@
  */
 
 import LocalizedStrings from 'react-native-localization';
+import gb from './jsonFiles/gb.json';
 
 export const authStrings = new LocalizedStrings({
   gb: {
-    logging_in: 'Logging in...',
-    login: 'Login',
-    password: 'Password',
-    repeat_password: 'Please re-enter password',
-    user_name: 'User Name',
-    email: 'E-mail Address',
-    invalid_username_or_password: 'Invalid username or password',
-    warning_sync_edit:
-      'WARNING:\nThis will effect syncing for this store.\nMake sure you know what you doing!',
+    logging_in: gb.authStrings.logging_in,
+    login: gb.authStrings.login,
+    password: gb.authStrings.password,
+    repeat_password: gb.authStrings.repeat_password,
+    user_name: gb.authStrings.user_name,
+    email: gb.authStrings.email,
+    invalid_username_or_password: gb.authStrings.invalid_username_or_password,
+    warning_sync_edit: gb.authStrings.warning_sync_edit,
   },
   fr: {
     logging_in: 'Connexion en cours',

--- a/src/localization/jsonFiles/gb.json
+++ b/src/localization/jsonFiles/gb.json
@@ -1,0 +1,13 @@
+{
+  "authStrings": {
+    "logging_in": "Logging in...",
+    "login": "Login",
+    "password": "Password",
+    "repeat_password": "Please re-enter password",
+    "user_name": "User Name",
+    "email": "E-mail Address",
+    "pushing_changes_text": "Pushing changes to the Server",
+    "invalid_username_or_password": "Invalid username or password",
+    "warning_sync_edit": "WARNING:\nThis will effect syncing for this store.\nMake sure you know what you doing!"
+  }
+}

--- a/src/localization/jsonFiles/gb.json
+++ b/src/localization/jsonFiles/gb.json
@@ -6,7 +6,6 @@
     "repeat_password": "Please re-enter password",
     "user_name": "User Name",
     "email": "E-mail Address",
-    "pushing_changes_text": "Pushing changes to the Server",
     "invalid_username_or_password": "Invalid username or password",
     "warning_sync_edit": "WARNING:\nThis will effect syncing for this store.\nMake sure you know what you doing!"
   }


### PR DESCRIPTION
Fixes #484 

## Change summary

For this PR `gb.json` is used to store english authStrings, removing hard-coded ones. It is connected with a node.js app (in progress) to export JSON to CSV and import that modified CSV to JSON again. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

Log in page:
- [ ] Check `Password` and `User name` placeholders
- [ ] Enter a valid user name and password and check the `Logging in...` message
- [ ] Enter an invalid username or password and check text `Invalid username or password` 

### Related areas to think about

This is a simple improvement that will is intended to be adopted for all localization files.