### PR TITLE
#1799 prescription summary to show quantities

### DIFF
--- a/src/actions/FinaliseActions.js
+++ b/src/actions/FinaliseActions.js
@@ -1,0 +1,14 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+export const FINALISE_ACTIONS = {
+  OPEN_MODAL: 'Finalise/openModal',
+  CLOSE_MODAL: 'Finalise/closeModal',
+};
+
+const openModal = () => ({ type: FINALISE_ACTIONS.OPEN_MODAL });
+const closeModal = () => ({ type: FINALISE_ACTIONS.CLOSE_MODAL });
+
+export const FinaliseActions = { openModal, closeModal };

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -185,6 +185,17 @@ export class Item extends Realm.Object {
   }
 
   /**
+   * Returns an array of all direction expansions related to this
+   * item.
+   */
+  getDirectionExpansions = database =>
+    this.directions.sorted('priority').reduce((acc, value) => {
+      const expansion = value.getExpansion(database);
+      if (expansion) return [...acc, expansion];
+      return acc;
+    }, []);
+
+  /**
    * Get string representation of item.
    *
    * @returns  {string}
@@ -210,6 +221,7 @@ Item.schema = {
     isVisible: { type: 'bool', default: false },
     crossReferenceItem: { type: 'Item', optional: true },
     unit: { type: 'Unit', optional: true },
+    directions: { type: 'linkingObjects', objectType: 'ItemDirection', property: 'item' },
   },
 };
 

--- a/src/database/DataTypes/ItemDirection.js
+++ b/src/database/DataTypes/ItemDirection.js
@@ -5,14 +5,23 @@
 
 import Realm from 'realm';
 
-export class ItemDirection extends Realm.Object {}
+export class ItemDirection extends Realm.Object {
+  /**
+   * Returns the matching expansion of this ItemDirection, defaulting
+   * to null for all falsey values.
+   */
+  getExpansion = database => {
+    const expansion = database.get('Abbreviation', this.directions, 'abbreviation')?.expansion;
+    return expansion || null;
+  };
+}
 
 ItemDirection.schema = {
   name: 'ItemDirection',
   primaryKey: 'id',
   properties: {
     id: 'string',
-    priority: 'string',
+    priority: 'int',
     directions: 'string',
     item: { type: 'Item', optional: true },
   },

--- a/src/database/DataTypes/TransactionItem.js
+++ b/src/database/DataTypes/TransactionItem.js
@@ -86,6 +86,13 @@ export class TransactionItem extends Realm.Object {
   }
 
   /**
+   * Returns the note of the underlying transaction batch.
+   */
+  get note() {
+    return this.batches[0]?.note || null;
+  }
+
+  /**
    * Get available quantity of items.
    *
    * For customer invoices, get how much can be issued in total, accounting for the fact that any
@@ -250,6 +257,18 @@ export class TransactionItem extends Realm.Object {
     });
     database.delete('TransactionBatch', batchesToDelete);
   }
+
+  /**
+   * Sets the item direction for the underlying transaction batch.
+   */
+  setItemDirection = (database, newDirection) => {
+    const batch = this.batches[0];
+    if (!batch) return;
+    database.write(() => {
+      batch.note = newDirection;
+      database.save('TransactionBatch', batch);
+    });
+  };
 }
 
 TransactionItem.schema = {

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -110,9 +110,8 @@ class UIDatabase {
       case 'CustomerInvoice':
         // Only show invoices generated from requisitions once finalised.
         return results.filtered(
-          'type == $0 AND mode == $1 AND (linkedRequisition == $2 OR status == $3)',
+          'type == $0 AND (linkedRequisition == $1 OR status == $2)',
           'customer_invoice',
-          'store',
           null,
           'finalised'
         );

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -637,7 +637,7 @@ const createTransactionBatch = (database, transactionItem, itemBatch, isAddition
  * @param   {Item}             item         Real item to create transaction item from.
  * @return  {TransactionItem}
  */
-const createTransactionItem = (database, transaction, item) => {
+const createTransactionItem = (database, transaction, item, initialQuantity = 0) => {
   // Handle cross reference items.
   const { realItem } = item;
 
@@ -646,6 +646,9 @@ const createTransactionItem = (database, transaction, item) => {
     item: realItem,
     transaction,
   });
+
+  const { isFinalised } = transaction;
+  if (!isFinalised) transactionItem.setTotalQuantity(database, initialQuantity);
 
   transaction.addItem(transactionItem);
   database.save('Transaction', transaction);

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -31,8 +31,9 @@ import { Synchroniser, PostSyncProcessor, SyncModal } from './sync';
 import { FinaliseButton, NavigationBar, SyncState, Spinner } from './widgets';
 import { FinaliseModal, LoginModal } from './widgets/modals';
 
-import { getCurrentParams, getCurrentRouteName, ReduxNavigator } from './navigation';
+import { getCurrentParams, getCurrentRouteName, ReduxNavigator, ROUTES } from './navigation';
 import { syncCompleteTransaction } from './actions/SyncActions';
+import { FinaliseActions } from './actions/FinaliseActions';
 import { migrateDataToVersion } from './dataMigration';
 import { SyncAuthenticator, UserAuthenticator } from './authentication';
 import Settings from './settings/MobileAppSettings';
@@ -51,10 +52,10 @@ class MSupplyMobileAppContainer extends React.Component {
   handleBackEvent = debounce(
     () => {
       const { dispatch, prevRouteName } = this.props;
-      const { confirmFinalise, syncModalIsOpen } = this.state;
+      const { syncModalIsOpen } = this.state;
       // If finalise or sync modals are open, close them rather than navigating.
-      if (confirmFinalise || syncModalIsOpen) {
-        this.setState({ confirmFinalise: false, syncModalIsOpen: false });
+      if (syncModalIsOpen) {
+        this.setState({ syncModalIsOpen: false });
         return true;
       }
       // If we are on base screen (e.g. home), back button should close app as we can't go back.
@@ -86,7 +87,6 @@ class MSupplyMobileAppContainer extends React.Component {
       }
     }, AUTHENTICATION_INTERVAL);
     this.state = {
-      confirmFinalise: false,
       isInitialised,
       isLoading: false,
       syncModalIsOpen: false,
@@ -164,12 +164,9 @@ class MSupplyMobileAppContainer extends React.Component {
   };
 
   renderFinaliseButton = () => {
-    const { finaliseItem } = this.props;
+    const { finaliseItem, openFinaliseModal } = this.props;
     return (
-      <FinaliseButton
-        isFinalised={finaliseItem.record.isFinalised}
-        onPress={() => this.setState({ confirmFinalise: true })}
-      />
+      <FinaliseButton isFinalised={finaliseItem.record.isFinalised} onPress={openFinaliseModal} />
     );
   };
 
@@ -213,14 +210,16 @@ class MSupplyMobileAppContainer extends React.Component {
   };
 
   render() {
-    const { dispatch, finaliseItem, navigationState, syncState, currentUser } = this.props;
     const {
-      confirmFinalise,
-      isInAdminMode,
-      isInitialised,
-      isLoading,
-      syncModalIsOpen,
-    } = this.state;
+      dispatch,
+      finaliseItem,
+      navigationState,
+      syncState,
+      currentUser,
+      finaliseModalOpen,
+      closeFinaliseModal,
+    } = this.props;
+    const { isInAdminMode, isInitialised, isLoading, syncModalIsOpen } = this.state;
 
     if (!isInitialised) {
       return (
@@ -239,7 +238,11 @@ class MSupplyMobileAppContainer extends React.Component {
           onPressBack={this.getCanNavigateBack() ? this.handleBackEvent : null}
           LeftComponent={this.getCanNavigateBack() ? this.renderPageTitle : null}
           CentreComponent={this.renderLogo}
-          RightComponent={finaliseItem ? this.renderFinaliseButton : this.renderSyncState}
+          RightComponent={
+            finaliseItem && finaliseItem?.visibleButton
+              ? this.renderFinaliseButton
+              : this.renderSyncState
+          }
         />
         <ReduxNavigator
           state={navigationState}
@@ -255,8 +258,8 @@ class MSupplyMobileAppContainer extends React.Component {
         />
         <FinaliseModal
           database={UIDatabase}
-          isOpen={confirmFinalise}
-          onClose={() => this.setState({ confirmFinalise: false })}
+          isOpen={finaliseModalOpen}
+          onClose={closeFinaliseModal}
           finaliseItem={finaliseItem}
           user={currentUser}
           runWithLoadingIndicator={this.runWithLoadingIndicator}
@@ -280,13 +283,22 @@ class MSupplyMobileAppContainer extends React.Component {
   }
 }
 
-const mapStateToProps = state => {
-  const { nav: navigationState, sync: syncState } = state;
+const mapDispatchToProps = dispatch => {
+  const openFinaliseModal = () => dispatch(FinaliseActions.openModal());
+  const closeFinaliseModal = () => dispatch(FinaliseActions.closeModal());
+  return { dispatch, openFinaliseModal, closeFinaliseModal };
+};
 
+const mapStateToProps = state => {
+  const { finalise, nav: navigationState, sync: syncState } = state;
+  const { finaliseModalOpen } = finalise;
   const currentParams = getCurrentParams(navigationState);
   const currentTitle = currentParams && currentParams.title;
-  const finaliseItem = FINALISABLE_PAGES[getCurrentRouteName(navigationState)];
+  const currentRouteName = getCurrentRouteName(navigationState);
+  const finaliseItem = FINALISABLE_PAGES[currentRouteName];
   if (finaliseItem && currentParams) {
+    if (currentRouteName === ROUTES.PRESCRIPTION) finaliseItem.visibleButton = false;
+    else finaliseItem.visibleButton = true;
     finaliseItem.record = currentParams[finaliseItem.recordToFinaliseKey];
   }
 
@@ -297,6 +309,7 @@ const mapStateToProps = state => {
     navigationState,
     syncState,
     currentUser: state.user.currentUser,
+    finaliseModalOpen,
   };
 };
 
@@ -314,6 +327,9 @@ MSupplyMobileAppContainer.propTypes = {
   syncState: PropTypes.object.isRequired,
   currentUser: PropTypes.object,
   prevRouteName: PropTypes.string.isRequired,
+  finaliseModalOpen: PropTypes.bool.isRequired,
+  openFinaliseModal: PropTypes.func.isRequired,
+  closeFinaliseModal: PropTypes.func.isRequired,
 };
 
-export default connect(mapStateToProps)(MSupplyMobileAppContainer);
+export default connect(mapStateToProps, mapDispatchToProps)(MSupplyMobileAppContainer);

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -11,12 +11,9 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { connect } from 'react-redux';
 
-import { Wizard, SimpleTable, PageButton } from '../widgets';
-import { PrescriptionCart } from '../widgets/PrescriptionCart';
+import { Wizard } from '../widgets';
 import { PrescriptionSummary } from '../widgets/PrescriptionSummary';
 
-import { UIDatabase } from '../database';
-import { getColumns } from './dataTableUtilities';
 import {
   selectItem,
   selectPrescriber,
@@ -26,11 +23,7 @@ import {
 
 import { PrescriptionInfo } from '../widgets/PrescriptionInfo';
 import { PrescriberSelect } from '../widgets/Tabs/PrescriberSelect';
-
-/**
- * File contains Four components for the PrescriptionPage. The container component Prescription and
- * three "Tab" components PrescriberSelect/ItemSelect/Summary.
- */
+import { ItemSelect } from '../widgets/Tabs/ItemSelect';
 
 const mapDispatchToProps = dispatch => {
   const choosePrescriber = prescriberID => dispatch(selectPrescriber(prescriberID));
@@ -45,36 +38,6 @@ const mapStateToProps = state => {
   return { ...prescription, ...patient, ...prescriber };
 };
 
-const ItemSelect = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(({ transaction, chooseItem, nextTab, updateQuantity }) => {
-  const { row, mediumFlex } = localStyles;
-  const columns = getColumns('itemSelect');
-
-  const tableRef = React.useRef(React.createRef());
-
-  return (
-    <>
-      <PrescriptionInfo />
-      <View style={{ ...row }}>
-        <View style={mediumFlex}>
-          <SimpleTable
-            data={UIDatabase.objects('Item')}
-            columns={columns}
-            selectRow={x => chooseItem(x)}
-            ref={tableRef}
-          />
-        </View>
-        <View style={{ flex: 15, marginHorizontal: 15 }}>
-          <PrescriptionCart items={transaction.items.slice()} onChangeQuantity={updateQuantity} />
-          <PageButton text="Next" onPress={() => nextTab(1)} style={{ alignSelf: 'flex-end' }} />
-        </View>
-      </View>
-    </>
-  );
-});
-
 const Summary = connect(mapStateToProps)(({ transaction }) => (
   <View style={{ flex: 1 }}>
     <PrescriptionInfo />
@@ -88,21 +51,6 @@ const titles = ['Select the Prescriber', 'Select items', 'Summary'];
 export const Prescription = ({ currentTab, nextTab }) => (
   <Wizard tabs={tabs} titles={titles} currentTabIndex={currentTab} onPress={nextTab} />
 );
-
-const localStyles = {
-  row: { flex: 1, flexDirection: 'row' },
-  extraLargeFlex: { flex: 19 },
-  largeFlex: { flex: 10 },
-  mediumFlex: { flex: 9 },
-  smallFlex: { flex: 1 },
-  searchBar: {
-    borderBottomWidth: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-    flexGrow: 1,
-  },
-};
 
 export const PrescriptionPage = connect(mapStateToProps, mapDispatchToProps)(Prescription);
 

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -5,14 +5,13 @@
  */
 
 import React from 'react';
-
 import PropTypes from 'prop-types';
-
-import { View } from 'react-native';
 import { connect } from 'react-redux';
 
 import { Wizard } from '../widgets';
-import { PrescriptionSummary } from '../widgets/PrescriptionSummary';
+import { PrescriberSelect } from '../widgets/Tabs/PrescriberSelect';
+import { ItemSelect } from '../widgets/Tabs/ItemSelect';
+import { PrescriptionConfirmation } from '../widgets/Tabs/PrescriptionConfirmation';
 
 import {
   selectItem,
@@ -20,10 +19,6 @@ import {
   switchTab,
   editQuantity,
 } from '../reducers/PrescriptionReducer';
-
-import { PrescriptionInfo } from '../widgets/PrescriptionInfo';
-import { PrescriberSelect } from '../widgets/Tabs/PrescriberSelect';
-import { ItemSelect } from '../widgets/Tabs/ItemSelect';
 
 const mapDispatchToProps = dispatch => {
   const choosePrescriber = prescriberID => dispatch(selectPrescriber(prescriberID));
@@ -38,15 +33,8 @@ const mapStateToProps = state => {
   return { ...prescription, ...patient, ...prescriber };
 };
 
-const Summary = connect(mapStateToProps)(({ transaction }) => (
-  <View style={{ flex: 1 }}>
-    <PrescriptionInfo />
-    <PrescriptionSummary transaction={transaction} />
-  </View>
-));
-
-const tabs = [PrescriberSelect, ItemSelect, Summary];
-const titles = ['Select the Prescriber', 'Select items', 'Summary'];
+const tabs = [PrescriberSelect, ItemSelect, PrescriptionConfirmation];
+const titles = ['Select the Prescriber', 'Select items', 'Finalise'];
 
 export const Prescription = ({ currentTab, nextTab }) => (
   <Wizard tabs={tabs} titles={titles} currentTabIndex={currentTab} onPress={nextTab} />

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -31,7 +31,7 @@ const PAGE_COLUMN_WIDTHS = {
   stocktakeBatchEditModalWithReasons: [1, 1, 1, 1, 1, 1],
   regimenDataModal: [4, 1, 5],
   prescriberSelect: [1, 1],
-  itemSelect: [1, 3],
+  itemSelect: [1, 3, 1],
   patientHistory: [1, 3, 1, 3],
 };
 
@@ -183,7 +183,7 @@ const PAGE_COLUMNS = {
     COLUMN_NAMES.EDITABLE_COMMENT,
   ],
   prescriberSelect: [COLUMN_NAMES.FIRST_NAME, COLUMN_NAMES.LAST_NAME],
-  itemSelect: [COLUMN_NAMES.CODE, COLUMN_NAMES.NAME],
+  itemSelect: [COLUMN_NAMES.CODE, COLUMN_NAMES.NAME, COLUMN_NAMES.TOTAL_QUANTITY],
   patientHistory: [
     COLUMN_NAMES.ITEM_CODE,
     COLUMN_NAMES.ITEM_NAME,

--- a/src/reducers/FinaliseReducer.js
+++ b/src/reducers/FinaliseReducer.js
@@ -1,0 +1,32 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import { FINALISE_ACTIONS } from '../actions/FinaliseActions';
+
+/**
+ * Simple reducer managing the stores current finalise state.
+ *
+ * State shape:
+ * {
+ *     finaliseModalOpen: [bool]
+ * }
+ */
+
+const initialState = () => ({ finaliseModalOpen: false });
+
+export const FinaliseReducer = (state = initialState(), action) => {
+  const { type } = action;
+
+  switch (type) {
+    case FINALISE_ACTIONS.OPEN_MODAL: {
+      return { ...state, finaliseModalOpen: true };
+    }
+    case FINALISE_ACTIONS.CLOSE_MODAL: {
+      return { ...state, finaliseModalOpen: false };
+    }
+    default:
+      return state;
+  }
+};

--- a/src/reducers/PrescriptionReducer.js
+++ b/src/reducers/PrescriptionReducer.js
@@ -15,8 +15,23 @@ const initialState = () => ({
 });
 
 const ACTIONS = {
-  SWITCH_TAB: 'PRESCRIPTION/SWITCH_TAB',
-  SELECT_ITEM: 'PRESCRIPTION/SELECT_ITEM',
+  SWITCH_TAB: 'Prescription/SWITCH_TAB',
+  SELECT_ITEM: 'Prescription/SELECT_ITEM',
+  REMOVE_ITEM: 'Prescription/REMOVE_ITEM',
+};
+
+export const removeItem = id => (dispatch, getState) => {
+  const { prescription } = getState();
+  const { transaction } = prescription;
+  const { items } = transaction;
+
+  const item = items.filtered('id == $0', id);
+
+  UIDatabase.write(() => {
+    UIDatabase.delete('TransactionItem', item);
+  });
+
+  dispatch({ type: ACTIONS.REMOVE_ITEM });
 };
 
 export const editQuantity = (id, quantity) => (_, getState) => {
@@ -62,7 +77,7 @@ export const selectItem = itemID => (dispatch, getState) => {
 
   if (!transaction.hasItem(item)) {
     UIDatabase.write(() => {
-      createRecord(UIDatabase, 'TransactionItem', transaction, item);
+      createRecord(UIDatabase, 'TransactionItem', transaction, item, 1);
     });
   }
 
@@ -81,7 +96,11 @@ export const PrescriptionReducer = (state = initialState(), action) => {
 
       return { ...state, transaction };
     }
-
+    case ACTIONS.REMOVE_ITEM: {
+      const { transaction } = state;
+      const { id } = transaction;
+      return { ...state, transaction: UIDatabase.get('Transaction', id) };
+    }
     case ACTIONS.SWITCH_TAB: {
       const { payload } = action;
       const { nextTab } = payload;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,6 +8,7 @@ import { PrescriptionReducer } from './PrescriptionReducer';
 import { PatientReducer } from './PatientReducer';
 import { FormReducer } from './FormReducer';
 import { PrescriberReducer } from './PrescriberReducer';
+import { FinaliseReducer } from './FinaliseReducer';
 
 export default combineReducers({
   user: UserReducer,
@@ -19,4 +20,5 @@ export default combineReducers({
   patient: PatientReducer,
   prescriber: PrescriberReducer,
   form: FormReducer,
+  finalise: FinaliseReducer,
 });

--- a/src/selectors/prescription.js
+++ b/src/selectors/prescription.js
@@ -1,0 +1,12 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+export const selectHasItemsAndQuantity = ({ prescription }) => {
+  const { transaction } = prescription;
+  const { totalQuantity, items } = transaction;
+  const hasItems = items.length > 0;
+  const hasQuantity = totalQuantity > 0;
+  return hasItems && hasQuantity;
+};

--- a/src/widgets/FlexColumn.js
+++ b/src/widgets/FlexColumn.js
@@ -1,0 +1,45 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+
+/**
+ * Simple layout component. For use when needing a simple View with flex
+ * direction of column.
+ * @param {React.node} children       Children of this component
+ * @param {Number}     flex           The flex amount i.e. 1
+ * @param {String}     alignItems     The alignItems style value
+ * @param {String}     justifyContent The justifyContent style value
+ * @param {Object}     style          An additional styles object.
+ */
+export const FlexColumn = ({ children, flex, alignItems, justifyContent, style }) => {
+  const internalStyle = React.useMemo(() => ({
+    flex,
+    flexDirection: 'column',
+    [alignItems ? 'alignItems' : undefined]: alignItems,
+    [justifyContent ? 'justifyContent' : undefined]: justifyContent,
+    ...style,
+  }));
+  return <View style={internalStyle}>{children}</View>;
+};
+
+FlexColumn.defaultProps = {
+  children: null,
+  flex: 0,
+  alignItems: '',
+  justifyContent: '',
+  style: {},
+};
+
+FlexColumn.propTypes = {
+  children: PropTypes.oneOf([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
+  flex: PropTypes.number,
+  alignItems: PropTypes.string,
+  justifyContent: PropTypes.string,
+  style: PropTypes.object,
+};

--- a/src/widgets/PrescriptionCart.js
+++ b/src/widgets/PrescriptionCart.js
@@ -7,12 +7,14 @@
 import React from 'react';
 import { View, Text, FlatList, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import { PrescriptionCartRow } from './PrescriptionCartRow';
 
 import { SUSSOL_ORANGE, WHITE } from '../globalStyles/index';
 
 import { recordKeyExtractor } from '../pages/dataTableUtilities';
+import { removeItem } from '../reducers/PrescriptionReducer';
 
 /**
  * Layout container component for a prescriptions item cart.
@@ -25,7 +27,12 @@ import { recordKeyExtractor } from '../pages/dataTableUtilities';
  * @prop {Func}  onOptionSelection Callback when an option in the dropdown is selected.
  * @prop {Func}  onRemoveItem      Callback when this row is removed.
  */
-export const PrescriptionCart = ({ items, onChangeQuantity, onOptionSelection, onRemoveItem }) => {
+export const PrescriptionCartComponent = ({
+  items,
+  onChangeQuantity,
+  onOptionSelection,
+  onRemoveItem,
+}) => {
   const renderPrescriptionCartRow = React.useCallback(
     ({ item }) => (
       <PrescriptionCartRow
@@ -53,7 +60,7 @@ export const PrescriptionCart = ({ items, onChangeQuantity, onOptionSelection, o
   );
 };
 
-PrescriptionCart.propTypes = {
+PrescriptionCartComponent.propTypes = {
   items: PropTypes.array.isRequired,
   onChangeQuantity: PropTypes.func.isRequired,
   onOptionSelection: PropTypes.func.isRequired,
@@ -79,3 +86,10 @@ const localStyles = StyleSheet.create({
   },
   flexNine: { flex: 9 },
 });
+
+const mapDispatchToProps = dispatch => ({
+  onRemoveItem: id => dispatch(removeItem(id)),
+  dispatch,
+});
+
+export const PrescriptionCart = connect(null, mapDispatchToProps)(PrescriptionCartComponent);

--- a/src/widgets/PrescriptionCartRow.js
+++ b/src/widgets/PrescriptionCartRow.js
@@ -14,6 +14,7 @@ import { DetailRow } from './DetailRow';
 import { StepperRow } from './StepperRow';
 import { CloseIcon } from './icons';
 import { Separator } from './Separator';
+import { TouchableNoFeedback } from './DataTable';
 
 /**
  * Renders a row in the PrescriptionCart consisting of a `StepperRow`, `DropdownRow`,
@@ -35,23 +36,23 @@ export const PrescriptionCartRow = ({
   onOptionSelection,
   currentOptionText,
 }) => {
-  const { itemName, totalQuantity, itemCode, price } = item;
+  const { itemName, totalQuantity, itemCode, price, id } = item;
 
+  const removeItem = React.useCallback(() => onRemoveItem(id), [id]);
   const onChangeValue = React.useCallback(
     quantity => {
-      onChangeQuantity(item.id, quantity);
+      onChangeQuantity(id, quantity);
     },
-    [item.id]
+    [id]
   );
 
   const itemDetails = [
     { label: 'Code', text: itemCode },
     { label: 'Price', text: price },
   ];
-
   return (
-    <View>
-      <View style={localStyles.flexRow}>
+    <>
+      <TouchableNoFeedback style={localStyles.flexRow}>
         <View style={localStyles.largeFlexRow}>
           <StepperRow text={itemName} quantity={totalQuantity} onChangeValue={onChangeValue} />
           <DetailRow details={itemDetails} />
@@ -64,10 +65,10 @@ export const PrescriptionCartRow = ({
           />
         </View>
         <View style={localStyles.flexOne} />
-        <CircleButton IconComponent={CloseIcon} onPress={onRemoveItem} />
-      </View>
+        <CircleButton IconComponent={CloseIcon} onPress={removeItem} />
+      </TouchableNoFeedback>
       <Separator width={1} />
-    </View>
+    </>
   );
 };
 

--- a/src/widgets/PrescriptionSummaryRow.js
+++ b/src/widgets/PrescriptionSummaryRow.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import { NumberLabelRow } from './NumberLabelRow';
 import { DetailRow } from './DetailRow';
 import { SimpleLabel } from './SimpleLabel';
+import { TouchableNoFeedback } from './DataTable';
 
 /**
  * Simple layout component for primary use within the PrescriptionSummary
@@ -26,13 +27,13 @@ export const PrescriptionSummaryRow = ({ item }) => {
   const details = [{ label: 'Code', text: itemCode }];
 
   return (
-    <View style={localStyles.mainContainer}>
+    <TouchableNoFeedback style={localStyles.mainContainer}>
       <NumberLabelRow text={itemName} number={totalQuantity} />
       <View style={localStyles.marginFive} />
       <DetailRow details={details} />
       <View style={localStyles.marginFive} />
       <SimpleLabel label="Directions" text={direction} />
-    </View>
+    </TouchableNoFeedback>
   );
 };
 

--- a/src/widgets/StepperRow.js
+++ b/src/widgets/StepperRow.js
@@ -60,7 +60,7 @@ const localStylez = {
 };
 
 StepperRow.defaultProps = {
-  lowerLimit: 0,
+  lowerLimit: 1,
   upperLimit: 99999,
   labelSize: 'large',
 };

--- a/src/widgets/Tabs/ItemSelect.js
+++ b/src/widgets/Tabs/ItemSelect.js
@@ -26,6 +26,7 @@ import { PrescriptionCart } from '../PrescriptionCart';
 import { FlexRow } from '../FlexRow';
 import { FlexColumn } from '../FlexColumn';
 import { FlexView } from '../FlexView';
+import { selectHasItemsAndQuantity } from '../../selectors/prescription';
 
 /**
  * Layout component used for a tab within the prescription wizard.
@@ -35,8 +36,8 @@ import { FlexView } from '../FlexView';
  * @prop {Func} nextTab        Callback for transitioning to the next step.
  * @prop {Func} updateQuantity Callback for updating an items quantity.
  */
-const ItemSelectComponent = ({ transaction, chooseItem, nextTab, updateQuantity }) => {
-  const columns = getColumns('itemSelect');
+const ItemSelectComponent = ({ transaction, chooseItem, nextTab, updateQuantity, canProceed }) => {
+  const columns = React.useMemo(() => getColumns('itemSelect'), []);
   const disabledRows = UIDatabase.objects('Item').reduce(
     (acc, value) => ({ ...acc, [value.id]: value.totalQuantity <= 0 }),
     {}
@@ -61,7 +62,12 @@ const ItemSelectComponent = ({ transaction, chooseItem, nextTab, updateQuantity 
         </FlexView>
         <FlexColumn flex={15}>
           <PrescriptionCart items={transaction.items.slice()} onChangeQuantity={updateQuantity} />
-          <PageButton text="Next" onPress={() => nextTab(1)} style={{ alignSelf: 'flex-end' }} />
+          <PageButton
+            isDisabled={!canProceed}
+            text="Next"
+            onPress={() => nextTab(1)}
+            style={{ alignSelf: 'flex-end' }}
+          />
         </FlexColumn>
       </FlexRow>
     </>
@@ -78,7 +84,8 @@ const mapDispatchToProps = dispatch => {
 
 const mapStateToProps = state => {
   const { prescription } = state;
-  return { ...prescription };
+  const canProceed = selectHasItemsAndQuantity(state);
+  return { ...prescription, canProceed };
 };
 
 ItemSelectComponent.propTypes = {
@@ -86,6 +93,7 @@ ItemSelectComponent.propTypes = {
   chooseItem: PropTypes.func.isRequired,
   nextTab: PropTypes.func.isRequired,
   updateQuantity: PropTypes.func.isRequired,
+  canProceed: PropTypes.bool.isRequired,
 };
 
 export const ItemSelect = connect(mapStateToProps, mapDispatchToProps)(ItemSelectComponent);

--- a/src/widgets/Tabs/ItemSelect.js
+++ b/src/widgets/Tabs/ItemSelect.js
@@ -27,9 +27,16 @@ import { FlexRow } from '../FlexRow';
 import { FlexColumn } from '../FlexColumn';
 import { FlexView } from '../FlexView';
 
+/**
+ * Layout component used for a tab within the prescription wizard.
+ *
+ * @prop {Func} transaction    Underlying realm Transaction for this script.
+ * @prop {Func} chooseItem     Callback for selecting an item.
+ * @prop {Func} nextTab        Callback for transitioning to the next step.
+ * @prop {Func} updateQuantity Callback for updating an items quantity.
+ */
 const ItemSelectComponent = ({ transaction, chooseItem, nextTab, updateQuantity }) => {
   const columns = getColumns('itemSelect');
-
   const disabledRows = UIDatabase.objects('Item').reduce(
     (acc, value) => ({ ...acc, [value.id]: value.totalQuantity <= 0 }),
     {}

--- a/src/widgets/Tabs/ItemSelect.js
+++ b/src/widgets/Tabs/ItemSelect.js
@@ -1,0 +1,84 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { connect } from 'react-redux';
+
+import { PageButton } from '../PageButton';
+import { PrescriptionInfo } from '../PrescriptionInfo';
+import { SimpleTable } from '../SimpleTable';
+
+import { UIDatabase } from '../../database';
+import { getColumns } from '../../pages/dataTableUtilities';
+import {
+  selectPrescriber,
+  selectItem,
+  switchTab,
+  editQuantity,
+} from '../../reducers/PrescriptionReducer';
+
+import { PrescriptionCart } from '../PrescriptionCart';
+import { FlexRow } from '../FlexRow';
+import { FlexColumn } from '../FlexColumn';
+import { FlexView } from '../FlexView';
+
+const ItemSelectComponent = ({ transaction, chooseItem, nextTab, updateQuantity }) => {
+  const columns = getColumns('itemSelect');
+
+  const disabledRows = UIDatabase.objects('Item').reduce(
+    (acc, value) => ({ ...acc, [value.id]: value.totalQuantity <= 0 }),
+    {}
+  );
+
+  const selectedRows = transaction.items.reduce(
+    (acc, { item }) => ({ ...acc, [item.id]: true }),
+    {}
+  );
+  return (
+    <>
+      <PrescriptionInfo />
+      <FlexRow flex={1}>
+        <FlexView flex={10}>
+          <SimpleTable
+            data={UIDatabase.objects('Item')}
+            columns={columns}
+            disabledRows={disabledRows}
+            selectedRows={selectedRows}
+            selectRow={chooseItem}
+          />
+        </FlexView>
+        <FlexColumn flex={15}>
+          <PrescriptionCart items={transaction.items.slice()} onChangeQuantity={updateQuantity} />
+          <PageButton text="Next" onPress={() => nextTab(1)} style={{ alignSelf: 'flex-end' }} />
+        </FlexColumn>
+      </FlexRow>
+    </>
+  );
+};
+
+const mapDispatchToProps = dispatch => {
+  const choosePrescriber = prescriberID => dispatch(selectPrescriber(prescriberID));
+  const chooseItem = itemID => dispatch(selectItem(itemID));
+  const nextTab = currentTab => dispatch(switchTab(currentTab + 1));
+  const updateQuantity = (id, quantity) => dispatch(editQuantity(id, quantity));
+  return { nextTab, choosePrescriber, chooseItem, updateQuantity };
+};
+
+const mapStateToProps = state => {
+  const { prescription } = state;
+  return { ...prescription };
+};
+
+ItemSelectComponent.propTypes = {
+  transaction: PropTypes.object.isRequired,
+  chooseItem: PropTypes.func.isRequired,
+  nextTab: PropTypes.func.isRequired,
+  updateQuantity: PropTypes.func.isRequired,
+};
+
+export const ItemSelect = connect(mapStateToProps, mapDispatchToProps)(ItemSelectComponent);

--- a/src/widgets/Tabs/PrescriptionConfirmation.js
+++ b/src/widgets/Tabs/PrescriptionConfirmation.js
@@ -1,0 +1,44 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { PrescriptionSummary } from '../PrescriptionSummary';
+import { PrescriptionInfo } from '../PrescriptionInfo';
+import { FlexView } from '../FlexView';
+import { PageButton } from '../PageButton';
+
+import { FinaliseActions } from '../../actions/FinaliseActions';
+
+const mapStateToProps = state => {
+  const { prescription, patient, prescriber } = state;
+  return { ...prescription, ...patient, ...prescriber };
+};
+
+const mapDispatchToProps = dispatch => {
+  const openFinaliseModal = () => dispatch(FinaliseActions.openModal());
+  return { openFinaliseModal };
+};
+
+const PrescriptionConfirmationComponent = ({ transaction, openFinaliseModal }) => (
+  <FlexView flex={1}>
+    <PrescriptionInfo />
+    <PrescriptionSummary transaction={transaction} />
+    <PageButton style={{ alignSelf: 'flex-end' }} text="Complete" onPress={openFinaliseModal} />
+  </FlexView>
+);
+
+PrescriptionConfirmationComponent.propTypes = {
+  transaction: PropTypes.object.isRequired,
+  openFinaliseModal: PropTypes.func.isRequired,
+};
+
+export const PrescriptionConfirmation = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PrescriptionConfirmationComponent);

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -6,6 +6,7 @@
 export { Button, ProgressBar } from 'react-native-ui-components';
 export { DataTablePageView } from './DataTablePageView';
 export { ExpiryDateInput } from './ExpiryDateInput';
+export { FlexColumn } from './FlexColumn';
 export { FlexRow } from './FlexRow';
 export { FlexView } from './FlexView';
 export { FinaliseButton } from './FinaliseButton';


### PR DESCRIPTION
### BRANCHED FROM #1793 

Fixes #1799 

## Change summary

The problem wasn't that the summary wasn't displaying the quantities, but rather quantities being added to items which were greater than available stock. It wasn't that the summary wasn't displaying only 0, rather I was adding quantity to items which had no stock, so it wasn't being updated in the actual transaction.

- Extracted `ItemSelect` from `PrescriptionPage`
- added a `TotalQuantity` column to `ItemSelect`
- Added some disabling logic to `SimpleTable` so that rows can have their `onPress` removed, and grey text when they're disabled -- This fixes the problem. No more items with 0 available quantity being added and causing confusion
- Added a `FlexColumn` component

## Testing

N/A

### Related areas to think about

N/A
