### PR TITLE
#1829 add indicator toggle logic

### DIFF
--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -66,6 +66,7 @@ const SupplierRequisition = ({
   onCheck,
   onUncheck,
   onSortColumn,
+  onShowIndicators,
   onShowOverStocked,
   onHideOverStocked,
   // onOpenRegimenDataModal,
@@ -212,7 +213,7 @@ const SupplierRequisition = ({
       {
         text: programStrings.indicators,
         isOn: showIndicators,
-        onPress: null,
+        onPress: onShowIndicators,
       },
     ],
     [showIndicators]
@@ -422,6 +423,7 @@ SupplierRequisition.propTypes = {
   onCheck: PropTypes.func.isRequired,
   onUncheck: PropTypes.func.isRequired,
   onSortColumn: PropTypes.func.isRequired,
+  onShowIndicators: PropTypes.func.isRequired,
   onShowOverStocked: PropTypes.func.isRequired,
   onHideOverStocked: PropTypes.func.isRequired,
   // onOpenRegimenDataModal: PropTypes.func.isRequired,

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -67,6 +67,7 @@ const SupplierRequisition = ({
   onUncheck,
   onSortColumn,
   onShowIndicators,
+  onHideIndicators,
   onShowOverStocked,
   onHideOverStocked,
   // onOpenRegimenDataModal,
@@ -208,7 +209,7 @@ const SupplierRequisition = ({
       {
         text: programStrings.items,
         isOn: !showIndicators,
-        onPress: null,
+        onPress: onHideIndicators,
       },
       {
         text: programStrings.indicators,
@@ -379,7 +380,6 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 
 const mapStateToProps = state => {
   // TODO: add indicator toggle flag to page state.
-
   const { pages } = state;
   return pages[ROUTES.SUPPLIER_REQUISITION];
 };
@@ -424,6 +424,7 @@ SupplierRequisition.propTypes = {
   onUncheck: PropTypes.func.isRequired,
   onSortColumn: PropTypes.func.isRequired,
   onShowIndicators: PropTypes.func.isRequired,
+  onHideIndicators: PropTypes.func.isRequired,
   onShowOverStocked: PropTypes.func.isRequired,
   onHideOverStocked: PropTypes.func.isRequired,
   // onOpenRegimenDataModal: PropTypes.func.isRequired,

--- a/src/pages/dataTableUtilities/actions/constants.js
+++ b/src/pages/dataTableUtilities/actions/constants.js
@@ -10,6 +10,7 @@ export const ACTIONS = {
   REFRESH_DATA: 'refreshData',
   ADD_ITEM: 'addItem',
   ADD_RECORD: 'addRecord',
+  SHOW_INDICATORS: 'showIndicators',
   HIDE_OVER_STOCKED: 'hideOverStocked',
   TOGGLE_STOCK_OUT: 'toggleStockOut',
   TOGGLE_SHOW_FINALISED: 'toggleShowFinalised',

--- a/src/pages/dataTableUtilities/actions/constants.js
+++ b/src/pages/dataTableUtilities/actions/constants.js
@@ -11,6 +11,7 @@ export const ACTIONS = {
   ADD_ITEM: 'addItem',
   ADD_RECORD: 'addRecord',
   SHOW_INDICATORS: 'showIndicators',
+  HIDE_INDICATORS: 'hideIndicators',
   HIDE_OVER_STOCKED: 'hideOverStocked',
   TOGGLE_STOCK_OUT: 'toggleStockOut',
   TOGGLE_SHOW_FINALISED: 'toggleShowFinalised',

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -52,6 +52,8 @@ export const addRecord = (record, route) => ({
  */
 export const refreshData = route => ({ type: ACTIONS.REFRESH_DATA, payload: { route } });
 
+export const showIndicators = route => ({ type: ACTIONS.SHOW_INDICATORS, payload: { route } });
+
 /**
  * Hides all items which have current stock on hand greater than the
  * threshold MOS stock for that item.
@@ -253,6 +255,7 @@ export const TableActionsLookup = {
   sortData,
   filterData,
   refreshData,
+  showIndicators,
   hideOverStocked,
   toggleShowFinalised,
   showOverStocked,

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -54,6 +54,8 @@ export const refreshData = route => ({ type: ACTIONS.REFRESH_DATA, payload: { ro
 
 export const showIndicators = route => ({ type: ACTIONS.SHOW_INDICATORS, payload: { route } });
 
+export const hideIndicators = route => ({ type: ACTIONS.HIDE_INDICATORS, payload: { route } });
+
 /**
  * Hides all items which have current stock on hand greater than the
  * threshold MOS stock for that item.
@@ -256,6 +258,7 @@ export const TableActionsLookup = {
   filterData,
   refreshData,
   showIndicators,
+  hideIndicators,
   hideOverStocked,
   toggleShowFinalised,
   showOverStocked,

--- a/src/pages/dataTableUtilities/getPageDispatchers.js
+++ b/src/pages/dataTableUtilities/getPageDispatchers.js
@@ -26,6 +26,7 @@ export const getPageDispatchers = (dispatch, props, dataType, route) => {
     toggleFinalised: () => dispatch(BasePageActions.toggleShowFinalised(route)),
     toggleStockOut: () => dispatch(BasePageActions.toggleStockOut(route)),
     onFilterData: debounce(value => dispatch(BasePageActions.filterData(value, route)), 75),
+    onShowIndicators: () => dispatch(BasePageActions.showIndicators(route)),
     onShowOverStocked: () => dispatch(BasePageActions.showOverStocked(route)),
     onHideOverStocked: () => dispatch(BasePageActions.hideOverStocked(route)),
     onDeselectAll: () => dispatch(BasePageActions.deselectAll(route)),

--- a/src/pages/dataTableUtilities/getPageDispatchers.js
+++ b/src/pages/dataTableUtilities/getPageDispatchers.js
@@ -27,6 +27,7 @@ export const getPageDispatchers = (dispatch, props, dataType, route) => {
     toggleStockOut: () => dispatch(BasePageActions.toggleStockOut(route)),
     onFilterData: debounce(value => dispatch(BasePageActions.filterData(value, route)), 75),
     onShowIndicators: () => dispatch(BasePageActions.showIndicators(route)),
+    onHideIndicators: () => dispatch(BasePageActions.hideIndicators(route)),
     onShowOverStocked: () => dispatch(BasePageActions.showOverStocked(route)),
     onHideOverStocked: () => dispatch(BasePageActions.hideOverStocked(route)),
     onDeselectAll: () => dispatch(BasePageActions.deselectAll(route)),

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -378,6 +378,7 @@ const supplierRequisitionInitialiser = requisition => {
     modalKey: '',
     hasSelection: false,
     modalValue: null,
+    showIndicators: false,
     showAll: !usingPrograms || isFinalised,
     route: ROUTES.SUPPLIER_REQUISITION,
     columns: getColumns(route),

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -144,6 +144,11 @@ export const toggleShowFinalised = state => {
   return { ...state, data: sortedData, showFinalised: newShowFinalisedState, searchTerm: '' };
 };
 
+export const showIndicators = state => {
+  console.log('SHOWING INDICATORS');
+  return { ...state, showIndicators: true };
+};
+
 /**
  * Filters backingData by the elements isLessThanThresholdMOS field.
  */
@@ -190,6 +195,7 @@ export const TableReducerLookup = {
   toggleStockOut,
   toggleShowFinalised,
   addRecord,
+  showIndicators,
   hideOverStocked,
   refreshData,
   filterData,

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -144,15 +144,9 @@ export const toggleShowFinalised = state => {
   return { ...state, data: sortedData, showFinalised: newShowFinalisedState, searchTerm: '' };
 };
 
-export const showIndicators = state => {
-  console.log('SHOWING INDICATORS');
-  return { ...state, showIndicators: true };
-};
+export const showIndicators = state => ({ ...state, showIndicators: true });
 
-export const hideIndicators = state => {
-  console.log('HIDING INDICATORS');
-  return { ...state, showIndicators: false };
-};
+export const hideIndicators = state => ({ ...state, showIndicators: false });
 
 /**
  * Filters backingData by the elements isLessThanThresholdMOS field.

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -149,6 +149,11 @@ export const showIndicators = state => {
   return { ...state, showIndicators: true };
 };
 
+export const hideIndicators = state => {
+  console.log('HIDING INDICATORS');
+  return { ...state, showIndicators: false };
+};
+
 /**
  * Filters backingData by the elements isLessThanThresholdMOS field.
  */
@@ -196,6 +201,7 @@ export const TableReducerLookup = {
   toggleShowFinalised,
   addRecord,
   showIndicators,
+  hideIndicators,
   hideOverStocked,
   refreshData,
   filterData,


### PR DESCRIPTION
Fixes #1829.

Branches off #1831.

## Change summary

Adds actions, reducers for toggling indicators. No data table logic.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When a supplier requisition is opened, the toggle defaults to "Items".
- [ ] When the "Indicators" toggle is clicked, the items buttons are swapped out for the indicators dropdown.
- [ ] When the "Items" toggle is clicked, the indicator dropdown is swapped out for the indicators buttons.

### Related areas to think about

Next steps are to add column swapping logic, which I think will probably be the most tricky part of this functionality. Discussion will follow on this in new issue.
