### PR TITLE
#1709 Add report class getters and setters

### DIFF
--- a/src/database/DataTypes/Report.js
+++ b/src/database/DataTypes/Report.js
@@ -2,6 +2,47 @@
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
  */
+
 import Realm from 'realm';
 
-export class Report extends Realm.Object {}
+/**
+ * A Report.
+ *
+ * @property  {string}            id
+ * @property  {string}            type
+ * @property  {string}            title
+ * @property  {string}            _data
+ */
+
+export class Report extends Realm.Object {
+  /**
+   * Get data.
+   *
+   * @return  {Object}
+   */
+  get data() {
+    return JSON.parse(this._data);
+  }
+
+  /**
+   * Set data.
+   *
+   * @param  {dataObject}  dataObject
+   */
+  set data(dataObject) {
+    this._data = JSON.stringify(dataObject);
+  }
+}
+
+Report.schema = {
+  name: 'Report',
+  primaryKey: 'id',
+  properties: {
+    id: 'string',
+    type: 'string',
+    title: 'string',
+    _data: 'string',
+  },
+};
+
+export default Report;

--- a/src/database/DataTypes/Report.js
+++ b/src/database/DataTypes/Report.js
@@ -5,6 +5,7 @@
 
 import Realm from 'realm';
 
+import checkIsObject from '../utilities';
 /**
  * A Report.
  *
@@ -30,7 +31,7 @@ export class Report extends Realm.Object {
    * @param  {dataObject}  dataObject
    */
   set data(dataObject) {
-    this._data = JSON.stringify(dataObject);
+    this._data = checkIsObject(dataObject) ? JSON.stringify(dataObject) : {};
   }
 }
 
@@ -46,3 +47,5 @@ Report.schema = {
 };
 
 export default Report;
+
+

--- a/src/database/DataTypes/Report.js
+++ b/src/database/DataTypes/Report.js
@@ -31,7 +31,7 @@ export class Report extends Realm.Object {
    * @param  {dataObject}  dataObject
    */
   set data(dataObject) {
-    this._data = checkIsObject(dataObject) ? JSON.stringify(dataObject) : {};
+    this._data = checkIsObject(dataObject) ? JSON.stringify(dataObject) : JSON.stringify({});
   }
 }
 

--- a/src/utilities/checkIsObject.js
+++ b/src/utilities/checkIsObject.js
@@ -1,0 +1,10 @@
+/**
+ * Check if the given parameter is an Object type {} and
+ * return a boolean.
+ *
+ * @param   {object}  object  The object to check.
+ *
+ */
+
+export const checkIsObject = object =>
+  object && typeof dataObject === 'object' && object.constructor === Object;

--- a/src/utilities/checkIsObject.js
+++ b/src/utilities/checkIsObject.js
@@ -7,4 +7,4 @@
  */
 
 export const checkIsObject = object =>
-  object && typeof dataObject === 'object' && object.constructor === Object;
+  !!(object && typeof object === 'object' && object.constructor === Object);

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -17,6 +17,7 @@ export { requestPermission } from './requestPermission';
 export { backupValidation } from './fileSystem';
 export { debounce } from './underscoreMethods';
 export { getModalTitle, MODAL_KEYS } from './getModalTitle';
+export { checkIsObject } from './checkIsObject';
 
 export {
   checkForCustomerInvoiceError,


### PR DESCRIPTION
Fixes #1709?

## Change summary

Getter and setter added to handle data in Report class. Mainly since the data field on the Report object will be a stringified JSON object, no will have getters/setters to help save these fields. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

Not sure (Same as #1706 maybe?)
- [ ] Run`yarn start` (or `react-native run-android`)
- [ ] Check BUILD SUCCESSFUL result.
- [ ] Again in the CLI, run `yarn build`
- [ ] Check BUILD SUCCESSFUL result again.
- [ ] Finally, the app should be running properly.

### Related areas to think about

Check #1709 for more details.
