### PR TITLE
#1801 Prescription finalization

### DIFF
--- a/src/actions/FinaliseActions.js
+++ b/src/actions/FinaliseActions.js
@@ -1,0 +1,14 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+export const FINALISE_ACTIONS = {
+  OPEN_MODAL: 'Finalise/openModal',
+  CLOSE_MODAL: 'Finalise/closeModal',
+};
+
+const openModal = () => ({ type: FINALISE_ACTIONS.OPEN_MODAL });
+const closeModal = () => ({ type: FINALISE_ACTIONS.CLOSE_MODAL });
+
+export const FinaliseActions = { openModal, closeModal };

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -185,6 +185,17 @@ export class Item extends Realm.Object {
   }
 
   /**
+   * Returns an array of all direction expansions related to this
+   * item.
+   */
+  getDirectionExpansions = database =>
+    this.directions.sorted('priority').reduce((acc, value) => {
+      const expansion = value.getExpansion(database);
+      if (expansion) return [...acc, expansion];
+      return acc;
+    }, []);
+
+  /**
    * Get string representation of item.
    *
    * @returns  {string}
@@ -210,6 +221,7 @@ Item.schema = {
     isVisible: { type: 'bool', default: false },
     crossReferenceItem: { type: 'Item', optional: true },
     unit: { type: 'Unit', optional: true },
+    directions: { type: 'linkingObjects', objectType: 'ItemDirection', property: 'item' },
   },
 };
 

--- a/src/database/DataTypes/ItemDirection.js
+++ b/src/database/DataTypes/ItemDirection.js
@@ -5,14 +5,23 @@
 
 import Realm from 'realm';
 
-export class ItemDirection extends Realm.Object {}
+export class ItemDirection extends Realm.Object {
+  /**
+   * Returns the matching expansion of this ItemDirection, defaulting
+   * to null for all falsey values.
+   */
+  getExpansion = database => {
+    const expansion = database.get('Abbreviation', this.directions, 'abbreviation')?.expansion;
+    return expansion || null;
+  };
+}
 
 ItemDirection.schema = {
   name: 'ItemDirection',
   primaryKey: 'id',
   properties: {
     id: 'string',
-    priority: 'string',
+    priority: 'int',
     directions: 'string',
     item: { type: 'Item', optional: true },
   },

--- a/src/database/DataTypes/TransactionItem.js
+++ b/src/database/DataTypes/TransactionItem.js
@@ -86,6 +86,13 @@ export class TransactionItem extends Realm.Object {
   }
 
   /**
+   * Returns the note of the underlying transaction batch.
+   */
+  get note() {
+    return this.batches[0]?.note || null;
+  }
+
+  /**
    * Get available quantity of items.
    *
    * For customer invoices, get how much can be issued in total, accounting for the fact that any
@@ -250,6 +257,18 @@ export class TransactionItem extends Realm.Object {
     });
     database.delete('TransactionBatch', batchesToDelete);
   }
+
+  /**
+   * Sets the item direction for the underlying transaction batch.
+   */
+  setItemDirection = (database, newDirection) => {
+    const batch = this.batches[0];
+    if (!batch) return;
+    database.write(() => {
+      batch.note = newDirection;
+      database.save('TransactionBatch', batch);
+    });
+  };
 }
 
 TransactionItem.schema = {

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -110,9 +110,8 @@ class UIDatabase {
       case 'CustomerInvoice':
         // Only show invoices generated from requisitions once finalised.
         return results.filtered(
-          'type == $0 AND mode == $1 AND (linkedRequisition == $2 OR status == $3)',
+          'type == $0 AND (linkedRequisition == $1 OR status == $2)',
           'customer_invoice',
-          'store',
           null,
           'finalised'
         );

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -647,7 +647,8 @@ const createTransactionItem = (database, transaction, item, initialQuantity = 0)
     transaction,
   });
 
-  transactionItem.setTotalQuantity(database, initialQuantity);
+  const { isFinalised } = transaction;
+  if (!isFinalised) transactionItem.setTotalQuantity(database, initialQuantity);
 
   transaction.addItem(transactionItem);
   database.save('Transaction', transaction);

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -31,7 +31,7 @@ import { Synchroniser, PostSyncProcessor, SyncModal } from './sync';
 import { FinaliseButton, NavigationBar, SyncState, Spinner } from './widgets';
 import { FinaliseModal, LoginModal } from './widgets/modals';
 
-import { getCurrentParams, getCurrentRouteName, ReduxNavigator } from './navigation';
+import { getCurrentParams, getCurrentRouteName, ReduxNavigator, ROUTES } from './navigation';
 import { syncCompleteTransaction } from './actions/SyncActions';
 import { FinaliseActions } from './actions/FinaliseActions';
 import { migrateDataToVersion } from './dataMigration';
@@ -238,7 +238,11 @@ class MSupplyMobileAppContainer extends React.Component {
           onPressBack={this.getCanNavigateBack() ? this.handleBackEvent : null}
           LeftComponent={this.getCanNavigateBack() ? this.renderPageTitle : null}
           CentreComponent={this.renderLogo}
-          RightComponent={finaliseItem ? this.renderFinaliseButton : this.renderSyncState}
+          RightComponent={
+            finaliseItem && finaliseItem?.visibleButton
+              ? this.renderFinaliseButton
+              : this.renderSyncState
+          }
         />
         <ReduxNavigator
           state={navigationState}
@@ -290,8 +294,11 @@ const mapStateToProps = state => {
   const { finaliseModalOpen } = finalise;
   const currentParams = getCurrentParams(navigationState);
   const currentTitle = currentParams && currentParams.title;
-  const finaliseItem = FINALISABLE_PAGES[getCurrentRouteName(navigationState)];
+  const currentRouteName = getCurrentRouteName(navigationState);
+  const finaliseItem = FINALISABLE_PAGES[currentRouteName];
   if (finaliseItem && currentParams) {
+    if (currentRouteName === ROUTES.PRESCRIPTION) finaliseItem.visibleButton = false;
+    else finaliseItem.visibleButton = true;
     finaliseItem.record = currentParams[finaliseItem.recordToFinaliseKey];
   }
 

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -5,14 +5,13 @@
  */
 
 import React from 'react';
-
 import PropTypes from 'prop-types';
-
-import { View } from 'react-native';
 import { connect } from 'react-redux';
 
 import { Wizard } from '../widgets';
-import { PrescriptionSummary } from '../widgets/PrescriptionSummary';
+import { PrescriberSelect } from '../widgets/Tabs/PrescriberSelect';
+import { ItemSelect } from '../widgets/Tabs/ItemSelect';
+import { PrescriptionConfirmation } from '../widgets/Tabs/PrescriptionConfirmation';
 
 import {
   selectItem,
@@ -20,10 +19,6 @@ import {
   switchTab,
   editQuantity,
 } from '../reducers/PrescriptionReducer';
-
-import { PrescriptionInfo } from '../widgets/PrescriptionInfo';
-import { PrescriberSelect } from '../widgets/Tabs/PrescriberSelect';
-import { ItemSelect } from '../widgets/Tabs/ItemSelect';
 
 const mapDispatchToProps = dispatch => {
   const choosePrescriber = prescriberID => dispatch(selectPrescriber(prescriberID));
@@ -38,15 +33,8 @@ const mapStateToProps = state => {
   return { ...prescription, ...patient, ...prescriber };
 };
 
-const Summary = connect(mapStateToProps)(({ transaction }) => (
-  <View style={{ flex: 1 }}>
-    <PrescriptionInfo />
-    <PrescriptionSummary transaction={transaction} />
-  </View>
-));
-
-const tabs = [PrescriberSelect, ItemSelect, Summary];
-const titles = ['Select the Prescriber', 'Select items', 'Summary'];
+const tabs = [PrescriberSelect, ItemSelect, PrescriptionConfirmation];
+const titles = ['Select the Prescriber', 'Select items', 'Finalise'];
 
 export const Prescription = ({ currentTab, nextTab }) => (
   <Wizard tabs={tabs} titles={titles} currentTabIndex={currentTab} onPress={nextTab} />

--- a/src/reducers/FinaliseReducer.js
+++ b/src/reducers/FinaliseReducer.js
@@ -1,0 +1,32 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import { FINALISE_ACTIONS } from '../actions/FinaliseActions';
+
+/**
+ * Simple reducer managing the stores current finalise state.
+ *
+ * State shape:
+ * {
+ *     finaliseModalOpen: [bool]
+ * }
+ */
+
+const initialState = () => ({ finaliseModalOpen: false });
+
+export const FinaliseReducer = (state = initialState(), action) => {
+  const { type } = action;
+
+  switch (type) {
+    case FINALISE_ACTIONS.OPEN_MODAL: {
+      return { ...state, finaliseModalOpen: true };
+    }
+    case FINALISE_ACTIONS.CLOSE_MODAL: {
+      return { ...state, finaliseModalOpen: false };
+    }
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,6 +8,7 @@ import { PrescriptionReducer } from './PrescriptionReducer';
 import { PatientReducer } from './PatientReducer';
 import { FormReducer } from './FormReducer';
 import { PrescriberReducer } from './PrescriberReducer';
+import { FinaliseReducer } from './FinaliseReducer';
 
 export default combineReducers({
   user: UserReducer,
@@ -19,4 +20,5 @@ export default combineReducers({
   patient: PatientReducer,
   prescriber: PrescriberReducer,
   form: FormReducer,
+  finalise: FinaliseReducer,
 });

--- a/src/widgets/Tabs/PrescriptionConfirmation.js
+++ b/src/widgets/Tabs/PrescriptionConfirmation.js
@@ -1,0 +1,44 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { PrescriptionSummary } from '../PrescriptionSummary';
+import { PrescriptionInfo } from '../PrescriptionInfo';
+import { FlexView } from '../FlexView';
+import { PageButton } from '../PageButton';
+
+import { FinaliseActions } from '../../actions/FinaliseActions';
+
+const mapStateToProps = state => {
+  const { prescription, patient, prescriber } = state;
+  return { ...prescription, ...patient, ...prescriber };
+};
+
+const mapDispatchToProps = dispatch => {
+  const openFinaliseModal = () => dispatch(FinaliseActions.openModal());
+  return { openFinaliseModal };
+};
+
+const PrescriptionConfirmationComponent = ({ transaction, openFinaliseModal }) => (
+  <FlexView flex={1}>
+    <PrescriptionInfo />
+    <PrescriptionSummary transaction={transaction} />
+    <PageButton style={{ alignSelf: 'flex-end' }} text="Complete" onPress={openFinaliseModal} />
+  </FlexView>
+);
+
+PrescriptionConfirmationComponent.propTypes = {
+  transaction: PropTypes.object.isRequired,
+  openFinaliseModal: PropTypes.func.isRequired,
+};
+
+export const PrescriptionConfirmation = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PrescriptionConfirmationComponent);


### PR DESCRIPTION
### BRANCHED FROM #1805 

Fixes #1801 

## Change summary

This has created two further issues: 
- #1808 - to "finish off" moving finalise logic into redux
- #1809 - to implement the 'locking' of the script after finalising


- Added a `Finalise` reducer.
- Finalise logic is extremely convoluted..but the `finaliseItem` comes from `pages/index` and is added to in `mSupplyMobileApp.mapStateToProps`. It's then(was) controlled by the state in `mSupplyMobileApp` which a callback was passed to `NavigationBar`
- It becomes more complicated to handle finalising if we use the navigation bar. I think we should put it back there eventually, but for now I have shifted some of this logic (handling the modal) into redux (which would be needed in any case) and just added a button in the bottom right

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/35858975/71552749-77e95580-2a67-11ea-8bfb-4eabc1875ff3.png">


- Otherwise, would be looking into various things such as mass locking of buttons, as a script could be valid and the user navigates back to the "items" step, for instance, and then finalises. But it's not quite as simple as just triggering a disabled prop, as the finalisation happens in a component at the same level in the hierarchy as the page, the page does not re-render in all cases etc. Becomes a bit of a nightmare :) 
- TLDR: Using a button for finalising at the moment, and adding a hack to not show the finalise button in the navigation bar for scripts. Will shift and use the navigation bar hopefully soon

## Testing

N/A

### Related areas to think about

N/A
