### PR TITLE
#1828 add indicator incoming sync

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -249,6 +249,10 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
       cannotBeBlank: [],
       canBeBlank: ['units', 'comment', 'order_number'],
     },
+    ProgramIndicator: {
+      cannotBeBlank: ['code', 'program_ID', 'is_active'],
+      canBeBlank: [],
+    },
   };
   if (!requiredFields[recordType]) return false; // Unsupported record type
   const hasAllNonBlankFields = requiredFields[recordType].cannotBeBlank.reduce(
@@ -693,6 +697,9 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         id: record.ID,
         name: record.name,
       });
+      break;
+    }
+    case 'ProgramIndicator': {
       break;
     }
     case 'Options': {

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -128,6 +128,19 @@ const getOrCreateAddress = (database, line1, line2, line3, line4, zipCode) => {
 export const sanityCheckIncomingRecord = (recordType, record) => {
   if (!record.ID || record.ID.length < 1) return false; // Every record must have an ID.
   const requiredFields = {
+    IndicatorAttribute: {
+      cannotBeBlank: [
+        'indicator_ID',
+        'description',
+        'code',
+        'index',
+        'is_required',
+        'data_type',
+        'axis',
+        'is_active',
+      ],
+      canBeBlank: [],
+    },
     Item: {
       cannotBeBlank: ['code', 'item_name'],
       canBeBlank: ['default_pack_size'],
@@ -288,6 +301,9 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
   if (!sanityCheckIncomingRecord(recordType, record)) return; // Unsupported or malformed record.
   let internalRecord;
   switch (recordType) {
+    case 'IndicatorAttribute': {
+      break;
+    }
     case 'Item': {
       internalRecord = {
         id: record.ID,

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -141,6 +141,10 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
       ],
       canBeBlank: [],
     },
+    IndicatorValue: {
+      cannotBeBlank: ['facility_ID', 'period_ID', 'column_ID', 'row_ID', 'value'],
+      canBeBlank: [],
+    },
     Item: {
       cannotBeBlank: ['code', 'item_name'],
       canBeBlank: ['default_pack_size'],
@@ -302,6 +306,9 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
   let internalRecord;
   switch (recordType) {
     case 'IndicatorAttribute': {
+      break;
+    }
+    case 'IndicatorValue': {
       break;
     }
     case 'Item': {

--- a/src/sync/syncTranslators.js
+++ b/src/sync/syncTranslators.js
@@ -33,6 +33,7 @@ class SyncTranslator {
 
 // Map of internal database object types to external record types.
 export const RECORD_TYPES = new SyncTranslator({
+  IndicatorAttribute: 'indicator_attribute',
   Item: 'item',
   ItemStoreJoin: 'item_store_join',
   ItemBatch: 'item_line',

--- a/src/sync/syncTranslators.js
+++ b/src/sync/syncTranslators.js
@@ -34,6 +34,7 @@ class SyncTranslator {
 // Map of internal database object types to external record types.
 export const RECORD_TYPES = new SyncTranslator({
   IndicatorAttribute: 'indicator_attribute',
+  IndicatorValue: 'indicator_value',
   Item: 'item',
   ItemStoreJoin: 'item_store_join',
   ItemBatch: 'item_line',

--- a/src/sync/syncTranslators.js
+++ b/src/sync/syncTranslators.js
@@ -49,6 +49,7 @@ export const RECORD_TYPES = new SyncTranslator({
   Options: 'options',
   Period: 'period',
   PeriodSchedule: 'periodSchedule',
+  ProgramIndicator: 'program_indicator',
   Requisition: 'requisition',
   RequisitionItem: 'requisition_line',
   Stocktake: 'Stock_take',

--- a/src/sync/syncTranslators.js
+++ b/src/sync/syncTranslators.js
@@ -4,6 +4,7 @@
  */
 
 /* eslint-disable quote-props */
+/* eslint-disable max-classes-per-file */
 
 export const INTERNAL_TO_EXTERNAL = 0;
 export const EXTERNAL_TO_INTERNAL = 1;


### PR DESCRIPTION
Fixes #1828.

## Change summary

Adds incoming sync stubs for indicator tables.

## Testing

NOTE: the below tests are duplicated in #1837.

## Setup

- Add `console.log` statements to `createOrUpdateRecord` case blocks for `ProgramIndicator`,, `IndicatorAttribute`, `IndicatorValue`.

## Test cases

- [ ] `ProgramIndicator` records sync to mobile.
- [ ] `IndicatorAttribute` records sync to mobile.
- [ ] `IndicatorValue` records sync to mobile.
  - Make an internal order to the mobile store for an indicator program.
  - Add some values and finalise the requisition.
  - New indicator values should be created and synced to mobile. 

### Related areas to think about

See #1837 for added indicator tables. 