### PR TITLE
#1847 Message added when no reports to show

### DIFF
--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -18,13 +18,15 @@
     "couldnt_export_data": "Couldn't export data",
     "sync_password": "Sync password",
     "sync_url": "Sync url",
-    "reports": "Reports"
+    "reports": "Reports",
+    "no_reports": "No Reports to show"
   },
   "fr": {
     "stocktake": "Inventaire",
     "start_typing_to_search": "Tapez pour rechercher",
     "not_available": "N/A",
-    "reports": "Rapports"
+    "reports": "Rapports",
+    "no_reports": "Aucun rapport à afficher"
   },
   "gil": {
     "stocktake": "Warebwai",

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Text } from 'react-native';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -14,23 +14,35 @@ import { ReportSideBar } from '../widgets/ReportSideBar';
 import { ReportChart } from '../widgets/ReportChart';
 
 import globalStyles from '../globalStyles';
+
 import { DashboardActions } from '../actions/index';
 
 const DashboardPageComponent = ({ reports, currentReport, switchReport }) => {
   const { pageContentContainer, container, pageTopSectionContainer } = globalStyles;
   const pageContainer = StyleSheet.flatten([pageTopSectionContainer, { paddingHorizontal: 0 }]);
 
+  if (reports.length) {
+    return (
+      <View style={pageContentContainer}>
+        <View style={container}>
+          <View style={pageContainer}>
+            <ReportSideBar
+              reports={reports}
+              onPressItem={switchReport}
+              currentReport={currentReport}
+              dimensions={localStyles.sidebarDimensions}
+            />
+            <ReportChart report={currentReport} />
+          </View>
+        </View>
+      </View>
+    );
+  }
   return (
     <View style={pageContentContainer}>
       <View style={container}>
-        <View style={pageContainer}>
-          <ReportSideBar
-            reports={reports}
-            onPressItem={switchReport}
-            currentReport={currentReport}
-            dimensions={localStyles.sidebarDimensions}
-          />
-          <ReportChart report={currentReport} />
+        <View style={localStyles.centeredText}>
+          <Text style={localStyles.noReportsText}>No Reports to show</Text>
         </View>
       </View>
     </View>
@@ -41,6 +53,17 @@ const localStyles = StyleSheet.create({
   sidebarDimensions: {
     width: '25%',
     height: '100%',
+  },
+  centeredText: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  noReportsText: {
+    fontFamily: globalStyles.APP_FONT_FAMILY,
+    color: globalStyles.GREY,
+    fontWeight: 'bold',
+    fontSize: 20,
   },
 });
 

--- a/src/pages/DashboardPage.js
+++ b/src/pages/DashboardPage.js
@@ -10,6 +10,8 @@ import { View, StyleSheet, Text } from 'react-native';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
+import { generalStrings } from '../localization';
+
 import { ReportSideBar } from '../widgets/ReportSideBar';
 import { ReportChart } from '../widgets/ReportChart';
 
@@ -42,7 +44,7 @@ const DashboardPageComponent = ({ reports, currentReport, switchReport }) => {
     <View style={pageContentContainer}>
       <View style={container}>
         <View style={localStyles.centeredText}>
-          <Text style={localStyles.noReportsText}>No Reports to show</Text>
+          <Text style={localStyles.noReportsText}>{generalStrings.no_reports}</Text>
         </View>
       </View>
     </View>


### PR DESCRIPTION
Fixes #1847

## Change summary

A message added (`No reports to show`), which is mainly feedback needed to advise the user that there is no reports to show. This was added to `DashboardPage.js`, and the returned view depends on `reports.length`

## Testing

Steps to reproduce or otherwise test the changes of this PR:

Further testing will be taking place later on together with the whole dashboard/feature branch.

- [ ] Make sure there is no Reports on the desktop site
- [ ] Go to Dashboard Page
- [ ] Check the message `No Reports to show`
