### PR TITLE
#1540 Fix autocomplete selector should use hooks api

### DIFF
--- a/src/widgets/AutocompleteSelector.js
+++ b/src/widgets/AutocompleteSelector.js
@@ -4,7 +4,7 @@
  */
 
 // eslint-disable-next-line max-classes-per-file
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FlatList, StyleSheet, View } from 'react-native';
 import { complement } from 'set-manipulator';
@@ -77,6 +77,21 @@ export const AutocompleteSelector = props => {
     return [];
   };
 
+  const renderItem = useCallback(
+    item => (
+      <ResultRowWithOnePress
+        data={item}
+        onPress={onSelect}
+        renderLeftText={renderLeftText}
+        renderRightText={renderRightText}
+        showCheckIcon={false}
+      />
+    ),
+    [renderLeftText, renderRightText]
+  );
+
+  const keyExtractor = item => item.id || item.name;
+
   const data = getData();
 
   const ResultRowWithOnePress = withOnePress(ResultRow);
@@ -96,16 +111,8 @@ export const AutocompleteSelector = props => {
       {data.length > 0 && (
         <FlatList
           data={data}
-          keyExtractor={item => item.id || item.name}
-          renderItem={item => (
-            <ResultRowWithOnePress
-              data={item}
-              onPress={onSelect}
-              renderLeftText={renderLeftText}
-              renderRightText={renderRightText}
-              showCheckIcon={false}
-            />
-          )}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
           keyboardShouldPersistTaps="always"
           style={localStyles.resultList}
         />

--- a/src/widgets/AutocompleteSelector.js
+++ b/src/widgets/AutocompleteSelector.js
@@ -4,42 +4,37 @@
  */
 
 // eslint-disable-next-line max-classes-per-file
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { SearchBar } from 'react-native-ui-components';
-import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { FlatList, StyleSheet, View } from 'react-native';
 import { complement } from 'set-manipulator';
 import { APP_FONT_FAMILY } from '../globalStyles';
 import { generalStrings } from '../localization';
 import { withOnePress } from './withOnePress';
+import { ResultRow } from '.';
 
-/**
- * A search bar that autocompletes from the options passed in, and allows any of
- * the dropdown options to be selected. Will gracefully handle null values
- * by using an empty array of searchable objects.
- * @prop  {array}     options         The options to select from
- * @prop  {function}  onSelect        A function taking the selected option as a parameter
- * @prop  {string}    queryString     The query to filter the options by, where $0 will
- *                                    be replaced by the user's current search
- *                                    e.g. 'name BEGINSWITH[c] $0 OR code BEGINSWITH[c] $0'
- * @prop  {string}    placeholderText The text to initially display in the search bar
- */
-export class AutocompleteSelector extends React.PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      queryText: '',
-    };
-  }
+export const AutocompleteSelector = props => {
+  const {
+    sortKeyString,
+    queryString,
+    queryStringSecondary,
+    primaryFilterProperty,
+    secondaryFilterProperty,
+    options,
+    onSelect,
+    placeholderText,
+    renderLeftText,
+    renderRightText,
+  } = props;
+
+  const [queryText, setQueryText] = useState('');
 
   /**
    * Filters a realm results object. Creates two realm results A, B
    * by two query strings. And concats A to B - A.
    */
-  filterResultData = options => {
-    const { sortKeyString, queryString, queryStringSecondary } = this.props;
-    const { queryText } = this.state;
-
+  const filterResultData = () => {
     let data = options
       .filtered(queryString, queryText)
       .sorted(sortKeyString)
@@ -59,10 +54,7 @@ export class AutocompleteSelector extends React.PureComponent {
    * Ignores case. Querying a realm result with filtered is more performant,
    * so have two cases for each.
    */
-  filterArrayData = options => {
-    const { primaryFilterProperty, secondaryFilterProperty } = this.props;
-    const { queryText } = this.state;
-
+  const filterArrayData = () => {
     const regexFilter = RegExp(queryText, 'i');
 
     return options.filter(
@@ -77,50 +69,48 @@ export class AutocompleteSelector extends React.PureComponent {
    * object (has the filtered member) or if it is an array. Otherwise,
    * return an empty list to display.
    */
-  getData = () => {
-    const { options, primaryFilterProperty, queryString } = this.props;
-    if (options && options.filtered && queryString) return this.filterResultData(options);
-    if (Array.isArray(options) && primaryFilterProperty) return this.filterArrayData(options);
+  const getData = () => {
+    if (options && options.filtered && queryString) return filterResultData(options);
+    if (Array.isArray(options) && primaryFilterProperty) return filterArrayData(options);
     return [];
   };
 
-  render() {
-    const { onSelect, placeholderText, renderLeftText, renderRightText } = this.props;
+  const data = getData();
 
-    const data = this.getData();
+  const ResultRowWithOnePress = withOnePress(ResultRow);
 
-    return (
-      <View style={localStyles.container}>
-        <SearchBar
-          autoCapitalize="none"
-          autoCorrect={false}
-          autoFocus
-          color="white"
-          onChange={text => this.setState({ queryText: text })}
-          placeholder={placeholderText}
-          placeholderTextColor="white"
-          style={[localStyles.text, localStyles.searchBar]}
+  return (
+    <View style={localStyles.container}>
+      <SearchBar
+        autoCapitalize="none"
+        autoCorrect={false}
+        autoFocus
+        color="white"
+        onChange={text => setQueryText(text)}
+        placeholder={placeholderText}
+        placeholderTextColor="white"
+        style={[localStyles.text, localStyles.searchBar]}
+      />
+      {data.length > 0 && (
+        <FlatList
+          data={data}
+          keyExtractor={item => item.id || item.name}
+          renderItem={item => (
+            <ResultRowWithOnePress
+              data={item}
+              onPress={onSelect}
+              renderLeftText={renderLeftText}
+              renderRightText={renderRightText}
+              showCheckIcon={false}
+            />
+          )}
+          keyboardShouldPersistTaps="always"
+          style={localStyles.resultList}
         />
-        {data.length > 0 && (
-          <FlatList
-            data={data}
-            keyExtractor={item => item.id || item.name}
-            renderItem={({ item }) => (
-              <ResultRowWithOnePress
-                item={item}
-                onPress={onSelect}
-                renderLeftText={renderLeftText}
-                renderRightText={renderRightText}
-              />
-            )}
-            keyboardShouldPersistTaps="always"
-            style={localStyles.resultList}
-          />
-        )}
-      </View>
-    );
-  }
-}
+      )}
+    </View>
+  );
+};
 
 export default AutocompleteSelector;
 
@@ -137,30 +127,10 @@ AutocompleteSelector.propTypes = {
   primaryFilterProperty: PropTypes.string,
   secondaryFilterProperty: PropTypes.string,
 };
+
 AutocompleteSelector.defaultProps = {
   placeholderText: generalStrings.start_typing_to_search,
 };
-
-// TODO: move ResultRow to dedicated file
-// eslint-disable-next-line react/no-multi-comp
-class ResultRow extends React.PureComponent {
-  render() {
-    // TODO: add ResultRow.propTypes
-    // eslint-disable-next-line react/prop-types
-    const { item, renderLeftText, renderRightText, onPress } = this.props;
-    return (
-      <TouchableOpacity style={localStyles.resultRow} onPress={() => onPress(item)}>
-        <Text style={[localStyles.text, localStyles.itemText]}>
-          {renderLeftText ? renderLeftText(item) : item.toString()}
-        </Text>
-        <Text style={[localStyles.text, localStyles.itemText]}>
-          {renderRightText ? renderRightText(item) : null}
-        </Text>
-      </TouchableOpacity>
-    );
-  }
-}
-const ResultRowWithOnePress = withOnePress(ResultRow);
 
 const localStyles = StyleSheet.create({
   container: {

--- a/src/widgets/AutocompleteSelector.js
+++ b/src/widgets/AutocompleteSelector.js
@@ -14,20 +14,18 @@ import { generalStrings } from '../localization';
 import { withOnePress } from './withOnePress';
 import { ResultRow } from '.';
 
-export const AutocompleteSelector = props => {
-  const {
-    sortKeyString,
-    queryString,
-    queryStringSecondary,
-    primaryFilterProperty,
-    secondaryFilterProperty,
-    options,
-    onSelect,
-    placeholderText,
-    renderLeftText,
-    renderRightText,
-  } = props;
-
+export const AutocompleteSelector = ({
+  sortKeyString,
+  queryString,
+  queryStringSecondary,
+  primaryFilterProperty,
+  secondaryFilterProperty,
+  options,
+  onSelect,
+  placeholderText,
+  renderLeftText,
+  renderRightText,
+}) => {
   const [queryText, setQueryText] = useState('');
 
   const onChangeText = () => setQueryText(queryText);

--- a/src/widgets/AutocompleteSelector.js
+++ b/src/widgets/AutocompleteSelector.js
@@ -8,13 +8,12 @@ import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FlatList, StyleSheet, View } from 'react-native';
 import { complement } from 'set-manipulator';
-import { SearchBar } from './SearchBar';
+import { SearchBar, ResultRow } from '.';
 import { APP_FONT_FAMILY, WHITE } from '../globalStyles';
 import { generalStrings } from '../localization';
 import { withOnePress } from './withOnePress';
-import { ResultRow } from '.';
 
-export const AutocompleteSelector = ({
+const AutocompleteSelector = ({
   sortKeyString,
   queryString,
   queryStringSecondary,

--- a/src/widgets/MultiSelectList.js
+++ b/src/widgets/MultiSelectList.js
@@ -15,7 +15,7 @@ import { WHITE } from '../globalStyles/colors';
 
 const keyExtractor = item => item.id || item.name;
 
-export const MultiSelectList = ({
+const MultiSelectList = ({
   options,
   sortByString,
   queryString,

--- a/src/widgets/MultiSelectList.js
+++ b/src/widgets/MultiSelectList.js
@@ -10,13 +10,12 @@ import PropTypes from 'prop-types';
 import { FlatList, StyleSheet, View } from 'react-native';
 import globalStyles, { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../globalStyles';
 import { generalStrings, buttonStrings } from '../localization';
-import { OnePressButton, SearchBar } from '.';
-import ResultRow from './ResultRow';
+import { ResultRow, OnePressButton, SearchBar } from '.';
 import { WHITE } from '../globalStyles/colors';
 
 const keyExtractor = item => item.id || item.name;
 
-const MultiSelectList = ({
+export const MultiSelectList = ({
   options,
   sortByString,
   queryString,
@@ -34,7 +33,7 @@ const MultiSelectList = ({
 
   const onDoneSelected = useCallback(() => onConfirmSelections(selected), [selected]);
   const onSelect = useCallback(
-    ({ item }) =>
+    item =>
       setSelected(prevState =>
         prevState.indexOf(item.id) === -1
           ? [...prevState, item.id]
@@ -112,7 +111,6 @@ const MultiSelectList = ({
 };
 
 export default MultiSelectList;
-export { MultiSelectList };
 
 MultiSelectList.propTypes = {
   options: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),

--- a/src/widgets/ResultRow.js
+++ b/src/widgets/ResultRow.js
@@ -9,9 +9,9 @@ import { Text, TouchableOpacity, StyleSheet } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
 import { APP_FONT_FAMILY, SUSSOL_ORANGE, BACKGROUND_COLOR, GREY } from '../globalStyles';
 
-const ResultRow = React.memo(
+export const ResultRow = React.memo(
   ({ data, renderLeftText, renderRightText, onPress, isSelected, showCheckIcon }) => {
-    const rowPressed = useCallback(() => onPress(data), [data]);
+    const rowPressed = useCallback(() => onPress(data.item), [data.item]);
 
     return (
       <TouchableOpacity

--- a/src/widgets/ResultRow.js
+++ b/src/widgets/ResultRow.js
@@ -18,11 +18,12 @@ const ResultRow = React.memo(
         style={[localStyles.resultRow, isSelected && localStyles.selected]}
         onPress={rowPressed}
       >
-        {showCheckIcon && isSelected ? (
-          <Icon name="md-checkbox" style={localStyles.checkIcon} />
-        ) : (
-          <Icon name="md-square-outline" style={[localStyles.checkIcon, { color: GREY }]} />
-        )}
+        {showCheckIcon &&
+          (isSelected ? (
+            <Icon name="md-checkbox" style={localStyles.checkIcon} />
+          ) : (
+            <Icon name="md-square-outline" style={[localStyles.checkIcon, { color: GREY }]} />
+          ))}
         <Text
           style={[
             localStyles.text,

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -4,11 +4,7 @@
  */
 
 export { Button, ProgressBar } from 'react-native-ui-components';
-// eslint-disable-next-line import/no-cycle
-export { AutocompleteSelector } from './AutocompleteSelector';
-export { ResultRow } from './ResultRow';
-// eslint-disable-next-line import/no-cycle
-export { MultiSelectList } from './MultiSelectList';
+
 export { FinaliseButton } from './FinaliseButton';
 export { GenericChoiceList } from './GenericChoiceList';
 export { IconCell } from './IconCell';
@@ -25,6 +21,7 @@ export { TextInput } from './TextInput';
 export { ToggleBar } from './ToggleBar';
 export { ToggleSelector } from './ToggleSelector';
 export { ExpiryDateInput } from './ExpiryDateInput';
+export { ResultRow } from './ResultRow';
 export { SearchBar } from './SearchBar';
 export { DataTablePageView } from './DataTablePageView';
 export { Flag } from './Flag';

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -4,8 +4,9 @@
  */
 
 export { Button, ProgressBar } from 'react-native-ui-components';
-
+// eslint-disable-next-line import/no-cycle
 export { AutocompleteSelector } from './AutocompleteSelector';
+export { ResultRow } from './ResultRow';
 // eslint-disable-next-line import/no-cycle
 export { MultiSelectList } from './MultiSelectList';
 export { FinaliseButton } from './FinaliseButton';
@@ -27,6 +28,7 @@ export { ExpiryDateInput } from './ExpiryDateInput';
 export { SearchBar } from './SearchBar';
 export { DataTablePageView } from './DataTablePageView';
 export { Flag } from './Flag';
+
 export {
   SortAscIcon,
   SortNeutralIcon,
@@ -42,6 +44,7 @@ export {
   ConfirmIcon,
   LockIcon,
 } from './icons';
+
 export {
   KiribatiFlag,
   EnglishFlag,
@@ -53,4 +56,5 @@ export {
   StockImage,
   ModulesImage,
 } from './images';
+
 export { InfoBadge } from './InfoBadge';

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -4,12 +4,13 @@ import PropTypes from 'prop-types';
 import { StyleSheet, View } from 'react-native';
 
 import { PageContentModal } from './PageContentModal';
-import { AutocompleteSelector, ToggleBar, PageButton, TextEditor, Step } from '..';
+import { ToggleBar, PageButton, TextEditor, Step } from '..';
 import globalStyles, { DARK_GREY, WARM_GREY, SUSSOL_ORANGE } from '../../globalStyles';
 import { SETTINGS_KEYS } from '../../settings';
 import { getAllPrograms, getAllPeriodsForProgram } from '../../utilities';
 import { programStrings, navStrings } from '../../localization';
 import { UIDatabase } from '../../database';
+import AutocompleteSelector from '../AutocompleteSelector';
 
 import {
   selectProgram,

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -13,7 +13,7 @@ import Settings from '../../settings/MobileAppSettings';
 import { getModalTitle, MODAL_KEYS } from '../../utilities/getModalTitle';
 
 import ModalContainer from './ModalContainer';
-import { AutocompleteSelector } from '../AutocompleteSelector';
+import { AutocompleteSelector } from '..';
 import { MultiSelectList } from '../MultiSelectList';
 import { TextEditor } from '../TextEditor';
 import { ByProgramModal } from './ByProgramModal';

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -13,8 +13,8 @@ import Settings from '../../settings/MobileAppSettings';
 import { getModalTitle, MODAL_KEYS } from '../../utilities/getModalTitle';
 
 import ModalContainer from './ModalContainer';
-import { AutocompleteSelector } from '..';
-import { MultiSelectList } from '../MultiSelectList';
+import AutocompleteSelector from '../AutocompleteSelector';
+import MultiSelectList from '../MultiSelectList';
 import { TextEditor } from '../TextEditor';
 import { ByProgramModal } from './ByProgramModal';
 import { ToggleSelector } from '../ToggleSelector';


### PR DESCRIPTION
Fixes #1540

## Change summary

- Refactor code 
  - Autocomplete selector should use hooks api
  - Move `ResultRow` component out of `AutocompleteSelector` component
  - User `ResultRow` already present in code, hence sharing the component among `AutocompleteSelector` and `MultiSelectList`.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Pages using `AutocompleteSelector` should work properly.
- [ ] Pages using `MultiSelectList` (Master-list selection) should work properly.
- [ ] Rest of the interface should be same. This is code refactor.

### Related areas to think about

None
