### PR TITLE
#1615 deleting doesnt work

### DIFF
--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -42,6 +42,7 @@ import { UIDatabase } from './database';
 import globalStyles, { textStyles, SUSSOL_ORANGE } from './globalStyles';
 import { UserActions } from './actions';
 import { debounce } from './utilities';
+import { prevRouteNameSelector } from './navigation/selectors';
 
 const SYNC_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 const AUTHENTICATION_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
@@ -49,7 +50,7 @@ const AUTHENTICATION_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 class MSupplyMobileAppContainer extends React.Component {
   handleBackEvent = debounce(
     () => {
-      const { dispatch } = this.props;
+      const { dispatch, prevRouteName } = this.props;
       const { confirmFinalise, syncModalIsOpen } = this.state;
       // If finalise or sync modals are open, close them rather than navigating.
       if (confirmFinalise || syncModalIsOpen) {
@@ -58,7 +59,7 @@ class MSupplyMobileAppContainer extends React.Component {
       }
       // If we are on base screen (e.g. home), back button should close app as we can't go back.
       if (!this.getCanNavigateBack()) BackHandler.exitApp();
-      else dispatch(NavigationActions.back());
+      else dispatch({ ...NavigationActions.back(), payload: { prevRouteName } });
 
       return true;
     },
@@ -281,6 +282,7 @@ class MSupplyMobileAppContainer extends React.Component {
 
 const mapStateToProps = state => {
   const { nav: navigationState, sync: syncState } = state;
+
   const currentParams = getCurrentParams(navigationState);
   const currentTitle = currentParams && currentParams.title;
   const finaliseItem = FINALISABLE_PAGES[getCurrentRouteName(navigationState)];
@@ -290,6 +292,7 @@ const mapStateToProps = state => {
 
   return {
     currentTitle,
+    prevRouteName: prevRouteNameSelector(state),
     finaliseItem,
     navigationState,
     syncState,
@@ -310,6 +313,7 @@ MSupplyMobileAppContainer.propTypes = {
   navigationState: PropTypes.object.isRequired,
   syncState: PropTypes.object.isRequired,
   currentUser: PropTypes.object,
+  prevRouteName: PropTypes.string.isRequired,
 };
 
 export default connect(mapStateToProps)(MSupplyMobileAppContainer);

--- a/src/navigation/selectors.js
+++ b/src/navigation/selectors.js
@@ -16,4 +16,15 @@ const getCurrentRouteName = state =>
 const getCurrentParams = state =>
   state.routes[state.index] ? state.routes[state.index].params : undefined;
 
-export { routeList, getCurrentRouteName, getCurrentParams };
+const prevRouteNameSelector = state => {
+  const { nav } = state;
+  const { routes } = nav;
+
+  const numberOfRoutes = routes.length;
+  const prevRouteIndex = numberOfRoutes > 1 ? numberOfRoutes - 2 : 0;
+  const { routeName } = routes[prevRouteIndex];
+
+  return routeName;
+};
+
+export { routeList, prevRouteNameSelector, getCurrentRouteName, getCurrentParams };

--- a/src/reducers/PagesReducer.js
+++ b/src/reducers/PagesReducer.js
@@ -15,6 +15,11 @@ export const PagesReducer = (state = {}, action) => {
   const { type } = action;
 
   switch (type) {
+    case 'Navigation/BACK': {
+      const { payload } = action;
+      const { prevRouteName } = payload;
+      return { ...state, currentRoute: prevRouteName };
+    }
     case 'Navigation/REPLACE':
     case 'Navigation/NAVIGATE': {
       const { routeName, params } = action;


### PR DESCRIPTION
Fixes #1615 

## Change summary

Bug was that after navigating back, the `currentRoute` wasn't being set correctly. Solution is to pass the previous route name in the `BACK` navigation, so you can set the `currentRoute` in state when navigating back

## Testing

 Navigate to `CustomerInvoices page - create a new invoice. Go back, try and delete.
- [ ] The invoice is deleted
- [ ] The invoice is removed from the list
- [ ] Try again on another page i.e. `SupplierInvoice`, `StocktakesPage` 

### Related areas to think about

I think `PagesReducer` has gotten to hacky for it to work 'correctly'. Probably should be refactored 
