### PR TITLE
#1754 Create ReportRow component

### DIFF
--- a/src/widgets/ReportTable/ReportRow.js
+++ b/src/widgets/ReportTable/ReportRow.js
@@ -1,0 +1,39 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2018
+ */
+
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { ReportCell } from './ReportCell';
+
+export const ReportRow = ({ isHeader, rowData, rowIndex }) => {
+  const headerStyle = isHeader ? localStyles.header : null;
+  const rowStyle = StyleSheet.flatten([localStyles.container, headerStyle]);
+  const cellsToRender = rowData.map(cell => (
+    <ReportCell key={rowIndex} even={rowIndex % 2 === 0}>
+      {cell}
+    </ReportCell>
+  ));
+
+  return <View style={rowStyle}>{cellsToRender}</View>;
+};
+
+const localStyles = StyleSheet.create({
+  header: {
+    marginBottom: 1,
+  },
+  container: {
+    width: '100%',
+    flexDirection: 'row',
+    height: 50,
+  },
+});
+
+ReportRow.propTypes = {
+  isHeader: PropTypes.bool.isRequired,
+  rowData: PropTypes.array.isRequired,
+  rowIndex: PropTypes.number.isRequired,
+};


### PR DESCRIPTION
Fixes #1754

## Change summary

Add `ReportRow` component to use together with `ReportCell` and `ReportTable` components for showing Table reports on the feature/dashboard. 

- It uses React Hooks API.
- Needed in conjunction with `ReportCell` and `ReportTable` components.

## Testing

Further testing will be taken once the feature/dashboard is intended to be merged into develop.

### Related areas to think about

Codebase taken from past work: [branch](https://github.com/openmsupply/mobile/blob/49d8ab764c85ec5e35699661da92aad8c3e1b03a/src/widgets/ReportChart.js). Further changes may be taken into consideration.