### PR TITLE
#976 sortIndex modified to start from 1

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -297,7 +297,7 @@ const createStocktakeBatch = (database, stocktakeItem, itemBatch) => {
     batch,
     costPrice,
     sellPrice,
-    sortIndex: stocktakeItem.stocktake ? stocktakeItem.stocktake.numberOfBatches + 1 : 1,
+    sortIndex: (stocktakeItem?.stocktake?.numberOfBatches || 0) + 1 || 1,
   });
 
   stocktakeItem.addBatch(stocktakeBatch);
@@ -359,7 +359,7 @@ const createTransactionBatch = (database, transactionItem, itemBatch) => {
     sellPrice,
     donor,
     transaction: transactionItem.transaction,
-    sortIndex: transactionItem.transaction ? transactionItem.transaction.numberOfBatches + 1 : 1,
+    sortIndex: (transactionItem?.transaction?.numberOfBatches || 0) + 1 || 1,
   });
 
   transactionItem.addBatch(transactionBatch);

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -297,7 +297,7 @@ const createStocktakeBatch = (database, stocktakeItem, itemBatch) => {
     batch,
     costPrice,
     sellPrice,
-    sortIndex: stocktakeItem.stocktake ? stocktakeItem.stocktake.numberOfBatches : 0,
+    sortIndex: stocktakeItem.stocktake ? stocktakeItem.stocktake.numberOfBatches + 1 : 1,
   });
 
   stocktakeItem.addBatch(stocktakeBatch);
@@ -359,7 +359,7 @@ const createTransactionBatch = (database, transactionItem, itemBatch) => {
     sellPrice,
     donor,
     transaction: transactionItem.transaction,
-    sortIndex: transactionItem.transaction ? transactionItem.transaction.numberOfBatches : 0,
+    sortIndex: transactionItem.transaction ? transactionItem.transaction.numberOfBatches + 1 : 1,
   });
 
   transactionItem.addBatch(transactionBatch);


### PR DESCRIPTION
Fixes #976 

## Change summary

Main intention is change sortIndex to start from 1 instead of 0. This is important because on desktop it is expected that line numbers start from 1.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a Supplier requisition (can be a General order), and select General Warehouse.
- [ ] Add items to the list and finalise it.
- [ ] Perform a manual sync and check internal customer requisitions.
- [ ] Open the requisition and check all items were added correctly.