### PR TITLE
#1621 Validate stocktake batch input

### DIFF
--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -166,7 +166,7 @@ export const editStocktakeBatchCountedQuantity = (value, rowKey, route) => (disp
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
   UIDatabase.write(() => {
-    objectToEdit.countedTotalQuantity = value;
+    objectToEdit.countedTotalQuantity = parsePositiveInteger(value);
     UIDatabase.save('StocktakeBatch', UIDatabase);
   });
 


### PR DESCRIPTION
Fixes #1621 

## Change summary

- Parses the number entered, the same as every other quantity input.

## Testing

- [ ] Can edit a `StocktakeBatch` with any positive integer and have make a persistent change.
- [ ] Entering invalid values into a `StocktakeBatch` quantity column ("!", "a" etc.) makes no change

### Related areas to think about

N/A
