### PR TITLE
Add indicator attributes to outgoing sync

### DIFF
--- a/src/sync/SyncQueue.js
+++ b/src/sync/SyncQueue.js
@@ -17,6 +17,7 @@ const recordTypesSynced = [
   'StocktakeBatch',
   'Transaction',
   'TransactionBatch',
+  'IndicatorValue',
 ];
 
 /**

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -73,6 +73,16 @@ const safeGet = (record, path) => {
  */
 const generateSyncData = (settings, recordType, record) => {
   switch (recordType) {
+    case 'IndicatorValue': {
+      return {
+        ID: record.id,
+        facility_ID: settings.get(THIS_STORE_ID),
+        period_ID: record.period.id,
+        column_ID: record.column.id,
+        row_ID: record.row.id,
+        value: record.value,
+      };
+    }
     case 'ItemBatch': {
       return {
         ID: record.id,


### PR DESCRIPTION
Fixes #1913. Branches off #1903.

## Change summary

Adds `IndicatorValue` to outgoing sync.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

Easiest way to test that a value is synced to desktop is to place a breakpoint into desktop mSupply incoming sync logic. If on a build, record browser can be used.

- [ ] Updated indicator values are synced to desktop. 

### Related areas to think about

N/A.

