### PR TITLE
#1697 Corrected flexing of SearchBar

### DIFF
--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -89,7 +89,11 @@ const Dispensing = ({
     <DataTablePageView>
       <View style={pageTopSectionContainer}>
         <ToggleBar toggles={toggles} />
-        <SearchBar onChangeText={onFilterData} value={searchTerm} />
+        <SearchBar
+          onChangeText={onFilterData}
+          value={searchTerm}
+          viewStyle={localStyles.searchBar}
+        />
         <PageButton text="New Patient" onPress={() => console.log('New Patient')} />
       </View>
       <DataTable
@@ -101,6 +105,17 @@ const Dispensing = ({
       />
     </DataTablePageView>
   );
+};
+
+const localStyles = {
+  searchBar: {
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: 5,
+    flex: 1,
+    flexGrow: 1,
+  },
 };
 
 const mapStateToProps = state => {

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -167,7 +167,7 @@ const Menu = ({
         </View>
       </View>
     ),
-    []
+    [usingModules]
   );
 
   const OriginalLayout = useCallback(
@@ -178,7 +178,7 @@ const Menu = ({
         <StockSection />
       </View>
     ),
-    []
+    [usingModules]
   );
 
   return (

--- a/src/widgets/SearchBar.js
+++ b/src/widgets/SearchBar.js
@@ -118,8 +118,6 @@ const defaultStyles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     marginHorizontal: 5,
-    flex: 1,
-    flexGrow: 1,
   },
   textInput: {
     height: 40,


### PR DESCRIPTION
### BRANCHED FROM #1697 

Fixes #1697 

## Change summary

- `SearchBar` `TextInput` was flexing, so I made the container flexing to fit on the dispensary page, but this made every other page crazy. Oops

## Testing

N/A

### Related areas to think about

N/A
