### PR TITLE
#1645 Add from MasterList runtime error

### DIFF
--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -214,7 +214,7 @@ export class Requisition extends Realm.Object {
    * @param  {Array.<string>}   selected masterlists from multiselect
    * @param  {Name}             thisStore
    */
-  addItemsFromMasterList(database, thisStore, selected) {
+  addItemsFromMasterList({ database, thisStore, selected }) {
     if (this.isFinalised) {
       throw new Error('Cannot add items to a finalised requisition');
     }
@@ -260,7 +260,7 @@ export class Requisition extends Realm.Object {
       throw new Error('Cannot add items to a finalised requisition');
     }
 
-    this.addItemsFromMasterList(database, thisStore);
+    this.addItemsFromMasterList({ database, thisStore });
     this.setRequestedToSuggested(database);
     this.pruneRedundantItems(database);
   }

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -230,7 +230,7 @@ export class Transaction extends Realm.Object {
    * @param  {Realm}            database
    * @param  {Array.<string>}   selected masterlists from multiselect
    */
-  addItemsFromMasterList(database, selected) {
+  addItemsFromMasterList({ database, selected }) {
     if (!this.isCustomerInvoice) {
       throw new Error(`Cannot add master lists to ${this.type}`);
     }

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -110,7 +110,7 @@ export const addMasterListItems = (selected, objectType, route) => (dispatch, ge
   )[0];
 
   UIDatabase.write(() => {
-    pageObject.addItemsFromMasterList(UIDatabase, thisStore, selected);
+    pageObject.addItemsFromMasterList({ database: UIDatabase, thisStore, selected });
     UIDatabase.save(objectType, pageObject);
   });
 


### PR DESCRIPTION
Fixes #1645 

## Change summary

- Corrected the parameters being passed to `AddFromMasterList` in `Transaction`.
- `Requisition` and `Transaction` both have this method - only certain calls need the optional parameter `thisStore`, others `selected` - so turned the arguments to an object.

## Testing

- [ ] Adding items from a master list on `CustomerInvoicePage` adds items from the selected masterlists
- [ ] Adding items from a master list on `SupplierRequisitionPage` adds items from the selected masterlists
- [ ] Creating a `Program` Requisition works correctly - adds all items to the requisition for that program.
- [ ] Using the `Create Automatic Order` button on `SupplierRequisitionPage` correctly creates an auto matic order.

### Related areas to think about

N/A
