### PR TITLE
#1858 disable payments

### DIFF
--- a/src/database/DataTypes/TransactionBatch.js
+++ b/src/database/DataTypes/TransactionBatch.js
@@ -62,7 +62,7 @@ export class TransactionBatch extends Realm.Object {
    * @return  {string}
    */
   get itemCode() {
-    return this.itemBatch.item.code;
+    return this.itemBatch?.item?.code || '';
   }
 
   /**
@@ -71,7 +71,7 @@ export class TransactionBatch extends Realm.Object {
    * @return  {string}
    */
   get itemBatchId() {
-    return this.itemBatch ? this.itemBatch.id : '';
+    return this.itemBatch?.id || '';
   }
 
   /**
@@ -144,7 +144,7 @@ export class TransactionBatch extends Realm.Object {
    * @return  {string}
    */
   toString() {
-    return `${this.itemBatch} in a ${this.transaction.type}`;
+    return `${this?.itemBatch} in a ${this.transaction.type}`;
   }
 }
 

--- a/src/reducers/PaymentReducer.js
+++ b/src/reducers/PaymentReducer.js
@@ -15,7 +15,7 @@ const initialState = () => ({
   patient: null,
   paymentAmount: currency(0),
   policy: null,
-  paymentValid: false,
+  paymentValid: true,
 });
 
 export const PaymentReducer = (state = initialState(), action) => {
@@ -55,11 +55,11 @@ export const PaymentReducer = (state = initialState(), action) => {
       const { payload } = action;
       const { amount } = payload;
 
-      return { ...state, paymentAmount: amount, creditOverflow: false };
+      return { ...state, paymentAmount: amount, creditOverflow: false, paymentValid: true };
     }
 
     case PAYMENT_ACTIONS.CREDIT_OVERFLOW: {
-      return { ...state, creditOverflow: true };
+      return { ...state, creditOverflow: true, paymentValid: false };
     }
 
     default:

--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -12,7 +12,9 @@ export const selectPatientHistory = ({ patient }) => {
 
   // Create a query string `transaction.id == "{id} OR transaction.id == "{id}" ...`
   // finding all transaction batches for the patient.
-  const queryString = transactions.map(({ id }) => `transaction.id == "${id}"`).join(' OR ');
+  const queryString = `(${transactions
+    .map(({ id }) => `transaction.id == "${id}"`)
+    .join(' OR ')}) AND type != "cash_in" AND type != "cash_out"`;
   return queryString ? UIDatabase.objects('TransactionBatch').filtered(queryString) : [];
 };
 

--- a/src/selectors/user.js
+++ b/src/selectors/user.js
@@ -1,0 +1,9 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+export const selectCurrentUser = ({ user }) => {
+  const { currentUser } = user;
+  return currentUser;
+};

--- a/src/widgets/PaymentSummary.js
+++ b/src/widgets/PaymentSummary.js
@@ -23,8 +23,9 @@ import {
 } from '../selectors/payment';
 
 const paymentState = state => {
-  const { payment } = state;
+  const { payment, wizard } = state;
 
+  const { isComplete } = wizard;
   const { paymentAmount, creditOverflow } = payment;
   const subtotal = selectPrescriptionSubTotal(state);
   const total = selectPrescriptionTotal(state);
@@ -37,6 +38,7 @@ const paymentState = state => {
     creditUsed,
     paymentAmount,
     creditOverflow,
+    isComplete,
   };
 };
 
@@ -55,6 +57,7 @@ const PaymentSummaryComponent = ({
   creditUsed,
   paymentAmount,
   creditOverflow,
+  isComplete,
 }) => (
   <ScrollView>
     <FlexView flex={1} style={localStyles.container}>
@@ -62,7 +65,11 @@ const PaymentSummaryComponent = ({
 
       <FlexView flex={1}>
         <FlexView flex={0.25}>
-          <CurrencyInputRow currencyAmount={paymentAmount} onChangeText={updatePayment} />
+          <CurrencyInputRow
+            isDisabled={isComplete}
+            currencyAmount={paymentAmount}
+            onChangeText={updatePayment}
+          />
         </FlexView>
 
         <FlexView flex={0.25}>
@@ -89,6 +96,7 @@ PaymentSummaryComponent.propTypes = {
   creditUsed: PropTypes.object.isRequired,
   paymentAmount: PropTypes.object.isRequired,
   creditOverflow: PropTypes.bool.isRequired,
+  isComplete: PropTypes.bool.isRequired,
 };
 
 const localStyles = {


### PR DESCRIPTION
Fixes #1858 

## Change summary

- Disables editing payment values when the transaction is finalised
- Disables the confirm button for the prescription when the payment is invalid or the transaction is finalised.

## Testing

N/A

### Related areas to think about

- The `paymentValid` field is pretty redundant at the moment, but feel it might become neccessary!