### PR TITLE
#1873 SearchBar placeholder

### DIFF
--- a/src/widgets/SearchBar.js
+++ b/src/widgets/SearchBar.js
@@ -8,9 +8,9 @@
 import React, { useCallback, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-import { StyleSheet, TextInput, View, TouchableOpacity } from 'react-native';
+import { Dimensions, StyleSheet, TextInput, View, TouchableOpacity } from 'react-native';
 import { MagnifyingGlass, Cancel } from './icons';
-import { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../globalStyles/index';
+import { APP_FONT_FAMILY, SUSSOL_ORANGE, LIGHT_GREY } from '../globalStyles/index';
 import { debounce } from '../utilities/index';
 
 /**
@@ -43,6 +43,7 @@ export const SearchBarComponent = ({
   viewStyle,
   debounceTimeout,
   onFocusOrBlur,
+  placeholderTextColor,
   ...textInputProps
 }) => {
   const [textValue, setTextValue] = useState('');
@@ -81,7 +82,7 @@ export const SearchBarComponent = ({
         style={internalTextStyle}
         value={textValue}
         underlineColorAndroid="transparent"
-        placeholderTextColor={color}
+        placeholderTextColor={placeholderTextColor}
         placeholder={placeholder}
         onChangeText={onChangeTextCallback}
         autoFocus={autoFocus}
@@ -122,7 +123,7 @@ const defaultStyles = StyleSheet.create({
   },
   textInput: {
     height: 40,
-    fontSize: 20,
+    fontSize: Dimensions.get('window').width / 80,
     fontFamily: APP_FONT_FAMILY,
     backgroundColor: 'rgba(0, 0, 0, 0)',
     flex: 1,
@@ -138,6 +139,7 @@ SearchBarComponent.defaultProps = {
   placeholder: '',
   autoFocus: false,
   onFocusOrBlur: null,
+  placeholderTextColor: LIGHT_GREY,
 };
 
 SearchBarComponent.propTypes = {
@@ -150,4 +152,5 @@ SearchBarComponent.propTypes = {
   textInputStyle: PropTypes.object,
   viewStyle: PropTypes.object,
   onFocusOrBlur: PropTypes.func,
+  placeholderTextColor: PropTypes.string,
 };


### PR DESCRIPTION
Fixes #1873 

## Change summary

- Changes the `placeholderTextColor` and font size 

![image](https://user-images.githubusercontent.com/35858975/72395914-dde01780-379f-11ea-8d67-a7f293625e9f.png)


## Testing

**Might be different on different size emulators?**
- [ ] `SearchBar` placeholder looks good in all the pages!

### Related areas to think about

N/A
