### PR TITLE
#1902 fix supplier requisition no indicator error

### DIFF
--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -140,6 +140,10 @@ export class Requisition extends Realm.Object {
     return (this.otherStoreName && this.otherStoreName.name) || '';
   }
 
+  get indicators() {
+    return this.program?.indicators.slice() || [];
+  }
+
   /**
    * Set the days to supply of this requisition in months.
    *

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -58,6 +58,7 @@ const SupplierRequisition = ({
   pageObject,
   hasSelection,
   showAll,
+  usingIndicators,
   showIndicators,
   selectedIndicator,
   indicators,
@@ -192,9 +193,9 @@ const SupplierRequisition = ({
     />
   );
 
-  const UseSuggestedQuantitiesButton = (isWide = false) => (
+  const UseSuggestedQuantitiesButton = () => (
     <PageButton
-      style={isWide ? globalStyles.wideButton : globalStyles.topButton}
+      style={usingIndicators ? globalStyles.wideButton : globalStyles.topButton}
       text={buttonStrings.use_suggested_quantities}
       onPress={onSetRequestedToSuggested}
       isDisabled={isFinalised}
@@ -351,8 +352,11 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 const mapStateToProps = state => {
   // TODO: add indicator toggle flag to page state.
   const { pages } = state;
-  const { showIndicators, indicatorColumns, indicatorRows } = pages[ROUTES.SUPPLIER_REQUISITION];
-  if (showIndicators) {
+  const { usingIndicators, showIndicators, indicatorColumns, indicatorRows } = pages[
+    ROUTES.SUPPLIER_REQUISITION
+  ];
+
+  if (usingIndicators && showIndicators) {
     return {
       ...pages[ROUTES.SUPPLIER_REQUISITION],
       data: indicatorRows,
@@ -370,6 +374,7 @@ export const SupplierRequisitionPage = connect(
 SupplierRequisition.defaultProps = {
   modalValue: null,
   showAll: false,
+  usingIndicators: false,
   showIndicators: false,
 };
 
@@ -390,6 +395,7 @@ SupplierRequisition.propTypes = {
   routeName: PropTypes.string.isRequired,
   hasSelection: PropTypes.bool.isRequired,
   showAll: PropTypes.bool,
+  usingIndicators: PropTypes.bool,
   showIndicators: PropTypes.bool,
   selectedIndicator: PropTypes.object.isRequired,
   indicators: PropTypes.array.isRequired,

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -350,7 +350,6 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 };
 
 const mapStateToProps = state => {
-  // TODO: add indicator toggle flag to page state.
   const { pages } = state;
   const { usingIndicators, showIndicators, indicatorColumns, indicatorRows } = pages[
     ROUTES.SUPPLIER_REQUISITION

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -354,7 +354,7 @@ const supplierInvoicesInitialiser = () => {
  * @returns  {object}
  */
 const supplierRequisitionInitialiser = requisition => {
-  const { isFinalised, program, period, items: backingData } = requisition;
+  const { isFinalised, program, period, items: backingData, indicators } = requisition;
 
   const usingPrograms = !!program;
   const route = program ? ROUTES.SUPPLIER_REQUISITION_WITH_PROGRAM : ROUTES.SUPPLIER_REQUISITION;
@@ -364,8 +364,6 @@ const supplierRequisitionInitialiser = requisition => {
     !usingPrograms || isFinalised
       ? sortedData
       : sortedData.filter(item => item.isLessThanThresholdMOS);
-
-  const indicators = program?.indicators?.slice() || [];
 
   const [selectedIndicator] = indicators;
   const { columns: indicatorColumns, rows: indicatorRows } = getIndicatorTableData(

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -365,6 +365,7 @@ const supplierRequisitionInitialiser = requisition => {
       ? sortedData
       : sortedData.filter(item => item.isLessThanThresholdMOS);
 
+  const usingIndicators = !!indicators.length;
   const [selectedIndicator] = indicators;
   const { columns: indicatorColumns, rows: indicatorRows } = getIndicatorTableData(
     selectedIndicator,
@@ -384,6 +385,7 @@ const supplierRequisitionInitialiser = requisition => {
     modalKey: '',
     hasSelection: false,
     modalValue: null,
+    usingIndicators,
     showIndicators: false,
     selectedIndicator,
     indicatorColumns,


### PR DESCRIPTION
Fixes #1902.

## Change summary

Adds `usingIndicators` prop to `SupplierRequisition` to prevent error when creating non-indicators requisitions.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Can successfully create a supplier requisition for a program with no indicator data.
- [ ] Can successfully create a non-program supplier requisition.

### Related areas to think about

N/A.
