### PR TITLE
#1592 refund utility

### DIFF
--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -1,10 +1,10 @@
-import { createRecord } from '../../../database/utilities/index';
-import { UIDatabase } from '../../../database/index';
-
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
  */
+
+import { createRecord } from '../../../database/utilities';
+import { UIDatabase } from '../../../database';
 
 /**
  * Helper method to pay off a prescription. Given a cash amount

--- a/src/utilities/modules/dispensary/refund.js
+++ b/src/utilities/modules/dispensary/refund.js
@@ -19,8 +19,8 @@ import { UIDatabase } from '../../../database';
  */
 export const refund = (currentUser, patient, batches) => {
   const forSamePatient = batches.every(({ transaction }) => {
-    const { otherPartyName } = transaction;
-    return patient.id === otherPartyName.id;
+    const { otherParty } = transaction;
+    return patient.id === otherParty?.id;
   });
 
   if (!batches.length) throw new Error('Trying to refund void');

--- a/src/utilities/modules/dispensary/refund.js
+++ b/src/utilities/modules/dispensary/refund.js
@@ -9,7 +9,7 @@ import { UIDatabase } from '../../../database';
 /**
  * Utility to refund a collection of TransactionBatch records. Creates a
  * single CustomerCredit and for each TransactionBatch that should be
- * refund, a RefundLine record, which enters the batch back into stock
+ * refunded, a RefundLine record, which enters the batch back into stock
  * and adds credit for the patient.
  *
  *

--- a/src/utilities/modules/dispensary/refund.js
+++ b/src/utilities/modules/dispensary/refund.js
@@ -6,6 +6,17 @@
 import { createRecord } from '../../../database/utilities';
 import { UIDatabase } from '../../../database';
 
+/**
+ * Utility to refund a collection of TransactionBatch records. Creates a
+ * single CustomerCredit and for each TransactionBatch that should be
+ * refund, a RefundLine record, which enters the batch back into stock
+ * and adds credit for the patient.
+ *
+ *
+ * @param {User}               currentUser The currently logged in user.
+ * @param {Name}               patient     The patient to refund to
+ * @param {TransactionBatch[]} batches     Array of batches to be refund
+ */
 export const refund = (currentUser, patient, batches) => {
   const forSamePatient = batches.every(({ transaction }) => {
     const { otherPartyName } = transaction;

--- a/src/utilities/modules/dispensary/refund.js
+++ b/src/utilities/modules/dispensary/refund.js
@@ -1,0 +1,33 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import { createRecord } from '../../../database/utilities';
+import { UIDatabase } from '../../../database';
+
+export const refund = (currentUser, patient, batches) => {
+  const forSamePatient = batches.every(({ transaction }) => {
+    const { otherPartyName } = transaction;
+    return patient.id === otherPartyName.id;
+  });
+
+  if (!batches.length) throw new Error('Trying to refund void');
+  if (!forSamePatient) throw new Error('Batches for different patients!');
+
+  const sumOfCredit = batches.reduce((acc, { total }) => acc + total, 0);
+
+  const customerCredit = createRecord(
+    UIDatabase,
+    'CustomerCredit',
+    currentUser,
+    patient,
+    sumOfCredit
+  );
+
+  const addedBatches = batches.map(batch =>
+    createRecord(UIDatabase, 'RefundLine', customerCredit, batch)
+  );
+
+  return [customerCredit, addedBatches];
+};


### PR DESCRIPTION
Fixes #1592 

## Change summary

- Adds refund() utility
- Added a `createRecord` for a `refundLine` - there's really just one more method to write - `cancel`, and that should cover all our use cases. Then it will be very easy to see where the shared/duplicated code is and can revert a few things. Finding it much easier this way

## Testing

N/A

### Related areas to think about

N/A
