### PR TITLE
#1647 Incorrect pricing

### DIFF
--- a/src/database/DataTypes/RequisitionItem.js
+++ b/src/database/DataTypes/RequisitionItem.js
@@ -148,6 +148,7 @@ export class RequisitionItem extends Realm.Object {
 
     // Return the maximum price of all MasterListItems.
     return UIDatabase.objects('MasterListItem')
+      .filtered('item.id == $0', this.item.id)
       .filtered(queryString, this.item)
       .max('price');
   }

--- a/src/database/DataTypes/RequisitionItem.js
+++ b/src/database/DataTypes/RequisitionItem.js
@@ -142,13 +142,12 @@ export class RequisitionItem extends Realm.Object {
       .map(({ masterList }) => masterList.id);
 
     // Query string: Query for all MasterList.IDs related to this store and this item.
-    const queryString = `${masterListIds
+    const queryString = `(${masterListIds
       .map(id => `masterList.id == '${id}'`)
-      .join(' OR ')} AND item = $0`;
+      .join(' OR ')}) AND item = $0`;
 
     // Return the maximum price of all MasterListItems.
     return UIDatabase.objects('MasterListItem')
-      .filtered('item.id == $0', this.item.id)
       .filtered(queryString, this.item)
       .max('price');
   }


### PR DESCRIPTION
Fixes #1647 

## Change summary

When having two master lists related with a mobile store, all items were taking the same max price. This issue was solved adding an extra filter to select the corresponding MasterListItem before applying max('price'). 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create two masters lists for the mobile store. (At least one should be a program). 
- [ ] Add two items in both lists and assign different prices to them.
- [ ] Create a new program requisition related with one master list created in step 1.
- [ ] Price for ITEM 1 and ITEM 2 are their maximum among all created ML and they don't take other item's prices.