### PR TITLE
Fix ProgramIndicator incoming sync error

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -270,6 +270,7 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
     },
     ProgramIndicator: {
       cannotBeBlank: ['code', 'program_ID', 'is_active'],
+      canBeBlank: [],
     },
     Report: {
       cannotBeBlank: ['ID', 'title', 'type', 'json'],


### PR DESCRIPTION
Fixes #1930.

## Change summary

Hotfix sync issue caused by bad merge.

## Testing

- [ ] `ProgramIndicator` records sync without error.

### Related areas to think about

N/A.
