### PR TITLE
#1744 Create ReportTable component

### DIFF
--- a/src/widgets/ReportTable/ReportTable.js
+++ b/src/widgets/ReportTable/ReportTable.js
@@ -1,91 +1,37 @@
 /* eslint-disable react/prop-types */
-/* eslint-disable no-unused-vars */
 /* eslint-disable react/forbid-prop-types */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2018
  */
 
-import React, { useState } from 'react';
-import { View, StyleSheet } from 'react-native';
+import React from 'react';
+import { StyleSheet, FlatList, View } from 'react-native';
 import PropTypes from 'prop-types';
-import { VictoryChart, VictoryBar, VictoryAxis } from 'victory-native';
-import { APP_FONT_FAMILY, GREY, LIGHT_GREY, DARK_GREY, SUSSOL_ORANGE } from '../../globalStyles';
+import { LIGHT_GREY } from '../../globalStyles';
+import { ReportRow } from './ReportRow';
 
-export const ReportTable = ({ title, type, data }) => {
-  const [dimensions, setDimensions] = useState({ height: null, width: null });
-  const { height, width } = dimensions;
+export const ReportTable = ({ rows, header }) => {
+  const renderItem = ({ item, index }) => <ReportRow rowData={item} rowIndex={index} />;
 
-  // Victory Native sizes are set using absolute values. Parents dimensions are used to
-  // calculate relative values for width and height for each chart.
-  const onLayout = event => {
-    const newDimensionsObj = {
-      height: event.nativeEvent.layout.width,
-      width: event.nativeEvent.layout.height,
-    };
-    setDimensions(newDimensionsObj);
-  };
+  const renderHeader = () => <ReportRow rowData={header} isHeader rowIndex={0} />;
 
-  const { padTop, padBottom, padLeft, padRight, padDomain, style } = victoryStyles.barChart;
-
-  const padding = {
-    top: height * padTop,
-    bottom: height * padBottom,
-    left: width * padLeft,
-    right: width * padRight,
-  };
-
-  const chartDimensions = width * (1 - (padLeft + padRight));
-  const domainPadding = chartDimensions * padDomain;
-
-  const { rows, header } = data;
-
+  // TODO: KeyExtractor should be altered to not use the index.
   return (
-    <View style={localStyles.ChartContainer} onLayout={onLayout}>
-      <ReportTable rows={rows} headers={header} />;
+    <View style={localStyles.container}>
+      {renderHeader()}
+      <FlatList data={rows} renderItem={renderItem} keyExtractor={(_, index) => `${index}`} />
     </View>
   );
 };
 
 ReportTable.propTypes = {
-  title: PropTypes.string.isRequired,
-  type: PropTypes.string.isRequired,
-  data: PropTypes.array.isRequired,
+  header: PropTypes.array.isRequired,
+  rows: PropTypes.array.isRequired,
 };
 
 const localStyles = StyleSheet.create({
-  ChartContainer: {
-    width: '75%',
-    minHeight: '100%',
-    backgroundColor: 'white',
-    alignItems: 'center',
-    justifyContent: 'center',
+  container: {
+    backgroundColor: LIGHT_GREY,
   },
 });
-
-const victoryStyles = {
-  axisX: {
-    fixLabelOverlap: true,
-    style: {
-      axis: { stroke: LIGHT_GREY },
-      ticks: { stroke: DARK_GREY },
-      tickLabels: { fontFamily: APP_FONT_FAMILY, fill: GREY, textAnchor: 'end', angle: -45 },
-    },
-  },
-  axisY: {
-    fixLabelOverlap: false,
-    style: {
-      axis: { stroke: LIGHT_GREY },
-      ticks: { stroke: DARK_GREY },
-      tickLabels: { fontFamily: APP_FONT_FAMILY, fill: GREY },
-    },
-  },
-  barChart: {
-    padTop: 0.1,
-    padBottom: 0.15,
-    padLeft: 0.1,
-    padRight: 0.05,
-    padDomain: 0.05,
-    style: { data: { fill: SUSSOL_ORANGE } },
-  },
-};

--- a/src/widgets/ReportTable/ReportTable.js
+++ b/src/widgets/ReportTable/ReportTable.js
@@ -14,13 +14,17 @@ import { ReportRow } from './ReportRow';
 export const ReportTable = ({ rows, header }) => {
   const renderItem = ({ item, index }) => <ReportRow rowData={item} rowIndex={index} />;
 
-  const renderHeader = () => <ReportRow rowData={header} isHeader rowIndex={0} />;
+  const renderHeader = () => <ReportRow rowData={header} rowIndex={0} />;
 
   // TODO: KeyExtractor should be altered to not use the index.
   return (
     <View style={localStyles.container}>
-      {renderHeader()}
-      <FlatList data={rows} renderItem={renderItem} keyExtractor={(_, index) => `${index}`} />
+      <FlatList
+        data={rows}
+        ListHeaderComponent={renderHeader}
+        renderItem={renderItem}
+        keyExtractor={(_, index) => `${index}`}
+      />
     </View>
   );
 };

--- a/src/widgets/ReportTable/ReportTable.js
+++ b/src/widgets/ReportTable/ReportTable.js
@@ -1,0 +1,91 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2018
+ */
+
+import React, { useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { VictoryChart, VictoryBar, VictoryAxis } from 'victory-native';
+import { APP_FONT_FAMILY, GREY, LIGHT_GREY, DARK_GREY, SUSSOL_ORANGE } from '../../globalStyles';
+
+export const ReportTable = ({ title, type, data }) => {
+  const [dimensions, setDimensions] = useState({ height: null, width: null });
+  const { height, width } = dimensions;
+
+  // Victory Native sizes are set using absolute values. Parents dimensions are used to
+  // calculate relative values for width and height for each chart.
+  const onLayout = event => {
+    const newDimensionsObj = {
+      height: event.nativeEvent.layout.width,
+      width: event.nativeEvent.layout.height,
+    };
+    setDimensions(newDimensionsObj);
+  };
+
+  const { padTop, padBottom, padLeft, padRight, padDomain, style } = victoryStyles.barChart;
+
+  const padding = {
+    top: height * padTop,
+    bottom: height * padBottom,
+    left: width * padLeft,
+    right: width * padRight,
+  };
+
+  const chartDimensions = width * (1 - (padLeft + padRight));
+  const domainPadding = chartDimensions * padDomain;
+
+  const { rows, header } = data;
+
+  return (
+    <View style={localStyles.ChartContainer} onLayout={onLayout}>
+      <ReportTable rows={rows} headers={header} />;
+    </View>
+  );
+};
+
+ReportTable.propTypes = {
+  title: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  data: PropTypes.array.isRequired,
+};
+
+const localStyles = StyleSheet.create({
+  ChartContainer: {
+    width: '75%',
+    minHeight: '100%',
+    backgroundColor: 'white',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+const victoryStyles = {
+  axisX: {
+    fixLabelOverlap: true,
+    style: {
+      axis: { stroke: LIGHT_GREY },
+      ticks: { stroke: DARK_GREY },
+      tickLabels: { fontFamily: APP_FONT_FAMILY, fill: GREY, textAnchor: 'end', angle: -45 },
+    },
+  },
+  axisY: {
+    fixLabelOverlap: false,
+    style: {
+      axis: { stroke: LIGHT_GREY },
+      ticks: { stroke: DARK_GREY },
+      tickLabels: { fontFamily: APP_FONT_FAMILY, fill: GREY },
+    },
+  },
+  barChart: {
+    padTop: 0.1,
+    padBottom: 0.15,
+    padLeft: 0.1,
+    padRight: 0.05,
+    padDomain: 0.05,
+    style: { data: { fill: SUSSOL_ORANGE } },
+  },
+};


### PR DESCRIPTION
Fixes #1755 

## Change summary

Add `ReportTable` component to use together with `ReportRow` and `ReportCell` components for visualising Table reports on the feature/dashboard. 

- It uses React Hooks API.
- Needed in conjunction with `ReportRow` and `ReportCell` components.

## Testing

Further testing will be taken once the feature/dashboard is intended to be merged into develop.

### Related areas to think about

Codebase taken from past work: [branch](https://github.com/openmsupply/mobile/blob/49d8ab764c85ec5e35699661da92aad8c3e1b03a/src/widgets/ReportChart.js). Further changes may be taken into consideration.