### PR TITLE
#1826 Updated Prescriber and Patient reducer state transitions

### DIFF
--- a/src/reducers/PatientReducer.js
+++ b/src/reducers/PatientReducer.js
@@ -35,18 +35,12 @@ export const PatientReducer = (state = patientInitialState(), action) => {
     }
 
     case PATIENT_ACTIONS.PATIENT_CREATION: {
-      return { ...state, isCreating: true };
+      return { ...state, currentPatient: null, isCreating: true };
     }
 
     case PATIENT_ACTIONS.COMPLETE: {
-      return {
-        ...state,
-        isEditing: false,
-        isCreating: false,
-        viewingHistory: false,
-        sortKey: 'itemName',
-        isAscending: true,
-      };
+      const { currentPatient } = state;
+      return { ...patientInitialState(), currentPatient };
     }
 
     case PATIENT_ACTIONS.SORT_HISTORY: {

--- a/src/reducers/PrescriberReducer.js
+++ b/src/reducers/PrescriberReducer.js
@@ -4,6 +4,7 @@
  */
 
 import { PRESCRIBER_ACTIONS } from '../actions/PrescriberActions';
+import { ROUTES } from '../navigation/index';
 
 const prescriberInitialState = () => ({
   currentPrescriber: null,
@@ -15,6 +16,13 @@ export const PrescriberReducer = (state = prescriberInitialState(), action) => {
   const { type } = action;
 
   switch (type) {
+    case 'Navigation/NAVIGATE': {
+      const { routeName } = action;
+
+      if (routeName !== ROUTES.PRESCRIPTION) return state;
+      return { ...state, currentPrescriber: null };
+    }
+
     case PRESCRIBER_ACTIONS.EDIT: {
       const { payload } = action;
       const { prescriber } = payload;
@@ -22,11 +30,12 @@ export const PrescriberReducer = (state = prescriberInitialState(), action) => {
     }
 
     case PRESCRIBER_ACTIONS.CREATE: {
-      return { ...state, isCreatingPrescriber: true };
+      return { ...state, currentPrescriber: null, isCreatingPrescriber: true };
     }
 
     case PRESCRIBER_ACTIONS.COMPLETE: {
-      return prescriberInitialState();
+      const { currentPrescriber } = state;
+      return { ...prescriberInitialState(), currentPrescriber };
     }
 
     case PRESCRIBER_ACTIONS.SET: {


### PR DESCRIPTION
Fixes #1826 

## Change summary

- Changed the state changes of prescriber and patient to correctly reset when required. When creating a patient/prescriber (CREATION), reset to no current. When navigating to a prescription, reset to no prescriber. And when closing the prescriber modal, don't clear the current prescriber, just the same as patient.

## Testing

N/A

### Related areas to think about

Possibly should clear the `currentPatient` and `currentPrescriber` when closing the modal.. Not doing that at the moment because of prescriptions, but could use the underlying `Transaction` customer and prescriber rather than having them stored in state for that.
