### PR TITLE
#1626 correct misspelt title of manage stock take

### DIFF
--- a/src/localization/navStrings.js
+++ b/src/localization/navStrings.js
@@ -16,7 +16,7 @@ export const navStrings = new LocalizedStrings({
     invoice: 'Invoice',
     language: 'LANGUAGE',
     log_out: 'LOG OUT',
-    manage_stocktake: 'Manage Stockake',
+    manage_stocktake: 'Manage Stocktake',
     new_stocktake: 'New Stocktake',
     requisition: 'Requisition',
     stocktakes: 'Stocktakes',


### PR DESCRIPTION
Fixes misspelt stocktake

## Change summary

Correct misspelt "stockake" to "stocktake" at navStrings. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to manage stock page, new stocktake on current and past pages.
- [ ] Check on manage stock page to see if the change already been made.
