### PR TITLE
#1737 SimpleLabel & Seperator components

### DIFF
--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -8,7 +8,7 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
 import { connect } from 'react-redux';
 
 import {
@@ -19,6 +19,8 @@ import {
   SimpleTable,
   PageButton,
 } from '../widgets';
+import { PrescriptionCart } from '../widgets/PrescriptionCart';
+import { PrescriptionSummary } from '../widgets/PrescriptionSummary';
 
 import { UIDatabase } from '../database';
 import { getColumns } from './dataTableUtilities';
@@ -104,7 +106,7 @@ const ItemSelect = connect(
   mapStateToProps,
   mapDispatchToProps
 )(({ transaction, chooseItem, nextTab }) => {
-  const { row, mediumFlex, largeFlex } = localStyles;
+  const { row, mediumFlex } = localStyles;
   const columns = getColumns('itemSelect');
 
   const tableRef = React.useRef(React.createRef());
@@ -128,7 +130,7 @@ const ItemSelect = connect(
   );
 
   return (
-    <View style={{ ...row, marginTop: 50 }}>
+    <View style={{ ...row, marginTop: 20 }}>
       <TableShortcuts>
         <TableShortcut>
           <FavouriteStarIcon />
@@ -143,27 +145,17 @@ const ItemSelect = connect(
           ref={tableRef}
         />
       </View>
-      <View style={largeFlex}>
-        <View>
-          {transaction.items.map(item => (
-            <View>
-              <Text>{item.itemName}</Text>
-            </View>
-          ))}
-        </View>
+      <View style={{ flex: 15, marginHorizontal: 15 }}>
+        <PrescriptionCart items={transaction.items.slice()} />
+        <PageButton text="Next" onPress={() => nextTab(1)} style={{ alignSelf: 'flex-end' }} />
       </View>
-      <PageButton text="NEXT" onPress={() => nextTab(1)} />
     </View>
   );
 });
 
 const Summary = connect(mapStateToProps)(({ transaction }) => (
   <View style={{ flex: 1 }}>
-    {transaction.items.map(item => (
-      <View key={item.id}>
-        <Text>{item.itemName}</Text>
-      </View>
-    ))}
+    <PrescriptionSummary transaction={transaction} />
   </View>
 ));
 

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -31,7 +31,7 @@ const PAGE_COLUMN_WIDTHS = {
   stocktakeBatchEditModalWithReasons: [1, 1, 1, 1, 1, 1],
   regimenDataModal: [4, 1, 5],
   prescriberSelect: [1, 1],
-  itemSelect: [1, 1],
+  itemSelect: [1, 3],
 };
 
 const PAGE_COLUMNS = {

--- a/src/widgets/CircleButton.js
+++ b/src/widgets/CircleButton.js
@@ -1,0 +1,55 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { TouchableOpacity, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { SUSSOL_ORANGE } from '../globalStyles/index';
+
+/**
+ * Simple component rendering a button with a circular border radius
+ * with an icon centered.
+ *
+ * @prop {Node} IconComponent An icon component to render in the center of the circle.
+ * @prop {Func} onPress       OnPress callback.
+ */
+export const CircleButton = ({ IconComponent, onPress, onPressIn, onPressOut }) => (
+  <TouchableOpacity
+    onPressIn={onPressIn}
+    onPressOut={onPressOut}
+    onPress={onPress}
+    style={localStyles.containerStyle}
+  >
+    <IconComponent />
+  </TouchableOpacity>
+);
+
+CircleButton.defaultProps = {
+  onPress: null,
+  onPressIn: null,
+  onPressOut: null,
+};
+
+CircleButton.propTypes = {
+  IconComponent: PropTypes.node.isRequired,
+  onPress: PropTypes.func,
+  onPressIn: PropTypes.func,
+  onPressOut: PropTypes.func,
+};
+
+const localStyles = StyleSheet.create({
+  containerStyle: {
+    borderRadius: 30,
+    height: 30,
+    width: 30,
+    elevation: 5,
+    borderColor: SUSSOL_ORANGE,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: SUSSOL_ORANGE,
+  },
+});

--- a/src/widgets/DetailRow.js
+++ b/src/widgets/DetailRow.js
@@ -1,0 +1,48 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2016
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { SimpleLabel } from './SimpleLabel';
+
+/**
+ * Simple layout component render sequential SimpleLabel components
+ * in a row.
+ *
+ * Each SimpleLabel has a label and some other text.
+ *
+ * @prop {Array} details Array of objects in the form {label, text}
+ */
+export const DetailRow = ({ details }) => {
+  const Details = React.useCallback(
+    () =>
+      details.map(({ label, text }) => (
+        <View key={label} style={{ flex: 1 }}>
+          <SimpleLabel label={label} size="small" text={text} />
+        </View>
+      )),
+    [details]
+  );
+
+  return (
+    <View style={localStyles.rowContainer}>
+      <Details />
+    </View>
+  );
+};
+
+const localStyles = {
+  rowContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    flex: 1,
+  },
+};
+
+DetailRow.propTypes = { details: PropTypes.array.isRequired };

--- a/src/widgets/DropdownRow.js
+++ b/src/widgets/DropdownRow.js
@@ -1,0 +1,108 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View, TouchableOpacity, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { ChevronDownIcon, BurgerMenuIcon } from './icons';
+import { PopoverDropDown } from './PopoverDropDown';
+import { SimpleLabel } from './SimpleLabel';
+
+import { SUSSOL_ORANGE } from '../globalStyles/index';
+
+/**
+ * Layout component rendering a DropdownPopover, a SimpleLabel and an optional
+ * secondary Burger menu icon with onPress gesture handler.
+ *
+ * Renders in a 1/9 ratio.
+ *
+ * Uses important props from PopoverDropdown and SimpleLabel. See the individual
+ * components for more detail.
+ *
+ * @prop {Text}   currentOptionText Text to display for the label text prop.
+ * @prop {Array}  options           The options of the drop down. See PopoverDropdown.
+ * @prop {Func}   onSelection       Callback when selecting a dropdown option.
+ * @prop {String} dropdownTitle     The title of the drop down menu when opened.
+ * @prop {Bool}   useSecondaryMenu  Indicator whether the secondary menu should show.
+ * @prop {Number} iconSize          The size of the drop down icon.
+ * @prop {String} labelSize         Size of the label component. See SimpleLabel.
+ */
+export const DropdownRow = ({
+  currentOptionText,
+  options,
+  onSelection,
+  dropdownTitle,
+  useSecondaryMenu,
+  secondaryCallback,
+  iconSize,
+  labelSize,
+}) => {
+  const DropDownMenuIcon = React.useCallback(
+    () => <ChevronDownIcon color={SUSSOL_ORANGE} size={iconSize} />,
+    []
+  );
+
+  const BurgerMenuButton = React.useCallback(
+    () => (
+      <TouchableOpacity onPress={secondaryCallback}>
+        <BurgerMenuIcon />
+      </TouchableOpacity>
+    ),
+    [useSecondaryMenu]
+  );
+
+  return (
+    <View style={localStyles.containerStyle}>
+      <View style={localStyles.flexOne}>
+        <PopoverDropDown
+          BaseComponent={DropDownMenuIcon}
+          options={options}
+          onSelection={onSelection}
+          title={dropdownTitle}
+        />
+      </View>
+      <View style={localStyles.flexNine}>
+        <SimpleLabel size={labelSize} text={currentOptionText} />
+      </View>
+      {useSecondaryMenu && <BurgerMenuButton />}
+    </View>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  containerStyle: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  iconsContainerStyle: {
+    flexDirection: 'row-reverse',
+    justifyContent: 'space-between',
+    flex: 1,
+  },
+  flexNine: { flex: 9 },
+  flexTwo: { flex: 2 },
+  flexOne: { flex: 1 },
+});
+
+DropdownRow.defaultProps = {
+  useSecondaryMenu: false,
+  secondaryCallback: null,
+  iconSize: 20,
+  labelSize: 'small',
+};
+
+DropdownRow.propTypes = {
+  currentOptionText: PropTypes.string.isRequired,
+  options: PropTypes.array.isRequired,
+  onSelection: PropTypes.func.isRequired,
+  dropdownTitle: PropTypes.string.isRequired,
+  useSecondaryMenu: PropTypes.bool,
+  secondaryCallback: PropTypes.func,
+  iconSize: PropTypes.number,
+  labelSize: PropTypes.oneOf(['small', 'large']),
+};

--- a/src/widgets/NumberLabelRow.js
+++ b/src/widgets/NumberLabelRow.js
@@ -1,0 +1,46 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { SimpleLabel } from './SimpleLabel';
+
+/**
+ * Layout and display component rendering some text and a number
+ * in a row.
+ *
+ * Simple wrapper around `SimpleLabel` component. See for further
+ * detail.
+ *
+ * @prop {String} size   The font size - see SimpleLabel for details.
+ * @prop {String} text   Left hand side text value.
+ * @prop {Number} number Right hand side number value.
+ */
+export const NumberLabelRow = ({ size, text, number }) => (
+  <View style={localStyles.mainContainer}>
+    <View style={localStyles.flexNine}>
+      <SimpleLabel text={text} size={size} />
+    </View>
+    <View style={localStyles.flexOne}>
+      <SimpleLabel text={number} size={size} />
+    </View>
+  </View>
+);
+
+const localStyles = StyleSheet.create({
+  mainContainer: { flex: 1, flexDirection: 'row', justifyContent: 'space-between' },
+  flexNine: { flex: 9 },
+  flexOne: { flex: 1 },
+});
+
+NumberLabelRow.propTypes = {
+  size: PropTypes.string,
+  text: PropTypes.string.isRequired,
+  number: PropTypes.number.isRequired,
+};
+
+NumberLabelRow.defaultProps = { size: 'large' };

--- a/src/widgets/PrescriptionCart.js
+++ b/src/widgets/PrescriptionCart.js
@@ -1,0 +1,81 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View, Text, FlatList, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { PrescriptionCartRow } from './PrescriptionCartRow';
+
+import { SUSSOL_ORANGE, WHITE } from '../globalStyles/index';
+
+import { recordKeyExtractor } from '../pages/dataTableUtilities';
+
+/**
+ * Layout container component for a prescriptions item cart.
+ *
+ * Pass a `Transaction.items` array and a callback which updates
+ * a transactionItems quantity.
+ *
+ * @prop {Array} items             The current prescriptions items
+ * @prop {Func}  onChangeQuantity  Callback when an items quantity is updated.
+ * @prop {Func}  onOptionSelection Callback when an option in the dropdown is selected.
+ * @prop {Func}  onRemoveItem      Callback when this row is removed.
+ */
+export const PrescriptionCart = ({ items, onChangeQuantity, onOptionSelection, onRemoveItem }) => {
+  const renderPrescriptionCartRow = React.useCallback(
+    ({ item }) => (
+      <PrescriptionCartRow
+        options={[]}
+        onChangeQuantity={onChangeQuantity}
+        item={item}
+        onOptionSelection={onOptionSelection}
+        onRemoveItem={onRemoveItem}
+      />
+    ),
+    [onChangeQuantity]
+  );
+
+  return (
+    <View style={localStyles.containerStyle}>
+      <Text style={localStyles.titleStyles}>Order</Text>
+      <View style={localStyles.flexNine}>
+        <FlatList
+          keyExtractor={recordKeyExtractor}
+          data={items}
+          renderItem={renderPrescriptionCartRow}
+        />
+      </View>
+    </View>
+  );
+};
+
+PrescriptionCart.propTypes = {
+  items: PropTypes.array.isRequired,
+  onChangeQuantity: PropTypes.func.isRequired,
+  onOptionSelection: PropTypes.func.isRequired,
+  onRemoveItem: PropTypes.func.isRequired,
+};
+
+const localStyles = StyleSheet.create({
+  containerStyle: {
+    elevation: 10,
+    borderRadius: 5,
+    paddingHorizontal: 10,
+    flex: 1,
+    backgroundColor: WHITE,
+    marginBottom: 10,
+  },
+  titleStyles: {
+    color: SUSSOL_ORANGE,
+    fontSize: 24,
+    fontWeight: 'bold',
+    borderBottomWidth: 1,
+    borderBottomColor: SUSSOL_ORANGE,
+    marginVertical: 5,
+  },
+  flexNine: { flex: 9 },
+});

--- a/src/widgets/PrescriptionCartRow.js
+++ b/src/widgets/PrescriptionCartRow.js
@@ -1,0 +1,91 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { CircleButton } from './CircleButton';
+import { DropdownRow } from './DropdownRow';
+import { DetailRow } from './DetailRow';
+import { StepperRow } from './StepperRow';
+import { CloseIcon } from './icons';
+import { Seperator } from './Seperator';
+
+/**
+ * Renders a row in the PrescriptionCart consisting of a `StepperRow`, `DropdownRow`,
+ * `DetailsRow` and a close button.
+ *
+ * Is passed all details needed as this is a simple layout and presentation component.
+ *
+ * @prop {Object} item
+ * @prop {Func}   onChangeQuantity
+ * @prop {Func}   onRemoveItem
+ * @prop {Array}  options
+ * @prop {Func}   onOptionSelection
+ */
+export const PrescriptionCartRow = ({
+  item,
+  onChangeQuantity,
+  onRemoveItem,
+  options,
+  onOptionSelection,
+  currentOptionText,
+}) => {
+  const { itemName, totalQuantity, itemCode, price } = item;
+
+  const itemDetails = [
+    { label: 'Code', text: itemCode },
+    { label: 'Price', text: price },
+  ];
+
+  return (
+    <View>
+      <View style={localStyles.flexRow}>
+        <View style={localStyles.largeFlexRow}>
+          <StepperRow text={itemName} quantity={totalQuantity} onChangeValue={onChangeQuantity} />
+          <DetailRow details={itemDetails} />
+          <View style={{ height: 10 }} />
+          <DropdownRow
+            currentOptionText={currentOptionText}
+            options={options}
+            onSelection={onOptionSelection}
+            dropdownTitle="Directions"
+          />
+        </View>
+        <View style={localStyles.flexOne} />
+        <CircleButton IconComponent={CloseIcon} onPress={onRemoveItem} />
+      </View>
+      <Seperator width={1} />
+    </View>
+  );
+};
+
+PrescriptionCartRow.defaultProps = {
+  currentOptionText: '',
+};
+
+PrescriptionCartRow.propTypes = {
+  item: PropTypes.object.isRequired,
+  onChangeQuantity: PropTypes.func.isRequired,
+  onRemoveItem: PropTypes.func.isRequired,
+  options: PropTypes.array.isRequired,
+  onOptionSelection: PropTypes.func.isRequired,
+  currentOptionText: PropTypes.string,
+};
+
+const localStyles = StyleSheet.create({
+  flexRow: { flex: 1, flexDirection: 'row' },
+  largeFlexRow: { flex: 10 },
+  flexOne: { flex: 1 },
+  centerFlex: { flex: 1, justifyContent: 'center' },
+  closeContainerStyle: {
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    flex: 1,
+  },
+});

--- a/src/widgets/PrescriptionSummary.js
+++ b/src/widgets/PrescriptionSummary.js
@@ -1,0 +1,54 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { Seperator } from './Seperator';
+import { PrescriptionSummaryRow } from './PrescriptionSummaryRow';
+
+import { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../globalStyles';
+
+/**
+ * Simple layout component, rendering a title and a list of summary
+ * rows on an elevated view.
+ *
+ * @param {Object} transaction
+ */
+export const PrescriptionSummary = ({ transaction }) => (
+  <View style={localStyles.containerStyle}>
+    <Text style={localStyles.titleStyle}>Item Details</Text>
+    <FlatList
+      data={transaction.items}
+      ItemSeparatorComponent={Seperator}
+      renderItem={PrescriptionSummaryRow}
+    />
+  </View>
+);
+
+const localStyles = StyleSheet.create({
+  containerStyle: {
+    flex: 1,
+    elevation: 5,
+    backgroundColor: 'white',
+    borderRadius: 5,
+    marginHorizontal: 50,
+    marginBottom: 10,
+    padding: 10,
+  },
+  titleStyle: {
+    color: SUSSOL_ORANGE,
+    fontFamily: APP_FONT_FAMILY,
+    fontSize: 24,
+    fontWeight: 'bold',
+    borderBottomWidth: 1,
+    borderBottomColor: SUSSOL_ORANGE,
+    marginVertical: 5,
+  },
+});
+
+PrescriptionSummary.propTypes = { transaction: PropTypes.object.isRequired };

--- a/src/widgets/PrescriptionSummaryRow.js
+++ b/src/widgets/PrescriptionSummaryRow.js
@@ -1,0 +1,44 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { NumberLabelRow } from './NumberLabelRow';
+import { DetailRow } from './DetailRow';
+import { SimpleLabel } from './SimpleLabel';
+
+/**
+ * Simple layout component for primary use within the PrescriptionSummary
+ * component.
+ *
+ * Simply lays out a TransactionItem record showing details related to
+ * the prescription it is related from.
+ *
+ * @param {Object} item A TransactionItem record to display details for.
+ */
+export const PrescriptionSummaryRow = ({ item }) => {
+  const { itemName, itemCode, totalQuantity, direction } = item;
+
+  const details = [{ label: 'Code', text: itemCode }];
+
+  return (
+    <View style={localStyles.mainContainer}>
+      <NumberLabelRow text={itemName} number={totalQuantity} />
+      <View style={localStyles.marginFive} />
+      <DetailRow details={details} />
+      <View style={localStyles.marginFive} />
+      <SimpleLabel label="Directions" text={direction} />
+    </View>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  mainContainer: { justifyContent: 'space-evenly', flex: 1, flexDirection: 'column' },
+  marginFive: { margin: 5 },
+});
+
+PrescriptionSummaryRow.propTypes = { item: PropTypes.object.isRequired };

--- a/src/widgets/Separator.js
+++ b/src/widgets/Separator.js
@@ -13,13 +13,13 @@ import { GREY } from '../globalStyles/index';
 /**
  * Simple Separator display component rendering a line.
  *
- * @prop {Number} width            The width of the seperator
- * @prop {String} length           The length of the seperator as a percentage string.
+ * @prop {Number} width            The width of the separator
+ * @prop {String} length           The length of the separator as a percentage string.
  * @prop {Number} marginBottom     Number of pixels for the bottom margin.
  * @prop {Number} marginTop        Number of pixels for the bottom margin.
  * @prop {Number} marginHorizontal Number of pixels for the top & bottom margin.
  */
-export const Seperator = props => {
+export const Separator = props => {
   const { mainContainerStyle, borderContainerStyle } = localStyles(props);
   return (
     <View style={mainContainerStyle}>
@@ -28,7 +28,7 @@ export const Seperator = props => {
   );
 };
 
-Seperator.defaultProps = {
+Separator.defaultProps = {
   width: 1,
   length: '100%',
   marginBottom: 5,
@@ -36,7 +36,7 @@ Seperator.defaultProps = {
   marginHorizontal: 0,
 };
 
-Seperator.propTypes = {
+Separator.propTypes = {
   width: PropTypes.number,
   length: PropTypes.string,
   marginBottom: PropTypes.number,
@@ -45,7 +45,7 @@ Seperator.propTypes = {
 };
 
 const localStyles = ({ width, length, marginBottom, marginTop, marginHorizontal }) => ({
-  mainConatinerStyle: {
+  mainContainerStyle: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',

--- a/src/widgets/Seperator.js
+++ b/src/widgets/Seperator.js
@@ -1,0 +1,57 @@
+/* eslint-disable react/no-unused-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { GREY } from '../globalStyles/index';
+
+/**
+ * Simple Separator display component rendering a line.
+ *
+ * @prop {Number} width            The width of the seperator
+ * @prop {String} length           The length of the seperator as a percentage string.
+ * @prop {Number} marginBottom     Number of pixels for the bottom margin.
+ * @prop {Number} marginTop        Number of pixels for the bottom margin.
+ * @prop {Number} marginHorizontal Number of pixels for the top & bottom margin.
+ */
+export const Seperator = props => {
+  const { mainContainerStyle, borderContainerStyle } = localStyles(props);
+  return (
+    <View style={mainContainerStyle}>
+      <View style={borderContainerStyle} />
+    </View>
+  );
+};
+
+Seperator.defaultProps = {
+  width: 1,
+  length: '100%',
+  marginBottom: 5,
+  marginTop: 0,
+  marginHorizontal: 0,
+};
+
+Seperator.propTypes = {
+  width: PropTypes.number,
+  length: PropTypes.string,
+  marginBottom: PropTypes.number,
+  marginTop: PropTypes.number,
+  marginHorizontal: PropTypes.number,
+};
+
+const localStyles = ({ width, length, marginBottom, marginTop, marginHorizontal }) => ({
+  mainConatinerStyle: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginHorizontal,
+    marginBottom,
+    marginTop,
+  },
+  borderContainerStyle: { width: length, borderBottomWidth: width, borderBottomColor: GREY },
+});

--- a/src/widgets/SimpleLabel.js
+++ b/src/widgets/SimpleLabel.js
@@ -1,0 +1,70 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View, Text } from 'react-native';
+import PropTypes from 'prop-types';
+
+import {
+  APP_GENERAL_FONT_SIZE,
+  APP_FONT_FAMILY,
+  SUSSOL_ORANGE,
+  DARKER_GREY,
+} from '../globalStyles/index';
+
+/**
+ * Simple text label rendering in the form [label] [text] in various
+ * sizes.
+ *
+ * @prop {String} label  The label text
+ * @prop {String} text   The text string
+ * @prop {String} size   The size of the label: "small" or "large"
+ *
+ */
+export const SimpleLabel = React.memo(({ label, text, size }) => {
+  // Ensure null is set rather than any other nullish value as null is a node, but "" is not.
+  const usingLabel = label || null;
+  const styles = React.useMemo(() => simpleLabelStyles(size), [size]);
+  const { labelStyle, textStyle, containerStyle } = styles;
+  return (
+    <View style={containerStyle}>
+      {usingLabel && (
+        <Text numberOfLines={2} ellipsizeMode="tail" style={labelStyle}>
+          {`${label}  `}
+        </Text>
+      )}
+      <Text numberOfLines={2} ellipsizeMode="tail" style={textStyle}>
+        {text}
+      </Text>
+    </View>
+  );
+});
+
+const simpleLabelStyles = size => ({
+  labelStyle: {
+    fontFamily: APP_FONT_FAMILY,
+    color: SUSSOL_ORANGE,
+    fontSize: size === 'small' ? APP_GENERAL_FONT_SIZE : 20,
+    fontWeight: 'bold',
+  },
+  textStyle: {
+    fontFamily: APP_FONT_FAMILY,
+    color: DARKER_GREY,
+    fontSize: size === 'small' ? APP_GENERAL_FONT_SIZE : 20,
+  },
+  containerStyle: { flexDirection: 'row', flex: 1, alignItems: 'center' },
+});
+
+SimpleLabel.defaultProps = {
+  size: 'small',
+  text: '',
+  label: '',
+};
+
+SimpleLabel.propTypes = {
+  text: PropTypes.string,
+  size: PropTypes.oneOf(['small', 'large']),
+  label: PropTypes.string,
+};

--- a/src/widgets/SimpleLabel.js
+++ b/src/widgets/SimpleLabel.js
@@ -48,8 +48,10 @@ const simpleLabelStyles = size => ({
     color: SUSSOL_ORANGE,
     fontSize: size === 'small' ? APP_GENERAL_FONT_SIZE : 20,
     fontWeight: 'bold',
+    flex: 1,
   },
   textStyle: {
+    flex: 4,
     fontFamily: APP_FONT_FAMILY,
     color: DARKER_GREY,
     fontSize: size === 'small' ? APP_GENERAL_FONT_SIZE : 20,

--- a/src/widgets/StepperInput.js
+++ b/src/widgets/StepperInput.js
@@ -1,10 +1,11 @@
 /* eslint-disable react/forbid-prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TextInput, View, TouchableOpacity, StyleSheet } from 'react-native';
+import { TextInput, View, StyleSheet } from 'react-native';
 
-import IonIcon from 'react-native-vector-icons/Ionicons';
-import { SUSSOL_ORANGE, APP_FONT_FAMILY } from '../globalStyles/index';
+import { APP_FONT_FAMILY } from '../globalStyles/index';
+import { CircleButton } from './CircleButton';
+import { AddIcon, MinusIcon } from './icons';
 
 /**
  * Input component which will update a numerical value. The `value` passed will be
@@ -18,20 +19,10 @@ import { SUSSOL_ORANGE, APP_FONT_FAMILY } from '../globalStyles/index';
  * @prop {Func}          onChangeText   Callback for updating the value.
  * @prop {Number}        lowerLimit     The lower limit of the numerical range.
  * @prop {Number}        upperLimit     The upper limit of the numerical range.
- * @prop {Number}        iconSize       The size of the icons.
- * @prop {Number}        iconColour     The colour of the icons.
  * @prop {Object}        textInputStyle Style object for the underlying TextInput.
  *
  */
-export const StepperInput = ({
-  value,
-  onChangeText,
-  lowerLimit,
-  upperLimit,
-  iconSize,
-  iconColour,
-  textInputStyle,
-}) => {
+export const StepperInput = ({ value, onChangeText, lowerLimit, upperLimit, textInputStyle }) => {
   const currentValue = React.useRef(Number(value));
   const currentAdjustmentAmount = React.useRef(1);
   const valueAdjustmentInterval = React.useRef();
@@ -85,24 +76,29 @@ export const StepperInput = ({
 
   return (
     <View style={localStyles.row}>
-      <TouchableOpacity onPressIn={onStartDecrementPress} onPressOut={onEndLongPress}>
-        <IonIcon name="ios-remove" size={iconSize} color={iconColour} />
-      </TouchableOpacity>
-      <TextInput onChangeText={onUpdate} value={String(value)} style={{ textInputStyle }} />
-      <TouchableOpacity onPressIn={onStartIncrementPress} onPressOut={onEndLongPress}>
-        <IonIcon name="ios-add" size={iconSize} color={iconColour} />
-      </TouchableOpacity>
+      <CircleButton
+        IconComponent={MinusIcon}
+        onPressIn={onStartDecrementPress}
+        onPressOut={onEndLongPress}
+      />
+      <TextInput onChangeText={onUpdate} value={String(value)} style={textInputStyle} />
+      <CircleButton
+        IconComponent={AddIcon}
+        onPressIn={onStartIncrementPress}
+        onPressOut={onEndLongPress}
+      />
     </View>
   );
 };
 
 const localStyles = StyleSheet.create({
-  row: { flexDirection: 'row' },
+  row: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center' },
   textInput: {
-    marginHorizontal: 50,
+    marginHorizontal: 25,
     width: 100,
     textAlign: 'center',
-    fontSize: 16,
+    fontSize: 24,
+
     fontFamily: APP_FONT_FAMILY,
   },
 });
@@ -110,8 +106,6 @@ const localStyles = StyleSheet.create({
 StepperInput.defaultProps = {
   lowerLimit: 0,
   upperLimit: 99999,
-  iconSize: 45,
-  iconColour: SUSSOL_ORANGE,
   textInputStyle: localStyles.textInput,
 };
 
@@ -120,7 +114,5 @@ StepperInput.propTypes = {
   upperLimit: PropTypes.number,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   onChangeText: PropTypes.func.isRequired,
-  iconSize: PropTypes.number,
-  iconColour: PropTypes.string,
   textInputStyle: PropTypes.object,
 };

--- a/src/widgets/StepperRow.js
+++ b/src/widgets/StepperRow.js
@@ -1,0 +1,75 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { SimpleLabel } from './SimpleLabel';
+import { StepperInput } from './StepperInput';
+
+/**
+ * Layout component for a StepperInput and SimpleLabel. Wraps both components
+ * and renders each as a row with a 5/1/3 flex - where the 1 is a filler view
+ * for a little extra space for the Stepper.
+ *
+ * Takes the main props of each a SimpleLabel and StepperInput. See the individual
+ * components for further details.
+ *
+ * @prop {String}        text           Label text value.
+ * @prop {Number|String} quantity       Initial value of the stepper input.
+ * @prop {Func}          onChangeValue  Callback when the stepper value changes.
+ * @prop {Number}        lowerLimit     Lower bound valid value of the stepper.
+ * @prop {Number}        upperLimit     Upper bound valid value of the stepper.
+ * @prop {String}        labelSize      Size of the label: See SimpleLabel for valid values.
+ */
+export const StepperRow = ({
+  text,
+  quantity,
+  onChangeValue,
+  lowerLimit,
+  upperLimit,
+  labelSize,
+}) => {
+  const { containerStyle, largeFlex, mediumFlex, smallFlex } = localStylez;
+  return (
+    <View style={containerStyle}>
+      <View style={largeFlex}>
+        <SimpleLabel size={labelSize} text={text} />
+      </View>
+      <View style={smallFlex} />
+      <View style={mediumFlex}>
+        <StepperInput
+          value={quantity}
+          onChangeText={onChangeValue}
+          lowerLimit={lowerLimit}
+          upperLimit={upperLimit}
+        />
+      </View>
+    </View>
+  );
+};
+
+const localStylez = {
+  containerStyle: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  largeFlex: { flex: 5 },
+  mediumFlex: { flex: 3 },
+  smallFlex: { flex: 1 },
+};
+
+StepperRow.defaultProps = {
+  lowerLimit: 0,
+  upperLimit: 99999,
+  labelSize: 'large',
+};
+
+StepperRow.propTypes = {
+  text: PropTypes.string.isRequired,
+  quantity: PropTypes.number.isRequired,
+  onChangeValue: PropTypes.func.isRequired,
+  lowerLimit: PropTypes.number,
+  upperLimit: PropTypes.number,
+  labelSize: PropTypes.oneOf(['large', 'small']),
+};

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -86,3 +86,13 @@ export const ChevronRightIcon = () => (
 );
 
 export const FavouriteStarIcon = () => <FAIcon name="star-o" color={SUSSOL_ORANGE} size={20} />;
+export const BurgerMenuIcon = () => <EntypoIcon name="menu" color={SUSSOL_ORANGE} size={30} />;
+export const AddIcon = ({ size, color }) => <IonIcon name="ios-add" size={size} color={color} />;
+AddIcon.defaultProps = { color: WHITE, size: 30 };
+AddIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
+
+export const MinusIcon = ({ size, color }) => (
+  <IonIcon name="ios-remove" size={size} color={color} />
+);
+MinusIcon.defaultProps = { color: WHITE, size: 30 };
+MinusIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };


### PR DESCRIPTION
Fixes #1737 

## Change summary

- Adds a `SimpleLabel` component:

[This is three `SimpleLabel`'s]
<img width="320" alt="image" src="https://user-images.githubusercontent.com/35858975/71160397-58ef0480-22ac-11ea-9ee3-06566b19d4b2.png">

- Also trying to sneak in a `Seperator` component 
<img width="770" alt="image" src="https://user-images.githubusercontent.com/35858975/71160435-6906e400-22ac-11ea-8479-cab42cbc6706.png">


## Testing
N/A

### Related areas to think about

- Trying to break components down to more basic parts
- Will need in the future a better project layout - `widgets` is getting a bit nutty!
