### PR TITLE
#1898 Add labels to charts

### DIFF
--- a/src/widgets/BarChart.js
+++ b/src/widgets/BarChart.js
@@ -7,7 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { VictoryChart, VictoryBar, VictoryAxis } from 'victory-native';
+import { VictoryChart, VictoryBar, VictoryAxis, VictoryLabel } from 'victory-native';
 
 import { APP_FONT_FAMILY, GREY, LIGHT_GREY, DARK_GREY, SUSSOL_ORANGE } from '../globalStyles';
 
@@ -33,7 +33,12 @@ export const BarChart = ({ data, width, height }) => {
   return (
     <VictoryChart width={width} height={height} padding={padding} domainPadding={domainPadding}>
       {data.map(({ values }) => (
-        <VictoryBar style={style} data={values} />
+        <VictoryBar
+          style={style}
+          data={values}
+          labels={({ datum }) => datum.y}
+          labelComponent={<VictoryLabel style={victoryStyles.labelStyle} />}
+        />
       ))}
       {renderYAxis()}
       {renderXAxis()}
@@ -66,4 +71,5 @@ const victoryStyles = {
     padDomain: 0.05,
     style: { data: { fill: SUSSOL_ORANGE } },
   },
+  labelStyle: { fontFamily: APP_FONT_FAMILY, fill: GREY },
 };

--- a/src/widgets/LineChart.js
+++ b/src/widgets/LineChart.js
@@ -6,7 +6,13 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { VictoryAxis, VictoryChart, VictoryLine, VictoryScatter } from 'victory-native';
+import {
+  VictoryAxis,
+  VictoryChart,
+  VictoryLabel,
+  VictoryLine,
+  VictoryScatter,
+} from 'victory-native';
 
 import { APP_FONT_FAMILY, GREY, LIGHT_GREY, DARK_GREY, SUSSOL_ORANGE } from '../globalStyles';
 
@@ -33,6 +39,7 @@ export const LineChart = ({ width, height, data }) => {
     left: width * padLeft,
     right: width * padRight,
   };
+
   return (
     <VictoryChart width={width} height={height} padding={padding}>
       {data.map(({ values }) => (
@@ -40,6 +47,14 @@ export const LineChart = ({ width, height, data }) => {
       ))}
       {data.map(({ values }) => (
         <VictoryLine style={lineStyle} data={values} />
+      ))}
+      {data.map(({ values, label }) => (
+        <VictoryLabel
+          datum={{ x: values.length - 1, y: values[values.length - 1].y }}
+          text={label}
+          style={victoryStyles.labelStyle}
+          textAnchor="middle"
+        />
       ))}
       {renderYAxis()}
       {renderXAxis()}
@@ -72,5 +87,11 @@ const victoryStyles = {
     dotSize: 3.5,
     dotStyle: { data: { fill: SUSSOL_ORANGE } },
     lineStyle: { data: { stroke: SUSSOL_ORANGE } },
+  },
+  style: { fontFamily: APP_FONT_FAMILY, fill: GREY },
+  labelStyle: {
+    fontFamily: APP_FONT_FAMILY,
+    fill: DARK_GREY,
+    fontSize: 16,
   },
 };

--- a/src/widgets/LineChart.js
+++ b/src/widgets/LineChart.js
@@ -14,7 +14,15 @@ import {
   VictoryScatter,
 } from 'victory-native';
 
-import { APP_FONT_FAMILY, GREY, LIGHT_GREY, DARK_GREY, SUSSOL_ORANGE } from '../globalStyles';
+import {
+  APP_FONT_FAMILY,
+  GREY,
+  LIGHT_GREY,
+  DARK_GREY,
+  SUSSOL_ORANGE,
+  FINALISE_GREEN,
+  FINALISED_RED,
+} from '../globalStyles';
 
 export const LineChart = ({ width, height, data }) => {
   const renderYAxis = () => <VictoryAxis dependentAxis style={victoryStyles.axisY} />;
@@ -23,15 +31,7 @@ export const LineChart = ({ width, height, data }) => {
     return <VictoryAxis tickFormat={tickTruncate} style={victoryStyles.axisX} />;
   };
 
-  const {
-    padTop,
-    padBottom,
-    padLeft,
-    padRight,
-    dotSize,
-    dotStyle,
-    lineStyle,
-  } = victoryStyles.lineChart;
+  const { padTop, padBottom, padLeft, padRight, dotSize } = victoryStyles.lineChart;
 
   const padding = {
     top: height * padTop,
@@ -40,19 +40,27 @@ export const LineChart = ({ width, height, data }) => {
     right: width * padRight,
   };
 
+  const COLOURS = {
+    0: SUSSOL_ORANGE,
+    1: FINALISE_GREEN,
+    2: GREY,
+    3: FINALISED_RED,
+    4: LIGHT_GREY,
+  };
+
   return (
     <VictoryChart width={width} height={height} padding={padding}>
-      {data.map(({ values }) => (
-        <VictoryScatter size={dotSize} style={dotStyle} data={values} />
+      {data.map(({ values }, index) => (
+        <VictoryScatter size={dotSize} style={{ data: { fill: COLOURS[index] } }} data={values} />
       ))}
-      {data.map(({ values }) => (
-        <VictoryLine style={lineStyle} data={values} />
+      {data.map(({ values }, index) => (
+        <VictoryLine style={{ data: { stroke: COLOURS[index] } }} data={values} />
       ))}
-      {data.map(({ values, label }) => (
+      {data.map(({ values, label }, index) => (
         <VictoryLabel
           datum={{ x: values.length - 1, y: values[values.length - 1].y }}
           text={label}
-          style={victoryStyles.labelStyle}
+          style={{ fontFamily: APP_FONT_FAMILY, fontSize: 18, fill: COLOURS[index] }}
           textAnchor="middle"
         />
       ))}
@@ -86,12 +94,7 @@ const victoryStyles = {
     padRight: 0.05,
     dotSize: 3.5,
     dotStyle: { data: { fill: SUSSOL_ORANGE } },
-    lineStyle: { data: { stroke: SUSSOL_ORANGE } },
-  },
-  style: { fontFamily: APP_FONT_FAMILY, fill: GREY },
-  labelStyle: {
-    fontFamily: APP_FONT_FAMILY,
-    fill: DARK_GREY,
-    fontSize: 16,
+    lineStyle: { data: { stroke: GREY }, color: GREY },
+    labelStyle: { fontFamily: APP_FONT_FAMILY, fontSize: 18 },
   },
 };

--- a/src/widgets/PieChart.js
+++ b/src/widgets/PieChart.js
@@ -38,6 +38,7 @@ export const PieChart = ({ width, height, data }) => {
       innerRadius={widthPadded * innerRadius}
       labelRadius={widthPadded * labelRadius}
       colorScale={colorScale}
+      labels={({ datum }) => `${datum.x} : ${datum.y}`}
       labelComponent={<VictoryLabel style={style} />}
       data={values}
     />


### PR DESCRIPTION
Fixes #1898

## Change summary

Graphs were needed to have its corresponding labels showing related data, specially for `LineChart` with more than one line per graph.
`label` information is part of the data received from desktop. For`LineChart` graphs with more than one line, the intention is to explicitly show what information each line represents.

Examples:

<img width="872" alt="Screen Shot 2020-01-14 at 2 11 40 PM" src="https://user-images.githubusercontent.com/32987464/72305198-ea00a200-36d7-11ea-9ecd-99ff97d1fcf1.png">
<img width="870" alt="Screen Shot 2020-01-14 at 2 11 54 PM" src="https://user-images.githubusercontent.com/32987464/72305204-ecfb9280-36d7-11ea-9b69-74016f4214eb.png">
<img width="869" alt="Screen Shot 2020-01-14 at 2 12 05 PM" src="https://user-images.githubusercontent.com/32987464/72305209-eff68300-36d7-11ea-8b89-e5a417c52e47.png">
<img width="873" alt="Screen Shot 2020-01-14 at 2 12 17 PM" src="https://user-images.githubusercontent.com/32987464/72305212-f38a0a00-36d7-11ea-9fb9-29733f7df4f3.png">

## Testing

Further testing will take place when the dashboard feature is ready.