### PR TITLE
#1740 Add PieChart component 

### DIFF
--- a/src/widgets/PieChart.js
+++ b/src/widgets/PieChart.js
@@ -1,9 +1,10 @@
+/* eslint-disable react/forbid-prop-types */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2018
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { VictoryLabel, VictoryPie } from 'victory-native';
@@ -18,47 +19,43 @@ import { APP_FONT_FAMILY, GREY } from '../globalStyles';
  *                               options are BarChart, LineChart and PieChart.
  * @prop  {data}         array   An array of {x, y} datapoints to plot.
  * @prop  {width}        number  The width of the parent container.
- * @prop  {height}       number  The height of the parent continer.
+ * @prop  {height}       number  The height of the parent container.
  */
 
-export const ReportChart = ({ report: initialReport }, props) => {
-  const [report, setReport] = useState(initialReport);
-  const [width, setWidth] = useState(null);
-  const [height, setHeight] = useState(null);
-
-  // Same affect as componentDidUpdate
-  useEffect(() => {
-    if (report.id !== props.report.id) setReport(props.report);
-  });
+export const PieChart = ({ title, type, data }) => {
+  const [state, setState] = useState({ height: null, width: null });
+  const { height, width } = state;
 
   // Victory Native sizes are set using absolute values. Parents dimensions are used to
   // calculate relative values for width and height for each chart.
+
   const onLayout = event => {
-    setWidth(event.nativeEvent.layout.width);
-    setHeight(event.nativeEvent.layout.height);
+    const newStateObj = {
+      height: event.nativeEvent.layout.width,
+      width: event.nativeEvent.layout.height,
+    };
+    setState(newStateObj);
+  };
+  const {
+    padVertical,
+    padHorizontal,
+    innerRadius,
+    labelRadius,
+    padAngle,
+    colorScale,
+    style,
+  } = victoryStyles.pieChart;
+
+  const padding = {
+    top: height * padVertical,
+    bottom: height * padVertical,
+    right: width * padHorizontal,
+    left: width * padHorizontal,
   };
 
-  const renderPieChart = () => {
-    const {
-      padVertical,
-      padHorizontal,
-      innerRadius,
-      labelRadius,
-      padAngle,
-      colorScale,
-      style,
-    } = victoryStyles.pieChart;
-
-    const padding = {
-      top: height * padVertical,
-      bottom: height * padVertical,
-      right: width * padHorizontal,
-      left: width * padHorizontal,
-    };
-
-    const widthPadded = width * (1 - padHorizontal);
-
-    return (
+  const widthPadded = state.width * (1 - padHorizontal);
+  return (
+    <View style={localStyles.ChartContainer} onLayout={onLayout}>
       <VictoryPie
         width={width}
         height={height}
@@ -68,29 +65,16 @@ export const ReportChart = ({ report: initialReport }, props) => {
         labelRadius={widthPadded * labelRadius}
         colorScale={colorScale}
         labelComponent={<VictoryLabel style={style} />}
-        data={report.data}
+        data={data}
       />
-    );
-  };
-
-  const renderVisualisation = () => {
-    if (report === null || !width || !height) return null;
-    switch (report.type) {
-      case 'PieChart':
-        return renderPieChart();
-      default:
-        return null;
-    }
-  };
-  return (
-    <View style={localStyles.ChartContainer} onLayout={onLayout}>
-      {renderVisualisation()}
     </View>
   );
 };
 
-ReportChart.propTypes = {
-  report: PropTypes.objectOf(PropTypes.object).isRequired,
+PieChart.propTypes = {
+  title: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  data: PropTypes.array.isRequired,
 };
 
 const localStyles = StyleSheet.create({

--- a/src/widgets/PieChart.js
+++ b/src/widgets/PieChart.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 /* eslint-disable react/forbid-prop-types */
 /**
  * mSupply Mobile
@@ -10,31 +11,18 @@ import PropTypes from 'prop-types';
 import { VictoryLabel, VictoryPie } from 'victory-native';
 import { APP_FONT_FAMILY, GREY } from '../globalStyles';
 
-/**
- * A charting widget for displaying Pie chart report.
- *
- * @prop  {string}       id      The report ID.
- * @prop  {string}       title   The title of the report.
- * @prop  {string}       type    The type of chart to use to display the report,
- *                               options are BarChart, LineChart and PieChart.
- * @prop  {data}         array   An array of {x, y} datapoints to plot.
- * @prop  {width}        number  The width of the parent container.
- * @prop  {height}       number  The height of the parent container.
- */
-
 export const PieChart = ({ title, type, data }) => {
-  const [state, setState] = useState({ height: null, width: null });
-  const { height, width } = state;
+  const [dimensions, setDimensions] = useState({ height: null, width: null });
+  const { height, width } = dimensions;
 
   // Victory Native sizes are set using absolute values. Parents dimensions are used to
   // calculate relative values for width and height for each chart.
-
   const onLayout = event => {
-    const newStateObj = {
+    const newDimensionsObj = {
       height: event.nativeEvent.layout.width,
       width: event.nativeEvent.layout.height,
     };
-    setState(newStateObj);
+    setDimensions(newDimensionsObj);
   };
   const {
     padVertical,
@@ -53,7 +41,7 @@ export const PieChart = ({ title, type, data }) => {
     left: width * padHorizontal,
   };
 
-  const widthPadded = state.width * (1 - padHorizontal);
+  const widthPadded = width * (1 - padHorizontal);
   return (
     <View style={localStyles.ChartContainer} onLayout={onLayout}>
       <VictoryPie

--- a/src/widgets/PieChart.js
+++ b/src/widgets/PieChart.js
@@ -1,0 +1,116 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2018
+ */
+
+import React, { useState, useEffect } from 'react';
+import { View, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { VictoryLabel, VictoryPie } from 'victory-native';
+import { APP_FONT_FAMILY, GREY } from '../globalStyles';
+
+/**
+ * A charting widget for displaying Pie chart report.
+ *
+ * @prop  {string}       id      The report ID.
+ * @prop  {string}       title   The title of the report.
+ * @prop  {string}       type    The type of chart to use to display the report,
+ *                               options are BarChart, LineChart and PieChart.
+ * @prop  {data}         array   An array of {x, y} datapoints to plot.
+ * @prop  {width}        number  The width of the parent container.
+ * @prop  {height}       number  The height of the parent continer.
+ */
+
+export const ReportChart = ({ report: initialReport }, props) => {
+  const [report, setReport] = useState(initialReport);
+  const [width, setWidth] = useState(null);
+  const [height, setHeight] = useState(null);
+
+  // Same affect as componentDidUpdate
+  useEffect(() => {
+    if (report.id !== props.report.id) setReport(props.report);
+  });
+
+  // Victory Native sizes are set using absolute values. Parents dimensions are used to
+  // calculate relative values for width and height for each chart.
+  const onLayout = event => {
+    setWidth(event.nativeEvent.layout.width);
+    setHeight(event.nativeEvent.layout.height);
+  };
+
+  const renderPieChart = () => {
+    const {
+      padVertical,
+      padHorizontal,
+      innerRadius,
+      labelRadius,
+      padAngle,
+      colorScale,
+      style,
+    } = victoryStyles.pieChart;
+
+    const padding = {
+      top: height * padVertical,
+      bottom: height * padVertical,
+      right: width * padHorizontal,
+      left: width * padHorizontal,
+    };
+
+    const widthPadded = width * (1 - padHorizontal);
+
+    return (
+      <VictoryPie
+        width={width}
+        height={height}
+        padding={padding}
+        padAngle={padAngle}
+        innerRadius={widthPadded * innerRadius}
+        labelRadius={widthPadded * labelRadius}
+        colorScale={colorScale}
+        labelComponent={<VictoryLabel style={style} />}
+        data={report.data}
+      />
+    );
+  };
+
+  const renderVisualisation = () => {
+    if (report === null || !width || !height) return null;
+    switch (report.type) {
+      case 'PieChart':
+        return renderPieChart();
+      default:
+        return null;
+    }
+  };
+  return (
+    <View style={localStyles.ChartContainer} onLayout={onLayout}>
+      {renderVisualisation()}
+    </View>
+  );
+};
+
+ReportChart.propTypes = {
+  report: PropTypes.objectOf(PropTypes.object).isRequired,
+};
+
+const localStyles = StyleSheet.create({
+  ChartContainer: {
+    width: '75%',
+    minHeight: '100%',
+    backgroundColor: 'white',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+const victoryStyles = {
+  pieChart: {
+    padVertical: 0.15,
+    padHorizontal: 0.15,
+    innerRadius: 0.2,
+    labelRadius: 0.375,
+    padAngle: 2.5,
+    colorScale: 'warm',
+    style: { fontFamily: APP_FONT_FAMILY, fill: GREY },
+  },
+};


### PR DESCRIPTION
Fixes #1740

## Change summary

Add `PieChart` to show the pie chart graphs on the dashboard. 

- It uses React Hooks API.
- It shares a similar skeleton than future components `LineChart` and `BarChart`

## Testing

Further testing will be taken once the feature/dashboard is intended to be merged into develop.

### Related areas to think about

Many lines of code were taken from this [branch](https://github.com/openmsupply/mobile/blob/49d8ab764c85ec5e35699661da92aad8c3e1b03a/src/widgets/ReportChart.js). Further changes may be taken into consideration.
