### PR TITLE
Add toLowerCase() for store tag checks

### DIFF
--- a/src/database/DataTypes/MasterList.js
+++ b/src/database/DataTypes/MasterList.js
@@ -60,13 +60,13 @@ export class MasterList extends Realm.Object {
    * @return {object} The matching storeTag programsettings field for the current store
    */
   getStoreTagObject(tags) {
-    const thisStoresTags = tags && tags.split(/[\s,]+/);
+    const thisStoresTags = tags && tags.toLowerCase().split(/[\s,]+/);
     const storeTags = this.parsedProgramSettings && this.parsedProgramSettings.storeTags;
 
     if (!(thisStoresTags && storeTags)) return null;
 
     const foundStoreTag = Object.keys(storeTags).find(
-      storeTag => thisStoresTags.indexOf(storeTag) >= 0
+      storeTag => thisStoresTags.indexOf(storeTag.toLowerCase()) >= 0
     );
 
     return foundStoreTag && storeTags[foundStoreTag];


### PR DESCRIPTION
Fixes #1611 

## Change summary

Makes comparing store tags case insensitive

## Testing

Set up a program such that the `[store]tags = test1` and a `program.storeTag = TEST1`

- [ ] Mobile recognizes the program being for the store with the above setup

### Related areas to think about

N/A