### PR TITLE
#1547 text editor refactor

### DIFF
--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -14,9 +14,10 @@ import { useRecordListener } from '../hooks';
 import { getItemLayout, getPageDispatchers } from './dataTableUtilities';
 import { ROUTES } from '../navigation/constants';
 
-import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
+import { DataTablePageModal } from '../widgets/modals';
 import { PageButton, PageInfo, SearchBar, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
+import { BottomConfirmModal } from '../widgets/bottomModals';
 
 import { buttonStrings, modalStrings } from '../localization';
 import globalStyles from '../globalStyles';

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -15,7 +15,8 @@ import { getItemLayout, getPageDispatchers, PageActions } from './dataTableUtili
 import { gotoCustomerInvoice, createCustomerInvoice } from '../navigation/actions';
 
 import { PageButton, SearchBar, DataTablePageView, ToggleBar } from '../widgets';
-import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
+import { DataTablePageModal } from '../widgets/modals';
+import { BottomConfirmModal } from '../widgets/bottomModals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
 import { buttonStrings, modalStrings } from '../localization';

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -39,7 +39,7 @@ const exportData = async () => {
 };
 
 const Menu = ({
-  isInAdminMode,
+  isInAdminMode, // isInAdminMode kept for backwards compatibility with Desktop < v4.07
   logout,
   toCustomerInvoices,
   toCustomerRequisitions,
@@ -242,7 +242,8 @@ const mapStateToProps = state => {
 export const MenuPage = connect(mapStateToProps, mapDispatchToProps)(Menu);
 
 Menu.defaultProps = {
-  isInAdminMode: false,
+  isInAdminMode: false, // isInAdminMode kept for backwards compatibility with Desktop < v4.07
+  isAdmin: false,
 };
 
 Menu.propTypes = {
@@ -256,7 +257,7 @@ Menu.propTypes = {
   toSupplierRequisitions: PropTypes.func.isRequired,
   toRealmExplorer: PropTypes.func.isRequired,
   toSettings: PropTypes.func.isRequired,
-  isAdmin: PropTypes.bool.isRequired,
+  isAdmin: PropTypes.bool,
   usingDispensary: PropTypes.bool.isRequired,
   usingModules: PropTypes.bool.isRequired,
 };

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -12,9 +12,9 @@ import { connect } from 'react-redux';
 import { getItemLayout, getPageDispatchers, PageActions } from './dataTableUtilities';
 import { createStocktake, updateStocktake } from '../navigation/actions';
 
-import { BottomTextEditor } from '../widgets/modals';
 import { ToggleBar, DataTablePageView, SearchBar } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
+import { BottomTextEditor } from '../widgets/bottomModals';
 
 import { buttonStrings, modalStrings } from '../localization';
 import globalStyles from '../globalStyles';

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -14,7 +14,8 @@ import { useSyncListener, useNavigationFocus } from '../hooks';
 import { getItemLayout, getPageDispatchers, PageActions } from './dataTableUtilities';
 
 import { PageButton, DataTablePageView, SearchBar, ToggleBar } from '../widgets';
-import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
+import { DataTablePageModal } from '../widgets/modals';
+import { BottomConfirmModal } from '../widgets/bottomModals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 import { ROUTES } from '../navigation/constants';
 

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -13,7 +13,8 @@ import { MODAL_KEYS } from '../utilities';
 import { useRecordListener } from '../hooks';
 import { getItemLayout, getPageDispatchers } from './dataTableUtilities';
 
-import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
+import { DataTablePageModal } from '../widgets/modals';
+import { BottomConfirmModal } from '../widgets/bottomModals';
 import { PageButton, PageInfo, SearchBar, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -15,7 +15,8 @@ import { getItemLayout, getPageDispatchers, PageActions } from './dataTableUtili
 import { gotoSupplierInvoice, createSupplierInvoice } from '../navigation/actions';
 
 import { PageButton, SearchBar, DataTablePageView, ToggleBar } from '../widgets';
-import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
+import { DataTablePageModal } from '../widgets/modals';
+import { BottomConfirmModal } from '../widgets/bottomModals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
 import { buttonStrings, modalStrings } from '../localization';

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -11,7 +11,8 @@ import { View, ToastAndroid } from 'react-native';
 import { connect } from 'react-redux';
 
 import { MODAL_KEYS } from '../utilities';
-import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
+import { DataTablePageModal } from '../widgets/modals';
+import { BottomConfirmModal } from '../widgets/bottomModals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 import { DataTablePageView, PageButton, PageInfo, ToggleBar, SearchBar } from '../widgets';
 

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -9,12 +9,12 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { connect } from 'react-redux';
 
-import { BottomConfirmModal, DataTablePageModal } from '../widgets/modals';
+import { DataTablePageModal } from '../widgets/modals';
 import { PageButton, SearchBar, DataTablePageView, ToggleBar } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
+import { BottomConfirmModal } from '../widgets/bottomModals';
 
 import { UIDatabase } from '../database';
-import { User } from '../database/DataTypes';
 import Settings from '../settings/MobileAppSettings';
 import { MODAL_KEYS, getAllPrograms } from '../utilities';
 import { ROUTES } from '../navigation/constants';

--- a/src/widgets/TextEditor.js
+++ b/src/widgets/TextEditor.js
@@ -17,47 +17,36 @@ import globalStyles from '../globalStyles';
 /**
  * Renders a View containing a TextInput and confirm Button, to allow editing
  * of the text passed in as a prop.
- * @prop {string}   text          The text in its initial state
- * @prop {function} onEndEditing  A function to call with the new text
- *                                on confirm
+ * @prop {string}   text            The text in its initial state
+ * @prop {function} onEndEditing    A function to call with the new text on confirm.
+ * @prop {Bool}     secureTextEntry Indicator if secure text entry should be used.
  */
-export class TextEditor extends React.Component {
-  constructor(props) {
-    super(props);
+const TextEditor = ({ onEndEditing, secureTextEntry, text }) => {
+  const [textValue, setTextValue] = React.useState(text);
 
-    const { text } = this.props;
+  const submitValue = React.useCallback(() => onEndEditing(textValue));
 
-    this.state = {
-      text,
-    };
-  }
-
-  render() {
-    const { onEndEditing, secureTextEntry } = this.props;
-    const { text } = this.state;
-
-    return (
-      <View style={localStyles.container}>
-        <TextInput
-          autoFocus={true}
-          style={localStyles.textInput}
-          textStyle={globalStyles.modalText}
-          underlineColorAndroid="transparent"
-          value={text}
-          onChangeText={newText => this.setState({ text: newText })}
-          onSubmitEditing={() => onEndEditing(text)}
-          secureTextEntry={secureTextEntry}
-        />
-        <Button
-          style={[globalStyles.button, globalStyles.modalOrangeButton]}
-          textStyle={[globalStyles.buttonText, globalStyles.modalButtonText]}
-          text={buttonStrings.done}
-          onPress={() => onEndEditing(text)}
-        />
-      </View>
-    );
-  }
-}
+  return (
+    <View style={localStyles.container}>
+      <TextInput
+        autoFocus={true}
+        style={localStyles.textInput}
+        textStyle={globalStyles.modalText}
+        underlineColorAndroid="transparent"
+        value={textValue}
+        onChangeText={setTextValue}
+        onSubmitEditing={submitValue}
+        secureTextEntry={secureTextEntry}
+      />
+      <Button
+        style={localStyles.confirmButtonStyle}
+        textStyle={localStyles.confirmButtonTextStyle}
+        text={buttonStrings.done}
+        onPress={submitValue}
+      />
+    </View>
+  );
+};
 
 export default TextEditor;
 
@@ -80,5 +69,13 @@ const localStyles = StyleSheet.create({
   textInput: {
     flex: 1,
     marginRight: 10,
+  },
+  confirmButtonStyle: {
+    ...globalStyles.button,
+    ...globalStyles.modalOrangeButton,
+  },
+  confirmButtonTextStyle: {
+    ...globalStyles.buttonText,
+    ...globalStyles.modalButtonText,
   },
 });

--- a/src/widgets/bottomModals/BottomModalContainer.js
+++ b/src/widgets/bottomModals/BottomModalContainer.js
@@ -33,6 +33,7 @@ export const BottomModalContainer = ({
       backdropPressToClose={backdropPressToClose}
       position={position}
       backdrop={backdrop}
+      isOpen={isOpen}
       {...modalProps}
       style={localStyles.modalStyle}
     >

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -8,7 +8,6 @@ export { Button, ProgressBar } from 'react-native-ui-components';
 export { FinaliseButton } from './FinaliseButton';
 export { GenericChoiceList } from './GenericChoiceList';
 export { IconCell } from './IconCell';
-// eslint-disable-next-line import/named
 export { NavigationBar } from './NavigationBar';
 export { OnePressButton } from './OnePressButton';
 export { PageButton } from './PageButton';

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -16,7 +16,6 @@ export { Spinner } from './Spinner';
 export { SyncState } from './SyncState';
 export { TextInput } from './TextInput';
 export { ToggleBar } from './ToggleBar';
-export { ToggleSelector } from './ToggleSelector';
 export { ExpiryDateInput } from './ExpiryDateInput';
 export { ResultRow } from './ResultRow';
 export { SearchBar } from './SearchBar';

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -6,7 +6,6 @@
 export { Button, ProgressBar } from 'react-native-ui-components';
 
 export { FinaliseButton } from './FinaliseButton';
-export { GenericChoiceList } from './GenericChoiceList';
 export { IconCell } from './IconCell';
 export { NavigationBar } from './NavigationBar';
 export { OnePressButton } from './OnePressButton';

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -16,7 +16,6 @@ export { PageInfo } from './PageInfo';
 export { Step } from './Step';
 export { Spinner } from './Spinner';
 export { SyncState } from './SyncState';
-export { TextEditor } from './TextEditor';
 export { TextInput } from './TextInput';
 export { ToggleBar } from './ToggleBar';
 export { ToggleSelector } from './ToggleSelector';

--- a/src/widgets/modalChildren/AutocompleteSelector.js
+++ b/src/widgets/modalChildren/AutocompleteSelector.js
@@ -17,7 +17,7 @@ import { SearchBar } from '../SearchBar';
 import { WHITE, APP_FONT_FAMILY } from '../../globalStyles';
 import { generalStrings } from '../../localization';
 
-const AutocompleteSelector = ({
+export const AutocompleteSelector = ({
   sortKeyString,
   queryString,
   queryStringSecondary,
@@ -121,8 +121,6 @@ const AutocompleteSelector = ({
     </View>
   );
 };
-
-export default AutocompleteSelector;
 
 /* eslint-disable react/forbid-prop-types, react/require-default-props */
 AutocompleteSelector.propTypes = {

--- a/src/widgets/modalChildren/AutocompleteSelector.js
+++ b/src/widgets/modalChildren/AutocompleteSelector.js
@@ -7,11 +7,15 @@
 import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FlatList, StyleSheet, View } from 'react-native';
+
 import { complement } from 'set-manipulator';
-import { SearchBar, ResultRow } from '.';
-import { APP_FONT_FAMILY, WHITE } from '../globalStyles';
-import { generalStrings } from '../localization';
-import { withOnePress } from './withOnePress';
+
+import { withOnePress } from '../withOnePress';
+import { ResultRow } from '../ResultRow';
+import { SearchBar } from '../SearchBar';
+
+import { WHITE, APP_FONT_FAMILY } from '../../globalStyles';
+import { generalStrings } from '../../localization';
 
 const AutocompleteSelector = ({
   sortKeyString,

--- a/src/widgets/modalChildren/GenericChoiceList.js
+++ b/src/widgets/modalChildren/GenericChoiceList.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 
 import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
-import { COMPONENT_HEIGHT } from '../globalStyles';
+import { COMPONENT_HEIGHT } from '../../globalStyles';
 
 /**
  * Generic choice list for use within a ModalContainer.
@@ -104,5 +104,3 @@ GenericChoiceList.propTypes = {
   highlightValue: PropTypes.string,
   renderLeftComponent: PropTypes.func,
 };
-
-export default GenericChoiceList;

--- a/src/widgets/modalChildren/MultiSelectList.js
+++ b/src/widgets/modalChildren/MultiSelectList.js
@@ -8,14 +8,14 @@ import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { FlatList, StyleSheet, View } from 'react-native';
-import globalStyles, { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../globalStyles';
-import { generalStrings, buttonStrings } from '../localization';
-import { ResultRow, OnePressButton, SearchBar } from '.';
-import { WHITE } from '../globalStyles/colors';
+import globalStyles, { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../../globalStyles';
+import { generalStrings, buttonStrings } from '../../localization';
+import { ResultRow, OnePressButton, SearchBar } from '..';
+import { WHITE } from '../../globalStyles/colors';
 
 const keyExtractor = item => item.id || item.name;
 
-const MultiSelectList = ({
+export const MultiSelectList = ({
   options,
   sortByString,
   queryString,
@@ -109,8 +109,6 @@ const MultiSelectList = ({
     </View>
   );
 };
-
-export default MultiSelectList;
 
 MultiSelectList.propTypes = {
   options: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),

--- a/src/widgets/modalChildren/NewConfirmModal.js
+++ b/src/widgets/modalChildren/NewConfirmModal.js
@@ -76,8 +76,6 @@ export const NewConfirmModal = props => {
   );
 };
 
-export default NewConfirmModal;
-
 /* eslint-disable react/require-default-props */
 NewConfirmModal.propTypes = {
   style: ViewPropTypes.style,

--- a/src/widgets/modalChildren/TextEditor.js
+++ b/src/widgets/modalChildren/TextEditor.js
@@ -9,10 +9,10 @@ import PropTypes from 'prop-types';
 import { View, StyleSheet } from 'react-native';
 import { Button } from 'react-native-ui-components';
 
-import { TextInput } from './TextInput';
+import { TextInput } from '../TextInput';
 
-import { buttonStrings } from '../localization';
-import globalStyles from '../globalStyles';
+import { buttonStrings } from '../../localization/index';
+import globalStyles from '../../globalStyles';
 
 /**
  * Renders a View containing a TextInput and confirm Button, to allow editing
@@ -21,7 +21,7 @@ import globalStyles from '../globalStyles';
  * @prop {function} onEndEditing    A function to call with the new text on confirm.
  * @prop {Bool}     secureTextEntry Indicator if secure text entry should be used.
  */
-const TextEditor = ({ onEndEditing, secureTextEntry, text }) => {
+export const TextEditor = ({ onEndEditing, secureTextEntry, text }) => {
   const [textValue, setTextValue] = React.useState(text);
 
   const submitValue = React.useCallback(() => onEndEditing(textValue));
@@ -47,8 +47,6 @@ const TextEditor = ({ onEndEditing, secureTextEntry, text }) => {
     </View>
   );
 };
-
-export default TextEditor;
 
 TextEditor.defaultProps = {
   text: '',

--- a/src/widgets/modalChildren/ToggleSelector.js
+++ b/src/widgets/modalChildren/ToggleSelector.js
@@ -6,9 +6,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { ToggleBar } from './ToggleBar';
+import { ToggleBar } from '../ToggleBar';
 
-import globalStyles from '../globalStyles';
+import globalStyles from '../../globalStyles';
 
 /**
  * A selector based on |ToggleBar|, will highlight currently selected.
@@ -37,8 +37,6 @@ export const ToggleSelector = props => {
     />
   );
 };
-
-export default ToggleSelector;
 
 /* eslint-disable react/forbid-prop-types, react/require-default-props */
 ToggleSelector.propTypes = {

--- a/src/widgets/modalChildren/index.js
+++ b/src/widgets/modalChildren/index.js
@@ -8,3 +8,4 @@ export { TextEditor } from './TextEditor';
 export { NewConfirmModal } from './NewConfirmModal';
 export { GenericChoiceList } from './GenericChoiceList';
 export { MultiSelectList } from './MultiSelectList';
+export { ToggleSelector } from './ToggleSelector';

--- a/src/widgets/modalChildren/index.js
+++ b/src/widgets/modalChildren/index.js
@@ -6,3 +6,5 @@
 export { AutocompleteSelector } from './AutocompleteSelector';
 export { TextEditor } from './TextEditor';
 export { NewConfirmModal } from './NewConfirmModal';
+export { GenericChoiceList } from './GenericChoiceList';
+export { MultiSelectList } from './MultiSelectList';

--- a/src/widgets/modalChildren/index.js
+++ b/src/widgets/modalChildren/index.js
@@ -1,0 +1,7 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+export { AutocompleteSelector } from './AutocompleteSelector';
+export { TextEditor } from './TextEditor';

--- a/src/widgets/modalChildren/index.js
+++ b/src/widgets/modalChildren/index.js
@@ -5,3 +5,4 @@
 
 export { AutocompleteSelector } from './AutocompleteSelector';
 export { TextEditor } from './TextEditor';
+export { NewConfirmModal } from './NewConfirmModal';

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -3,14 +3,16 @@ import React, { useReducer, useEffect, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, View } from 'react-native';
 
-import { ToggleBar, PageButton, TextEditor, Step } from '..';
+import { ToggleBar, PageButton, Step } from '..';
+import { AutocompleteSelector, TextEditor } from '../modalChildren';
+import ModalContainer from './ModalContainer';
+
 import globalStyles, { DARK_GREY, WARM_GREY, SUSSOL_ORANGE } from '../../globalStyles';
+
 import { SETTINGS_KEYS } from '../../settings';
 import { getAllPrograms, getAllPeriodsForProgram } from '../../utilities';
 import { programStrings, navStrings } from '../../localization';
 import { UIDatabase } from '../../database';
-import AutocompleteSelector from '../AutocompleteSelector';
-
 import {
   selectProgram,
   selectSupplier,
@@ -25,7 +27,6 @@ import {
   byProgramReducer,
   initialState,
 } from '../../reducers/ByProgramReducer';
-import ModalContainer from './ModalContainer';
 
 const { THIS_STORE_TAGS } = SETTINGS_KEYS;
 

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -13,9 +13,9 @@ import Settings from '../../settings/MobileAppSettings';
 import { getModalTitle, MODAL_KEYS } from '../../utilities/getModalTitle';
 
 import ModalContainer from './ModalContainer';
-import AutocompleteSelector from '../AutocompleteSelector';
+import AutocompleteSelector from '../modalChildren/AutocompleteSelector';
 import MultiSelectList from '../MultiSelectList';
-import { TextEditor } from '../TextEditor';
+import { TextEditor } from '../modalChildren/TextEditor';
 import { ByProgramModal } from './ByProgramModal';
 import { ToggleSelector } from '../ToggleSelector';
 import { RegimenDataModal } from './RegimenDataModal';

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -19,9 +19,10 @@ import {
   NewConfirmModal,
   GenericChoiceList,
   MultiSelectList,
+  ToggleSelector,
 } from '../modalChildren';
+
 import { ByProgramModal } from './ByProgramModal';
-import { ToggleSelector } from '../ToggleSelector';
 import { RegimenDataModal } from './RegimenDataModal';
 import { StocktakeBatchModal } from './StocktakeBatchModal';
 

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -13,12 +13,16 @@ import Settings from '../../settings/MobileAppSettings';
 import { getModalTitle, MODAL_KEYS } from '../../utilities/getModalTitle';
 
 import ModalContainer from './ModalContainer';
-import { TextEditor, AutocompleteSelector, NewConfirmModal } from '../modalChildren';
-import MultiSelectList from '../MultiSelectList';
+import {
+  TextEditor,
+  AutocompleteSelector,
+  NewConfirmModal,
+  GenericChoiceList,
+  MultiSelectList,
+} from '../modalChildren';
 import { ByProgramModal } from './ByProgramModal';
 import { ToggleSelector } from '../ToggleSelector';
 import { RegimenDataModal } from './RegimenDataModal';
-import { GenericChoiceList } from '../GenericChoiceList';
 import { StocktakeBatchModal } from './StocktakeBatchModal';
 
 import { modalStrings } from '../../localization';

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -13,9 +13,8 @@ import Settings from '../../settings/MobileAppSettings';
 import { getModalTitle, MODAL_KEYS } from '../../utilities/getModalTitle';
 
 import ModalContainer from './ModalContainer';
-import AutocompleteSelector from '../modalChildren/AutocompleteSelector';
+import { TextEditor, AutocompleteSelector } from '../modalChildren';
 import MultiSelectList from '../MultiSelectList';
-import { TextEditor } from '../modalChildren/TextEditor';
 import { ByProgramModal } from './ByProgramModal';
 import { ToggleSelector } from '../ToggleSelector';
 import { RegimenDataModal } from './RegimenDataModal';

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -13,12 +13,11 @@ import Settings from '../../settings/MobileAppSettings';
 import { getModalTitle, MODAL_KEYS } from '../../utilities/getModalTitle';
 
 import ModalContainer from './ModalContainer';
-import { TextEditor, AutocompleteSelector } from '../modalChildren';
+import { TextEditor, AutocompleteSelector, NewConfirmModal } from '../modalChildren';
 import MultiSelectList from '../MultiSelectList';
 import { ByProgramModal } from './ByProgramModal';
 import { ToggleSelector } from '../ToggleSelector';
 import { RegimenDataModal } from './RegimenDataModal';
-import { NewConfirmModal } from './NewConfirmModal';
 import { GenericChoiceList } from '../GenericChoiceList';
 import { StocktakeBatchModal } from './StocktakeBatchModal';
 

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -13,7 +13,8 @@ import Icon from 'react-native-vector-icons/FontAwesome';
 import { SETTINGS_KEYS, getAppVersion } from '../../settings';
 
 import globalStyles, { SUSSOL_ORANGE, GREY, WARM_GREY } from '../../globalStyles';
-import { GenericChoiceList, Flag } from '..';
+import { Flag } from '..';
+import { GenericChoiceList } from '../modalChildren/GenericChoiceList';
 import ModalContainer from './ModalContainer';
 
 import { LANGUAGE_NAMES, LANGUAGE_CHOICE, authStrings, navStrings } from '../../localization';
@@ -185,10 +186,7 @@ export class LoginModal extends React.Component {
                   returnKeyType="done"
                   selectTextOnFocus
                   onChangeText={text =>
-                    this.setState({
-                      password: text,
-                      authStatus: 'unauthenticated',
-                    })
+                    this.setState({ password: text, authStatus: 'unauthenticated' })
                   }
                   onSubmitEditing={() => {
                     if (this.passwordInputRef) this.passwordInputRef.blur();

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -13,7 +13,7 @@ import { MODAL_KEYS } from '../../utilities';
 import { usePageReducer } from '../../hooks';
 import { getItemLayout } from '../../pages/dataTableUtilities';
 
-import { GenericChoiceList } from '../GenericChoiceList';
+import { GenericChoiceList } from '../modalChildren/GenericChoiceList';
 import { PageInfo, DataTablePageView, PageButton } from '..';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../DataTable';
 

--- a/src/widgets/modals/index.js
+++ b/src/widgets/modals/index.js
@@ -9,4 +9,3 @@ export { DataTablePageModal } from './DataTablePageModal';
 export { DemoUserModal } from './DemoUserModal';
 export { FinaliseModal } from './FinaliseModal';
 export { LoginModal } from './LoginModal';
-export { NewConfirmModal } from './NewConfirmModal';


### PR DESCRIPTION
Fixes #1547 

## Change summary

![offroad](https://user-images.githubusercontent.com/35858975/71388652-16d41300-265e-11ea-988a-aab2b98ffb14.gif)


- Went a little offroad.. - I messed up another import in another refactor, so I have changed that in each of the pages. This is the `BottomConfirmModal` import in each of the `...pages` components. Oops
- I made a folder `widget/modalChildren` which now contains all of the components which are designed to be children of `ModalContainer`
- Refactored `TextEditor` to be functional and use hooks

## Testing

**This PR is a refactor, so behaviour should mimic the old behaviour. This is a vague test case, so please check the current MASTER branch behaviour, and see that the behaviour is the same on THIS branch**


`TextEditor` Component used:
- [ ] For comment editing in:
    - [ ] `SupplierInvoicePage`
    - [ ] `CustomerInvoicePage`
    - [ ] `CustomerRequisitionPage`
    - [ ] `SupplierRequisitionPage`
    - [ ] `StocktakeEditPage`
- [ ] For "Their Ref" editing in:
    - [ ] `SupplierInvoicePage`
    - [ ] `CustomerInvoicePage`
    - [ ] `CustomerRequisitionPage`
    - [ ] `SupplierRequisitionPage`
    - [ ] `StocktakeEditPage`


### Related areas to think about

This will complete all the refactors aimed at `3.2`
