### PR TITLE
#1635 table shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@react-native-community/async-storage": "^1.6.2",
+    "@react-native-community/slider": "^2.0.7",
     "@react-navigation/core": "^3.5.1",
     "@react-navigation/native": "^3.6.2",
     "bugsnag-react-native": "2.23.2",

--- a/src/utilities/formatters.js
+++ b/src/utilities/formatters.js
@@ -24,3 +24,13 @@ export const formatErrorItemNames = items => {
   }
   return itemsString;
 };
+
+/**
+ * Rounds a number to the provided number of digits. I.e.
+ * roundNumber(17.123, 2) = 17.12
+ *
+ * @param {Number} number           The number to round.
+ * @param {Number} fractionalDigits The number of digits to round to.
+ */
+export const roundNumber = (number, fractionalDigits) =>
+  Number(parseFloat(number).toFixed(fractionalDigits));

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -26,4 +26,4 @@ export {
   checkForCustomerRequisitionError,
 } from './finalisation';
 
-export { formatErrorItemNames } from './formatters';
+export { formatErrorItemNames, roundNumber } from './formatters';

--- a/src/widgets/Slider.js
+++ b/src/widgets/Slider.js
@@ -1,0 +1,158 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { StyleSheet, View, Text, TextInput } from 'react-native';
+
+import RNSlider from '@react-native-community/slider';
+import { SUSSOL_ORANGE, WARMER_GREY, FINALISED_RED } from '../globalStyles/index';
+import { roundNumber } from '../utilities/index';
+
+/**
+ * Component rendering a slider with an additional TextInput in a row.
+ * Numbers entered through the TextInput are validated to be a valid number
+ * and within the bounds passed as minimumValue and maximumValue.
+ *
+ * The callback on value changes is invoked when sliding has finished and when
+ * a valid number is entered into the TextInput.
+ *
+ * @prop {Number} minimumValue           The lower bound of valid values.
+ * @prop {Number} maximumValue           The upper bound of valid values.
+ * @prop {String} minimumTrackTintColour The colour of the track lower than the slider.
+ * @prop {String} maximumTrackTintColour The colour of the track greater than the slider.
+ * @prop {String} thumbTintColour        The colour of the slider thumb
+ * @prop {Number} fractionDigits         How many decimal places.
+ * @prop {Number} step                   The steps of the slider. i.e. 0.25 for [.0, .25,.5,.75]
+ * @prop {Number} value                  The current value of the input.
+ * @prop {Number} onEndEditing           The callback on editing.
+ *
+ */
+export const Slider = ({
+  minimumValue,
+  maximumValue,
+  minimumTrackTintColour,
+  maximumTrackTintColour,
+  thumbTintColour,
+  fractionDigits,
+  step,
+  value,
+  onEndEditing,
+}) => {
+  if (!onEndEditing) throw new Error('Must provide onEndEditing prop!');
+
+  // Current value of the component which is an always-valid Number.
+  const [currentValue, setValue] = React.useState(value);
+
+  // The current string value for the text input. Essentially a buffer for
+  // typing while being able to enter invalid numbers and receive feedback.
+  const [currentStringValue, setStringValue] = React.useState(String(value));
+
+  // A flag for if the current set value is a valid Number, within the bounds of max and
+  // min numbers.
+  const [isValid, setValidity] = React.useState(true);
+
+  const { mainContainerStyle, rowStyle, sliderStyle, textInputStyle, errorTextStyle } = localStyles;
+
+  // Ensures a value is a number and within the valid bounds able to be set.
+  const validateNewValue = newValue => {
+    const tooHigh = newValue > maximumValue;
+    const tooLow = newValue < minimumValue;
+    const tooNaNy = Number.isNaN(Number(newValue)) || newValue === '';
+
+    const isJustRight = !tooHigh && !tooLow && !tooNaNy;
+
+    return isJustRight;
+  };
+
+  // Sets the string value buffer which can be an invalid number. If so,
+  // do not set the number value and set the validity flag.
+  const setString = React.useCallback(newValue => {
+    setStringValue(newValue);
+    const isValidNewValue = validateNewValue(newValue);
+    if (isValidNewValue) {
+      setValidity(true);
+      setValue(roundNumber(newValue, fractionDigits));
+      onEndEditing(roundNumber(newValue, fractionDigits));
+    } else {
+      setValidity(false);
+    }
+  }, []);
+
+  // All slider values will be valid. Set the validity, new value and
+  // string value.
+  const setSlider = React.useCallback(newValue => {
+    const roundedNewValue = roundNumber(newValue, fractionDigits);
+    setValue(roundedNewValue);
+    setValidity(true);
+    setStringValue(String(roundedNewValue));
+  }, []);
+
+  return (
+    <View style={mainContainerStyle}>
+      <View style={rowStyle}>
+        <RNSlider
+          style={sliderStyle}
+          value={currentValue}
+          step={step}
+          minimumValue={minimumValue}
+          maximumValue={maximumValue}
+          minimumTrackTintColor={minimumTrackTintColour}
+          maximumTrackTintColor={maximumTrackTintColour}
+          thumbTintColor={thumbTintColour}
+          onValueChange={setSlider}
+          onSlidingComplete={onEndEditing}
+        />
+
+        <TextInput
+          style={textInputStyle}
+          underlineColorAndroid={isValid ? WARMER_GREY : FINALISED_RED}
+          value={currentStringValue}
+          onChangeText={setString}
+          selectTextOnFocus
+        />
+      </View>
+      {!isValid && (
+        <Text style={errorTextStyle}>
+          {`Must be a number between ${minimumValue} - ${maximumValue} (inclusive)`}
+        </Text>
+      )}
+    </View>
+  );
+};
+
+const localStyles = StyleSheet({
+  mainContainerStyle: { flexDirection: 'column', flex: 1 },
+  rowStyle: { flexDirection: 'row' },
+  sliderStyle: { flex: 19 },
+  textInputStyle: { textAlign: 'right', flex: 1 },
+  errorTextStyle: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    color: 'red',
+    flexGrow: 1,
+    fontStyle: 'italic',
+    alignSelf: 'flex-end',
+  },
+});
+
+Slider.defaultProps = {
+  minimumValue: 0,
+  maximumValue: 100,
+  minimumTrackTintColour: SUSSOL_ORANGE,
+  maximumTrackTintColour: WARMER_GREY,
+  thumbTintColour: SUSSOL_ORANGE,
+  fractionDigits: 2,
+  step: 0.25,
+  value: 20,
+};
+
+Slider.propTypes = {
+  minimumValue: PropTypes.number,
+  maximumValue: PropTypes.number,
+  minimumTrackTintColour: PropTypes.string,
+  maximumTrackTintColour: PropTypes.string,
+  thumbTintColour: PropTypes.string,
+  fractionDigits: PropTypes.number,
+  step: PropTypes.number,
+  value: PropTypes.number,
+  onEndEditing: PropTypes.func.isRequired,
+};

--- a/src/widgets/TableShortcuts.js
+++ b/src/widgets/TableShortcuts.js
@@ -1,0 +1,83 @@
+/* eslint-disable react/forbid-prop-types */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+
+import { APP_FONT_FAMILY, APP_GENERAL_FONT_SIZE } from '../globalStyles';
+
+const TableShortcut = ({
+  children,
+  onPress,
+  shortcutKey,
+  containerStyle,
+  innerContainerStyle,
+  textStyle,
+}) => {
+  const Container = onPress ? TouchableOpacity : View;
+
+  const wrappedOnPress = React.useCallback(() => onPress(shortcutKey), []);
+  const renderChildren = React.useCallback(
+    child => (typeof child === 'string' ? <Text style={textStyle}>{child}</Text> : child),
+    []
+  );
+
+  return (
+    <View onPress={wrappedOnPress} style={containerStyle}>
+      <Container style={innerContainerStyle}>
+        {React.Children.map(children, renderChildren)}
+      </Container>
+    </View>
+  );
+};
+
+const TableShortcuts = ({ children }) => {
+  const { shortcutsContainer } = localStyles;
+  return <View style={shortcutsContainer}>{children}</View>;
+};
+
+const localStyles = StyleSheet.create({
+  container: {},
+  shortcutContainer: {
+    flex: 1,
+    borderBottomColor: 'black',
+    borderBottomWidth: 1,
+  },
+  innerShortcutContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  shotCutText: {
+    fontFamily: APP_FONT_FAMILY,
+    fontSize: APP_GENERAL_FONT_SIZE,
+  },
+  shortcutsContainer: {
+    flex: 1,
+    flexDirection: 'column',
+    borderWidth: 1,
+    borderColor: 'black',
+  },
+});
+
+TableShortcut.defaultProps = {
+  onPress: null,
+  shortcutKey: '',
+
+  innerContainerStyle: localStyles.innerShortcutContainer,
+  textStyle: localStyles.shortcutText,
+  containerStyle: localStyles.shortcutContainer,
+};
+
+TableShortcut.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+  onPress: PropTypes.func,
+  shortcutKey: PropTypes.string,
+  containerStyle: PropTypes.object,
+  innerContainerStyle: PropTypes.object,
+  textStyle: PropTypes.object,
+};
+
+TableShortcuts.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+};

--- a/src/widgets/TableShortcuts.js
+++ b/src/widgets/TableShortcuts.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 
-import { APP_FONT_FAMILY, APP_GENERAL_FONT_SIZE } from '../globalStyles';
+import { APP_FONT_FAMILY, APP_GENERAL_FONT_SIZE, SHADOW_BORDER } from '../globalStyles';
 
 export const TableShortcut = ({
   children,
@@ -40,7 +40,7 @@ const localStyles = StyleSheet.create({
   container: {},
   shortcutContainer: {
     flex: 1,
-    borderBottomColor: 'black',
+    borderBottomColor: SHADOW_BORDER,
     borderBottomWidth: 1,
   },
   innerShortcutContainer: {
@@ -56,14 +56,13 @@ const localStyles = StyleSheet.create({
     flex: 1,
     flexDirection: 'column',
     borderWidth: 1,
-    borderColor: 'black',
+    borderColor: SHADOW_BORDER,
   },
 });
 
 TableShortcut.defaultProps = {
   onPress: null,
   shortcutKey: '',
-
   innerContainerStyle: localStyles.innerShortcutContainer,
   textStyle: localStyles.shortcutText,
   containerStyle: localStyles.shortcutContainer,

--- a/src/widgets/TableShortcuts.js
+++ b/src/widgets/TableShortcuts.js
@@ -6,7 +6,7 @@ import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 
 import { APP_FONT_FAMILY, APP_GENERAL_FONT_SIZE } from '../globalStyles';
 
-const TableShortcut = ({
+export const TableShortcut = ({
   children,
   onPress,
   shortcutKey,
@@ -31,7 +31,7 @@ const TableShortcut = ({
   );
 };
 
-const TableShortcuts = ({ children }) => {
+export const TableShortcuts = ({ children }) => {
   const { shortcutsContainer } = localStyles;
   return <View style={shortcutsContainer}>{children}</View>;
 };

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -25,6 +25,7 @@ export { Spinner } from './Spinner';
 export { Step } from './Step';
 export { StepperInput } from './StepperInput';
 export { Stepper } from './Stepper';
+export { Slider } from './Slider';
 export { SyncState } from './SyncState';
 export { TabNavigator } from './TabNavigator';
 export { TableShortcuts } from './TableShortcuts';

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -27,6 +27,7 @@ export { StepperInput } from './StepperInput';
 export { Stepper } from './Stepper';
 export { SyncState } from './SyncState';
 export { TabNavigator } from './TabNavigator';
+export { TableShortcuts } from './TableShortcuts';
 export { TextEditor } from './TextEditor';
 export { TextInput } from './TextInput';
 export { ToggleBar } from './ToggleBar';

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,6 +955,11 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
+"@react-native-community/slider@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-2.0.7.tgz#5c2d474d6f5210193dd64d802254f45a8528a9a7"
+  integrity sha512-MepSA4XOQbMAE/vc47XsFPPUtWVB//l9ea+x9Bp7lKwaBbtwRUMC1miDFO045ud4YEQ7a0PrviczyxkoiSUFwQ==
+
 "@react-navigation/core@^3.5.1":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.5.1.tgz#7a2339fca3496979305fb3a8ab88c2ca8d8c214d"


### PR DESCRIPTION
Fixes #1635 

## Change summary

- Adds a simple `TableShortcuts` component, basically a layout component, which is just going to basically stack some components on top of each other with a gesture handler

Basic code could look like:

```
export const TestPage = () => (
  <View style={{ flexDirection: 'row', flex: 1 }}>
    <TableShortcuts>
      <TableShortcut onPress={() => console.log(':)')}>Favs</TableShortcut>
      <TableShortcut onPress={() => console.log(':)')}>A-F</TableShortcut>
      <TableShortcut onPress={() => console.log(':)')}>G-L</TableShortcut>
      <TableShortcut onPress={() => console.log(':)')}>M-Z</TableShortcut>
    </TableShortcuts>
    <View style={{ flex: 19 }}>
      <SimpleTable data={testData} columns={[{ key: 'col1' }]} />
    </View>
  </View>
);
```

But each `TableShortcut` can also have it's own children, and icon for example

Basic component atm: 
<img width="1393" alt="image" src="https://user-images.githubusercontent.com/35858975/70013039-1acec100-15db-11ea-8022-d173ba843cb7.png">

Leaving styles to do when I go to use the component, should be easier to get a better idea of what this should look like,.. bit clueless at the mo 🤣 

## Testing

N/A

### Related areas to think about

N/A
