### PR TITLE
#1739 prescription summary

### DIFF
--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -8,7 +8,7 @@ import React from 'react';
 
 import PropTypes from 'prop-types';
 
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
 import { connect } from 'react-redux';
 
 import {
@@ -20,6 +20,7 @@ import {
   PageButton,
 } from '../widgets';
 import { PrescriptionCart } from '../widgets/PrescriptionCart';
+import { PrescriptionSummary } from '../widgets/PrescriptionSummary';
 
 import { UIDatabase } from '../database';
 import { getColumns } from './dataTableUtilities';
@@ -154,11 +155,7 @@ const ItemSelect = connect(
 
 const Summary = connect(mapStateToProps)(({ transaction }) => (
   <View style={{ flex: 1 }}>
-    {transaction.items.map(item => (
-      <View key={item.id}>
-        <Text>{item.itemName}</Text>
-      </View>
-    ))}
+    <PrescriptionSummary transaction={transaction} />
   </View>
 ));
 

--- a/src/widgets/DetailRow.js
+++ b/src/widgets/DetailRow.js
@@ -22,7 +22,7 @@ export const DetailRow = ({ details }) => {
   const Details = React.useCallback(
     () =>
       details.map(({ label, text }) => (
-        <View>
+        <View style={{ flex: 1 }}>
           <SimpleLabel label={label} size="small" text={text} />
         </View>
       )),
@@ -40,6 +40,8 @@ const localStyles = {
   rowContainer: {
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'flex-start',
+    flex: 1,
   },
 };
 

--- a/src/widgets/NumberLabelRow.js
+++ b/src/widgets/NumberLabelRow.js
@@ -1,0 +1,46 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { SimpleLabel } from './SimpleLabel';
+
+/**
+ * Layout and display component rendering some text and a number
+ * in a row.
+ *
+ * Simple wrapper around `SimpleLabel` component. See for further
+ * detail.
+ *
+ * @prop {String} size   The font size - see SimpleLabel for details.
+ * @prop {String} text   Left hand side text value.
+ * @prop {Number} number Right hand side number value.
+ */
+export const NumberLabelRow = ({ size, text, number }) => (
+  <View style={localStyles.mainContainer}>
+    <View style={localStyles.flexNine}>
+      <SimpleLabel text={text} size={size} />
+    </View>
+    <View style={localStyles.flexOne}>
+      <SimpleLabel text={number} size={size} />
+    </View>
+  </View>
+);
+
+const localStyles = StyleSheet.create({
+  mainContainer: { flex: 1, flexDirection: 'row', justifyContent: 'space-between' },
+  flexNine: { flex: 9 },
+  flexOne: { flex: 1 },
+});
+
+NumberLabelRow.propTypes = {
+  size: PropTypes.string,
+  text: PropTypes.string.isRequired,
+  number: PropTypes.number.isRequired,
+};
+
+NumberLabelRow.defaultProps = { size: 'large' };

--- a/src/widgets/PrescriptionSummary.js
+++ b/src/widgets/PrescriptionSummary.js
@@ -1,0 +1,54 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { Seperator } from './Seperator';
+import { PrescriptionSummaryRow } from './PrescriptionSummaryRow';
+
+import { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../globalStyles';
+
+/**
+ * Simple layout component, rendering a title and a list of summary
+ * rows on an elevated view.
+ *
+ * @param {Object} transaction
+ */
+export const PrescriptionSummary = ({ transaction }) => (
+  <View style={localStyles.containerStyle}>
+    <Text style={localStyles.titleStyle}>Item Details</Text>
+    <FlatList
+      data={transaction.items}
+      ItemSeparatorComponent={Seperator}
+      renderItem={PrescriptionSummaryRow}
+    />
+  </View>
+);
+
+const localStyles = StyleSheet.create({
+  containerStyle: {
+    flex: 1,
+    elevation: 5,
+    backgroundColor: 'white',
+    borderRadius: 5,
+    marginHorizontal: 50,
+    marginBottom: 10,
+    padding: 10,
+  },
+  titleStyle: {
+    color: SUSSOL_ORANGE,
+    fontFamily: APP_FONT_FAMILY,
+    fontSize: 24,
+    fontWeight: 'bold',
+    borderBottomWidth: 1,
+    borderBottomColor: SUSSOL_ORANGE,
+    marginVertical: 5,
+  },
+});
+
+PrescriptionSummary.propTypes = { transaction: PropTypes.object.isRequired };

--- a/src/widgets/PrescriptionSummaryRow.js
+++ b/src/widgets/PrescriptionSummaryRow.js
@@ -1,0 +1,35 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { NumberLabelRow } from './NumberLabelRow';
+import { DetailRow } from './DetailRow';
+import { SimpleLabel } from './SimpleLabel';
+
+export const PrescriptionSummaryRow = ({ item }) => {
+  const { itemName, itemCode, totalQuantity, direction } = item;
+
+  const details = React.useMemo([{ label: 'Code', text: itemCode }], []);
+
+  return (
+    <View style={localStyles.mainContainer}>
+      <NumberLabelRow text={itemName} number={totalQuantity} />
+      <View style={localStyles.marginFive} />
+      <DetailRow details={details} />
+      <View style={localStyles.marginFive} />
+      <SimpleLabel label="Directions" text={direction} />
+    </View>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  mainContainer: { justifyContent: 'space-evenly', flex: 1, flexDirection: 'column' },
+  marginFive: { margin: 5 },
+});
+
+PrescriptionSummaryRow.propTypes = { item: PropTypes.object.isRequired };

--- a/src/widgets/PrescriptionSummaryRow.js
+++ b/src/widgets/PrescriptionSummaryRow.js
@@ -11,10 +11,19 @@ import { NumberLabelRow } from './NumberLabelRow';
 import { DetailRow } from './DetailRow';
 import { SimpleLabel } from './SimpleLabel';
 
+/**
+ * Simple layout component for primary use within the PrescriptionSummary
+ * component.
+ *
+ * Simply lays out a TransactionItem record showing details related to
+ * the prescription it is related from.
+ *
+ * @param {Object} item A TransactionItem record to display details for.
+ */
 export const PrescriptionSummaryRow = ({ item }) => {
   const { itemName, itemCode, totalQuantity, direction } = item;
 
-  const details = React.useMemo([{ label: 'Code', text: itemCode }], []);
+  const details = [{ label: 'Code', text: itemCode }];
 
   return (
     <View style={localStyles.mainContainer}>

--- a/src/widgets/SimpleLabel.js
+++ b/src/widgets/SimpleLabel.js
@@ -48,8 +48,10 @@ const simpleLabelStyles = size => ({
     color: SUSSOL_ORANGE,
     fontSize: size === 'small' ? APP_GENERAL_FONT_SIZE : 20,
     fontWeight: 'bold',
+    flex: 1,
   },
   textStyle: {
+    flex: 4,
     fontFamily: APP_FONT_FAMILY,
     color: DARKER_GREY,
     fontSize: size === 'small' ? APP_GENERAL_FONT_SIZE : 20,


### PR DESCRIPTION
### BRANCHED FROM: #1738 

Fixes #1739 

## Change summary

- Adds `NumberLabel` component. Little odd but will be used in the pricing/payment section also.. so will possibly be relying on the value being a number for some things.
- Adds `PrescriptionSummary`/`PrescriptionSummaryRow` components

looks like this at the moment:
<img width="1365" alt="image" src="https://user-images.githubusercontent.com/35858975/71222615-0e19cf00-2336-11ea-9fd8-86d2b3f5e341.png">

Or a little smaller:

<img width="1357" alt="image" src="https://user-images.githubusercontent.com/35858975/71223653-82a23d00-2339-11ea-8b7b-95c5ced2613e.png">

- Obviously still needs tidying!
- Might need prices, units or other values.. will go in the smaller middle row

## Testing

N/A

### Related areas to think about

N/A
