### PR TITLE
#1708 Report class added to Realm schema

### DIFF
--- a/src/database/DataTypes/Report.js
+++ b/src/database/DataTypes/Report.js
@@ -1,0 +1,7 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+import Realm from 'realm';
+
+export class Report extends Realm.Object {}

--- a/src/database/DataTypes/index.js
+++ b/src/database/DataTypes/index.js
@@ -8,7 +8,6 @@ import Realm from 'realm';
 export class Address extends Realm.Object {}
 export class ItemCategory extends Realm.Object {}
 export class ItemDepartment extends Realm.Object {}
-export class Report extends Realm.Object {}
 export class Setting extends Realm.Object {}
 export class SyncOut extends Realm.Object {}
 export class TransactionCategory extends Realm.Object {}
@@ -27,6 +26,7 @@ export { NumberToReuse } from './NumberToReuse';
 export { Options } from './Options';
 export { Period } from './Period';
 export { PeriodSchedule } from './PeriodSchedule';
+export { Report } from './Report';
 export { Requisition } from './Requisition';
 export { RequisitionItem } from './RequisitionItem';
 export { Stocktake } from './Stocktake';

--- a/src/database/DataTypes/index.js
+++ b/src/database/DataTypes/index.js
@@ -8,6 +8,7 @@ import Realm from 'realm';
 export class Address extends Realm.Object {}
 export class ItemCategory extends Realm.Object {}
 export class ItemDepartment extends Realm.Object {}
+export class Report extends Realm.Object {}
 export class Setting extends Realm.Object {}
 export class SyncOut extends Realm.Object {}
 export class TransactionCategory extends Realm.Object {}

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -18,6 +18,7 @@ import {
   NumberSequence,
   NumberToReuse,
   Options,
+  Report,
   Requisition,
   RequisitionItem,
   Setting,
@@ -65,6 +66,17 @@ ItemDepartment.schema = {
     id: 'string',
     name: { type: 'string', default: 'placeholderName' },
     parentDepartment: { type: 'ItemDepartment', optional: true },
+  },
+};
+
+Report.schema = {
+  name: 'Report',
+  primaryKey: 'id',
+  properties: {
+    id: 'string',
+    type: 'string',
+    title: 'string',
+    _data: 'string',
   },
 };
 
@@ -141,6 +153,7 @@ export const schema = {
     NumberSequence,
     NumberToReuse,
     Options,
+    Report,
     Requisition,
     RequisitionItem,
     Setting,


### PR DESCRIPTION
Fixes #1708

## Change summary

Report class was added to the realm schema with the structure suggested in #1708.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

No sure. Same as #1706 maybe?

### Related areas to think about

Less fields than suggested as first option here #441 were added to Report schema, so maybe later it needs to by checked and adjusted in consequence.