### PR TITLE
#1842 add indicator row column relations

### DIFF
--- a/src/database/DataTypes/IndicatorAttribute.js
+++ b/src/database/DataTypes/IndicatorAttribute.js
@@ -19,7 +19,21 @@ import Realm from 'realm';
  * @property  {string}            axis
  * @property  {boolean}           isActive
  */
-export class IndicatorAttribute extends Realm.Object {}
+export class IndicatorAttribute extends Realm.Object {
+  /**
+   * Get if an attribute is a row.
+   */
+  get isRow() {
+    return this.axis === 'row';
+  }
+
+  /**
+   * Get if an attribute is a column.
+   */
+  get isColumn() {
+    return this.axis === 'column';
+  }
+}
 
 export default IndicatorAttribute;
 

--- a/src/database/DataTypes/ProgramIndicator.js
+++ b/src/database/DataTypes/ProgramIndicator.js
@@ -14,7 +14,34 @@ import Realm from 'realm';
  * @property  {MasterList}  program
  * @property  {boolean}     isActive
  */
-export class ProgramIndicator extends Realm.Object {}
+export class ProgramIndicator extends Realm.Object {
+  /**
+   * Add an attribute to this indicator.
+   *
+   * @param {IndicatorAttribute} indicatorAttribute
+   */
+  addIndicatorAttribute(indicatorAttribute) {
+    if (indicatorAttribute.isRow) {
+      this.rows.push(indicatorAttribute);
+    }
+    if (indicatorAttribute.isColumn) {
+      this.columns.push(indicatorAttribute);
+    }
+  }
+
+  /**
+   * Add an attribute to this indicator.
+   *
+   * @param {IndicatorAttribute} indicatorAttribute
+   */
+  addIndicatorAttributeIfUnique(indicatorAttribute) {
+    const isUnique = !(
+      this.rows.filtered('id == $0', indicatorAttribute.id).length > 0 ||
+      this.columns.filtered('id == $0', indicatorAttribute.id).length > 0
+    );
+    if (isUnique) this.addIndicatorAttribute(indicatorAttribute);
+  }
+}
 
 export default ProgramIndicator;
 

--- a/src/database/DataTypes/ProgramIndicator.js
+++ b/src/database/DataTypes/ProgramIndicator.js
@@ -26,5 +26,7 @@ ProgramIndicator.schema = {
     code: { type: 'string', default: 'placeholderCode' },
     program: { type: 'MasterList', optional: true },
     isActive: { type: 'bool', default: false },
+    rows: { type: 'list', objectType: 'IndicatorAttribute' },
+    columns: { type: 'list', objectType: 'IndicatorAttribute' },
   },
 };

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -306,7 +306,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
   let internalRecord;
   switch (recordType) {
     case 'IndicatorAttribute': {
-      internalRecord = {
+      const indicatorAttribute = database.update(recordType, {
         id: record.ID,
         indicator: database.getOrCreate('ProgramIndicator', record.indicator_ID),
         description: record.description,
@@ -317,8 +317,8 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         valueDefault: record.data_type && record.data_type.default,
         axis: record.axis,
         isActive: parseBoolean(record.is_active),
-      };
-      database.update(recordType, internalRecord);
+      });
+      indicatorAttribute.indicator.addIndicatorAttributeIfUnique(indicatorAttribute);
       break;
     }
     case 'IndicatorValue': {


### PR DESCRIPTION
Fixes #1842.

Branches off #1829.

## Change summary

- Adds  `ProgramIndicator.rows`, `ProgramIndicator.columns` links.
- Adds related `ProgramIndicator`, `IndicatorAttribute` helpers.
- Adds related incoming sync logic.

## Testing

### Setup

- Create a new indicator program and sync to mobile.
- Navigate to the Realm Explorer to view synced data.

### Test cases

- [ ] `ProgramIndicator.rows` has non-zero length.
- [ ] `ProgramIndicator.columns` has non-zero length.

### Related areas to think about

N/A.
