### PR TITLE
#1877 edit indicator values

### DIFF
--- a/src/database/DataTypes/IndicatorAttribute.js
+++ b/src/database/DataTypes/IndicatorAttribute.js
@@ -57,7 +57,7 @@ IndicatorAttribute.schema = {
     index: { type: 'int', default: 0 },
     isRequired: { type: 'bool', default: true },
     valueType: { type: 'string', default: 'string' },
-    defaultValue: { type: 'string', default: 'string' },
+    defaultValue: { type: 'string', default: '' },
     axis: { type: 'string', default: 'row' },
     isActive: { type: 'bool', default: false },
     values: { type: 'list', objectType: 'IndicatorValue' },

--- a/src/database/DataTypes/IndicatorAttribute.js
+++ b/src/database/DataTypes/IndicatorAttribute.js
@@ -15,7 +15,7 @@ import Realm from 'realm';
  * @property  {number}            index
  * @property  {boolean}           isRequired
  * @property  {string}            valueType
- * @property  {string}            valueDefault
+ * @property  {string}            defaultValue
  * @property  {string}            axis
  * @property  {boolean}           isActive
  */
@@ -57,7 +57,7 @@ IndicatorAttribute.schema = {
     index: { type: 'int', default: 0 },
     isRequired: { type: 'bool', default: true },
     valueType: { type: 'string', default: 'string' },
-    valueDefault: { type: 'string', default: 'string' },
+    defaultValue: { type: 'string', default: 'string' },
     axis: { type: 'string', default: 'row' },
     isActive: { type: 'bool', default: false },
     values: { type: 'list', objectType: 'IndicatorValue' },

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -100,7 +100,7 @@ const createNumberToReuse = (database, numberSequence, number) => {
 };
 
 const createIndicatorValue = (database, row, column, period) => {
-  const { valueDefault: value } = column;
+  const { defaultValue: value } = column;
   const indicatorValue = database.create('IndicatorValue', {
     id: generateUUID(),
     storeId: UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_NAME_ID),

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -112,7 +112,8 @@ const SupplierRequisition = ({
         if (propName === 'onCheck') return onCheck;
         return onUncheck;
       default:
-        // TODO: check indicator keys.
+        // Indicators functionality generates columns at run-time from indicator attribute
+        // data. If known column key not found, assume column is a dynamic indicators column.
         return onEditIndicatorValue;
     }
   };

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -78,6 +78,7 @@ const SupplierRequisition = ({
   onShowIndicators,
   onHideIndicators,
   onSelectIndicator,
+  onEditIndicatorValue,
   onShowOverStocked,
   onHideOverStocked,
   onEditMonth,
@@ -111,7 +112,8 @@ const SupplierRequisition = ({
         if (propName === 'onCheck') return onCheck;
         return onUncheck;
       default:
-        return null;
+        // TODO: check indicator keys.
+        return onEditIndicatorValue;
     }
   };
 
@@ -407,6 +409,7 @@ SupplierRequisition.propTypes = {
   onShowOverStocked: PropTypes.func.isRequired,
   onHideOverStocked: PropTypes.func.isRequired,
   onSelectIndicator: PropTypes.func.isRequired,
+  onEditIndicatorValue: PropTypes.func.isRequired,
   onEditMonth: PropTypes.func.isRequired,
   onEditRequiredQuantity: PropTypes.func.isRequired,
   onAddRequisitionItem: PropTypes.func.isRequired,

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -21,6 +21,11 @@ export const refreshRow = (rowKey, route) => ({
   payload: { rowKey, route },
 });
 
+export const refreshIndicatorRow = route => ({
+  type: 'refreshIndicatorRow',
+  payload: { route },
+});
+
 /**
  * Edits a rows underlying `batch` field.
  *

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -8,6 +8,12 @@ import { parsePositiveInteger, MODAL_KEYS } from '../../../utilities';
 import { ACTIONS } from './constants';
 import { openModal, closeModal } from './pageActions';
 import { pageStateSelector } from '../selectors';
+// eslint-disable-next-line import/no-cycle
+import {
+  getIndicatorRows,
+  getIndicatorColumns,
+  getIndicatorRowColumnValue,
+} from '../../../utilities/getIndicatorTableData';
 
 /**
  * Refreshes a row in the DataTable component.
@@ -45,6 +51,24 @@ export const editBatchName = (value, rowKey, objectType, route) => (dispatch, ge
 
     dispatch(refreshRow(rowKey, route));
   }
+};
+
+export const editIndicatorValue = (value, rowKey, columnKey, route) => (dispatch, getState) => {
+  const rowCode = rowKey;
+  const columnCode = columnKey;
+
+  const { selectedIndicator: indicator, pageObject } = pageStateSelector(getState());
+  const { period } = pageObject;
+
+  const [column] = getIndicatorColumns(indicator, columnCode);
+
+  const [row] = getIndicatorRows(indicator, rowCode);
+
+  const valueRecord = getIndicatorRowColumnValue(row, column, period);
+
+  UIDatabase.write(() => UIDatabase.update('IndicatorValue', { ...valueRecord, value }));
+
+  dispatch(refreshIndicatorRow(route));
 };
 
 /**
@@ -278,6 +302,7 @@ export const CellActionsLookup = {
   enforceReasonChoice,
   applyReason,
   editBatchName,
+  editIndicatorValue,
   editStocktakeBatchName,
   editCountedQuantityWithReason,
   editStocktakeBatchCountedQuantityWithReason,

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -27,9 +27,9 @@ export const refreshRow = (rowKey, route) => ({
   payload: { rowKey, route },
 });
 
-export const refreshIndicatorRow = route => ({
+export const refreshIndicatorRow = (rowKey, route) => ({
   type: 'refreshIndicatorRow',
-  payload: { route },
+  payload: { rowKey, route },
 });
 
 /**
@@ -68,7 +68,7 @@ export const editIndicatorValue = (value, rowKey, columnKey, route) => (dispatch
 
   UIDatabase.write(() => UIDatabase.update('IndicatorValue', { ...valueRecord, value }));
 
-  dispatch(refreshIndicatorRow(route));
+  dispatch(refreshIndicatorRow(rowKey, route));
 };
 
 /**
@@ -289,6 +289,7 @@ export const editStocktakeBatchCountedQuantityWithReason = (value, rowKey, route
 
 export const CellActionsLookup = {
   refreshRow,
+  refreshIndicatorRow,
   editExpiryDate,
   editTransactionBatchExpiryDate,
   editStocktakeBatchExpiryDate,

--- a/src/pages/dataTableUtilities/getPageDispatchers.js
+++ b/src/pages/dataTableUtilities/getPageDispatchers.js
@@ -3,6 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
+// eslint-disable-next-line import/no-cycle
 import { BasePageActions } from './actions/getPageActions';
 import { MODAL_KEYS } from '../../utilities/getModalTitle';
 import { debounce } from '../../utilities/underscoreMethods';
@@ -39,6 +40,9 @@ export const getPageDispatchers = (dispatch, props, dataType, route) => {
       300,
       true
     ),
+
+    onEditIndicatorValue: (value, rowKey, columnKey) =>
+      dispatch(BasePageActions.editIndicatorValue(value, rowKey, columnKey, route)),
 
     // Modals
     onOpenRegimenDataModal: () =>

--- a/src/pages/dataTableUtilities/reducer/cellReducers.js
+++ b/src/pages/dataTableUtilities/reducer/cellReducers.js
@@ -1,3 +1,5 @@
+import { getIndicatorTableRows } from '../../../utilities';
+
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
@@ -21,6 +23,16 @@ export const refreshRow = (state, action) => {
   return { ...state, dataState: newDataState };
 };
 
+export const refreshIndicatorRow = state => {
+  const { selectedIndicator, pageObject } = state;
+  const { period } = pageObject;
+
+  const newIndicatorRows = getIndicatorTableRows(selectedIndicator, period);
+
+  return { ...state, indicatorRows: newIndicatorRows };
+};
+
 export const CellReducerLookup = {
   refreshRow,
+  refreshIndicatorRow,
 };

--- a/src/pages/dataTableUtilities/reducer/cellReducers.js
+++ b/src/pages/dataTableUtilities/reducer/cellReducers.js
@@ -1,4 +1,4 @@
-import { getIndicatorTableRows } from '../../../utilities';
+import { getIndicatorTableRow } from '../../../utilities';
 
 /**
  * mSupply Mobile
@@ -23,12 +23,17 @@ export const refreshRow = (state, action) => {
   return { ...state, dataState: newDataState };
 };
 
-export const refreshIndicatorRow = state => {
-  const { selectedIndicator, pageObject } = state;
+export const refreshIndicatorRow = (state, action) => {
+  const { selectedIndicator, indicatorRows, pageObject } = state;
   const { period } = pageObject;
 
-  const newIndicatorRows = getIndicatorTableRows(selectedIndicator, period);
+  const { payload } = action;
+  const { rowKey } = payload;
 
+  const rowIndex = indicatorRows.findIndex(({ id }) => id === rowKey);
+
+  const newIndicatorRows = [...indicatorRows];
+  newIndicatorRows[rowIndex] = getIndicatorTableRow(rowKey, selectedIndicator, period);
   return { ...state, indicatorRows: newIndicatorRows };
 };
 

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -129,16 +129,17 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
   if (!record.ID || record.ID.length < 1) return false; // Every record must have an ID.
   const requiredFields = {
     IndicatorAttribute: {
-      cannotBeBlank: [
-        'indicator_ID',
+      canBeBlank: [
+        'code',
         'description',
         'index',
         'is_required',
-        'data_type',
+        'value_type',
+        'default_value',
         'axis',
         'is_active',
       ],
-      canBeBlank: ['code'],
+      cannotBeBlank: ['indicator_ID'],
     },
     IndicatorValue: {
       cannotBeBlank: ['facility_ID', 'period_ID', 'column_ID', 'row_ID', 'value'],
@@ -312,8 +313,8 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         code: record.code,
         index: parseNumber(record.index),
         isRequired: parseBoolean(record.is_required),
-        valueType: record?.data_type?.value,
-        valueDefault: record?.data_type?.default,
+        valueType: record.value_type,
+        defaultValue: record?.default_value,
         axis: record.axis,
         isActive: parseBoolean(record.is_active),
       });

--- a/src/utilities/getIndicatorTableData.js
+++ b/src/utilities/getIndicatorTableData.js
@@ -38,6 +38,8 @@ export const initialiseRowColumnValue = (row, column, period) => {
   });
 };
 
+const getIndicatorColumns = (indicator, code) =>
+  indicator?.columns?.filter(({ description: columnCode }) => columnCode === code);
 
 const getIndicatorRows = (indicator, code) =>
   indicator?.rows?.filter(({ id: rowCode }) => rowCode === code);
@@ -122,4 +124,5 @@ const getIndicatorTableData = (indicator, period) => {
 
 export {
   getIndicatorRows,
+  getIndicatorColumns,
 };

--- a/src/utilities/getIndicatorTableData.js
+++ b/src/utilities/getIndicatorTableData.js
@@ -49,13 +49,12 @@ const getIndicatorRows = (indicator, code) =>
  *
  * @param {IndicatorAttribute} row
  * @param {IndicatorAttribute} column
+ * @param {Period} period
  * @returns {IndicatorValue}
  */
-export const getIndicatorRowColumnValue = (row, column, period) => {
-  const columnValues = column?.values?.filter(
-    ({ period: valuePeriod }) => valuePeriod.ID === period.ID
-  );
-  const rowValues = row?.values?.filter(({ period: valuePeriod }) => valuePeriod.ID === period.ID);
+const getIndicatorRowColumnValue = (row, column, period) => {
+  const columnValues = column.values.filtered('period == $0', period);
+  const rowValues = row.values.filter(({ period: valuePeriod }) => valuePeriod.ID === period.ID);
   const columnValueIds = columnValues?.map(({ id }) => id);
   const rowValueIds = rowValues?.map(({ id }) => id);
   const [rowColumnValueId] = columnValueIds?.filter(id => rowValueIds.includes(id)) || [];
@@ -81,11 +80,10 @@ const getIndicatorTableColumns = (indicator, period) => {
   const descriptionColumn = COLUMNS.DESCRIPTION;
   const codeColumn = COLUMNS.CODE;
   // eslint-disable-next-line no-unused-vars
-  const valueColumns = indicator.columns.map(({ description, code, valueType }) => ({
+  const valueColumns = indicator.columns.map(({ description, code }) => ({
+    ...COLUMN_INDICATOR_MUTABLE,
     title: description,
     key: description,
-    type: valueType,
-    ...COLUMN_DEFAULTS,
   }));
 
   return [descriptionColumn, codeColumn, ...valueColumns];

--- a/src/utilities/getIndicatorTableData.js
+++ b/src/utilities/getIndicatorTableData.js
@@ -32,7 +32,7 @@ const COLUMNS = {
  * @param {IndicatorAttribute} column
  * @param {Period} period
  */
-export const initialiseRowColumnValue = (row, column, period) => {
+const initialiseRowColumnValue = (row, column, period) => {
   UIDatabase.write(() => {
     createRecord(UIDatabase, 'IndicatorValue', row, column, period);
   });
@@ -123,4 +123,7 @@ const getIndicatorTableData = (indicator, period) => {
 export {
   getIndicatorRows,
   getIndicatorColumns,
+  getIndicatorTableRows,
+  getIndicatorRowColumnValue,
+  getIndicatorTableData,
 };

--- a/src/utilities/getIndicatorTableData.js
+++ b/src/utilities/getIndicatorTableData.js
@@ -3,25 +3,37 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
+// eslint-disable-next-line import/no-cycle
+import { COLUMN_TYPES } from '../pages/dataTableUtilities';
 import { UIDatabase, createRecord } from '../database';
 
-const COLUMN_DEFAULTS = {
-  type: 'string',
+const COLUMN_INDICATOR = {
   width: 1,
   sortable: false,
+};
+
+const COLUMN_INDICATOR_IMMUTABLE = {
+  type: COLUMN_TYPES.STRING,
   editable: false,
+  ...COLUMN_INDICATOR,
+};
+
+const COLUMN_INDICATOR_MUTABLE = {
+  type: COLUMN_TYPES.EDITABLE_STRING,
+  editable: true,
+  ...COLUMN_INDICATOR,
 };
 
 const COLUMNS = {
   DESCRIPTION: {
+    ...COLUMN_INDICATOR_IMMUTABLE,
     title: 'Description',
     key: 'description',
-    ...COLUMN_DEFAULTS,
   },
   CODE: {
+    ...COLUMN_INDICATOR_IMMUTABLE,
     title: 'Code',
     key: 'code',
-    ...COLUMN_DEFAULTS,
   },
 };
 

--- a/src/utilities/getIndicatorTableData.js
+++ b/src/utilities/getIndicatorTableData.js
@@ -101,6 +101,17 @@ const getIndicatorTableColumns = (indicator, period) => {
   return [descriptionColumn, codeColumn, ...valueColumns];
 };
 
+const getIndicatorTableRow = (rowId, indicator, period) => {
+  const [row] = indicator.rows.filter(({ id }) => id === rowId);
+  const { description, code } = row;
+  const values = indicator.columns.reduce((acc, column) => {
+    const { description: key } = column;
+    const value = getIndicatorRowColumnValue(row, column, period);
+    return { ...acc, [key]: value.value };
+  }, {});
+  return { id: rowId, description, code, ...values };
+};
+
 /**
  * Get indicator data table rows.
  *
@@ -109,15 +120,7 @@ const getIndicatorTableColumns = (indicator, period) => {
  * @returns {Array.<object>}
  */
 const getIndicatorTableRows = (indicator, period) =>
-  indicator.rows.map(row => {
-    const { id, description, code } = row;
-    const values = indicator.columns.reduce((acc, column) => {
-      const { description: key } = column;
-      const value = getIndicatorRowColumnValue(row, column, period);
-      return { ...acc, [key]: value.value };
-    }, {});
-    return { id, description, code, ...values };
-  });
+  indicator.rows.map(({ id }) => getIndicatorTableRow(id, indicator, period));
 
 /**
  * Get indicator data table rows and columns.
@@ -135,6 +138,7 @@ const getIndicatorTableData = (indicator, period) => {
 export {
   getIndicatorRows,
   getIndicatorColumns,
+  getIndicatorTableRow,
   getIndicatorTableRows,
   getIndicatorRowColumnValue,
   getIndicatorTableData,

--- a/src/utilities/getIndicatorTableData.js
+++ b/src/utilities/getIndicatorTableData.js
@@ -38,6 +38,10 @@ export const initialiseRowColumnValue = (row, column, period) => {
   });
 };
 
+
+const getIndicatorRows = (indicator, code) =>
+  indicator?.rows?.filter(({ id: rowCode }) => rowCode === code);
+
 /**
  * Get value for indicator row, column tuple.
  *
@@ -116,4 +120,6 @@ const getIndicatorTableData = (indicator, period) => {
   return { columns, rows };
 };
 
-export { getIndicatorTableData };
+export {
+  getIndicatorRows,
+};

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -21,6 +21,7 @@ export { getModalTitle, MODAL_KEYS } from './getModalTitle';
 export {
   getIndicatorRows,
   getIndicatorColumns,
+  getIndicatorTableRow,
   getIndicatorTableRows,
   getIndicatorRowColumnValue,
   getIndicatorTableData,

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -18,8 +18,13 @@ export { backupValidation } from './fileSystem';
 export { debounce } from './underscoreMethods';
 export { getModalTitle, MODAL_KEYS } from './getModalTitle';
 // eslint-disable-next-line import/no-cycle
-export { getIndicatorTableData } from './getIndicatorTableData';
-
+export {
+  getIndicatorRows,
+  getIndicatorColumns,
+  getIndicatorTableRows,
+  getIndicatorRowColumnValue,
+  getIndicatorTableData,
+} from './getIndicatorTableData';
 // eslint-disable-next-line import/no-cycle
 export {
   checkForCustomerInvoiceError,


### PR DESCRIPTION
Fixes #1877. 

## Change summary

Add actions, reducers for editing, saving and re-rendering indicator values.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Description column values cannot be edited.
- [ ] Code column values cannot be edited.
- [ ] All non-description, non-code columns are editable.
  - [ ] Layout is re-rendered on edit.
  - [ ] Updated value is persisted after requisition is closed.

### Related areas to think about

N/A.