### PR TITLE
#1604 stepper input

### DIFF
--- a/src/widgets/Stepper.js
+++ b/src/widgets/Stepper.js
@@ -1,24 +1,43 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { TextInput, View, TouchableOpacity } from 'react-native';
 
-const Stepper = ({ value, onUpdate, lowerLimit, upperLimit }) => {
+import IonIcon from 'react-native-vector-icons/Ionicons';
+import { SUSSOL_ORANGE, APP_FONT_FAMILY } from '../globalStyles/index';
+
+/**
+ * Stepper component to update a numerical value. The `value` passed will be
+ * cast to a Number, so should return a valid number when cast to `Number`.
+ *
+ * @prop {String|Number} value        The current numerical value
+ * @prop {Func}          onChangeText Callback for updating the value
+ * @prop {Number}        lowerLimit   The lower limit of the numerical range
+ * @prop {Number}        upperLimit   The upper limit of the numerical range
+ * @prop {Number}        iconSize     The size of the icons
+ * @prop {Number}        iconColour   The colour of the icons
+ *
+ */
+const Stepper = ({ value, onChangeText, lowerLimit, upperLimit, iconSize, iconColour }) => {
   const currentValue = React.useRef(Number(value));
   const currentAdjustmentAmount = React.useRef(1);
   const valueAdjustmentInterval = React.useRef();
   const adjustmentIncreaseInterval = React.useRef();
 
+  const onUpdate = newValue => {
+    currentValue.current = newValue;
+    onChangeText(newValue);
+  };
+
   const decrementValue = () => {
     if (lowerLimit >= currentValue.current) return;
     currentValue.current -= currentAdjustmentAmount.current;
-    onUpdate(currentValue.current);
+    onChangeText(currentValue.current);
   };
 
   const incrementValue = () => {
     if (currentValue.current > upperLimit) return;
     currentValue.current += currentAdjustmentAmount.current;
-    onUpdate(currentValue.current);
+    onChangeText(currentValue.current);
   };
 
   const inreaseIncrement = () => {
@@ -48,14 +67,23 @@ const Stepper = ({ value, onUpdate, lowerLimit, upperLimit }) => {
   };
 
   return (
-    <View>
-      <TouchableOpacity onPressIn={() => onStartingLongPress(true)} onPressOut={onEndLongPress}>
-        <View style={{ backgroundColor: 'red', width: 100, height: 100 }} />
-      </TouchableOpacity>
-
-      <TextInput onChangeText={onUpdate} value={String(currentValue.current)} />
+    <View style={{ flexDirection: 'row' }}>
       <TouchableOpacity onPressIn={() => onStartingLongPress(false)} onPressOut={onEndLongPress}>
-        <View style={{ backgroundColor: 'blue', width: 100, height: 100 }} />
+        <IonIcon name="ios-remove" size={iconSize} color={iconColour} />
+      </TouchableOpacity>
+      <TextInput
+        onChangeText={onUpdate}
+        value={String(value)}
+        style={{
+          marginHorizontal: 50,
+          width: 100,
+          textAlign: 'center',
+          fontSize: 16,
+          fontFamily: APP_FONT_FAMILY,
+        }}
+      />
+      <TouchableOpacity onPressIn={() => onStartingLongPress(true)} onPressOut={onEndLongPress}>
+        <IonIcon name="ios-add" size={iconSize} color={iconColour} />
       </TouchableOpacity>
     </View>
   );
@@ -64,13 +92,17 @@ const Stepper = ({ value, onUpdate, lowerLimit, upperLimit }) => {
 Stepper.defaultProps = {
   lowerLimit: 0,
   upperLimit: 99999,
+  iconSize: 45,
+  iconColour: SUSSOL_ORANGE,
 };
 
 Stepper.propTypes = {
   lowerLimit: PropTypes.number,
   upperLimit: PropTypes.number,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  onUpdate: PropTypes.func.isRequired,
+  onChangeText: PropTypes.func.isRequired,
+  iconSize: PropTypes.number,
+  iconColour: PropTypes.string,
 };
 
 export const TestPage = () => {
@@ -78,7 +110,7 @@ export const TestPage = () => {
   const onUpdate = x => setValue(String(x));
   return (
     <View>
-      <Stepper value={value} onUpdate={onUpdate} />
+      <Stepper value={value} onChangeText={onUpdate} />
     </View>
   );
 };

--- a/src/widgets/Stepper.js
+++ b/src/widgets/Stepper.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { TextInput, View, Text, TouchableOpacity } from 'react-native';
+
+const Stepper = ({ value, onUpdate }) => {
+  const currentValue = React.useRef(Number(value));
+  const currentIncrementAmount = React.useRef(1);
+  const valueIncreaseInterval = React.useRef();
+  const incrementIncreaseInterval = React.useRef();
+
+  const decrementValue = () => onUpdate(Number(value) - 1);
+  const incrementValue = () => {
+    currentValue.current += currentIncrementAmount.current;
+    onUpdate(Number(currentValue.current) + currentIncrementAmount.current);
+  };
+
+  const inreaseIncrement = () => {
+    currentIncrementAmount.current *= 2;
+  };
+
+  const onStartingLongPress = isIncrement => {
+    if (!valueIncreaseInterval.current) {
+      valueIncreaseInterval.current = setInterval(
+        isIncrement ? incrementValue : decrementValue,
+        50
+      );
+    }
+
+    if (!incrementIncreaseInterval.current) {
+      incrementIncreaseInterval.current = setInterval(inreaseIncrement, 500);
+    }
+  };
+
+  const onEndLongPress = () => {
+    clearInterval(valueIncreaseInterval.current);
+    valueIncreaseInterval.current = null;
+    clearInterval(incrementIncreaseInterval.current);
+    incrementIncreaseInterval.current = null;
+    currentIncrementAmount.current = 1;
+  };
+
+  return (
+    <View>
+      <TouchableOpacity onPressIn={onStartingLongPress} onPressOut={onEndLongPress}>
+        <View style={{ backgroundColor: 'red', width: 100, height: 10 }} />
+      </TouchableOpacity>
+
+      <TextInput onChangeText={onUpdate} value={String(currentValue.current)} />
+    </View>
+  );
+};
+
+export const TestPage = () => {
+  const [value, setValue] = React.useState('0');
+  const onUpdate = x => setValue(String(x));
+  return (
+    <View>
+      <Stepper value={value} onUpdate={onUpdate} />
+    </View>
+  );
+};

--- a/src/widgets/Stepper.js
+++ b/src/widgets/Stepper.js
@@ -1,23 +1,37 @@
+/* eslint-disable react/forbid-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TextInput, View, TouchableOpacity } from 'react-native';
+import { TextInput, View, TouchableOpacity, StyleSheet } from 'react-native';
 
 import IonIcon from 'react-native-vector-icons/Ionicons';
 import { SUSSOL_ORANGE, APP_FONT_FAMILY } from '../globalStyles/index';
 
 /**
  * Stepper component to update a numerical value. The `value` passed will be
- * cast to a Number, so should return a valid number when cast to `Number`.
+ * cast, so should return a valid number when cast to `Number`.
  *
- * @prop {String|Number} value        The current numerical value
- * @prop {Func}          onChangeText Callback for updating the value
- * @prop {Number}        lowerLimit   The lower limit of the numerical range
- * @prop {Number}        upperLimit   The upper limit of the numerical range
- * @prop {Number}        iconSize     The size of the icons
- * @prop {Number}        iconColour   The colour of the icons
+ * Has increment and decrement buttons which increase the passed value by one.
+ * The buttons can also be held, increase by one every 50ms. The increment amount
+ * then grows exponentially every 500ms, reseting to one after releasing.
+ *
+ * @prop {String|Number} value          The current numerical value.
+ * @prop {Func}          onChangeText   Callback for updating the value.
+ * @prop {Number}        lowerLimit     The lower limit of the numerical range.
+ * @prop {Number}        upperLimit     The upper limit of the numerical range.
+ * @prop {Number}        iconSize       The size of the icons.
+ * @prop {Number}        iconColour     The colour of the icons.
+ * @prop {Object}        textInputStyle Style object for the underlying TextInput.
  *
  */
-const Stepper = ({ value, onChangeText, lowerLimit, upperLimit, iconSize, iconColour }) => {
+const Stepper = ({
+  value,
+  onChangeText,
+  lowerLimit,
+  upperLimit,
+  iconSize,
+  iconColour,
+  textInputStyle,
+}) => {
   const currentValue = React.useRef(Number(value));
   const currentAdjustmentAmount = React.useRef(1);
   const valueAdjustmentInterval = React.useRef();
@@ -66,34 +80,39 @@ const Stepper = ({ value, onChangeText, lowerLimit, upperLimit, iconSize, iconCo
     currentAdjustmentAmount.current = 1;
   };
 
+  const onStartDecrementPress = () => onStartingLongPress(false);
+  const onStartIncrementPress = () => onStartingLongPress(true);
+
   return (
-    <View style={{ flexDirection: 'row' }}>
-      <TouchableOpacity onPressIn={() => onStartingLongPress(false)} onPressOut={onEndLongPress}>
+    <View style={localStyles.row}>
+      <TouchableOpacity onPressIn={onStartDecrementPress} onPressOut={onEndLongPress}>
         <IonIcon name="ios-remove" size={iconSize} color={iconColour} />
       </TouchableOpacity>
-      <TextInput
-        onChangeText={onUpdate}
-        value={String(value)}
-        style={{
-          marginHorizontal: 50,
-          width: 100,
-          textAlign: 'center',
-          fontSize: 16,
-          fontFamily: APP_FONT_FAMILY,
-        }}
-      />
-      <TouchableOpacity onPressIn={() => onStartingLongPress(true)} onPressOut={onEndLongPress}>
+      <TextInput onChangeText={onUpdate} value={String(value)} style={{ textInputStyle }} />
+      <TouchableOpacity onPressIn={onStartIncrementPress} onPressOut={onEndLongPress}>
         <IonIcon name="ios-add" size={iconSize} color={iconColour} />
       </TouchableOpacity>
     </View>
   );
 };
 
+const localStyles = StyleSheet.create({
+  row: { flexDirection: 'row' },
+  textInput: {
+    marginHorizontal: 50,
+    width: 100,
+    textAlign: 'center',
+    fontSize: 16,
+    fontFamily: APP_FONT_FAMILY,
+  },
+});
+
 Stepper.defaultProps = {
   lowerLimit: 0,
   upperLimit: 99999,
   iconSize: 45,
   iconColour: SUSSOL_ORANGE,
+  textInputStyle: localStyles.textInput,
 };
 
 Stepper.propTypes = {
@@ -103,14 +122,5 @@ Stepper.propTypes = {
   onChangeText: PropTypes.func.isRequired,
   iconSize: PropTypes.number,
   iconColour: PropTypes.string,
-};
-
-export const TestPage = () => {
-  const [value, setValue] = React.useState('0');
-  const onUpdate = x => setValue(String(x));
-  return (
-    <View>
-      <Stepper value={value} onChangeText={onUpdate} />
-    </View>
-  );
+  textInputStyle: PropTypes.object,
 };

--- a/src/widgets/Stepper.js
+++ b/src/widgets/Stepper.js
@@ -1,20 +1,28 @@
 import React from 'react';
-import { TextInput, View, Text, TouchableOpacity } from 'react-native';
+import PropTypes from 'prop-types';
 
-const Stepper = ({ value, onUpdate }) => {
+import { TextInput, View, TouchableOpacity } from 'react-native';
+
+const Stepper = ({ value, onUpdate, lowerLimit, upperLimit }) => {
   const currentValue = React.useRef(Number(value));
-  const currentIncrementAmount = React.useRef(1);
+  const currentAdjustmentAmount = React.useRef(1);
   const valueIncreaseInterval = React.useRef();
   const incrementIncreaseInterval = React.useRef();
 
-  const decrementValue = () => onUpdate(Number(value) - 1);
+  const decrementValue = () => {
+    if (lowerLimit >= currentValue.current) return;
+    currentValue.current -= currentAdjustmentAmount.current;
+    onUpdate(currentValue.current);
+  };
+
   const incrementValue = () => {
-    currentValue.current += currentIncrementAmount.current;
-    onUpdate(Number(currentValue.current) + currentIncrementAmount.current);
+    if (currentValue.current > upperLimit) return;
+    currentValue.current += currentAdjustmentAmount.current;
+    onUpdate(currentValue.current);
   };
 
   const inreaseIncrement = () => {
-    currentIncrementAmount.current *= 2;
+    currentAdjustmentAmount.current *= 2;
   };
 
   const onStartingLongPress = isIncrement => {
@@ -32,21 +40,37 @@ const Stepper = ({ value, onUpdate }) => {
 
   const onEndLongPress = () => {
     clearInterval(valueIncreaseInterval.current);
-    valueIncreaseInterval.current = null;
     clearInterval(incrementIncreaseInterval.current);
+
+    valueIncreaseInterval.current = null;
     incrementIncreaseInterval.current = null;
-    currentIncrementAmount.current = 1;
+    currentAdjustmentAmount.current = 1;
   };
 
   return (
     <View>
-      <TouchableOpacity onPressIn={onStartingLongPress} onPressOut={onEndLongPress}>
-        <View style={{ backgroundColor: 'red', width: 100, height: 10 }} />
+      <TouchableOpacity onPressIn={() => onStartingLongPress(true)} onPressOut={onEndLongPress}>
+        <View style={{ backgroundColor: 'red', width: 100, height: 100 }} />
       </TouchableOpacity>
 
       <TextInput onChangeText={onUpdate} value={String(currentValue.current)} />
+      <TouchableOpacity onPressIn={() => onStartingLongPress(false)} onPressOut={onEndLongPress}>
+        <View style={{ backgroundColor: 'blue', width: 100, height: 100 }} />
+      </TouchableOpacity>
     </View>
   );
+};
+
+Stepper.defaultProps = {
+  lowerLimit: 0,
+  upperLimit: 99999,
+};
+
+Stepper.propTypes = {
+  lowerLimit: PropTypes.number,
+  upperLimit: PropTypes.number,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  onUpdate: PropTypes.func.isRequired,
 };
 
 export const TestPage = () => {

--- a/src/widgets/Stepper.js
+++ b/src/widgets/Stepper.js
@@ -6,8 +6,8 @@ import { TextInput, View, TouchableOpacity } from 'react-native';
 const Stepper = ({ value, onUpdate, lowerLimit, upperLimit }) => {
   const currentValue = React.useRef(Number(value));
   const currentAdjustmentAmount = React.useRef(1);
-  const valueIncreaseInterval = React.useRef();
-  const incrementIncreaseInterval = React.useRef();
+  const valueAdjustmentInterval = React.useRef();
+  const adjustmentIncreaseInterval = React.useRef();
 
   const decrementValue = () => {
     if (lowerLimit >= currentValue.current) return;
@@ -26,24 +26,24 @@ const Stepper = ({ value, onUpdate, lowerLimit, upperLimit }) => {
   };
 
   const onStartingLongPress = isIncrement => {
-    if (!valueIncreaseInterval.current) {
-      valueIncreaseInterval.current = setInterval(
+    if (!valueAdjustmentInterval.current) {
+      valueAdjustmentInterval.current = setInterval(
         isIncrement ? incrementValue : decrementValue,
         50
       );
     }
 
-    if (!incrementIncreaseInterval.current) {
-      incrementIncreaseInterval.current = setInterval(inreaseIncrement, 500);
+    if (!adjustmentIncreaseInterval.current) {
+      adjustmentIncreaseInterval.current = setInterval(inreaseIncrement, 500);
     }
   };
 
   const onEndLongPress = () => {
-    clearInterval(valueIncreaseInterval.current);
-    clearInterval(incrementIncreaseInterval.current);
+    clearInterval(valueAdjustmentInterval.current);
+    clearInterval(adjustmentIncreaseInterval.current);
 
-    valueIncreaseInterval.current = null;
-    incrementIncreaseInterval.current = null;
+    valueAdjustmentInterval.current = null;
+    adjustmentIncreaseInterval.current = null;
     currentAdjustmentAmount.current = 1;
   };
 


### PR DESCRIPTION
Fixes #1604 

## Change summary

- Adds a `Stepper` component
- Another ugly component that needs a stylist. I think easier when it's on a page but the basic idea is there.
- Not sure about the holding down.. I think I really like it but not 100% sure. Possibly need to adjust the frequency of increments but I'm really not the best person to find the most optimal amount, would be good to get user feedback or at least a few peoples opinions on a real physical tablet
- Pretty heavy use of `useRef` which I don't like, but ended up being the most fluid with the UI, otherwise you get strange values - i.e. from 10->17 then 17->29 in one go due to the component re-rendering with React batch updating
- Possibly a better implementation is to add more of a delay to the start of the 'long press incrementing'. Use the standard `onPress` to increment by one and then only start increasing after say, a second or so, but then it might be better off to just type. Not sure, will be interesting to see people use it when a page is all done, I think 

![stepper2](https://user-images.githubusercontent.com/35858975/69835571-93661280-12a7-11ea-915f-3ed01f11348f.gif)

## Testing

N/A

### Related areas to think about

N/A
