### PR TITLE
#1755 Create ReportCell component

### DIFF
--- a/src/widgets/ReportTable/ReportCell.js
+++ b/src/widgets/ReportTable/ReportCell.js
@@ -1,0 +1,41 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2018
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { APP_FONT_FAMILY, BACKGROUND_COLOR } from '../../globalStyles';
+
+export const ReportCell = ({ even, children }) => {
+  const backgroundColor = even ? { backgroundColor: 'white' } : null;
+  return (
+    <View style={[localStyles.container, backgroundColor]}>
+      <Text style={localStyles.cell}>{children}</Text>
+    </View>
+  );
+};
+
+ReportCell.propTypes = {
+  even: PropTypes.bool,
+  children: PropTypes.string.isRequired,
+};
+
+const localStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingLeft: '2%',
+    marginRight: 1,
+    backgroundColor: BACKGROUND_COLOR,
+  },
+  cell: {
+    fontFamily: APP_FONT_FAMILY,
+    fontSize: 12,
+  },
+});
+
+ReportCell.propTypes = {
+  even: PropTypes.bool.isRequired,
+};


### PR DESCRIPTION
Fixes #1755 

## Change summary

Add `ReportCell` component to use together with `ReportRow` and `ReportTable` components for showing Table reports on the feature/dashboard. 

- It uses React Hooks API.
- Needed in conjunction with `ReportRow` and `ReportTable` components.

## Testing

Further testing will be taken once the feature/dashboard is intended to be merged into develop.

### Related areas to think about

Codebase taken from past work: [branch](https://github.com/openmsupply/mobile/blob/49d8ab764c85ec5e35699661da92aad8c3e1b03a/src/widgets/ReportChart.js). Further changes may be taken into consideration.