### PR TITLE
#1613 Add corrected useNavigationFocus condition

### DIFF
--- a/src/hooks/useNavigationFocus.js
+++ b/src/hooks/useNavigationFocus.js
@@ -25,7 +25,7 @@ export const useNavigationFocus = (navigation, willFocusCallback, willBlurCallba
   const willBlurSub = useRef(null);
 
   const subscribe = () => {
-    if (!willFocusSub && willFocusCallback) {
+    if (!willFocusSub.current && willFocusCallback) {
       willFocusSub.current = navigation.addListener('willFocus', () => willFocusCallback());
     }
     if (!willBlurSub.current && willBlurCallback) {


### PR DESCRIPTION
Fixes #1613 

## Change summary

- Just a wrong condition causing the listener to not get attached. `willFocusSub` will always be true, so the condition evaluates to false. But `willFocusSub.current` is only true when the listener is attached

## Testing
*Described better in the issue*
- [ ] When creating some record (customer invoice, stocktake etc.) it is correctly shown when navigating back

### Related areas to think about

N/A
