### PR TITLE
#1042 Change `Show over stocked` as default in program requisitions

### DIFF
--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -360,11 +360,15 @@ const supplierRequisitionInitialiser = requisition => {
   const route = program ? ROUTES.SUPPLIER_REQUISITION_WITH_PROGRAM : ROUTES.SUPPLIER_REQUISITION;
 
   const sortedData = backingData.sorted('item.name').slice();
+  const isFinalised = requisition.status === 'finalised';
+  const filteredData = !isFinalised
+    ? sortedData.filter(item => item.isLessThanThresholdMOS)
+    : sortedData;
 
   return {
     pageObject: requisition,
     backingData,
-    data: sortedData,
+    data: filteredData,
     keyExtractor: recordKeyExtractor,
     dataState: new Map(),
     searchTerm: '',
@@ -374,7 +378,7 @@ const supplierRequisitionInitialiser = requisition => {
     modalKey: '',
     hasSelection: false,
     modalValue: null,
-    showAll: usingPrograms,
+    showAll: usingPrograms && isFinalised,
     route: ROUTES.SUPPLIER_REQUISITION,
     columns: getColumns(route),
     getPageInfoColumns: getPageInfoColumns(route),

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -354,16 +354,16 @@ const supplierInvoicesInitialiser = () => {
  * @returns  {object}
  */
 const supplierRequisitionInitialiser = requisition => {
-  const { program, items: backingData } = requisition;
+  const { isFinalised, program, items: backingData } = requisition;
 
   const usingPrograms = !!program;
   const route = program ? ROUTES.SUPPLIER_REQUISITION_WITH_PROGRAM : ROUTES.SUPPLIER_REQUISITION;
 
   const sortedData = backingData.sorted('item.name').slice();
-  const isFinalised = requisition.status === 'finalised';
-  const filteredData = !isFinalised
-    ? sortedData.filter(item => item.isLessThanThresholdMOS)
-    : sortedData;
+  const filteredData =
+    !usingPrograms || isFinalised
+      ? sortedData
+      : sortedData.filter(item => item.isLessThanThresholdMOS);
 
   return {
     pageObject: requisition,
@@ -378,7 +378,7 @@ const supplierRequisitionInitialiser = requisition => {
     modalKey: '',
     hasSelection: false,
     modalValue: null,
-    showAll: usingPrograms && isFinalised,
+    showAll: !usingPrograms || isFinalised,
     route: ROUTES.SUPPLIER_REQUISITION,
     columns: getColumns(route),
     getPageInfoColumns: getPageInfoColumns(route),

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -360,14 +360,11 @@ const supplierRequisitionInitialiser = requisition => {
   const route = program ? ROUTES.SUPPLIER_REQUISITION_WITH_PROGRAM : ROUTES.SUPPLIER_REQUISITION;
 
   const sortedData = backingData.sorted('item.name').slice();
-  const filteredData = usingPrograms
-    ? sortedData.filter(item => item.isLessThanThresholdMOS)
-    : sortedData;
 
   return {
     pageObject: requisition,
     backingData,
-    data: filteredData,
+    data: sortedData,
     keyExtractor: recordKeyExtractor,
     dataState: new Map(),
     searchTerm: '',
@@ -377,7 +374,7 @@ const supplierRequisitionInitialiser = requisition => {
     modalKey: '',
     hasSelection: false,
     modalValue: null,
-    showAll: !usingPrograms,
+    showAll: usingPrograms,
     route: ROUTES.SUPPLIER_REQUISITION,
     columns: getColumns(route),
     getPageInfoColumns: getPageInfoColumns(route),


### PR DESCRIPTION
Fixes #1042 

## Change summary

When opening a finalised program requisition, the toggle was set `Hide over stocked` as default, causing confusions when opening to see its items. Now it is `Show over stocked` as default, and anyway it can by toggle to hide/show as before (option remains enable).

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a new program requisition (the program should have over stock items, otherwise modify quantities performing a stocktake).
- [ ] Finalise the requisition
- [ ] Check that the option `Show over stocked items` is set as default and items are visible
- [ ] Press `Hide over stocked` and check toggle works.

Attention: Remember to add items that are over stocked, otherwise the toggle will not make any sense (all items will be shown either hide/show is pressed).
