### PR TITLE
#1866 Modify setQueryText argument

### DIFF
--- a/src/widgets/modalChildren/AutocompleteSelector.js
+++ b/src/widgets/modalChildren/AutocompleteSelector.js
@@ -31,6 +31,8 @@ export const AutocompleteSelector = ({
 }) => {
   const [queryText, setQueryText] = useState('');
 
+  const onChangeText = React.useCallback(inputValue => setQueryText(inputValue), []);
+
   /**
    * Filters a realm results object. Creates two realm results A, B
    * by two query strings. And concat A to B - A.
@@ -102,7 +104,7 @@ export const AutocompleteSelector = ({
         autoCorrect={false}
         autoFocus
         color={WHITE}
-        onChangeText={inputValue => setQueryText(inputValue)}
+        onChangeText={onChangeText}
         placeholder={placeholderText}
         placeholderTextColor="white"
         style={[localStyles.text, localStyles.searchBar]}

--- a/src/widgets/modalChildren/AutocompleteSelector.js
+++ b/src/widgets/modalChildren/AutocompleteSelector.js
@@ -31,8 +31,6 @@ export const AutocompleteSelector = ({
 }) => {
   const [queryText, setQueryText] = useState('');
 
-  const onChangeText = () => setQueryText(queryText);
-
   /**
    * Filters a realm results object. Creates two realm results A, B
    * by two query strings. And concat A to B - A.
@@ -104,7 +102,7 @@ export const AutocompleteSelector = ({
         autoCorrect={false}
         autoFocus
         color={WHITE}
-        onChangeText={onChangeText}
+        onChangeText={inputValue => setQueryText(inputValue)}
         placeholder={placeholderText}
         placeholderTextColor="white"
         style={[localStyles.text, localStyles.searchBar]}


### PR DESCRIPTION
Fixes #1866 

## Change summary

Now `onChangeText` is directly calling `setQueryText` and setting up the new value of `queryText`. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Download the APK and install it the tablet (or use an AVD)
- [ ] Go to customer invoice
- [ ] Click on "new invoice"
- [ ] Search for a customer.
- [ ] See the filter is working ok.