### PR TITLE
#1710 Add Report to incoming sync utils

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -252,7 +252,7 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
       canBeBlank: ['units', 'comment', 'order_number'],
     },
     Report: {
-      cannotBeBlank: ['ID', 'title', 'type', '_data'],
+      cannotBeBlank: ['ID', 'title', 'type', 'data'],
       canBeBlank: [],
     },
   };
@@ -262,7 +262,7 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
       containsAllFieldsSoFar &&
       record[fieldName] !== null && // Key must exist.
       record[fieldName] !== undefined && // Field may be undefined.
-      record[fieldName].length > 0, // Fild must not be empty string.
+      record[fieldName].length > 0, // Field must not be empty string.
     true
   );
 

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -249,6 +249,10 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
       cannotBeBlank: [],
       canBeBlank: ['units', 'comment', 'order_number'],
     },
+    Report: {
+      cannotBeBlank: ['ID', 'title', 'type', '_data'],
+      canBeBlank: [],
+    },
   };
   if (!requiredFields[recordType]) return false; // Unsupported record type
   const hasAllNonBlankFields = requiredFields[recordType].cannotBeBlank.reduce(
@@ -256,7 +260,7 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
       containsAllFieldsSoFar &&
       record[fieldName] !== null && // Key must exist.
       record[fieldName] !== undefined && // Field may be undefined.
-      record[fieldName].length > 0, // Fidl must not be empty string.
+      record[fieldName].length > 0, // Fild must not be empty string.
     true
   );
 
@@ -491,6 +495,16 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       const numberToReuse = database.update(recordType, internalRecord);
       // Attach the number to reuse to the number sequence.
       numberSequence.addNumberToReuse(numberToReuse);
+      break;
+    }
+    case 'Report': {
+      internalRecord = {
+        id: record.ID,
+        title: record.title,
+        type: record.type,
+        _data: record.data,
+      };
+      database.update(recordType, internalRecord);
       break;
     }
     case 'Requisition': {


### PR DESCRIPTION
Fixes #1710

## Change summary

Report class was added to list of record types to check in `incomingSyncUtils`

## Testing

Not sure by now. Same as #1706 ?

### Related areas to think about

@joshxg @andreievg 
Should I use `checkIsObject()` here as well? In that case, it is not useful to have it in `Report.js`. Once might be enough (as far as I understand), please correct me if I am wrong. Thanks!
