### PR TITLE
#1783 patient and prescriber labels

### DIFF
--- a/src/actions/FinaliseActions.js
+++ b/src/actions/FinaliseActions.js
@@ -1,0 +1,14 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+export const FINALISE_ACTIONS = {
+  OPEN_MODAL: 'Finalise/openModal',
+  CLOSE_MODAL: 'Finalise/closeModal',
+};
+
+const openModal = () => ({ type: FINALISE_ACTIONS.OPEN_MODAL });
+const closeModal = () => ({ type: FINALISE_ACTIONS.CLOSE_MODAL });
+
+export const FinaliseActions = { openModal, closeModal };

--- a/src/actions/PrescriberActions.js
+++ b/src/actions/PrescriberActions.js
@@ -12,7 +12,10 @@ export const PRESCRIBER_ACTIONS = {
   CREATE: 'Prescriber/create',
   COMPLETE: 'Prescriber/complete',
   SET: 'Prescriber/set',
+  FILTER: 'Prescriber/filter',
 };
+
+const filterData = searchTerm => ({ type: PRESCRIBER_ACTIONS.FILTER, payload: { searchTerm } });
 
 const setPrescriber = prescriber => ({ type: PRESCRIBER_ACTIONS.SET, payload: { prescriber } });
 
@@ -59,4 +62,5 @@ export const PrescriberActions = {
   closeModal,
   saveNewPrescriber,
   setPrescriber,
+  filterData,
 };

--- a/src/actions/PrescriberActions.js
+++ b/src/actions/PrescriberActions.js
@@ -11,7 +11,10 @@ export const PRESCRIBER_ACTIONS = {
   EDIT: 'Prescriber/edit',
   CREATE: 'Prescriber/create',
   COMPLETE: 'Prescriber/complete',
+  SET: 'Prescriber/set',
 };
+
+const setPrescriber = prescriber => ({ type: PRESCRIBER_ACTIONS.SET, payload: { prescriber } });
 
 const closeModal = () => ({ type: PRESCRIBER_ACTIONS.COMPLETE });
 
@@ -55,4 +58,5 @@ export const PrescriberActions = {
   editPrescriber,
   closeModal,
   saveNewPrescriber,
+  setPrescriber,
 };

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -185,6 +185,17 @@ export class Item extends Realm.Object {
   }
 
   /**
+   * Returns an array of all direction expansions related to this
+   * item.
+   */
+  getDirectionExpansions = database =>
+    this.directions.sorted('priority').reduce((acc, value) => {
+      const expansion = value.getExpansion(database);
+      if (expansion) return [...acc, expansion];
+      return acc;
+    }, []);
+
+  /**
    * Get string representation of item.
    *
    * @returns  {string}
@@ -210,6 +221,7 @@ Item.schema = {
     isVisible: { type: 'bool', default: false },
     crossReferenceItem: { type: 'Item', optional: true },
     unit: { type: 'Unit', optional: true },
+    directions: { type: 'linkingObjects', objectType: 'ItemDirection', property: 'item' },
   },
 };
 

--- a/src/database/DataTypes/ItemDirection.js
+++ b/src/database/DataTypes/ItemDirection.js
@@ -5,14 +5,23 @@
 
 import Realm from 'realm';
 
-export class ItemDirection extends Realm.Object {}
+export class ItemDirection extends Realm.Object {
+  /**
+   * Returns the matching expansion of this ItemDirection, defaulting
+   * to null for all falsey values.
+   */
+  getExpansion = database => {
+    const expansion = database.get('Abbreviation', this.directions, 'abbreviation')?.expansion;
+    return expansion || null;
+  };
+}
 
 ItemDirection.schema = {
   name: 'ItemDirection',
   primaryKey: 'id',
   properties: {
     id: 'string',
-    priority: 'string',
+    priority: 'int',
     directions: 'string',
     item: { type: 'Item', optional: true },
   },

--- a/src/database/DataTypes/TransactionItem.js
+++ b/src/database/DataTypes/TransactionItem.js
@@ -86,6 +86,13 @@ export class TransactionItem extends Realm.Object {
   }
 
   /**
+   * Returns the note of the underlying transaction batch.
+   */
+  get note() {
+    return this.batches[0]?.note || null;
+  }
+
+  /**
    * Get available quantity of items.
    *
    * For customer invoices, get how much can be issued in total, accounting for the fact that any
@@ -250,6 +257,18 @@ export class TransactionItem extends Realm.Object {
     });
     database.delete('TransactionBatch', batchesToDelete);
   }
+
+  /**
+   * Sets the item direction for the underlying transaction batch.
+   */
+  setItemDirection = (database, newDirection) => {
+    const batch = this.batches[0];
+    if (!batch) return;
+    database.write(() => {
+      batch.note = newDirection;
+      database.save('TransactionBatch', batch);
+    });
+  };
 }
 
 TransactionItem.schema = {

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -110,9 +110,8 @@ class UIDatabase {
       case 'CustomerInvoice':
         // Only show invoices generated from requisitions once finalised.
         return results.filtered(
-          'type == $0 AND mode == $1 AND (linkedRequisition == $2 OR status == $3)',
+          'type == $0 AND (linkedRequisition == $1 OR status == $2)',
           'customer_invoice',
-          'store',
           null,
           'finalised'
         );

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -637,7 +637,7 @@ const createTransactionBatch = (database, transactionItem, itemBatch, isAddition
  * @param   {Item}             item         Real item to create transaction item from.
  * @return  {TransactionItem}
  */
-const createTransactionItem = (database, transaction, item) => {
+const createTransactionItem = (database, transaction, item, initialQuantity = 0) => {
   // Handle cross reference items.
   const { realItem } = item;
 
@@ -646,6 +646,9 @@ const createTransactionItem = (database, transaction, item) => {
     item: realItem,
     transaction,
   });
+
+  const { isFinalised } = transaction;
+  if (!isFinalised) transactionItem.setTotalQuantity(database, initialQuantity);
 
   transaction.addItem(transactionItem);
   database.save('Transaction', transaction);

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -31,8 +31,9 @@ import { Synchroniser, PostSyncProcessor, SyncModal } from './sync';
 import { FinaliseButton, NavigationBar, SyncState, Spinner } from './widgets';
 import { FinaliseModal, LoginModal } from './widgets/modals';
 
-import { getCurrentParams, getCurrentRouteName, ReduxNavigator } from './navigation';
+import { getCurrentParams, getCurrentRouteName, ReduxNavigator, ROUTES } from './navigation';
 import { syncCompleteTransaction } from './actions/SyncActions';
+import { FinaliseActions } from './actions/FinaliseActions';
 import { migrateDataToVersion } from './dataMigration';
 import { SyncAuthenticator, UserAuthenticator } from './authentication';
 import Settings from './settings/MobileAppSettings';
@@ -51,10 +52,10 @@ class MSupplyMobileAppContainer extends React.Component {
   handleBackEvent = debounce(
     () => {
       const { dispatch, prevRouteName } = this.props;
-      const { confirmFinalise, syncModalIsOpen } = this.state;
+      const { syncModalIsOpen } = this.state;
       // If finalise or sync modals are open, close them rather than navigating.
-      if (confirmFinalise || syncModalIsOpen) {
-        this.setState({ confirmFinalise: false, syncModalIsOpen: false });
+      if (syncModalIsOpen) {
+        this.setState({ syncModalIsOpen: false });
         return true;
       }
       // If we are on base screen (e.g. home), back button should close app as we can't go back.
@@ -86,7 +87,6 @@ class MSupplyMobileAppContainer extends React.Component {
       }
     }, AUTHENTICATION_INTERVAL);
     this.state = {
-      confirmFinalise: false,
       isInitialised,
       isLoading: false,
       syncModalIsOpen: false,
@@ -164,12 +164,9 @@ class MSupplyMobileAppContainer extends React.Component {
   };
 
   renderFinaliseButton = () => {
-    const { finaliseItem } = this.props;
+    const { finaliseItem, openFinaliseModal } = this.props;
     return (
-      <FinaliseButton
-        isFinalised={finaliseItem.record.isFinalised}
-        onPress={() => this.setState({ confirmFinalise: true })}
-      />
+      <FinaliseButton isFinalised={finaliseItem.record.isFinalised} onPress={openFinaliseModal} />
     );
   };
 
@@ -213,14 +210,16 @@ class MSupplyMobileAppContainer extends React.Component {
   };
 
   render() {
-    const { dispatch, finaliseItem, navigationState, syncState, currentUser } = this.props;
     const {
-      confirmFinalise,
-      isInAdminMode,
-      isInitialised,
-      isLoading,
-      syncModalIsOpen,
-    } = this.state;
+      dispatch,
+      finaliseItem,
+      navigationState,
+      syncState,
+      currentUser,
+      finaliseModalOpen,
+      closeFinaliseModal,
+    } = this.props;
+    const { isInAdminMode, isInitialised, isLoading, syncModalIsOpen } = this.state;
 
     if (!isInitialised) {
       return (
@@ -239,7 +238,11 @@ class MSupplyMobileAppContainer extends React.Component {
           onPressBack={this.getCanNavigateBack() ? this.handleBackEvent : null}
           LeftComponent={this.getCanNavigateBack() ? this.renderPageTitle : null}
           CentreComponent={this.renderLogo}
-          RightComponent={finaliseItem ? this.renderFinaliseButton : this.renderSyncState}
+          RightComponent={
+            finaliseItem && finaliseItem?.visibleButton
+              ? this.renderFinaliseButton
+              : this.renderSyncState
+          }
         />
         <ReduxNavigator
           state={navigationState}
@@ -255,8 +258,8 @@ class MSupplyMobileAppContainer extends React.Component {
         />
         <FinaliseModal
           database={UIDatabase}
-          isOpen={confirmFinalise}
-          onClose={() => this.setState({ confirmFinalise: false })}
+          isOpen={finaliseModalOpen}
+          onClose={closeFinaliseModal}
           finaliseItem={finaliseItem}
           user={currentUser}
           runWithLoadingIndicator={this.runWithLoadingIndicator}
@@ -280,13 +283,22 @@ class MSupplyMobileAppContainer extends React.Component {
   }
 }
 
-const mapStateToProps = state => {
-  const { nav: navigationState, sync: syncState } = state;
+const mapDispatchToProps = dispatch => {
+  const openFinaliseModal = () => dispatch(FinaliseActions.openModal());
+  const closeFinaliseModal = () => dispatch(FinaliseActions.closeModal());
+  return { dispatch, openFinaliseModal, closeFinaliseModal };
+};
 
+const mapStateToProps = state => {
+  const { finalise, nav: navigationState, sync: syncState } = state;
+  const { finaliseModalOpen } = finalise;
   const currentParams = getCurrentParams(navigationState);
   const currentTitle = currentParams && currentParams.title;
-  const finaliseItem = FINALISABLE_PAGES[getCurrentRouteName(navigationState)];
+  const currentRouteName = getCurrentRouteName(navigationState);
+  const finaliseItem = FINALISABLE_PAGES[currentRouteName];
   if (finaliseItem && currentParams) {
+    if (currentRouteName === ROUTES.PRESCRIPTION) finaliseItem.visibleButton = false;
+    else finaliseItem.visibleButton = true;
     finaliseItem.record = currentParams[finaliseItem.recordToFinaliseKey];
   }
 
@@ -297,6 +309,7 @@ const mapStateToProps = state => {
     navigationState,
     syncState,
     currentUser: state.user.currentUser,
+    finaliseModalOpen,
   };
 };
 
@@ -314,6 +327,9 @@ MSupplyMobileAppContainer.propTypes = {
   syncState: PropTypes.object.isRequired,
   currentUser: PropTypes.object,
   prevRouteName: PropTypes.string.isRequired,
+  finaliseModalOpen: PropTypes.bool.isRequired,
+  openFinaliseModal: PropTypes.func.isRequired,
+  closeFinaliseModal: PropTypes.func.isRequired,
 };
 
-export default connect(mapStateToProps)(MSupplyMobileAppContainer);
+export default connect(mapStateToProps, mapDispatchToProps)(MSupplyMobileAppContainer);

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -22,6 +22,7 @@ import { PrescriberActions } from '../actions/PrescriberActions';
 
 import { FormControl } from '../widgets/FormControl';
 import { getFormInputConfig } from '../utilities/formInputConfigs';
+import { PatientHistoryModal } from '../widgets/modals/PatientHistory';
 
 const Dispensing = ({
   data,
@@ -53,6 +54,7 @@ const Dispensing = ({
   prescriberModalOpen,
   usingPatientsDataSet,
   usingPrescribersDataSet,
+  viewingHistory,
 }) => {
   const getCellCallbacks = colKey => {
     switch (colKey) {
@@ -152,6 +154,14 @@ const Dispensing = ({
           inputConfig={getFormInputConfig('prescriber', currentPrescriber)}
         />
       </ModalContainer>
+      <ModalContainer
+        title={`Patient History: ${currentPatient?.firstName} ${currentPatient?.lastName}`}
+        onClose={cancelPatientEdit}
+        fullScreen
+        isVisible={viewingHistory}
+      >
+        <PatientHistoryModal />
+      </ModalContainer>
     </>
   );
 };
@@ -170,7 +180,7 @@ const localStyles = {
 const mapStateToProps = state => {
   const { pages, patient, prescriber } = state;
   const { dispensary } = pages;
-  const { isCreating, isEditing, currentPatient } = patient;
+  const { isCreating, isEditing, currentPatient, viewingHistory } = patient;
   const { isCreatingPrescriber, isEditingPrescriber, currentPrescriber } = prescriber;
 
   const { dataSet } = dispensary;
@@ -183,6 +193,7 @@ const mapStateToProps = state => {
     prescriberModalOpen: isCreatingPrescriber || isEditingPrescriber,
     isCreating,
     currentPatient,
+    viewingHistory,
     isCreatingPrescriber,
     isEditingPrescriber,
     currentPrescriber,
@@ -246,4 +257,5 @@ Dispensing.propTypes = {
   prescriberModalOpen: PropTypes.bool.isRequired,
   usingPatientsDataSet: PropTypes.bool.isRequired,
   usingPrescribersDataSet: PropTypes.bool.isRequired,
+  viewingHistory: PropTypes.bool.isRequired,
 };

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -5,31 +5,20 @@
  */
 
 import React from 'react';
-
 import PropTypes from 'prop-types';
-
-import { View } from 'react-native';
 import { connect } from 'react-redux';
 
-import { Wizard, SimpleTable, PageButton } from '../widgets';
-import { PrescriptionCart } from '../widgets/PrescriptionCart';
-import { PrescriptionSummary } from '../widgets/PrescriptionSummary';
+import { Wizard } from '../widgets';
+import { PrescriberSelect } from '../widgets/Tabs/PrescriberSelect';
+import { ItemSelect } from '../widgets/Tabs/ItemSelect';
+import { PrescriptionConfirmation } from '../widgets/Tabs/PrescriptionConfirmation';
 
-import { UIDatabase } from '../database';
-import { getColumns } from './dataTableUtilities';
 import {
   selectItem,
   selectPrescriber,
   switchTab,
   editQuantity,
 } from '../reducers/PrescriptionReducer';
-
-import { PrescriptionInfo } from '../widgets/PrescriptionInfo';
-
-/**
- * File contains Four components for the PrescriptionPage. The container component Prescription and
- * three "Tab" components PrescriberSelect/ItemSelect/Summary.
- */
 
 const mapDispatchToProps = dispatch => {
   const choosePrescriber = prescriberID => dispatch(selectPrescriber(prescriberID));
@@ -44,83 +33,12 @@ const mapStateToProps = state => {
   return { ...prescription, ...patient, ...prescriber };
 };
 
-const PrescriberSelect = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(({ choosePrescriber }) => {
-  const { row, extraLargeFlex } = localStyles;
-  const columns = getColumns('prescriberSelect');
-
-  const tableRef = React.useRef(React.createRef());
-
-  return (
-    <>
-      <PrescriptionInfo />
-      <View style={row}>
-        <View style={extraLargeFlex}>
-          <SimpleTable
-            data={UIDatabase.objects('Prescriber')}
-            columns={columns}
-            selectRow={choosePrescriber}
-            ref={tableRef}
-          />
-        </View>
-      </View>
-    </>
-  );
-});
-
-const ItemSelect = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(({ transaction, chooseItem, nextTab, updateQuantity }) => {
-  const { row, mediumFlex } = localStyles;
-  const columns = getColumns('itemSelect');
-
-  const tableRef = React.useRef(React.createRef());
-
-  return (
-    <>
-      <PrescriptionInfo />
-      <View style={{ ...row }}>
-        <View style={mediumFlex}>
-          <SimpleTable
-            data={UIDatabase.objects('Item')}
-            columns={columns}
-            selectRow={x => chooseItem(x)}
-            ref={tableRef}
-          />
-        </View>
-        <View style={{ flex: 15, marginHorizontal: 15 }}>
-          <PrescriptionCart items={transaction.items.slice()} onChangeQuantity={updateQuantity} />
-          <PageButton text="Next" onPress={() => nextTab(1)} style={{ alignSelf: 'flex-end' }} />
-        </View>
-      </View>
-    </>
-  );
-});
-
-const Summary = connect(mapStateToProps)(({ transaction }) => (
-  <View style={{ flex: 1 }}>
-    <PrescriptionInfo />
-    <PrescriptionSummary transaction={transaction} />
-  </View>
-));
-
-const tabs = [PrescriberSelect, ItemSelect, Summary];
-const titles = ['Select the Prescriber', 'Select items', 'Summary'];
+const tabs = [PrescriberSelect, ItemSelect, PrescriptionConfirmation];
+const titles = ['Select the Prescriber', 'Select items', 'Finalise'];
 
 export const Prescription = ({ currentTab, nextTab }) => (
   <Wizard tabs={tabs} titles={titles} currentTabIndex={currentTab} onPress={nextTab} />
 );
-
-const localStyles = {
-  row: { flex: 1, flexDirection: 'row' },
-  extraLargeFlex: { flex: 19 },
-  largeFlex: { flex: 10 },
-  mediumFlex: { flex: 9 },
-  smallFlex: { flex: 1 },
-};
 
 export const PrescriptionPage = connect(mapStateToProps, mapDispatchToProps)(Prescription);
 

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -11,26 +11,20 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { connect } from 'react-redux';
 
-import {
-  FavouriteStarIcon,
-  TableShortcut,
-  TableShortcuts,
-  Wizard,
-  SimpleTable,
-  PageButton,
-} from '../widgets';
+import { Wizard, SimpleTable, PageButton } from '../widgets';
 import { PrescriptionCart } from '../widgets/PrescriptionCart';
 import { PrescriptionSummary } from '../widgets/PrescriptionSummary';
 
 import { UIDatabase } from '../database';
 import { getColumns } from './dataTableUtilities';
-import { ALPHABET } from '../widgets/constants';
 import {
   selectItem,
   selectPrescriber,
   switchTab,
   editQuantity,
 } from '../reducers/PrescriptionReducer';
+
+import { PrescriptionInfo } from '../widgets/PrescriptionInfo';
 
 /**
  * File contains Four components for the PrescriptionPage. The container component Prescription and
@@ -46,22 +40,12 @@ const mapDispatchToProps = dispatch => {
 };
 
 const mapStateToProps = state => {
-  const { prescription } = state;
-  return prescription;
+  const { prescription, patient, prescriber } = state;
+  return { ...prescription, ...patient, ...prescriber };
 };
 
-// Helper method finding the first instance of a Prescriber whos first name starts with
-// the passed character.
-const getPrescriberIndex = char =>
-  UIDatabase.objects('Prescriber').findIndex(item => item.firstName[0].toLowerCase() === char);
-
-// Helper method finding the first instance of an Item whos first name starts with
-// the passed character.
-const getItemIndex = char =>
-  UIDatabase.objects('Item').findIndex(item => item.name[0].toLowerCase() === char);
-
 const PrescriberSelect = connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(({ choosePrescriber }) => {
   const { row, extraLargeFlex } = localStyles;
@@ -69,42 +53,20 @@ const PrescriberSelect = connect(
 
   const tableRef = React.useRef(React.createRef());
 
-  const alphabetCallback = React.useCallback(
-    character => {
-      const startIndex = getPrescriberIndex(character);
-
-      if (startIndex > -1) tableRef.current.scrollToIndex({ index: startIndex });
-    },
-    [tableRef.current]
-  );
-
-  const AlphabetShortcuts = React.useCallback(
-    () =>
-      ALPHABET.map(character => (
-        <TableShortcut key={character} onPress={() => alphabetCallback(character)}>
-          {character.toUpperCase()}
-        </TableShortcut>
-      )),
-    []
-  );
-
   return (
-    <View style={row}>
-      <TableShortcuts>
-        <TableShortcut extraLarge>
-          <FavouriteStarIcon />
-        </TableShortcut>
-        <AlphabetShortcuts />
-      </TableShortcuts>
-      <View style={extraLargeFlex}>
-        <SimpleTable
-          data={UIDatabase.objects('Prescriber')}
-          columns={columns}
-          selectRow={choosePrescriber}
-          ref={tableRef}
-        />
+    <>
+      <PrescriptionInfo />
+      <View style={row}>
+        <View style={extraLargeFlex}>
+          <SimpleTable
+            data={UIDatabase.objects('Prescriber')}
+            columns={columns}
+            selectRow={choosePrescriber}
+            ref={tableRef}
+          />
+        </View>
       </View>
-    </View>
+    </>
   );
 });
 
@@ -117,50 +79,30 @@ const ItemSelect = connect(
 
   const tableRef = React.useRef(React.createRef());
 
-  const alphabetCallback = React.useCallback(
-    character => {
-      const startIndex = getItemIndex(character);
-      if (startIndex > -1) tableRef.current.scrollToIndex({ index: startIndex });
-    },
-    [tableRef.current]
-  );
-
-  const AlphabetShortcuts = React.useCallback(
-    () =>
-      ALPHABET.map(character => (
-        <TableShortcut key={character} onPress={alphabetCallback}>
-          {character.toUpperCase()}
-        </TableShortcut>
-      )),
-    []
-  );
-
   return (
-    <View style={{ ...row, marginTop: 20 }}>
-      <TableShortcuts>
-        <TableShortcut>
-          <FavouriteStarIcon />
-        </TableShortcut>
-        <AlphabetShortcuts />
-      </TableShortcuts>
-      <View style={mediumFlex}>
-        <SimpleTable
-          data={UIDatabase.objects('Item')}
-          columns={columns}
-          selectRow={x => chooseItem(x)}
-          ref={tableRef}
-        />
+    <>
+      <PrescriptionInfo />
+      <View style={{ ...row }}>
+        <View style={mediumFlex}>
+          <SimpleTable
+            data={UIDatabase.objects('Item')}
+            columns={columns}
+            selectRow={x => chooseItem(x)}
+            ref={tableRef}
+          />
+        </View>
+        <View style={{ flex: 15, marginHorizontal: 15 }}>
+          <PrescriptionCart items={transaction.items.slice()} onChangeQuantity={updateQuantity} />
+          <PageButton text="Next" onPress={() => nextTab(1)} style={{ alignSelf: 'flex-end' }} />
+        </View>
       </View>
-      <View style={{ flex: 15, marginHorizontal: 15 }}>
-        <PrescriptionCart items={transaction.items.slice()} onChangeQuantity={updateQuantity} />
-        <PageButton text="Next" onPress={() => nextTab(1)} style={{ alignSelf: 'flex-end' }} />
-      </View>
-    </View>
+    </>
   );
 });
 
 const Summary = connect(mapStateToProps)(({ transaction }) => (
   <View style={{ flex: 1 }}>
+    <PrescriptionInfo />
     <PrescriptionSummary transaction={transaction} />
   </View>
 ));

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -31,7 +31,7 @@ const PAGE_COLUMN_WIDTHS = {
   stocktakeBatchEditModalWithReasons: [1, 1, 1, 1, 1, 1],
   regimenDataModal: [4, 1, 5],
   prescriberSelect: [1, 1],
-  itemSelect: [1, 3],
+  itemSelect: [1, 3, 1],
   patientHistory: [1, 3, 1, 3],
 };
 
@@ -183,7 +183,7 @@ const PAGE_COLUMNS = {
     COLUMN_NAMES.EDITABLE_COMMENT,
   ],
   prescriberSelect: [COLUMN_NAMES.FIRST_NAME, COLUMN_NAMES.LAST_NAME],
-  itemSelect: [COLUMN_NAMES.CODE, COLUMN_NAMES.NAME],
+  itemSelect: [COLUMN_NAMES.CODE, COLUMN_NAMES.NAME, COLUMN_NAMES.TOTAL_QUANTITY],
   patientHistory: [
     COLUMN_NAMES.ITEM_CODE,
     COLUMN_NAMES.ITEM_NAME,

--- a/src/reducers/FinaliseReducer.js
+++ b/src/reducers/FinaliseReducer.js
@@ -1,0 +1,32 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import { FINALISE_ACTIONS } from '../actions/FinaliseActions';
+
+/**
+ * Simple reducer managing the stores current finalise state.
+ *
+ * State shape:
+ * {
+ *     finaliseModalOpen: [bool]
+ * }
+ */
+
+const initialState = () => ({ finaliseModalOpen: false });
+
+export const FinaliseReducer = (state = initialState(), action) => {
+  const { type } = action;
+
+  switch (type) {
+    case FINALISE_ACTIONS.OPEN_MODAL: {
+      return { ...state, finaliseModalOpen: true };
+    }
+    case FINALISE_ACTIONS.CLOSE_MODAL: {
+      return { ...state, finaliseModalOpen: false };
+    }
+    default:
+      return state;
+  }
+};

--- a/src/reducers/PatientReducer.js
+++ b/src/reducers/PatientReducer.js
@@ -4,6 +4,7 @@
  */
 
 import { PATIENT_ACTIONS } from '../actions/PatientActions';
+import { ROUTES } from '../navigation/index';
 
 const patientInitialState = () => ({
   currentPatient: null,
@@ -18,6 +19,15 @@ export const PatientReducer = (state = patientInitialState(), action) => {
   const { type } = action;
 
   switch (type) {
+    case 'Navigation/NAVIGATE': {
+      const { routeName, params } = action;
+
+      if (routeName !== ROUTES.PRESCRIPTION) return state;
+      const { transaction } = params;
+      const { otherParty } = transaction;
+      return { ...state, currentPatient: otherParty };
+    }
+
     case PATIENT_ACTIONS.PATIENT_EDIT: {
       const { payload } = action;
       const { patient } = payload;
@@ -29,7 +39,14 @@ export const PatientReducer = (state = patientInitialState(), action) => {
     }
 
     case PATIENT_ACTIONS.COMPLETE: {
-      return patientInitialState();
+      return {
+        ...state,
+        isEditing: false,
+        isCreating: false,
+        viewingHistory: false,
+        sortKey: 'itemName',
+        isAscending: true,
+      };
     }
 
     case PATIENT_ACTIONS.SORT_HISTORY: {

--- a/src/reducers/PrescriberReducer.js
+++ b/src/reducers/PrescriberReducer.js
@@ -35,6 +35,12 @@ export const PrescriberReducer = (state = prescriberInitialState(), action) => {
       return { ...state, currentPrescriber: prescriber };
     }
 
+    case PRESCRIBER_ACTIONS.FILTER: {
+      const { payload } = action;
+      const { searchTerm } = payload;
+      return { ...state, searchTerm };
+    }
+
     default: {
       return state;
     }

--- a/src/reducers/PrescriberReducer.js
+++ b/src/reducers/PrescriberReducer.js
@@ -29,6 +29,12 @@ export const PrescriberReducer = (state = prescriberInitialState(), action) => {
       return prescriberInitialState();
     }
 
+    case PRESCRIBER_ACTIONS.SET: {
+      const { payload } = action;
+      const { prescriber } = payload;
+      return { ...state, currentPrescriber: prescriber };
+    }
+
     default: {
       return state;
     }

--- a/src/reducers/PrescriptionReducer.js
+++ b/src/reducers/PrescriptionReducer.js
@@ -3,9 +3,11 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
+import { batch } from 'react-redux';
 import { ROUTES } from '../navigation/constants';
 import { UIDatabase } from '../database';
-import { createRecord } from '../database/utilities/index';
+import { createRecord } from '../database/utilities';
+import { PrescriberActions } from '../actions/PrescriberActions';
 
 const initialState = () => ({
   currentTab: 0,
@@ -47,7 +49,10 @@ export const selectPrescriber = prescriberID => (dispatch, getState) => {
     })
   );
 
-  dispatch(switchTab(currentTab + 1));
+  batch(() => {
+    dispatch(PrescriberActions.setPrescriber(prescriber));
+    dispatch(switchTab(currentTab + 1));
+  });
 };
 
 export const selectItem = itemID => (dispatch, getState) => {

--- a/src/reducers/PrescriptionReducer.js
+++ b/src/reducers/PrescriptionReducer.js
@@ -15,8 +15,23 @@ const initialState = () => ({
 });
 
 const ACTIONS = {
-  SWITCH_TAB: 'PRESCRIPTION/SWITCH_TAB',
-  SELECT_ITEM: 'PRESCRIPTION/SELECT_ITEM',
+  SWITCH_TAB: 'Prescription/SWITCH_TAB',
+  SELECT_ITEM: 'Prescription/SELECT_ITEM',
+  REMOVE_ITEM: 'Prescription/REMOVE_ITEM',
+};
+
+export const removeItem = id => (dispatch, getState) => {
+  const { prescription } = getState();
+  const { transaction } = prescription;
+  const { items } = transaction;
+
+  const item = items.filtered('id == $0', id);
+
+  UIDatabase.write(() => {
+    UIDatabase.delete('TransactionItem', item);
+  });
+
+  dispatch({ type: ACTIONS.REMOVE_ITEM });
 };
 
 export const editQuantity = (id, quantity) => (_, getState) => {
@@ -62,7 +77,7 @@ export const selectItem = itemID => (dispatch, getState) => {
 
   if (!transaction.hasItem(item)) {
     UIDatabase.write(() => {
-      createRecord(UIDatabase, 'TransactionItem', transaction, item);
+      createRecord(UIDatabase, 'TransactionItem', transaction, item, 1);
     });
   }
 
@@ -81,7 +96,11 @@ export const PrescriptionReducer = (state = initialState(), action) => {
 
       return { ...state, transaction };
     }
-
+    case ACTIONS.REMOVE_ITEM: {
+      const { transaction } = state;
+      const { id } = transaction;
+      return { ...state, transaction: UIDatabase.get('Transaction', id) };
+    }
     case ACTIONS.SWITCH_TAB: {
       const { payload } = action;
       const { nextTab } = payload;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,6 +8,7 @@ import { PrescriptionReducer } from './PrescriptionReducer';
 import { PatientReducer } from './PatientReducer';
 import { FormReducer } from './FormReducer';
 import { PrescriberReducer } from './PrescriberReducer';
+import { FinaliseReducer } from './FinaliseReducer';
 
 export default combineReducers({
   user: UserReducer,
@@ -19,4 +20,5 @@ export default combineReducers({
   patient: PatientReducer,
   prescriber: PrescriberReducer,
   form: FormReducer,
+  finalise: FinaliseReducer,
 });

--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -22,3 +22,13 @@ export const selectSortedPatientHistory = ({ patient }) => {
 
   return patientHistory ? sortDataBy(patientHistory.slice(), sortKey, isAscending) : patientHistory;
 };
+
+export const selectCurrentPatient = ({ patient }) => {
+  const { currentPatient } = patient;
+  return currentPatient;
+};
+
+export const selectPatientName = ({ patient }) => {
+  const currentPatient = selectCurrentPatient({ patient });
+  return `${currentPatient?.firstName} ${currentPatient?.lastName}`;
+};

--- a/src/selectors/prescriber.js
+++ b/src/selectors/prescriber.js
@@ -1,0 +1,14 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+export const selectCurrentPrescriber = ({ prescriber }) => {
+  const { currentPrescriber } = prescriber;
+  return currentPrescriber;
+};
+
+export const selectPrescriberName = ({ prescriber }) => {
+  const currentPrescriber = selectCurrentPrescriber({ prescriber });
+  return `${currentPrescriber?.firstName} ${currentPrescriber?.lastName}`;
+};

--- a/src/selectors/prescription.js
+++ b/src/selectors/prescription.js
@@ -1,0 +1,12 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+export const selectHasItemsAndQuantity = ({ prescription }) => {
+  const { transaction } = prescription;
+  const { totalQuantity, items } = transaction;
+  const hasItems = items.length > 0;
+  const hasQuantity = totalQuantity > 0;
+  return hasItems && hasQuantity;
+};

--- a/src/widgets/FlexColumn.js
+++ b/src/widgets/FlexColumn.js
@@ -1,0 +1,45 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+
+/**
+ * Simple layout component. For use when needing a simple View with flex
+ * direction of column.
+ * @param {React.node} children       Children of this component
+ * @param {Number}     flex           The flex amount i.e. 1
+ * @param {String}     alignItems     The alignItems style value
+ * @param {String}     justifyContent The justifyContent style value
+ * @param {Object}     style          An additional styles object.
+ */
+export const FlexColumn = ({ children, flex, alignItems, justifyContent, style }) => {
+  const internalStyle = React.useMemo(() => ({
+    flex,
+    flexDirection: 'column',
+    [alignItems ? 'alignItems' : undefined]: alignItems,
+    [justifyContent ? 'justifyContent' : undefined]: justifyContent,
+    ...style,
+  }));
+  return <View style={internalStyle}>{children}</View>;
+};
+
+FlexColumn.defaultProps = {
+  children: null,
+  flex: 0,
+  alignItems: '',
+  justifyContent: '',
+  style: {},
+};
+
+FlexColumn.propTypes = {
+  children: PropTypes.oneOf([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
+  flex: PropTypes.number,
+  alignItems: PropTypes.string,
+  justifyContent: PropTypes.string,
+  style: PropTypes.object,
+};

--- a/src/widgets/FlexRow.js
+++ b/src/widgets/FlexRow.js
@@ -1,0 +1,45 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+
+/**
+ * Simple layout component. For use when needing a simple View with flex
+ * direction of row.
+ * @param {React.node} children       Children of this component
+ * @param {Number}     flex           The flex amount i.e. 1
+ * @param {String}     alignItems     The alignItems style value
+ * @param {String}     justifyContent The justifyContent style value
+ * @param {Object}     style          An additional styles object.
+ */
+export const FlexRow = ({ children, flex, alignItems, justifyContent, style }) => {
+  const internalStyle = React.useMemo(() => ({
+    flex,
+    flexDirection: 'row',
+    [alignItems ? 'alignItems' : undefined]: alignItems,
+    [justifyContent ? 'justifyContent' : undefined]: justifyContent,
+    ...style,
+  }));
+  return <View style={internalStyle}>{children}</View>;
+};
+
+FlexRow.defaultProps = {
+  children: null,
+  flex: 0,
+  alignItems: '',
+  justifyContent: '',
+  style: {},
+};
+
+FlexRow.propTypes = {
+  children: PropTypes.oneOf([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
+  flex: PropTypes.number,
+  alignItems: PropTypes.string,
+  justifyContent: PropTypes.string,
+  style: PropTypes.object,
+};

--- a/src/widgets/FlexView.js
+++ b/src/widgets/FlexView.js
@@ -1,0 +1,33 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+
+/**
+ * Simple layout component. For use when needing a simple View with flex.
+ *
+ * @param {React.node} children       Children of this component
+ * @param {Number}     flex           The flex amount i.e. 1
+ * @param {Object}     style          An additional styles object.
+ */
+export const FlexView = ({ children, flex, style }) => {
+  const internalStyle = React.useMemo(() => ({ flex, ...style }));
+  return <View style={internalStyle}>{children}</View>;
+};
+
+FlexView.defaultProps = {
+  children: null,
+  flex: 1,
+  style: {},
+};
+
+FlexView.propTypes = {
+  children: PropTypes.oneOf([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
+  flex: PropTypes.number,
+  style: PropTypes.object,
+};

--- a/src/widgets/PrescriptionCart.js
+++ b/src/widgets/PrescriptionCart.js
@@ -7,12 +7,14 @@
 import React from 'react';
 import { View, Text, FlatList, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import { PrescriptionCartRow } from './PrescriptionCartRow';
 
 import { SUSSOL_ORANGE, WHITE } from '../globalStyles/index';
 
 import { recordKeyExtractor } from '../pages/dataTableUtilities';
+import { removeItem } from '../reducers/PrescriptionReducer';
 
 /**
  * Layout container component for a prescriptions item cart.
@@ -25,7 +27,12 @@ import { recordKeyExtractor } from '../pages/dataTableUtilities';
  * @prop {Func}  onOptionSelection Callback when an option in the dropdown is selected.
  * @prop {Func}  onRemoveItem      Callback when this row is removed.
  */
-export const PrescriptionCart = ({ items, onChangeQuantity, onOptionSelection, onRemoveItem }) => {
+export const PrescriptionCartComponent = ({
+  items,
+  onChangeQuantity,
+  onOptionSelection,
+  onRemoveItem,
+}) => {
   const renderPrescriptionCartRow = React.useCallback(
     ({ item }) => (
       <PrescriptionCartRow
@@ -53,7 +60,7 @@ export const PrescriptionCart = ({ items, onChangeQuantity, onOptionSelection, o
   );
 };
 
-PrescriptionCart.propTypes = {
+PrescriptionCartComponent.propTypes = {
   items: PropTypes.array.isRequired,
   onChangeQuantity: PropTypes.func.isRequired,
   onOptionSelection: PropTypes.func.isRequired,
@@ -79,3 +86,10 @@ const localStyles = StyleSheet.create({
   },
   flexNine: { flex: 9 },
 });
+
+const mapDispatchToProps = dispatch => ({
+  onRemoveItem: id => dispatch(removeItem(id)),
+  dispatch,
+});
+
+export const PrescriptionCart = connect(null, mapDispatchToProps)(PrescriptionCartComponent);

--- a/src/widgets/PrescriptionCartRow.js
+++ b/src/widgets/PrescriptionCartRow.js
@@ -14,6 +14,7 @@ import { DetailRow } from './DetailRow';
 import { StepperRow } from './StepperRow';
 import { CloseIcon } from './icons';
 import { Separator } from './Separator';
+import { TouchableNoFeedback } from './DataTable';
 
 /**
  * Renders a row in the PrescriptionCart consisting of a `StepperRow`, `DropdownRow`,
@@ -35,23 +36,23 @@ export const PrescriptionCartRow = ({
   onOptionSelection,
   currentOptionText,
 }) => {
-  const { itemName, totalQuantity, itemCode, price } = item;
+  const { itemName, totalQuantity, itemCode, price, id } = item;
 
+  const removeItem = React.useCallback(() => onRemoveItem(id), [id]);
   const onChangeValue = React.useCallback(
     quantity => {
-      onChangeQuantity(item.id, quantity);
+      onChangeQuantity(id, quantity);
     },
-    [item.id]
+    [id]
   );
 
   const itemDetails = [
     { label: 'Code', text: itemCode },
     { label: 'Price', text: price },
   ];
-
   return (
-    <View>
-      <View style={localStyles.flexRow}>
+    <>
+      <TouchableNoFeedback style={localStyles.flexRow}>
         <View style={localStyles.largeFlexRow}>
           <StepperRow text={itemName} quantity={totalQuantity} onChangeValue={onChangeValue} />
           <DetailRow details={itemDetails} />
@@ -64,10 +65,10 @@ export const PrescriptionCartRow = ({
           />
         </View>
         <View style={localStyles.flexOne} />
-        <CircleButton IconComponent={CloseIcon} onPress={onRemoveItem} />
-      </View>
+        <CircleButton IconComponent={CloseIcon} onPress={removeItem} />
+      </TouchableNoFeedback>
       <Separator width={1} />
-    </View>
+    </>
   );
 };
 

--- a/src/widgets/PrescriptionInfo.js
+++ b/src/widgets/PrescriptionInfo.js
@@ -1,0 +1,102 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { FlexRow } from './FlexRow';
+import { SimpleLabel } from './SimpleLabel';
+import { CircleButton } from './CircleButton';
+import { PencilIcon, HistoryIcon } from './icons';
+
+import { selectCurrentPatient, selectPatientName } from '../selectors/patient';
+import { selectCurrentPrescriber, selectPrescriberName } from '../selectors/prescriber';
+import { PatientActions } from '../actions/PatientActions';
+import { PrescriberActions } from '../actions/PrescriberActions';
+
+import { WHITE, BLUE_WHITE } from '../globalStyles';
+
+const PrescriptionInfoComponent = ({
+  currentPatient,
+  patientName,
+  prescriberName,
+  currentPrescriber,
+  editPatient,
+  viewHistory,
+  editPrescriber,
+}) => {
+  const { mainContainerStyles, leftContainerStyle } = localStyles;
+
+  const editPatientCallback = React.useCallback(() => editPatient(currentPatient), [
+    currentPatient,
+  ]);
+
+  const viewHistoryCallback = React.useCallback(() => viewHistory(currentPatient), [
+    currentPatient,
+  ]);
+
+  const prescriberEditCallback = React.useCallback(() => editPrescriber(currentPrescriber), [
+    currentPrescriber,
+  ]);
+
+  return (
+    <FlexRow justifyContent="space-between" style={mainContainerStyles}>
+      <FlexRow alignItems="center" flex={1} style={leftContainerStyle}>
+        <SimpleLabel label="Patient" text={patientName} size="large" />
+        <CircleButton IconComponent={HistoryIcon} onPress={viewHistoryCallback} />
+        <CircleButton IconComponent={PencilIcon} onPress={editPatientCallback} />
+      </FlexRow>
+      {currentPrescriber && (
+        <FlexRow alignItems="center" justifyContent="flex-end" flex={1}>
+          <SimpleLabel label="Prescriber" text={prescriberName} size="large" />
+          <CircleButton IconComponent={PencilIcon} onPress={prescriberEditCallback} />
+        </FlexRow>
+      )}
+    </FlexRow>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  mainContainerStyle: { backgroundColor: WHITE, marginVertical: 10 },
+  leftContainerStyle: { borderRightWidth: 10, borderRightColor: BLUE_WHITE },
+});
+
+const mapDispatchToProps = dispatch => {
+  const editPatient = patient => dispatch(PatientActions.editPatient(patient));
+  const viewHistory = patient => dispatch(PatientActions.viewPatientHistory(patient));
+  const editPrescriber = prescriber => dispatch(PrescriberActions.editPrescriber(prescriber));
+  return { editPatient, viewHistory, editPrescriber };
+};
+
+const mapStateToProps = state => {
+  const currentPatient = selectCurrentPatient(state);
+  const currentPrescriber = selectCurrentPrescriber(state);
+  const patientName = selectPatientName(state);
+  const prescriberName = selectPrescriberName(state);
+  return { currentPatient, currentPrescriber, patientName, prescriberName };
+};
+
+PrescriptionInfoComponent.defaultProps = {
+  prescriberName: '',
+  currentPrescriber: null,
+};
+
+PrescriptionInfoComponent.propTypes = {
+  currentPatient: PropTypes.object.isRequired,
+  patientName: PropTypes.string.isRequired,
+  prescriberName: PropTypes.string,
+  currentPrescriber: PropTypes.object,
+  editPatient: PropTypes.func.isRequired,
+  viewHistory: PropTypes.func.isRequired,
+  editPrescriber: PropTypes.func.isRequired,
+};
+
+export const PrescriptionInfo = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PrescriptionInfoComponent);

--- a/src/widgets/PrescriptionSummaryRow.js
+++ b/src/widgets/PrescriptionSummaryRow.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import { NumberLabelRow } from './NumberLabelRow';
 import { DetailRow } from './DetailRow';
 import { SimpleLabel } from './SimpleLabel';
+import { TouchableNoFeedback } from './DataTable';
 
 /**
  * Simple layout component for primary use within the PrescriptionSummary
@@ -26,13 +27,13 @@ export const PrescriptionSummaryRow = ({ item }) => {
   const details = [{ label: 'Code', text: itemCode }];
 
   return (
-    <View style={localStyles.mainContainer}>
+    <TouchableNoFeedback style={localStyles.mainContainer}>
       <NumberLabelRow text={itemName} number={totalQuantity} />
       <View style={localStyles.marginFive} />
       <DetailRow details={details} />
       <View style={localStyles.marginFive} />
       <SimpleLabel label="Directions" text={direction} />
-    </View>
+    </TouchableNoFeedback>
   );
 };
 

--- a/src/widgets/StepperRow.js
+++ b/src/widgets/StepperRow.js
@@ -60,7 +60,7 @@ const localStylez = {
 };
 
 StepperRow.defaultProps = {
-  lowerLimit: 0,
+  lowerLimit: 1,
   upperLimit: 99999,
   labelSize: 'large',
 };

--- a/src/widgets/Tabs/ItemSelect.js
+++ b/src/widgets/Tabs/ItemSelect.js
@@ -1,0 +1,99 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { connect } from 'react-redux';
+
+import { PageButton } from '../PageButton';
+import { PrescriptionInfo } from '../PrescriptionInfo';
+import { SimpleTable } from '../SimpleTable';
+
+import { UIDatabase } from '../../database';
+import { getColumns } from '../../pages/dataTableUtilities';
+import {
+  selectPrescriber,
+  selectItem,
+  switchTab,
+  editQuantity,
+} from '../../reducers/PrescriptionReducer';
+
+import { PrescriptionCart } from '../PrescriptionCart';
+import { FlexRow } from '../FlexRow';
+import { FlexColumn } from '../FlexColumn';
+import { FlexView } from '../FlexView';
+import { selectHasItemsAndQuantity } from '../../selectors/prescription';
+
+/**
+ * Layout component used for a tab within the prescription wizard.
+ *
+ * @prop {Func} transaction    Underlying realm Transaction for this script.
+ * @prop {Func} chooseItem     Callback for selecting an item.
+ * @prop {Func} nextTab        Callback for transitioning to the next step.
+ * @prop {Func} updateQuantity Callback for updating an items quantity.
+ */
+const ItemSelectComponent = ({ transaction, chooseItem, nextTab, updateQuantity, canProceed }) => {
+  const columns = React.useMemo(() => getColumns('itemSelect'), []);
+  const disabledRows = UIDatabase.objects('Item').reduce(
+    (acc, value) => ({ ...acc, [value.id]: value.totalQuantity <= 0 }),
+    {}
+  );
+
+  const selectedRows = transaction.items.reduce(
+    (acc, { item }) => ({ ...acc, [item.id]: true }),
+    {}
+  );
+  return (
+    <>
+      <PrescriptionInfo />
+      <FlexRow flex={1}>
+        <FlexView flex={10}>
+          <SimpleTable
+            data={UIDatabase.objects('Item')}
+            columns={columns}
+            disabledRows={disabledRows}
+            selectedRows={selectedRows}
+            selectRow={chooseItem}
+          />
+        </FlexView>
+        <FlexColumn flex={15}>
+          <PrescriptionCart items={transaction.items.slice()} onChangeQuantity={updateQuantity} />
+          <PageButton
+            isDisabled={!canProceed}
+            text="Next"
+            onPress={() => nextTab(1)}
+            style={{ alignSelf: 'flex-end' }}
+          />
+        </FlexColumn>
+      </FlexRow>
+    </>
+  );
+};
+
+const mapDispatchToProps = dispatch => {
+  const choosePrescriber = prescriberID => dispatch(selectPrescriber(prescriberID));
+  const chooseItem = itemID => dispatch(selectItem(itemID));
+  const nextTab = currentTab => dispatch(switchTab(currentTab + 1));
+  const updateQuantity = (id, quantity) => dispatch(editQuantity(id, quantity));
+  return { nextTab, choosePrescriber, chooseItem, updateQuantity };
+};
+
+const mapStateToProps = state => {
+  const { prescription } = state;
+  const canProceed = selectHasItemsAndQuantity(state);
+  return { ...prescription, canProceed };
+};
+
+ItemSelectComponent.propTypes = {
+  transaction: PropTypes.object.isRequired,
+  chooseItem: PropTypes.func.isRequired,
+  nextTab: PropTypes.func.isRequired,
+  updateQuantity: PropTypes.func.isRequired,
+  canProceed: PropTypes.bool.isRequired,
+};
+
+export const ItemSelect = connect(mapStateToProps, mapDispatchToProps)(ItemSelectComponent);

--- a/src/widgets/Tabs/PrescriberSelect.js
+++ b/src/widgets/Tabs/PrescriberSelect.js
@@ -1,0 +1,91 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { StyleSheet } from 'react-native';
+import { connect } from 'react-redux';
+
+import { SearchBar } from '../SearchBar';
+import { PageButton } from '../PageButton';
+import { FlexRow } from '../FlexRow';
+import { PrescriptionInfo } from '../PrescriptionInfo';
+import { SimpleTable } from '../SimpleTable';
+
+import { UIDatabase } from '../../database';
+import { getColumns } from '../../pages/dataTableUtilities';
+import { selectPrescriber } from '../../reducers/PrescriptionReducer';
+import { PrescriberActions } from '../../actions/PrescriberActions';
+
+/**
+ * Layout component used for a tab within the prescription wizard.
+ *
+ * @props {Func} choosePrescriber   Callback for selecting a supplier.
+ */
+const PrescriberSelectComponent = ({
+  choosePrescriber,
+  data,
+  onFilterData,
+  searchTerm,
+  createPrescriber,
+}) => {
+  const columns = React.useMemo(() => getColumns('prescriberSelect'), []);
+
+  return (
+    <>
+      <PrescriptionInfo />
+      <FlexRow>
+        <SearchBar
+          viewStyle={localStyles.searchBar}
+          onChangeText={onFilterData}
+          value={searchTerm}
+        />
+        <PageButton text="Add Prescriber" onPress={createPrescriber} />
+      </FlexRow>
+      <SimpleTable data={data} columns={columns} selectRow={choosePrescriber} />
+    </>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  searchBar: {
+    borderBottomWidth: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+    flexGrow: 1,
+  },
+});
+
+const mapDispatchToProps = dispatch => {
+  const choosePrescriber = prescriberID => dispatch(selectPrescriber(prescriberID));
+  const onFilterData = searchTerm => dispatch(PrescriberActions.filterData(searchTerm));
+  const createPrescriber = () => dispatch(PrescriberActions.createPrescriber());
+  return { choosePrescriber, onFilterData, createPrescriber };
+};
+
+const mapStateToProps = state => {
+  const { prescriber } = state;
+  const { searchTerm } = prescriber;
+  const data = UIDatabase.objects('Prescriber').filtered(
+    'firstName CONTAINS[c] $0 OR lastName CONTAINS[c] $0',
+    searchTerm
+  );
+  return { data, searchTerm };
+};
+
+PrescriberSelectComponent.propTypes = {
+  choosePrescriber: PropTypes.func.isRequired,
+  data: PropTypes.object.isRequired,
+  onFilterData: PropTypes.func.isRequired,
+  searchTerm: PropTypes.string.isRequired,
+  createPrescriber: PropTypes.func.isRequired,
+};
+
+export const PrescriberSelect = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PrescriberSelectComponent);

--- a/src/widgets/Tabs/PrescriptionConfirmation.js
+++ b/src/widgets/Tabs/PrescriptionConfirmation.js
@@ -1,0 +1,44 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { PrescriptionSummary } from '../PrescriptionSummary';
+import { PrescriptionInfo } from '../PrescriptionInfo';
+import { FlexView } from '../FlexView';
+import { PageButton } from '../PageButton';
+
+import { FinaliseActions } from '../../actions/FinaliseActions';
+
+const mapStateToProps = state => {
+  const { prescription, patient, prescriber } = state;
+  return { ...prescription, ...patient, ...prescriber };
+};
+
+const mapDispatchToProps = dispatch => {
+  const openFinaliseModal = () => dispatch(FinaliseActions.openModal());
+  return { openFinaliseModal };
+};
+
+const PrescriptionConfirmationComponent = ({ transaction, openFinaliseModal }) => (
+  <FlexView flex={1}>
+    <PrescriptionInfo />
+    <PrescriptionSummary transaction={transaction} />
+    <PageButton style={{ alignSelf: 'flex-end' }} text="Complete" onPress={openFinaliseModal} />
+  </FlexView>
+);
+
+PrescriptionConfirmationComponent.propTypes = {
+  transaction: PropTypes.object.isRequired,
+  openFinaliseModal: PropTypes.func.isRequired,
+};
+
+export const PrescriptionConfirmation = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PrescriptionConfirmationComponent);

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -79,7 +79,7 @@ export const PencilIcon = React.memo(({ color, size }) => (
 PencilIcon.defaultProps = { color: WHITE, size: 20 };
 PencilIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
 
-export const HistoryIcon = React.memo(() => <FA5Icon name="history" />);
+export const HistoryIcon = React.memo(() => <FA5Icon name="history" size={20} color={WHITE} />);
 
 export const ChevronRightIcon = () => (
   <FA5Icon name="chevron-right" color={SUSSOL_ORANGE} size={20} />

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -6,6 +6,7 @@
 export { Button, ProgressBar } from 'react-native-ui-components';
 export { DataTablePageView } from './DataTablePageView';
 export { ExpiryDateInput } from './ExpiryDateInput';
+export { FlexRow } from './FlexRow';
 export { FinaliseButton } from './FinaliseButton';
 export { Flag } from './Flag';
 export { IconCell } from './IconCell';

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -6,7 +6,9 @@
 export { Button, ProgressBar } from 'react-native-ui-components';
 export { DataTablePageView } from './DataTablePageView';
 export { ExpiryDateInput } from './ExpiryDateInput';
+export { FlexColumn } from './FlexColumn';
 export { FlexRow } from './FlexRow';
+export { FlexView } from './FlexView';
 export { FinaliseButton } from './FinaliseButton';
 export { Flag } from './Flag';
 export { IconCell } from './IconCell';


### PR DESCRIPTION
### BRANCHED FROM #1792 

Fixes #1783 

## Change summary

- Adds a pretty simple component which displays the current patient and prescriber
- Added some reducer/actions/selector helpers to aid in this
- Added a `FlexRow` component.. was thinking `FlexView`/`FlexRow` and `FlexColumn`..  a `FlexView` with a direction prop would do the same thing, but it's such minimal effort for what I think is way nicer/clearer/easier
- This looks super ugly/cramped/busy but I can imagine it looking nice!


![patientandprescriberlabels](https://user-images.githubusercontent.com/35858975/71497998-79781980-28bf-11ea-9c96-2514c24fea4a.gif)


## Testing

N/A

### Related areas to think about

- Idea here is that the modals are actually children of the `dispensing` page, which the buttons in the prescription wizard trigger to set the 'current' prescriber and trigger modals to open. This makes things very easy, but makes dispensing page a little bit to massive, trying to think of a way to reduce this. I think this concept would actually be better to have all the modals at the root of the app 🤷‍♂ 
- Starting to make `PrescriptionPage` a little cleaner
