### PR TITLE
#1742 Create Line chart component

### DIFF
--- a/src/widgets/LineChart.js
+++ b/src/widgets/LineChart.js
@@ -77,7 +77,6 @@ const localStyles = StyleSheet.create({
     justifyContent: 'center',
   },
 });
-
 const victoryStyles = {
   axisX: {
     fixLabelOverlap: true,
@@ -88,20 +87,11 @@ const victoryStyles = {
     },
   },
   axisY: {
-    fixLabelOverlap: false,
     style: {
       axis: { stroke: LIGHT_GREY },
       ticks: { stroke: DARK_GREY },
       tickLabels: { fontFamily: APP_FONT_FAMILY, fill: GREY },
     },
-  },
-  barChart: {
-    padTop: 0.1,
-    padBottom: 0.15,
-    padLeft: 0.1,
-    padRight: 0.05,
-    padDomain: 0.05,
-    style: { data: { fill: SUSSOL_ORANGE } },
   },
   lineChart: {
     padTop: 0.1,

--- a/src/widgets/LineChart.js
+++ b/src/widgets/LineChart.js
@@ -1,0 +1,115 @@
+/* eslint-disable react/forbid-prop-types */
+/* eslint-disable react/prop-types */
+/* eslint-disable no-unused-vars */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2018
+ */
+
+import React, { useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { VictoryAxis, VictoryChart, VictoryLine, VictoryScatter } from 'victory-native';
+import { APP_FONT_FAMILY, GREY, LIGHT_GREY, DARK_GREY, SUSSOL_ORANGE } from '../globalStyles';
+
+export const LineChart = ({ title, type, data }) => {
+  const [dimensions, setDimensions] = useState({ height: null, width: null });
+  const { height, width } = dimensions;
+
+  // Victory Native sizes are set using absolute values. Parents dimensions are used to
+  // calculate relative values for width and height for each chart.
+  const onLayout = event => {
+    const newDimensionsObj = {
+      height: event.nativeEvent.layout.width,
+      width: event.nativeEvent.layout.height,
+    };
+    setDimensions(newDimensionsObj);
+  };
+  // X-axis for bar and line charts.
+  const renderXAxis = () => {
+    const tickTruncate = label => (label.length > 11 ? `${label.slice(0, 11)}...` : label);
+    return <VictoryAxis tickFormat={tickTruncate} style={victoryStyles.axisX.style} />;
+  };
+
+  // Y-axis for bar and line charts.
+  const renderYAxis = () => <VictoryAxis dependentAxis style={victoryStyles.axisY.style} />;
+
+  const {
+    padTop,
+    padBottom,
+    padLeft,
+    padRight,
+    dotSize,
+    dotStyle,
+    lineStyle,
+  } = victoryStyles.lineChart;
+
+  const padding = {
+    top: height * padTop,
+    bottom: height * padBottom,
+    left: width * padLeft,
+    right: width * padRight,
+  };
+  return (
+    <View style={localStyles.ChartContainer} onLayout={onLayout}>
+      <VictoryChart width={width} height={height} padding={padding}>
+        <VictoryScatter size={dotSize} style={dotStyle} data={data} />
+        <VictoryLine style={lineStyle} data={data} />
+        {renderXAxis()}
+        {renderYAxis()}
+      </VictoryChart>
+    </View>
+  );
+};
+
+LineChart.propTypes = {
+  title: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  data: PropTypes.array.isRequired,
+};
+
+const localStyles = StyleSheet.create({
+  ChartContainer: {
+    width: '75%',
+    minHeight: '100%',
+    backgroundColor: 'white',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+const victoryStyles = {
+  axisX: {
+    fixLabelOverlap: true,
+    style: {
+      axis: { stroke: LIGHT_GREY },
+      ticks: { stroke: DARK_GREY },
+      tickLabels: { fontFamily: APP_FONT_FAMILY, fill: GREY, textAnchor: 'end', angle: -45 },
+    },
+  },
+  axisY: {
+    fixLabelOverlap: false,
+    style: {
+      axis: { stroke: LIGHT_GREY },
+      ticks: { stroke: DARK_GREY },
+      tickLabels: { fontFamily: APP_FONT_FAMILY, fill: GREY },
+    },
+  },
+  barChart: {
+    padTop: 0.1,
+    padBottom: 0.15,
+    padLeft: 0.1,
+    padRight: 0.05,
+    padDomain: 0.05,
+    style: { data: { fill: SUSSOL_ORANGE } },
+  },
+  lineChart: {
+    padTop: 0.1,
+    padBottom: 0.15,
+    padLeft: 0.1,
+    padRight: 0.05,
+    dotSize: 3.5,
+    dotStyle: { data: { fill: SUSSOL_ORANGE } },
+    lineStyle: { data: { stroke: SUSSOL_ORANGE } },
+  },
+};


### PR DESCRIPTION
Fixes #1742 

## Change summary

Add `LineChart` component to show line chart graphs on the dashboard. 

- It uses React Hooks API.
- It shares a similar skeleton than `LineChart`, `BarChart` and `ReportTable`

## Testing

Further testing will be taken once the feature/dashboard is intended to be merged into develop.

### Related areas to think about

Codebase taken from past work: [branch](https://github.com/openmsupply/mobile/blob/49d8ab764c85ec5e35699661da92aad8c3e1b03a/src/widgets/ReportChart.js). Further changes may be taken into consideration.