### PR TITLE
#1777 Corrected isAdmin propType

### DIFF
--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -39,7 +39,7 @@ const exportData = async () => {
 };
 
 const Menu = ({
-  isInAdminMode,
+  isInAdminMode, // isInAdminMode kept for backwards compatibility with Desktop < v4.07
   logout,
   toCustomerInvoices,
   toCustomerRequisitions,
@@ -242,7 +242,8 @@ const mapStateToProps = state => {
 export const MenuPage = connect(mapStateToProps, mapDispatchToProps)(Menu);
 
 Menu.defaultProps = {
-  isInAdminMode: false,
+  isInAdminMode: false, // isInAdminMode kept for backwards compatibility with Desktop < v4.07
+  isAdmin: false,
 };
 
 Menu.propTypes = {
@@ -256,7 +257,7 @@ Menu.propTypes = {
   toSupplierRequisitions: PropTypes.func.isRequired,
   toRealmExplorer: PropTypes.func.isRequired,
   toSettings: PropTypes.func.isRequired,
-  isAdmin: PropTypes.bool.isRequired,
+  isAdmin: PropTypes.bool,
   usingDispensary: PropTypes.bool.isRequired,
   usingModules: PropTypes.bool.isRequired,
 };


### PR DESCRIPTION
Fixes #1777 

## Change summary

- Adds correct proptype for `isAdmin` 
- Adds some comments!

## Testing

- [ ] When running the app in dev environment (`react-native run-android`) there is no prop type warning for the `isAdmin` prop when trying to log in

### Related areas to think about

N/A