### PR TITLE
#1634 Slider component

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@react-native-community/async-storage": "^1.6.2",
+    "@react-native-community/slider": "^2.0.7",
     "@react-navigation/core": "^3.5.1",
     "@react-navigation/native": "^3.6.2",
     "bugsnag-react-native": "2.23.2",

--- a/src/utilities/formatters.js
+++ b/src/utilities/formatters.js
@@ -24,3 +24,13 @@ export const formatErrorItemNames = items => {
   }
   return itemsString;
 };
+
+/**
+ * Rounds a number to the provided number of digits. I.e.
+ * roundNumber(17.123, 2) = 17.12
+ *
+ * @param {Number} number           The number to round.
+ * @param {Number} fractionalDigits The number of digits to round to.
+ */
+export const roundNumber = (number, fractionalDigits) =>
+  Number(parseFloat(number).toFixed(fractionalDigits));

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -26,4 +26,4 @@ export {
   checkForCustomerRequisitionError,
 } from './finalisation';
 
-export { formatErrorItemNames } from './formatters';
+export { formatErrorItemNames, roundNumber } from './formatters';

--- a/src/widgets/Slider.js
+++ b/src/widgets/Slider.js
@@ -7,18 +7,31 @@ import RNSlider from '@react-native-community/slider';
 import { SUSSOL_ORANGE, WARMER_GREY, FINALISED_RED } from '../globalStyles/index';
 import { roundNumber } from '../utilities/index';
 
-export const TestPage = () => (
-  <View style={{ flex: 1 }}>
-    <Slider />
-  </View>
-);
-
-const Slider = ({
+/**
+ * Component rendering a slider with an additional TextInput in a row.
+ * Numbers entered through the TextInput are validated to be a valid number
+ * and within the bounds passed as minimumValue and maximumValue.
+ *
+ * The callback on value changes is invoked when sliding has finished and when
+ * a valid number is entered into the TextInput.
+ *
+ * @prop {Number} minimumValue           The lower bound of valid values.
+ * @prop {Number} maximumValue           The upper bound of valid values.
+ * @prop {String} minimumTrackTintColour The colour of the track lower than the slider.
+ * @prop {String} maximumTrackTintColour The colour of the track greater than the slider.
+ * @prop {String} thumbTintColour        The colour of the slider thumb
+ * @prop {Number} fractionDigits         How many decimal places.
+ * @prop {Number} step                   The steps of the slider. i.e. 0.25 for [.0, .25,.5,.75]
+ * @prop {Number} value                  The current value of the input.
+ * @prop {Number} onEndEditing           The callback on editing.
+ *
+ */
+export const Slider = ({
   minimumValue,
   maximumValue,
-  minimumTrackTintColor,
-  maximumTrackTintColor,
-  thumbTintColor,
+  minimumTrackTintColour,
+  maximumTrackTintColour,
+  thumbTintColour,
   fractionDigits,
   step,
   value,
@@ -82,9 +95,9 @@ const Slider = ({
           step={step}
           minimumValue={minimumValue}
           maximumValue={maximumValue}
-          minimumTrackTintColor={minimumTrackTintColor}
-          maximumTrackTintColor={maximumTrackTintColor}
-          thumbTintColor={thumbTintColor}
+          minimumTrackTintColor={minimumTrackTintColour}
+          maximumTrackTintColor={maximumTrackTintColour}
+          thumbTintColor={thumbTintColour}
           onValueChange={setSlider}
           onSlidingComplete={onEndEditing}
         />
@@ -124,9 +137,9 @@ const localStyles = StyleSheet({
 Slider.defaultProps = {
   minimumValue: 0,
   maximumValue: 100,
-  minimumTrackTintColor: SUSSOL_ORANGE,
-  maximumTrackTintColor: WARMER_GREY,
-  thumbTintColor: SUSSOL_ORANGE,
+  minimumTrackTintColour: SUSSOL_ORANGE,
+  maximumTrackTintColour: WARMER_GREY,
+  thumbTintColour: SUSSOL_ORANGE,
   fractionDigits: 2,
   step: 0.25,
   value: 20,
@@ -135,9 +148,9 @@ Slider.defaultProps = {
 Slider.propTypes = {
   minimumValue: PropTypes.number,
   maximumValue: PropTypes.number,
-  minimumTrackTintColor: PropTypes.string,
-  maximumTrackTintColor: PropTypes.string,
-  thumbTintColor: PropTypes.string,
+  minimumTrackTintColour: PropTypes.string,
+  maximumTrackTintColour: PropTypes.string,
+  thumbTintColour: PropTypes.string,
   fractionDigits: PropTypes.number,
   step: PropTypes.number,
   value: PropTypes.number,

--- a/src/widgets/Slider.js
+++ b/src/widgets/Slider.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { StyleSheet, View, Text, TextInput } from 'react-native';
+
+import RNSlider from '@react-native-community/slider';
+import { SUSSOL_ORANGE, WARMER_GREY, FINALISED_RED } from '../globalStyles/index';
+import { roundNumber } from '../utilities/index';
+
+export const TestPage = () => (
+  <View style={{ flex: 1 }}>
+    <Slider />
+  </View>
+);
+
+const Slider = ({
+  minimumValue,
+  maximumValue,
+  minimumTrackTintColor,
+  maximumTrackTintColor,
+  thumbTintColor,
+  fractionDigits,
+  step,
+  value,
+  onEndEditing,
+}) => {
+  if (!onEndEditing) throw new Error('Must provide onEndEditing prop!');
+
+  // Current value of the component which is an always-valid Number.
+  const [currentValue, setValue] = React.useState(value);
+
+  // The current string value for the text input. Essentially a buffer for
+  // typing while being able to enter invalid numbers and receive feedback.
+  const [currentStringValue, setStringValue] = React.useState(String(value));
+
+  // A flag for if the current set value is a valid Number, within the bounds of max and
+  // min numbers.
+  const [isValid, setValidity] = React.useState(true);
+
+  const { mainContainerStyle, rowStyle, sliderStyle, textInputStyle, errorTextStyle } = localStyles;
+
+  // Ensures a value is a number and within the valid bounds able to be set.
+  const validateNewValue = newValue => {
+    const tooHigh = newValue > maximumValue;
+    const tooLow = newValue < minimumValue;
+    const tooNaNy = Number.isNaN(Number(newValue)) || newValue === '';
+
+    const isJustRight = !tooHigh && !tooLow && !tooNaNy;
+
+    return isJustRight;
+  };
+
+  // Sets the string value buffer which can be an invalid number. If so,
+  // do not set the number value and set the validity flag.
+  const setString = React.useCallback(newValue => {
+    setStringValue(newValue);
+    const isValidNewValue = validateNewValue(newValue);
+    if (isValidNewValue) {
+      setValidity(true);
+      setValue(roundNumber(newValue, fractionDigits));
+      onEndEditing(roundNumber(newValue, fractionDigits));
+    } else {
+      setValidity(false);
+    }
+  }, []);
+
+  // All slider values will be valid. Set the validity, new value and
+  // string value.
+  const setSlider = React.useCallback(newValue => {
+    const roundedNewValue = roundNumber(newValue, fractionDigits);
+    setValue(roundedNewValue);
+    setValidity(true);
+    setStringValue(String(roundedNewValue));
+  }, []);
+
+  return (
+    <View style={mainContainerStyle}>
+      <View style={rowStyle}>
+        <RNSlider
+          style={sliderStyle}
+          value={currentValue}
+          step={step}
+          minimumValue={minimumValue}
+          maximumValue={maximumValue}
+          minimumTrackTintColor={minimumTrackTintColor}
+          maximumTrackTintColor={maximumTrackTintColor}
+          thumbTintColor={thumbTintColor}
+          onValueChange={setSlider}
+          onSlidingComplete={onEndEditing}
+        />
+
+        <TextInput
+          style={textInputStyle}
+          underlineColorAndroid={isValid ? WARMER_GREY : FINALISED_RED}
+          value={currentStringValue}
+          onChangeText={setString}
+          selectTextOnFocus
+        />
+      </View>
+      {!isValid && (
+        <Text style={errorTextStyle}>
+          {`Must be a number between ${minimumValue} - ${maximumValue} (inclusive)`}
+        </Text>
+      )}
+    </View>
+  );
+};
+
+const localStyles = StyleSheet({
+  mainContainerStyle: { flexDirection: 'column', flex: 1 },
+  rowStyle: { flexDirection: 'row' },
+  sliderStyle: { flex: 19 },
+  textInputStyle: { textAlign: 'right', flex: 1 },
+  errorTextStyle: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    color: 'red',
+    flexGrow: 1,
+    fontStyle: 'italic',
+    alignSelf: 'flex-end',
+  },
+});
+
+Slider.defaultProps = {
+  minimumValue: 0,
+  maximumValue: 100,
+  minimumTrackTintColor: SUSSOL_ORANGE,
+  maximumTrackTintColor: WARMER_GREY,
+  thumbTintColor: SUSSOL_ORANGE,
+  fractionDigits: 2,
+  step: 0.25,
+  value: 20,
+};
+
+Slider.propTypes = {
+  minimumValue: PropTypes.number,
+  maximumValue: PropTypes.number,
+  minimumTrackTintColor: PropTypes.string,
+  maximumTrackTintColor: PropTypes.string,
+  thumbTintColor: PropTypes.string,
+  fractionDigits: PropTypes.number,
+  step: PropTypes.number,
+  value: PropTypes.number,
+  onEndEditing: PropTypes.func.isRequired,
+};

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -25,6 +25,7 @@ export { Spinner } from './Spinner';
 export { Step } from './Step';
 export { StepperInput } from './StepperInput';
 export { Stepper } from './Stepper';
+export { Slider } from './Slider';
 export { SyncState } from './SyncState';
 export { TabNavigator } from './TabNavigator';
 export { TableShortcuts } from './TableShortcuts';

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,6 +955,11 @@
     wcwidth "^1.0.1"
     ws "^1.1.0"
 
+"@react-native-community/slider@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-2.0.7.tgz#5c2d474d6f5210193dd64d802254f45a8528a9a7"
+  integrity sha512-MepSA4XOQbMAE/vc47XsFPPUtWVB//l9ea+x9Bp7lKwaBbtwRUMC1miDFO045ud4YEQ7a0PrviczyxkoiSUFwQ==
+
 "@react-navigation/core@^3.5.1":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-3.5.1.tgz#7a2339fca3496979305fb3a8ab88c2ca8d8c214d"


### PR DESCRIPTION


Fixes #1634 

## Change summary

- Adds a `Slider` component, a wrapper around the react native community edition of a native slider - the `Slider` component from `react-native` has been deprecated and extracted out in favour of this component.
- Potentially the `TextInput` would be replaced by a component made from #1632  when that is complete.
- Should you rename props that are american spelling to english spelling? Dunno! But I did
- Don't want to conflict with diego's localizing so will do that later.
- Overall this could be more dynamic and extensible, especially with styles, but will leave it for now

![slider](https://user-images.githubusercontent.com/35858975/70099889-08b15900-1695-11ea-9a8b-89d704ec0fc4.gif)
![slider2](https://user-images.githubusercontent.com/35858975/70099877-fdf6c400-1694-11ea-9ab2-04a2af4bf843.gif)

## Testing


N/A

### Related areas to think about

N/A