### PR TITLE
Add fix for regression from parameter additions

### DIFF
--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -214,22 +214,25 @@ export class Requisition extends Realm.Object {
    * @param  {Array.<string>}   selected masterlists from multiselect
    * @param  {Name}             thisStore
    */
-  addItemsFromMasterList(database, selected, thisStore) {
+  addItemsFromMasterList(database, thisStore, selected) {
     if (this.isFinalised) {
       throw new Error('Cannot add items to a finalised requisition');
     }
+
     // Filter through masterList ids that are on multiselect list
-    thisStore.masterLists
-      .filter(item => selected.indexOf(item.id) !== -1)
-      .forEach(masterList => {
-        const itemsToAdd = complement(masterList.items, this.items, item => item.itemId);
-        itemsToAdd.forEach(masterListItem => {
-          if (!masterListItem.item.crossReferenceItem) {
-            // Do not add cross reference items as causes unwanted duplicates.
-            createRecord(database, 'RequisitionItem', this, masterListItem.item);
-          }
-        });
+    const filteredMasterLists = selected
+      ? thisStore.masterLists.filter(item => selected.indexOf(item.id) !== -1)
+      : thisStore.masterLists;
+
+    filteredMasterLists.forEach(masterList => {
+      const itemsToAdd = complement(masterList.items, this.items, item => item.itemId);
+      itemsToAdd.forEach(masterListItem => {
+        if (!masterListItem.item.crossReferenceItem) {
+          // Do not add cross reference items as causes unwanted duplicates.
+          createRecord(database, 'RequisitionItem', this, masterListItem.item);
+        }
       });
+    });
   }
 
   /**

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -110,7 +110,7 @@ export const addMasterListItems = (selected, objectType, route) => (dispatch, ge
   )[0];
 
   UIDatabase.write(() => {
-    pageObject.addItemsFromMasterList(UIDatabase, selected, thisStore);
+    pageObject.addItemsFromMasterList(UIDatabase, thisStore, selected);
     UIDatabase.save(objectType, pageObject);
   });
 


### PR DESCRIPTION
Fixes #1640 

## Change summary

- This was a regression from this PR: https://github.com/openmsupply/mobile/pull/1551 - where a new parameter was added to handle adding from master lists via the `Add from MasterList` button. The call from this button was not accounted for
- This is a quick fix for the runtime error and potentially for the release if #1576 is not completed before then.

## Testing

*This PR relates to the `Create Automatic Order` Button on `SupplierRequisitionsPage`*. An automatic order will add all items to the requisition which have a suggested quantity > 0, and will set the `requested quantity` to the `suggested quantity`.

- [ ] Clicking `Create Automatic Order` creates an automatic order and does not crash the app!

### Related areas to think about

Other calls to the `Requisition.addFromMasterLists` and `Transaction.addFromMasterLists` buttons - but there are no others.
