### PR TITLE
#1662 Prescriptions Wizard

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -12,7 +12,7 @@ const persistConfig = {
   keyPrefix: '',
   key: 'root',
   storage: AsyncStorage,
-  blacklist: ['nav', 'pages', 'user', 'dispensary'],
+  blacklist: ['nav', 'pages', 'user', 'prescription'],
 };
 
 const persistedReducer = persistReducer(persistConfig, reducers);

--- a/src/Store.js
+++ b/src/Store.js
@@ -12,7 +12,7 @@ const persistConfig = {
   keyPrefix: '',
   key: 'root',
   storage: AsyncStorage,
-  blacklist: ['nav', 'pages', 'user'],
+  blacklist: ['nav', 'pages', 'user', 'dispensary'],
 };
 
 const persistedReducer = persistReducer(persistConfig, reducers);

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -49,7 +49,12 @@ export const gotoPrescribers = () =>
  * @param {Object} patient     The other party of the invoice (Customer)
  * @param {Object} currentUser    The currently logged in user.
  */
-export const createPrescription = (patient, currentUser) => dispatch => {
+export const createPrescription = patientID => (dispatch, getState) => {
+  const { user } = getState();
+  const { currentUser } = user;
+
+  const patient = UIDatabase.get('Name', patientID);
+
   let newPrescription;
   UIDatabase.write(() => {
     newPrescription = createRecord(
@@ -70,6 +75,7 @@ export const gotoPrescription = prescription =>
     params: {
       title: `Prescription ${prescription.serialNumber}`,
       transaction: prescription,
+      patient: prescription.otherParty,
       pageObject: prescription,
     },
   });

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -12,7 +12,8 @@ import { ToggleBar, DataTablePageView, SearchBar, PageButton } from '../widgets'
 import { DataTable, DataTableRow, DataTableHeaderRow } from '../widgets/DataTable';
 
 import globalStyles from '../globalStyles';
-import { PageActions, DATA_SET, getPageDispatchers, getItemLayout } from './dataTableUtilities';
+import { PageActions, DATA_SET, getItemLayout } from './dataTableUtilities';
+import { createPrescription } from '../navigation/actions';
 import { ROUTES } from '../navigation/constants';
 
 const Dispensing = ({
@@ -26,11 +27,12 @@ const Dispensing = ({
   onSortColumn,
   searchTerm,
   onFilterData,
+  gotoPrescription,
 }) => {
   const getCellCallbacks = colKey => {
     switch (colKey) {
       case 'dispense':
-        return () => console.log('dispense');
+        return gotoPrescription;
       default:
         return null;
     }
@@ -108,9 +110,13 @@ const mapStateToProps = state => {
   return dispensing;
 };
 
-export const DispensingPage = connect(mapStateToProps, (dispatch, ownProps) => ({
-  ...getPageDispatchers(dispatch, ownProps, 'Name', 'dispensing'),
-}))(Dispensing);
+const mapDispatchToProps = dispatch => {
+  const gotoPrescription = patientID => dispatch(createPrescription(patientID));
+
+  return { gotoPrescription };
+};
+
+export const DispensingPage = connect(mapStateToProps, mapDispatchToProps)(Dispensing);
 
 Dispensing.propTypes = {
   data: PropTypes.array.isRequired,
@@ -123,4 +129,5 @@ Dispensing.propTypes = {
   onSortColumn: PropTypes.func.isRequired,
   searchTerm: PropTypes.string.isRequired,
   onFilterData: PropTypes.func.isRequired,
+  gotoPrescription: PropTypes.func.isRequired,
 };

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -72,12 +72,12 @@ const Dispensing = ({
     () => [
       {
         text: 'Patients',
-        onPress: () => dispatch(PageActions.toggleDataSet(DATA_SET.PATIENTS, 'dispensing')),
+        onPress: () => dispatch(PageActions.toggleDataSet(DATA_SET.PATIENTS, ROUTES.DISPENSARY)),
         isOn: dataSet === DATA_SET.PATIENTS,
       },
       {
         text: 'Prescribers',
-        onPress: () => dispatch(PageActions.toggleDataSet(DATA_SET.PRESCRIBERS, 'dispensing')),
+        onPress: () => dispatch(PageActions.toggleDataSet(DATA_SET.PRESCRIBERS, ROUTES.DISPENSARY)),
         isOn: dataSet === DATA_SET.PRESCRIBERS,
       },
     ],
@@ -105,9 +105,9 @@ const Dispensing = ({
 
 const mapStateToProps = state => {
   const { pages } = state;
-  const { dispensing } = pages;
+  const { dispensary } = pages;
 
-  return dispensing;
+  return dispensary;
 };
 
 const mapDispatchToProps = (dispatch, ownProps) => {

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -12,7 +12,7 @@ import { ToggleBar, DataTablePageView, SearchBar, PageButton } from '../widgets'
 import { DataTable, DataTableRow, DataTableHeaderRow } from '../widgets/DataTable';
 
 import globalStyles from '../globalStyles';
-import { PageActions, DATA_SET, getItemLayout } from './dataTableUtilities';
+import { PageActions, DATA_SET, getItemLayout, getPageDispatchers } from './dataTableUtilities';
 import { createPrescription } from '../navigation/actions';
 import { ROUTES } from '../navigation/constants';
 
@@ -110,10 +110,13 @@ const mapStateToProps = state => {
   return dispensing;
 };
 
-const mapDispatchToProps = dispatch => {
+const mapDispatchToProps = (dispatch, ownProps) => {
   const gotoPrescription = patientID => dispatch(createPrescription(patientID));
 
-  return { gotoPrescription };
+  return {
+    ...getPageDispatchers(dispatch, ownProps, 'Transaction', ROUTES.DISPENSARY),
+    gotoPrescription,
+  };
 };
 
 export const DispensingPage = connect(mapStateToProps, mapDispatchToProps)(Dispensing);

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -72,12 +72,12 @@ const Dispensing = ({
     () => [
       {
         text: 'Patients',
-        onPress: () => dispatch(PageActions.toggleDataSet(DATA_SET.PATIENTS, ROUTES.DISPENSARY)),
+        onPress: () => dispatch(PageActions.toggleDataSet(DATA_SET.PATIENTS, 'dispensing')),
         isOn: dataSet === DATA_SET.PATIENTS,
       },
       {
         text: 'Prescribers',
-        onPress: () => dispatch(PageActions.toggleDataSet(DATA_SET.PRESCRIBERS, ROUTES.DISPENSARY)),
+        onPress: () => dispatch(PageActions.toggleDataSet(DATA_SET.PRESCRIBERS, 'dispensing')),
         isOn: dataSet === DATA_SET.PRESCRIBERS,
       },
     ],

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -17,7 +17,7 @@ import { FavouriteStarIcon, TableShortcut, TableShortcuts, Wizard, SimpleTable }
 import { UIDatabase } from '../database';
 import { getColumns, getPageDispatchers } from './dataTableUtilities';
 
-import { selectPrescriber } from '../reducers/DispensaryReducer';
+import { selectPrescriber } from '../reducers/PrescriptionReducer';
 
 const mapStateToProps = state => {
   const { dispensary } = state;

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -25,6 +25,11 @@ import { getColumns } from './dataTableUtilities';
 
 import { selectItem, selectPrescriber, switchTab } from '../reducers/PrescriptionReducer';
 
+/**
+ * File contains Four components for the PrescriptionPage. The container component Prescription and
+ * three "Tab" components PrescriberSelect/ItemSelect/Summary.
+ */
+
 const ALPHABET = [...'abcdefghijklmnopqrstuvwxyz'];
 
 const mapDispatchToProps = dispatch => {
@@ -36,16 +41,18 @@ const mapDispatchToProps = dispatch => {
 
 const mapStateToProps = state => {
   const { dispensary } = state;
-
   return dispensary;
 };
 
-const getPrescriberIndex = char => {
-  const foundIndex = UIDatabase.objects('Prescriber').findIndex(
-    item => item.firstName[0].toLowerCase() === char
-  );
-  return foundIndex;
-};
+// Helper method finding the first instance of a Prescriber whos first name starts with
+// the passed character.
+const getPrescriberIndex = char =>
+  UIDatabase.objects('Prescriber').findIndex(item => item.firstName[0].toLowerCase() === char);
+
+// Helper method finding the first instance of an Item whos first name starts with
+// the passed character.
+const getItemIndex = char =>
+  UIDatabase.objects('Item').findIndex(item => item.name[0].toLowerCase() === char);
 
 const PrescriberSelect = connect(
   null,
@@ -94,9 +101,6 @@ const PrescriberSelect = connect(
     </View>
   );
 });
-
-const getItemIndex = char =>
-  UIDatabase.objects('Item').findIndex(item => item.name[0].toLowerCase() === char);
 
 const ItemSelect = connect(
   mapStateToProps,

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -22,15 +22,13 @@ import {
 
 import { UIDatabase } from '../database';
 import { getColumns } from './dataTableUtilities';
-
+import { ALPHABET } from '../widgets/constants';
 import { selectItem, selectPrescriber, switchTab } from '../reducers/PrescriptionReducer';
 
 /**
  * File contains Four components for the PrescriptionPage. The container component Prescription and
  * three "Tab" components PrescriberSelect/ItemSelect/Summary.
  */
-
-const ALPHABET = [...'abcdefghijklmnopqrstuvwxyz'];
 
 const mapDispatchToProps = dispatch => {
   const choosePrescriber = prescriberID => dispatch(selectPrescriber(prescriberID));

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -33,8 +33,8 @@ import { selectItem, selectPrescriber, switchTab } from '../reducers/Prescriptio
 const mapDispatchToProps = dispatch => {
   const choosePrescriber = prescriberID => dispatch(selectPrescriber(prescriberID));
   const chooseItem = itemID => dispatch(selectItem(itemID));
-  const changeTab = currentTab => dispatch(switchTab(currentTab + 1));
-  return { changeTab, choosePrescriber, chooseItem };
+  const nextTab = currentTab => dispatch(switchTab(currentTab + 1));
+  return { nextTab, choosePrescriber, chooseItem };
 };
 
 const mapStateToProps = state => {
@@ -103,7 +103,7 @@ const PrescriberSelect = connect(
 const ItemSelect = connect(
   mapStateToProps,
   mapDispatchToProps
-)(({ transaction, chooseItem, changeTab }) => {
+)(({ transaction, chooseItem, nextTab }) => {
   const { row, mediumFlex, largeFlex } = localStyles;
   const columns = getColumns('itemSelect');
 
@@ -152,7 +152,7 @@ const ItemSelect = connect(
           ))}
         </View>
       </View>
-      <PageButton text="NEXT" onPress={() => changeTab(1)} />
+      <PageButton text="NEXT" onPress={() => nextTab(1)} />
     </View>
   );
 });
@@ -170,8 +170,8 @@ const Summary = connect(mapStateToProps)(({ transaction }) => (
 const tabs = [PrescriberSelect, ItemSelect, Summary];
 const titles = ['Select the Prescriber', 'Select items', 'Summary'];
 
-export const Prescription = ({ currentTab, changeTab }) => (
-  <Wizard tabs={tabs} titles={titles} currentTabIndex={currentTab} onPress={changeTab} />
+export const Prescription = ({ currentTab, nextTab }) => (
+  <Wizard tabs={tabs} titles={titles} currentTabIndex={currentTab} onPress={nextTab} />
 );
 
 const localStyles = {
@@ -186,5 +186,5 @@ export const PrescriptionPage = connect(mapStateToProps, mapDispatchToProps)(Pre
 
 Prescription.propTypes = {
   currentTab: PropTypes.number.isRequired,
-  changeTab: PropTypes.func.isRequired,
+  nextTab: PropTypes.func.isRequired,
 };

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -40,8 +40,8 @@ const mapDispatchToProps = dispatch => {
 };
 
 const mapStateToProps = state => {
-  const { dispensary } = state;
-  return dispensary;
+  const { prescription } = state;
+  return prescription;
 };
 
 // Helper method finding the first instance of a Prescriber whos first name starts with
@@ -105,7 +105,7 @@ const PrescriberSelect = connect(
 const ItemSelect = connect(
   mapStateToProps,
   mapDispatchToProps
-)(({ prescription, chooseItem, changeTab }) => {
+)(({ transaction, chooseItem, changeTab }) => {
   const { row, mediumFlex, largeFlex } = localStyles;
   const columns = getColumns('itemSelect');
 
@@ -147,7 +147,7 @@ const ItemSelect = connect(
       </View>
       <View style={largeFlex}>
         <View>
-          {prescription.items.map(item => (
+          {transaction.items.map(item => (
             <View>
               <Text>{item.itemName}</Text>
             </View>
@@ -159,9 +159,9 @@ const ItemSelect = connect(
   );
 });
 
-const Summary = connect(mapStateToProps)(({ prescription }) => (
+const Summary = connect(mapStateToProps)(({ transaction }) => (
   <View style={{ flex: 1 }}>
-    {prescription.items.map(item => (
+    {transaction.items.map(item => (
       <View>
         <Text>{item.itemName}</Text>
       </View>

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -160,7 +160,7 @@ const ItemSelect = connect(
 const Summary = connect(mapStateToProps)(({ transaction }) => (
   <View style={{ flex: 1 }}>
     {transaction.items.map(item => (
-      <View>
+      <View key={item.id}>
         <Text>{item.itemName}</Text>
       </View>
     ))}

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -30,6 +30,8 @@ const PAGE_COLUMN_WIDTHS = {
   stocktakeBatchEditModal: [1, 1, 1, 1, 1],
   stocktakeBatchEditModalWithReasons: [1, 1, 1, 1, 1, 1],
   regimenDataModal: [4, 1, 5],
+  prescriberSelect: [1, 1],
+  itemSelect: [1, 1],
 };
 
 const PAGE_COLUMNS = {
@@ -178,6 +180,8 @@ const PAGE_COLUMNS = {
     COLUMN_NAMES.EDITABLE_VALUE,
     COLUMN_NAMES.EDITABLE_COMMENT,
   ],
+  prescriberSelect: [COLUMN_NAMES.FIRST_NAME, COLUMN_NAMES.LAST_NAME],
+  itemSelect: [COLUMN_NAMES.CODE, COLUMN_NAMES.NAME],
 };
 
 const COLUMNS = () => ({

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -536,7 +536,7 @@ const pageInitialisers = {
   prescription: prescriptionInitialiser,
   prescribers: prescribersInitialiser,
   patients: patientsInitialiser,
-  dispensing: dispensingInitialiser,
+  dispensary: dispensingInitialiser,
 };
 
 /**

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -39,7 +39,7 @@ import { PrescribersPage } from './PrescribersPage';
 export { FirstUsePage } from './FirstUsePage';
 
 export const PAGES = {
-  [ROUTES.ROOT]: props => <PageContainer page={MenuPage} {...props} />,
+  [ROUTES.ROOT]: props => <PageContainer page={DispensingPage} {...props} />,
 
   [ROUTES.MENU]: props => <PageContainer page={MenuPage} {...props} />,
 
@@ -76,7 +76,7 @@ export const PAGES = {
   [ROUTES.STOCKTAKE_EDITOR_WITH_REASONS]: props => (
     <PageContainer page={StocktakeEditPage} {...props} />
   ),
-  dispensing: props => <PageContainer page={DispensingPage} {...props} />,
+  [ROUTES.DISPENSARY]: props => <PageContainer page={DispensingPage} {...props} />,
   [ROUTES.PRESCRIPTIONS]: props => <PageContainer page={PrescriptionsPage} {...props} />,
   [ROUTES.PRESCRIPTION]: props => <PageContainer page={PrescriptionPage} {...props} />,
 

--- a/src/reducers/DispensaryReducer.js
+++ b/src/reducers/DispensaryReducer.js
@@ -1,5 +1,5 @@
 import { ROUTES } from '../navigation/constants';
-import { UIDatabase } from '../database/index';
+import { UIDatabase } from '../database';
 
 /**
  * mSupply Mobile
@@ -14,9 +14,13 @@ const initialState = () => ({
   items: [],
 });
 
-export const switchTab = currentTab => ({
-  type: 'SWITCH_TAB',
-  payload: { currentTab },
+const ACTIONS = {
+  SWITCH_TAB: 'DISPENSARY/SWITCH_TAB',
+};
+
+export const switchTab = nextTab => ({
+  type: ACTIONS.SWITCH_TAB,
+  payload: { nextTab },
 });
 
 export const selectPrescriber = prescriberID => (dispatch, getState) => {
@@ -33,7 +37,7 @@ export const selectPrescriber = prescriberID => (dispatch, getState) => {
     })
   );
 
-  dispatch({ type: 'SWITCH_TAB', payload: { nextTab: currentTab + 1 } });
+  dispatch(switchTab(currentTab + 1));
 };
 
 export const DispensaryReducer = (state = initialState(), action) => {
@@ -49,7 +53,7 @@ export const DispensaryReducer = (state = initialState(), action) => {
       return { ...state, prescription: transaction };
     }
 
-    case 'SWITCH_TAB': {
+    case ACTIONS.SWITCH_TAB: {
       const { payload } = action;
       const { nextTab } = payload;
       return { ...state, currentTab: nextTab };

--- a/src/reducers/DispensaryReducer.js
+++ b/src/reducers/DispensaryReducer.js
@@ -1,0 +1,60 @@
+import { ROUTES } from '../navigation/constants';
+import { UIDatabase } from '../database/index';
+
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+const initialState = () => ({
+  currentTab: 0,
+  patient: null,
+  prescriber: null,
+  itemsById: {},
+  items: [],
+});
+
+export const switchTab = currentTab => ({
+  type: 'SWITCH_TAB',
+  payload: { currentTab },
+});
+
+export const selectPrescriber = prescriberID => (dispatch, getState) => {
+  const { dispensary } = getState();
+
+  const { prescription, currentTab } = dispensary;
+
+  const prescriber = UIDatabase.get('Prescriber', prescriberID);
+
+  UIDatabase.write(() =>
+    UIDatabase.update('Transaction', {
+      ...prescription,
+      prescriber,
+    })
+  );
+
+  dispatch({ type: 'SWITCH_TAB', payload: { nextTab: currentTab + 1 } });
+};
+
+export const DispensaryReducer = (state = initialState(), action) => {
+  const { type } = action;
+
+  switch (type) {
+    case 'Navigation/NAVIGATE': {
+      const { routeName, params } = action;
+
+      if (routeName !== ROUTES.PRESCRIPTION) return state;
+      const { transaction } = params;
+
+      return { ...state, prescription: transaction };
+    }
+
+    case 'SWITCH_TAB': {
+      const { payload } = action;
+      const { nextTab } = payload;
+      return { ...state, currentTab: nextTab };
+    }
+    default:
+      return state;
+  }
+};

--- a/src/reducers/PrescriptionReducer.js
+++ b/src/reducers/PrescriptionReducer.js
@@ -1,10 +1,10 @@
-import { ROUTES } from '../navigation/constants';
-import { UIDatabase } from '../database';
-
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
  */
+
+import { ROUTES } from '../navigation/constants';
+import { UIDatabase } from '../database';
 
 const initialState = () => ({
   currentTab: 0,
@@ -40,7 +40,7 @@ export const selectPrescriber = prescriberID => (dispatch, getState) => {
   dispatch(switchTab(currentTab + 1));
 };
 
-export const DispensaryReducer = (state = initialState(), action) => {
+export const PrescriptionReducer = (state = initialState(), action) => {
   const { type } = action;
 
   switch (type) {

--- a/src/reducers/PrescriptionReducer.js
+++ b/src/reducers/PrescriptionReducer.js
@@ -24,9 +24,7 @@ export const switchTab = nextTab => ({
 
 export const selectPrescriber = prescriberID => (dispatch, getState) => {
   const { prescription } = getState();
-
   const { transaction, currentTab } = prescription;
-
   const prescriber = UIDatabase.get('Prescriber', prescriberID);
 
   UIDatabase.write(() =>

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -4,7 +4,7 @@ import SyncReducer from './SyncReducer';
 import { PagesReducer } from './PagesReducer';
 import { ModulesReducer } from './ModulesReducer';
 import { UserReducer } from './UserReducer';
-import { DispensaryReducer } from './DispensaryReducer';
+import { PrescriptionReducer } from './PrescriptionReducer';
 
 export default combineReducers({
   user: UserReducer,
@@ -12,5 +12,5 @@ export default combineReducers({
   sync: SyncReducer,
   pages: PagesReducer,
   modules: ModulesReducer,
-  dispensary: DispensaryReducer,
+  dispensary: PrescriptionReducer,
 });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -12,5 +12,5 @@ export default combineReducers({
   sync: SyncReducer,
   pages: PagesReducer,
   modules: ModulesReducer,
-  dispensary: PrescriptionReducer,
+  prescription: PrescriptionReducer,
 });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -4,6 +4,7 @@ import SyncReducer from './SyncReducer';
 import { PagesReducer } from './PagesReducer';
 import { ModulesReducer } from './ModulesReducer';
 import { UserReducer } from './UserReducer';
+import { DispensaryReducer } from './DispensaryReducer';
 
 export default combineReducers({
   user: UserReducer,
@@ -11,4 +12,5 @@ export default combineReducers({
   sync: SyncReducer,
   pages: PagesReducer,
   modules: ModulesReducer,
+  dispensary: DispensaryReducer,
 });

--- a/src/widgets/DataTable/HeaderCell.js
+++ b/src/widgets/DataTable/HeaderCell.js
@@ -76,6 +76,9 @@ HeaderCell.defaultProps = {
   sortable: false,
   width: 0,
   isLastCell: false,
+  SortAscComponent: null,
+  SortDescComponent: null,
+  SortNeutralComponent: null,
 };
 
 HeaderCell.propTypes = {
@@ -85,9 +88,9 @@ HeaderCell.propTypes = {
   onPressAction: PropTypes.func,
   dispatch: PropTypes.func,
   sortDirection: PropTypes.oneOf(['ASC', 'DESC']),
-  SortAscComponent: PropTypes.node.isRequired,
-  SortDescComponent: PropTypes.node.isRequired,
-  SortNeutralComponent: PropTypes.node.isRequired,
+  SortAscComponent: PropTypes.node,
+  SortDescComponent: PropTypes.node,
+  SortNeutralComponent: PropTypes.node,
   containerStyle: PropTypes.object,
   textStyle: PropTypes.object,
   width: PropTypes.number,

--- a/src/widgets/DataTable/HeaderCell.js
+++ b/src/widgets/DataTable/HeaderCell.js
@@ -79,12 +79,13 @@ HeaderCell.defaultProps = {
   SortAscComponent: null,
   SortDescComponent: null,
   SortNeutralComponent: null,
+  columnKey: '',
 };
 
 HeaderCell.propTypes = {
   ...TouchableOpacityPropTypes,
   title: PropTypes.string.isRequired,
-  columnKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  columnKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onPressAction: PropTypes.func,
   dispatch: PropTypes.func,
   sortDirection: PropTypes.oneOf(['ASC', 'DESC']),

--- a/src/widgets/SimpleTable.js
+++ b/src/widgets/SimpleTable.js
@@ -5,7 +5,7 @@ import { View, FlatList, TouchableOpacity } from 'react-native';
 import Cell from './DataTable/Cell';
 import { dataTableStyles } from '../globalStyles/index';
 import { HeaderCell, HeaderRow } from './DataTable/index';
-import { getItemLayout } from '../pages/dataTableUtilities';
+import { getItemLayout, recordKeyExtractor } from '../pages/dataTableUtilities';
 
 /**
  * Simple table component for rendering a large list of un-changing data.
@@ -75,6 +75,7 @@ export const SimpleTable = React.memo(
       () =>
         columns.map(({ title, width, alignText }, index) => (
           <HeaderCell
+            key={title}
             title={title}
             containerStyle={headerCells[alignText]}
             textStyle={cellText[alignText]}
@@ -94,6 +95,7 @@ export const SimpleTable = React.memo(
       <FlatList
         ref={ref}
         data={data}
+        keyExtractor={recordKeyExtractor}
         getItemLayout={getItemLayout}
         renderItem={renderRow}
         stickyHeaderIndices={[0]}
@@ -104,11 +106,15 @@ export const SimpleTable = React.memo(
   })
 );
 
+SimpleTable.defaultProps = {
+  extraData: {},
+};
+
 SimpleTable.propTypes = {
-  data: PropTypes.array.isRequired,
+  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
   columns: PropTypes.array.isRequired,
   selectRow: PropTypes.func.isRequired,
-  extraData: PropTypes.object.isRequired,
+  extraData: PropTypes.object,
 };
 
 const SimpleRow = React.memo(({ rowData, style, rowKey, renderCells, onPress }) => {

--- a/src/widgets/SimpleTable.js
+++ b/src/widgets/SimpleTable.js
@@ -5,6 +5,7 @@ import { View, FlatList, TouchableOpacity } from 'react-native';
 import Cell from './DataTable/Cell';
 import { dataTableStyles } from '../globalStyles/index';
 import { HeaderCell, HeaderRow } from './DataTable/index';
+import { getItemLayout } from '../pages/dataTableUtilities';
 
 /**
  * Simple table component for rendering a large list of un-changing data.
@@ -93,14 +94,7 @@ export const SimpleTable = React.memo(
       <FlatList
         ref={ref}
         data={data}
-        getItemLayout={(_, index) => {
-          const { height } = dataTableStyles.row;
-          return {
-            length: height,
-            offset: height * index,
-            index,
-          };
-        }}
+        getItemLayout={getItemLayout}
         renderItem={renderRow}
         stickyHeaderIndices={[0]}
         ListHeaderComponent={renderHeaders}

--- a/src/widgets/SimpleTable.js
+++ b/src/widgets/SimpleTable.js
@@ -12,7 +12,7 @@ import { getItemLayout, recordKeyExtractor } from '../pages/dataTableUtilities';
  * Only offers a selection feature.
  *
  * Usage:
- * Pass an array - data: [ { id, .. }, { id, .. }, .. ]
+ * Pass an array - data: [ { id, .. }, { id, .. }, .. ] (Also accepts a Realm Results array)
  * Also an array - columns: [ { key, alignText, title } ] (example: getColumns.js)
  * Such that each column.key is a field within an object in the data array.
  *

--- a/src/widgets/SimpleTable.js
+++ b/src/widgets/SimpleTable.js
@@ -51,7 +51,7 @@ export const SimpleTable = React.memo(
     const renderRow = useCallback(
       ({ item, index }) => {
         const { id } = item;
-        const isSelected = extraData[id];
+        const isSelected = extraData?.[id];
         const rowStyle = isSelected
           ? selectedRowStyle
           : (index % 2 === 0 && alternateRowStyle) || basicRowStyle;

--- a/src/widgets/SimpleTable.js
+++ b/src/widgets/SimpleTable.js
@@ -20,84 +20,95 @@ import { HeaderCell, HeaderRow } from './DataTable/index';
  * extraData, an object with the shape: {rowId1: [bool], rowId2: [bool], ... } used
  * to trigger styling effects on selected rows.
  */
-export const SimpleTable = React.memo(({ data, columns, selectRow, extraData }) => {
-  const {
-    cellText,
-    cellContainer,
-    selectedRow: selectedRowStyle,
-    alternateRow: alternateRowStyle,
-    row: basicRowStyle,
-    headerRow,
-    headerCells,
-  } = dataTableStyles;
+export const SimpleTable = React.memo(
+  React.forwardRef(({ data, columns, selectRow, extraData }, ref) => {
+    const {
+      cellText,
+      cellContainer,
+      selectedRow: selectedRowStyle,
+      alternateRow: alternateRowStyle,
+      row: basicRowStyle,
+      headerRow,
+      headerCells,
+    } = dataTableStyles;
 
-  const renderCells = useCallback(rowData => {
-    const { id } = rowData;
+    const renderCells = useCallback(rowData => {
+      const { id } = rowData;
 
-    return columns.map(({ key, width, alignText }, index) => (
-      <Cell
-        value={rowData[key]}
-        viewStyle={cellContainer[alignText]}
-        textStyle={cellText[alignText]}
-        isLastCell={index === columns.length - 1}
-        width={width}
-        key={`${id}${key}`}
-      />
-    ));
-  }, []);
-
-  const renderRow = useCallback(
-    ({ item, index }) => {
-      const { id } = item;
-      const isSelected = extraData[id];
-      const rowStyle = isSelected
-        ? selectedRowStyle
-        : (index % 2 === 0 && alternateRowStyle) || basicRowStyle;
-
-      return (
-        <SimpleRow
-          rowData={item}
-          rowIndex={index}
-          rowKey={id}
-          style={rowStyle}
-          renderCells={renderCells}
-          onPress={selectRow}
-          isSelected={isSelected}
-        />
-      );
-    },
-    [extraData]
-  );
-
-  const renderHeaderCells = useCallback(
-    () =>
-      columns.map(({ title, width, alignText }, index) => (
-        <HeaderCell
-          title={title}
-          containerStyle={headerCells[alignText]}
+      return columns.map(({ key, width, alignText }, index) => (
+        <Cell
+          value={rowData[key]}
+          viewStyle={cellContainer[alignText]}
           textStyle={cellText[alignText]}
           isLastCell={index === columns.length - 1}
           width={width}
+          key={`${id}${key}`}
         />
-      )),
-    [columns]
-  );
+      ));
+    }, []);
 
-  const renderHeaders = useCallback(
-    () => <HeaderRow style={headerRow} columns={columns} renderCells={renderHeaderCells} />,
-    [columns]
-  );
+    const renderRow = useCallback(
+      ({ item, index }) => {
+        const { id } = item;
+        const isSelected = extraData[id];
+        const rowStyle = isSelected
+          ? selectedRowStyle
+          : (index % 2 === 0 && alternateRowStyle) || basicRowStyle;
 
-  return (
-    <FlatList
-      data={data}
-      renderItem={renderRow}
-      stickyHeaderIndices={[0]}
-      ListHeaderComponent={renderHeaders}
-      extraData={extraData}
-    />
-  );
-});
+        return (
+          <SimpleRow
+            rowData={item}
+            rowIndex={index}
+            rowKey={id}
+            style={rowStyle}
+            renderCells={renderCells}
+            onPress={selectRow}
+            isSelected={isSelected}
+          />
+        );
+      },
+      [extraData]
+    );
+
+    const renderHeaderCells = useCallback(
+      () =>
+        columns.map(({ title, width, alignText }, index) => (
+          <HeaderCell
+            title={title}
+            containerStyle={headerCells[alignText]}
+            textStyle={cellText[alignText]}
+            isLastCell={index === columns.length - 1}
+            width={width}
+          />
+        )),
+      [columns]
+    );
+
+    const renderHeaders = useCallback(
+      () => <HeaderRow style={headerRow} columns={columns} renderCells={renderHeaderCells} />,
+      [columns]
+    );
+
+    return (
+      <FlatList
+        ref={ref}
+        data={data}
+        getItemLayout={(_, index) => {
+          const { height } = dataTableStyles.row;
+          return {
+            length: height,
+            offset: height * index,
+            index,
+          };
+        }}
+        renderItem={renderRow}
+        stickyHeaderIndices={[0]}
+        ListHeaderComponent={renderHeaders}
+        extraData={extraData}
+      />
+    );
+  })
+);
 
 SimpleTable.propTypes = {
   data: PropTypes.array.isRequired,

--- a/src/widgets/Stepper.js
+++ b/src/widgets/Stepper.js
@@ -66,7 +66,7 @@ const StepperNumber = ({ step, numberOfSteps, currentStep, title, onPress }) => 
         {title}
       </Text>
 
-      {lastStep && <View style={stepSeperator} />}
+      {!lastStep && <View style={stepSeperator} />}
     </Container>
   );
 };

--- a/src/widgets/TableShortcuts.js
+++ b/src/widgets/TableShortcuts.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 
-import { APP_FONT_FAMILY, APP_GENERAL_FONT_SIZE, SHADOW_BORDER } from '../globalStyles';
+import { APP_FONT_FAMILY, APP_GENERAL_FONT_SIZE } from '../globalStyles';
 
 export const TableShortcut = ({
   children,
@@ -13,8 +13,13 @@ export const TableShortcut = ({
   containerStyle,
   innerContainerStyle,
   textStyle,
+  extraLarge,
 }) => {
   const Container = onPress ? TouchableOpacity : View;
+
+  const internalStyle = extraLarge
+    ? { ...containerStyle, flex: containerStyle.flex * 2 }
+    : containerStyle;
 
   const wrappedOnPress = React.useCallback(() => onPress(shortcutKey), []);
   const renderChildren = React.useCallback(
@@ -23,8 +28,8 @@ export const TableShortcut = ({
   );
 
   return (
-    <View onPress={wrappedOnPress} style={containerStyle}>
-      <Container style={innerContainerStyle}>
+    <View style={internalStyle}>
+      <Container onPress={wrappedOnPress} style={innerContainerStyle}>
         {React.Children.map(children, renderChildren)}
       </Container>
     </View>
@@ -40,8 +45,6 @@ const localStyles = StyleSheet.create({
   container: {},
   shortcutContainer: {
     flex: 1,
-    borderBottomColor: SHADOW_BORDER,
-    borderBottomWidth: 1,
   },
   innerShortcutContainer: {
     flex: 1,
@@ -55,8 +58,6 @@ const localStyles = StyleSheet.create({
   shortcutsContainer: {
     flex: 1,
     flexDirection: 'column',
-    borderWidth: 1,
-    borderColor: SHADOW_BORDER,
   },
 });
 
@@ -65,6 +66,7 @@ TableShortcut.defaultProps = {
   shortcutKey: '',
   innerContainerStyle: localStyles.innerShortcutContainer,
   textStyle: localStyles.shortcutText,
+  extraLarge: false,
   containerStyle: localStyles.shortcutContainer,
 };
 
@@ -75,6 +77,7 @@ TableShortcut.propTypes = {
   containerStyle: PropTypes.object,
   innerContainerStyle: PropTypes.object,
   textStyle: PropTypes.object,
+  extraLarge: PropTypes.bool,
 };
 
 TableShortcuts.propTypes = {

--- a/src/widgets/constants.js
+++ b/src/widgets/constants.js
@@ -1,0 +1,10 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2016
+ */
+
+/**
+ * Constants used for various widgets.
+ */
+
+export const ALPHABET = [...'abcdefghijklmnopqrstuvwxyz'];

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -84,3 +84,5 @@ export const HistoryIcon = React.memo(() => <FA5Icon name="history" />);
 export const ChevronRightIcon = () => (
   <FA5Icon name="chevron-right" color={SUSSOL_ORANGE} size={20} />
 );
+
+export const FavouriteStarIcon = () => <FAIcon name="star-o" color={SUSSOL_ORANGE} size={20} />;

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -28,6 +28,7 @@ export { Stepper } from './Stepper';
 export { Slider } from './Slider';
 export { SyncState } from './SyncState';
 export { TabNavigator } from './TabNavigator';
+export { TableShortcut } from './TableShortcuts';
 export { TableShortcuts } from './TableShortcuts';
 export { TextEditor } from './TextEditor';
 export { TextInput } from './TextInput';


### PR DESCRIPTION
### BRANCHED FROM #1630

Fixes #1662 

## Change summary

- Adds the basic structure for the prescriptions Wizard for to enable more focused iterations
- Adds a `PrescriptionReducer`  - Not sure on this. I think having a reducer and state for this flow is good and there will many more actions/reducer cases/state to hold when there is full functionality, but not sure if it should be split up more. For example, a `TabsReducer` which handles the state of the tabs, which would be re-used elsewhere. Also an `ItemsReducer` which handles interactions with the items. a `PaymentsReducer` which handles payments. Seems over the top right now, but possibly this would be the way to go.
- Couple other minor offroad adventures: added a star icon, added forwarding of a ref to `SimpleTable` to control the scrolling, changed a few propTypes in order to handle new use cases

![prescriptionwizard1](https://user-images.githubusercontent.com/35858975/70857346-65dcc280-1f51-11ea-8832-3c1590b970a1.gif)

- Also not sure what to do with the many-components-makeup of the page. Maybe `WizardTabs` folder is a good idea but not sure

## Testing

N/A

### Related areas to think about

I prefer to have smaller issues, so trying to get this main structure part done and in and iterate on that with more focused code changes. Next steps would be:

- Add quantity increment/decrement feature changes
- Add finalise logic
- Add abbreviation/direction feature
- Add payment features
- "Favourites" feature
- Tidy up UI [broken up further]
- Performance enhancements