### PR TITLE
#1714 Create ReportSideBar component

### DIFF
--- a/src/widgets/ReportSideBar/ReportSideBar.js
+++ b/src/widgets/ReportSideBar/ReportSideBar.js
@@ -1,0 +1,77 @@
+/* eslint-disable react/no-unused-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2018
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View, ListItem, FlatList, Text, StyleSheet } from 'react-native';
+import { APP_FONT_FAMILY, GREY } from '../../globalStyles';
+import { pageInfoStrings } from '../../localization/pageInfoStrings';
+
+export const ReportSidebar = props => {
+  const { dimensions, onPressItem, selectedItemIndex, data } = props;
+
+  const renderItem = ({ item }) => {
+    const { id, index, title, type, date } = item;
+    return (
+      <ListItem
+        id={id}
+        index={index}
+        onPress={onPressItem}
+        isLastItem={index + 1 === data.length}
+        isSelected={selectedItemIndex === index}
+        icon={type}
+        content={title}
+        subContent={date}
+      />
+    );
+  };
+
+  const renderHeader = () => (
+    <View>
+      <Text style={localStyles.ListViewHeader}>{pageInfoStrings.reports}</Text>
+    </View>
+  );
+
+  return (
+    <View style={[localStyles.ListViewContainer, dimensions]}>
+      <FlatList
+        ListHeaderComponent={renderHeader}
+        data={data}
+        ReportSideBarItem={renderItem}
+        keyExtractor={item => item.id}
+        extraData={props}
+      />
+    </View>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  ListViewHeader: {
+    fontFamily: APP_FONT_FAMILY,
+    fontSize: 18,
+    alignItems: 'flex-start',
+    paddingVertical: 10,
+    paddingHorizontal: 5,
+    color: GREY,
+    minHeight: 50,
+  },
+  ListViewContainer: {
+    backgroundColor: 'white',
+    paddingHorizontal: 0,
+    paddingVertical: 0,
+    borderRightColor: GREY,
+    borderRightWidth: 1,
+    margin: 0,
+  },
+});
+
+ReportSidebar.propTypes = {
+  item: PropTypes.objectOf(PropTypes.object).isRequired,
+  data: PropTypes.PropTypes.shape([]).isRequired,
+  onPressItem: PropTypes.func.isRequired,
+  selectedItemIndex: PropTypes.number.isRequired,
+  dimensions: PropTypes.objectOf(PropTypes.object).isRequired,
+};

--- a/src/widgets/ReportSideBar/index.js
+++ b/src/widgets/ReportSideBar/index.js
@@ -1,0 +1,1 @@
+export { ReportSideBarItem } from './ReportSideBarItem';


### PR DESCRIPTION
Fixes #1714 

## Change summary

This component manages the list of items available to be render, using its children `ReportSideBarItem` component.

## Testing

Further testing will be taken once the feature/dashboard is intended to be merged into develop.

### Related areas to think about

Codebase taken from past work: [branch](https://github.com/openmsupply/mobile/blob/49d8ab764c85ec5e35699661da92aad8c3e1b03a/src/widgets/ReportChart.js). Further changes may be taken into consideration.