### PR TITLE
#1666 Corrected usage calculation

### DIFF
--- a/src/utilities/dailyUsage.js
+++ b/src/utilities/dailyUsage.js
@@ -58,5 +58,5 @@ export const dailyUsage = item => {
     .filtered('transaction.confirmDate >= $0 && transaction.confirmDate <= $1', startDate, dateNow)
     .reduce((sum, { totalQuantity }) => sum + totalQuantity, 0);
 
-  return usage / numberOfUsageDays || 1;
+  return usage / (numberOfUsageDays || 1);
 };


### PR DESCRIPTION
Fixes #1666 

## Change summary

- Corrects the usage return value, which was returning `1`, instead of `0`


## Testing

### This is somewhat confusing - I've tried to explain as simply as I can, I'm sorry

**[ You can check monthly usage by going to `Current Stock` page - and clicking on an item. A popup will open from the bottom of the screen, which will display monthly usage ]**

example:
![image](https://user-images.githubusercontent.com/35858975/70610917-41d76380-1c69-11ea-94ca-ec9292d83577.png)

**Usage calculation can be found in `dailyUsage.js`. It is the sum of all usage within the lookback period (defined through store custom data `monthlyConsumptionLookBackPeriod` field, defaults to 30 if not defined in store custom data), over the number of days in the lookback period.**

However, if the item was added (earliest stock in transaction batch confirm date for that item) more recently than the lookback period, the usage is calculated only since the item was added. UNLESS the store custom data `monthlyConsumptionEnforceLookBackPeriod` is set, in which case the lookback period is always used.

**Note: This PRs aim is to only make a small change to ensure the correct usage is being returned when there is no usage**

- [ ] Items which have NO usage, display NO usage

### Related areas to think about

N/A