### PR TITLE
#1681 Corrected nested object usage

### DIFF
--- a/src/utilities/finalisation.js
+++ b/src/utilities/finalisation.js
@@ -54,13 +54,13 @@ export function checkForSupplierInvoiceError(transaction) {
  * @return  {string}               Null if safe to finalise, else an error message.
  */
 export function checkForSupplierRequisitionError(requisition) {
-  const { numberOfOrderedItems, totalRequiredQuantity, program = {}, orderType } = requisition;
+  const { numberOfOrderedItems, totalRequiredQuantity, program, orderType } = requisition;
 
   if (!numberOfOrderedItems) return modalStrings.add_at_least_one_item_before_finalising;
   if (!totalRequiredQuantity) return modalStrings.record_stock_required_before_finalising;
 
   const thisStoresTags = UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_TAGS);
-  const maxLinesForOrder = program.getMaxLines?.(orderType, thisStoresTags);
+  const maxLinesForOrder = program?.getMaxLines?.(orderType, thisStoresTags);
 
   if (numberOfOrderedItems > maxLinesForOrder) {
     return `${modalStrings.emergency_orders_can_only_have} ${maxLinesForOrder} ${modalStrings.items_remove_some}`;


### PR DESCRIPTION
Fixes #1681 

## Change summary

- Forgot realm objects which aren't defined are null, not undefined. Default destructuring only occurs when something is undefined

## Testing

- [ ] Can finalise a non-program supplier requisition without the app crashing

### Related areas to think about

N/A
