### PR TITLE
#1696 Non-updating styles on MenuPage

### DIFF
--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -167,7 +167,7 @@ const Menu = ({
         </View>
       </View>
     ),
-    []
+    [usingModules]
   );
 
   const OriginalLayout = useCallback(
@@ -178,7 +178,7 @@ const Menu = ({
         <StockSection />
       </View>
     ),
-    []
+    [usingModules]
   );
 
   return (


### PR DESCRIPTION
Fixes #1696 

## Change summary

Incorrectly never-update-memoizing components!

## Testing

This relates to the following flow: Go to your store and add to custom data `usesDispensaryModule: true`. Sync on mobile. Your MenuPage should then look like this:
<img width="1369" alt="image" src="https://user-images.githubusercontent.com/35858975/70884374-bc71fb80-203a-11ea-9f5f-d3c780304dd3.png">

- [ ] MenuPage looks like this ^^^^

### Related areas to think about

N/A