### PR TITLE
#1663 Debounced callback

### DIFF
--- a/src/pages/dataTableUtilities/getPageDispatchers.js
+++ b/src/pages/dataTableUtilities/getPageDispatchers.js
@@ -25,7 +25,7 @@ export const getPageDispatchers = (dispatch, props, dataType, route) => {
     toggleSelectAll: () => dispatch(BasePageActions.toggleSelectAll(route)),
     toggleFinalised: () => dispatch(BasePageActions.toggleShowFinalised(route)),
     toggleStockOut: () => dispatch(BasePageActions.toggleStockOut(route)),
-    onFilterData: value => dispatch(BasePageActions.filterData(value, route)),
+    onFilterData: debounce(value => dispatch(BasePageActions.filterData(value, route)), 75),
     onShowOverStocked: () => dispatch(BasePageActions.showOverStocked(route)),
     onHideOverStocked: () => dispatch(BasePageActions.hideOverStocked(route)),
     onDeselectAll: () => dispatch(BasePageActions.deselectAll(route)),


### PR DESCRIPTION
Fixes #1663 

## Change summary

- Adds debouncing of filtering

## Testing

*debouncing ensures a function is invoked only once when called consecutively (in this case within 75 ms)
- [ ] Searching is debounced 

### Related areas to think about

N/A
