### PR TITLE
#1557 item limit for emergency orders

### DIFF
--- a/src/database/DataTypes/MasterList.js
+++ b/src/database/DataTypes/MasterList.js
@@ -72,6 +72,45 @@ export class MasterList extends Realm.Object {
     return foundStoreTag && storeTags[foundStoreTag];
   }
 
+  /**
+   * Returns an array of order type objects for this program, for the
+   * current store.
+   *
+   * @param  {String}  tags   Current stores tags field
+   * @return {Array} An array of order types for this program/store.
+   */
+  getOrderTypes(tags) {
+    const storeTagObject = this.getStoreTagObject(tags);
+    return storeTagObject?.orderTypes;
+  }
+
+  /**
+   * Returns a specific order type object which matches the name provided.
+   *
+   * @param   {String} orderTypeToFind
+   * @param   {String} tags
+   * @returns {Object} An order type object
+   */
+  getOrderType(orderTypeName, tags) {
+    const orderTypes = this.getOrderTypes(tags);
+    if (!orderTypes) return null;
+
+    return orderTypes.find(orderType => orderType.name === orderTypeName);
+  }
+
+  /**
+   * Returns the maximum number of lines for the provided order type.
+   *
+   * @param   {String} orderTypeName
+   * @param   {String} tags
+   * @returns {Number} The maximum number of lines an order can have with the supplied order type
+   */
+  getMaxLines(orderTypeName, tags) {
+    const orderType = this.getOrderType(orderTypeName, tags);
+    const maxLinesForOrder = orderType?.maxEmergencyOrders;
+    return maxLinesForOrder || Infinity;
+  }
+
   toString() {
     return this.name;
   }

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -114,6 +114,11 @@ export class Requisition extends Realm.Object {
     return getTotal(this.items, 'requiredQuantity');
   }
 
+  get numberOfOrderedItems() {
+    const hasBeenCounted = requisitionItem => (requisitionItem.requiredQuantity !== 0 ? 1 : 0);
+    return this.items.reduce((acc, item) => acc + hasBeenCounted(item), 0);
+  }
+
   /**
    * Get number of items associated with requisition.
    *

--- a/src/localization/modalStrings.js
+++ b/src/localization/modalStrings.js
@@ -114,6 +114,8 @@ export const modalStrings = new LocalizedStrings({
        d'autres relevé d'inventaire). La quantité actuelle et celle de l'instantané seront \
        réinitialisées.",
     select_a_reason: 'Sélectionnez une raison',
+    emergency_orders_can_only_have: "Commandes urgentes peuvent n'avoir que",
+    items_remove_some: 'articles ! Enlevez-en quelques-uns avant de finaliser.',
   },
   gil: {
     // TODO: add |edit_the_stocktake_comment|, |edit_the_stocktake_name|, |stocktake_invalid_stock|

--- a/src/localization/modalStrings.js
+++ b/src/localization/modalStrings.js
@@ -57,6 +57,8 @@ export const modalStrings = new LocalizedStrings({
     select_master_lists: 'Select master list',
     customer_no_masterlist_available: 'This customer has no master lists!',
     supplier_no_masterlist_available: 'Your store has no master lists!',
+    emergency_orders_can_only_have: 'Emergency orders can only have',
+    items_remove_some: 'items! Remove some before you can finalise',
   },
   fr: {
     add_at_least_one_item_before_finalising:

--- a/src/localization/programStrings.js
+++ b/src/localization/programStrings.js
@@ -33,7 +33,7 @@ export const programStrings = new LocalizedStrings({
     general_stocktake: 'General stocktake',
     program_stocktake: 'Program stocktake',
     general_order: 'General order',
-    emergency_orders: 'Emergency orders',
+    emergency_order: 'Emergency order',
   },
   fr: {
     select_a_program: 'Sélectionnez un programme',
@@ -62,7 +62,7 @@ export const programStrings = new LocalizedStrings({
     general_stocktake: 'Inventaire général',
     general_order: 'Commande Générale',
     program_stocktake: 'Inventaire par\n programme',
-    emergency_orders: ' Commandes urgence',
+    emergency_order: ' Commandes urgence',
   },
   gil: {
     select_a_program: 'Select a program',

--- a/src/localization/programStrings.js
+++ b/src/localization/programStrings.js
@@ -34,6 +34,7 @@ export const programStrings = new LocalizedStrings({
     program_stocktake: 'Program stocktake',
     general_order: 'General order',
     emergency_order: 'Emergency order',
+    max_items: 'Max. Items',
   },
   fr: {
     select_a_program: 'Sélectionnez un programme',

--- a/src/utilities/finalisation.js
+++ b/src/utilities/finalisation.js
@@ -54,17 +54,15 @@ export function checkForSupplierInvoiceError(transaction) {
  * @return  {string}               Null if safe to finalise, else an error message.
  */
 export function checkForSupplierRequisitionError(requisition) {
-  const { items, totalRequiredQuantity, program = {}, orderType } = requisition;
+  const { numberOfOrderedItems, totalRequiredQuantity, program = {}, orderType } = requisition;
 
-  const numberOfItems = items.length;
-
-  if (!numberOfItems) return modalStrings.add_at_least_one_item_before_finalising;
+  if (!numberOfOrderedItems) return modalStrings.add_at_least_one_item_before_finalising;
   if (!totalRequiredQuantity) return modalStrings.record_stock_required_before_finalising;
 
   const thisStoresTags = UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_TAGS);
   const maxLinesForOrder = program.getMaxLines?.(orderType, thisStoresTags);
 
-  if (numberOfItems > maxLinesForOrder) {
+  if (numberOfOrderedItems > maxLinesForOrder) {
     return `${modalStrings.emergency_orders_can_only_have} ${maxLinesForOrder} ${modalStrings.items_remove_some}`;
   }
 

--- a/src/utilities/finalisation.js
+++ b/src/utilities/finalisation.js
@@ -6,6 +6,8 @@
 
 import { modalStrings } from '../localization';
 import { formatErrorItemNames } from './formatters';
+import { UIDatabase } from '../database/index';
+import { SETTINGS_KEYS } from '../settings/index';
 
 /**
  * Check whether a given customer invoice is safe to be finalised. If safe to finalise,
@@ -52,12 +54,18 @@ export function checkForSupplierInvoiceError(transaction) {
  * @return  {string}               Null if safe to finalise, else an error message.
  */
 export function checkForSupplierRequisitionError(requisition) {
-  if (requisition.items.length === 0) {
-    return modalStrings.add_at_least_one_item_before_finalising;
-  }
+  const { items, totalRequiredQuantity, program = {}, orderType } = requisition;
 
-  if (requisition.totalRequiredQuantity === 0) {
-    return modalStrings.record_stock_required_before_finalising;
+  const numberOfItems = items.length;
+
+  if (!numberOfItems) return modalStrings.add_at_least_one_item_before_finalising;
+  if (!totalRequiredQuantity) return modalStrings.record_stock_required_before_finalising;
+
+  const thisStoresTags = UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_TAGS);
+  const maxLinesForOrder = program.getMaxLines?.(orderType, thisStoresTags);
+
+  if (numberOfItems > maxLinesForOrder) {
+    return `${modalStrings.emergency_orders_can_only_have} ${maxLinesForOrder} ${modalStrings.items_remove_some}`;
   }
 
   return null;

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -9,6 +9,7 @@ import globalStyles, { DARK_GREY, WARM_GREY, SUSSOL_ORANGE } from '../../globalS
 import { SETTINGS_KEYS } from '../../settings';
 import { getAllPrograms, getAllPeriodsForProgram } from '../../utilities';
 import { programStrings, navStrings } from '../../localization';
+import { UIDatabase } from '../../database';
 
 import {
   selectProgram,
@@ -48,13 +49,15 @@ const modalProps = ({ dispatch, program, orderType }) => ({
         isEmergency,
       } = item;
 
+      const thisStoresTags = UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_TAGS);
+      const maxLinesForOrder = program.getMaxLines?.(item.name, thisStoresTags);
+
       const mosText = `${maxMOS}: ${itemMOS}`;
       const thresholdText = `${threshMOS}: ${itemThreshMOS}`;
-      const maxOrdersText = isEmergency
-        ? programStrings.emergency_orders
-        : `${maxOPP}: ${maxOrders}`;
+      const emergencyText = `[${programStrings.emergency_order}]  Max Items: ${maxLinesForOrder}`;
+      const maxOrdersText = isEmergency ? emergencyText : `${maxOPP}: ${maxOrders}`;
 
-      return `${mosText} - ${thresholdText} - ${maxOrdersText}`;
+      return `${maxOrdersText} - ${mosText} - ${thresholdText}`;
     },
   },
   period: {

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -54,7 +54,11 @@ const modalProps = ({ dispatch, program, orderType }) => ({
 
       const mosText = `${maxMOS}: ${itemMOS}`;
       const thresholdText = `${threshMOS}: ${itemThreshMOS}`;
-      const emergencyText = `[${programStrings.emergency_order}]  Max Items: ${maxLinesForOrder}`;
+      const maxItemsText =
+        maxLinesForOrder && maxLinesForOrder !== Infinity
+          ? `${programStrings.max_items}: ${maxLinesForOrder}`
+          : '';
+      const emergencyText = `[${programStrings.emergency_order}]  ${maxItemsText}`;
       const maxOrdersText = isEmergency ? emergencyText : `${maxOPP}: ${maxOrders}`;
 
       return `${maxOrdersText} - ${mosText} - ${thresholdText}`;

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -74,7 +74,7 @@ const modalProps = ({ dispatch, program, orderType }) => ({
       const requisitionsCount = `${requisitionsInPeriod}/${maxOrdersPerPeriod} ${requisitions}`;
 
       const periodText = isEmergency
-        ? `${requisitionsInPeriod} ${programStrings.emergency_orders}`
+        ? `${requisitionsInPeriod} ${programStrings.emergency_order}`
         : requisitionsCount;
 
       return `${item} - ${periodText}`;


### PR DESCRIPTION
Fixes #1557

- Adds the maximum number of lines functionality to program requisitions.

## Change summary

- Change is just a few helpers to determine order types/max lines and add a condition in the finalisation validation.
- Bit spaghetti, but returning a string from the requisition finalisation validation method will display this in a modal
- Currently in desktop you can set the max number of lines to 0. This implementation just ignores the max number of lines if it's 0
- Displays the max lines when selecting an order type

<img width="1119" alt="image" src="https://user-images.githubusercontent.com/35858975/70126296-9c0e7c80-16dd-11ea-80e8-51f0d3aa1b1d.png">

<img width="1128" alt="image" src="https://user-images.githubusercontent.com/35858975/70126818-a41aec00-16de-11ea-9098-c03769270e6e.png">


## Testing

*This PR is related to this PR in desktop: https://github.com/sussol/msupply/issues/4557 - which adds a configuration to an `Order Type`, which limits the number of items that can be ordered, when a requisition is created when created with that `OrderType`. 


e.g. with the setup below, creating a requisition with the `New order type1` ordertype, you should only be able to finalise a program requisition with <= 5 items.
<img width="687" alt="image" src="https://user-images.githubusercontent.com/35858975/70126203-6b2e4780-16dd-11ea-94eb-74c98b3ce809.png">


- [ ] Can only finalise a program requisition created with an emergency order type with items <= the max lines for the order type
- [ ] The max lines for an emergency order is listed correctly in the modal when selecting an order type
- [ ] Works correctly when using a desktop structure < 4.07 [max lines field only added in 4.07]
- [ ] 

### Related areas to think about

- Not sure if `MasterList` was the best place to put these helpers, over `Requisition` or just utility functions
- Wish we had `program/storeTag/orderType` objects 