### PR TITLE
#1952 searchbar placeholder text

### DIFF
--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -20,14 +20,30 @@
     "sync_url": "Sync url",
     "reports": "Reports",
     "no_reports": "No Reports to show",
-    "search_by": "Search by"
+    "search_by": "Search by",
+    "invoice_number": "invoice number",
+    "requisition_number": "requisition number",
+    "item_name": "item name",
+    "item_code": "item code",
+    "customer": "customer",
+    "code": "code",
+    "name": "name",
+    "or": "or"
   },
   "fr": {
     "stocktake": "Inventaire",
     "start_typing_to_search": "Tapez pour rechercher",
     "not_available": "N/A",
     "reports": "Rapports",
-    "no_reports": "Aucun rapport à afficher"
+    "no_reports": "Aucun rapport à afficher",
+    "invoice_number": "numéro de facture",
+    "requisition_number": "numéro de réquisition",
+    "item_name": "nom de l'article",
+    "item_code": "code de l'article",
+    "customer": "cliente",
+    "code": "code",
+    "name": "nom",
+    "or": "ou"
   },
   "gil": {
     "stocktake": "Warebwai",

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -19,7 +19,7 @@ import { PageButton, PageInfo, SearchBar, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 import { BottomConfirmModal } from '../widgets/bottomModals';
 
-import { buttonStrings, modalStrings, tableStrings, generalStrings } from '../localization';
+import { buttonStrings, modalStrings, generalStrings } from '../localization';
 import globalStyles from '../globalStyles';
 
 /**
@@ -151,7 +151,7 @@ export const CustomerInvoice = ({
           <SearchBar
             onChangeText={onFilterData}
             value={searchTerm}
-            placeholder={`${generalStrings.search_by} ${tableStrings.item_name}`}
+            placeholder={`${generalStrings.search_by} ${generalStrings.item_name} ${generalStrings.or} ${generalStrings.item_code}`}
           />
         </View>
         <View style={pageTopRightSectionContainer}>

--- a/src/pages/CustomerInvoicesPage.js
+++ b/src/pages/CustomerInvoicesPage.js
@@ -19,7 +19,7 @@ import { DataTablePageModal } from '../widgets/modals';
 import { BottomConfirmModal } from '../widgets/bottomModals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
-import { buttonStrings, modalStrings, tableStrings, generalStrings } from '../localization';
+import { buttonStrings, modalStrings, generalStrings } from '../localization';
 import globalStyles from '../globalStyles';
 import { ROUTES } from '../navigation/constants';
 
@@ -131,7 +131,7 @@ export const CustomerInvoices = ({
           <SearchBar
             onChangeText={onFilterData}
             value={searchTerm}
-            placeholder={`${generalStrings.search_by} ${tableStrings.customer}`}
+            placeholder={`${generalStrings.search_by} ${generalStrings.customer}`}
           />
         </View>
         <View style={pageTopRightSectionContainer}>

--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -20,7 +20,7 @@ import { getItemLayout, getPageDispatchers, PageActions } from './dataTableUtili
 import { useRecordListener } from '../hooks';
 
 import globalStyles from '../globalStyles';
-import { buttonStrings, generalStrings, tableStrings } from '../localization';
+import { buttonStrings, generalStrings } from '../localization';
 
 /**
  * Renders a mSupply mobile page with a customer requisition loaded for editing
@@ -133,7 +133,7 @@ export const CustomerRequisition = ({
           <SearchBar
             onChangeText={onFilterData}
             value={searchTerm}
-            placeholder={`${generalStrings.search_by} ${tableStrings.item_name}`}
+            placeholder={`${generalStrings.search_by} ${generalStrings.item_name} ${generalStrings.or} ${generalStrings.item_code}`}
           />
         </View>
         <View style={pageTopRightSectionContainer}>

--- a/src/pages/CustomerRequisitionsPage.js
+++ b/src/pages/CustomerRequisitionsPage.js
@@ -17,7 +17,7 @@ import { gotoCustomerRequisition } from '../navigation/actions';
 import { getItemLayout, getPageDispatchers, PageActions } from './dataTableUtilities';
 
 import globalStyles from '../globalStyles';
-import { buttonStrings, generalStrings, tableStrings } from '../localization';
+import { buttonStrings, generalStrings } from '../localization';
 
 import { ROUTES } from '../navigation/constants';
 
@@ -105,7 +105,7 @@ export const CustomerRequisitions = ({
           <SearchBar
             onChangeText={onFilterData}
             value={searchTerm}
-            placeholder={`${generalStrings.search_by} ${tableStrings.item_name}`}
+            placeholder={`${generalStrings.search_by} ${generalStrings.requisition_number}`}
           />
         </View>
       </View>

--- a/src/pages/StockPage.js
+++ b/src/pages/StockPage.js
@@ -19,7 +19,7 @@ import globalStyles from '../globalStyles';
 import { useSyncListener } from '../hooks';
 
 import { ROUTES } from '../navigation/constants';
-import { generalStrings, tableStrings } from '../localization';
+import { generalStrings } from '../localization';
 
 /**
  * Renders a mSupply mobile page with Items and their stock levels.
@@ -87,7 +87,7 @@ export const Stock = ({
           onChangeText={onFilterData}
           value={searchTerm}
           onFocusOrBlur={selectedRow && onDeselectRow}
-          placeholder={`${generalStrings.search_by} ${tableStrings.name}, ${tableStrings.item_code}`}
+          placeholder={`${generalStrings.search_by} ${generalStrings.code} ${generalStrings.or} ${generalStrings.name}`}
         />
       </View>
 

--- a/src/pages/StocktakeEditPage.js
+++ b/src/pages/StocktakeEditPage.js
@@ -16,7 +16,7 @@ import { DataTablePageModal } from '../widgets/modals';
 import { PageButton, PageInfo, DataTablePageView, SearchBar } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
-import { buttonStrings, generalStrings, tableStrings } from '../localization';
+import { buttonStrings, generalStrings } from '../localization';
 import globalStyles from '../globalStyles';
 import { useRecordListener, useNavigationFocus } from '../hooks/index';
 
@@ -164,7 +164,7 @@ export const StocktakeEdit = ({
           <SearchBar
             onChangeText={onFilterData}
             value={searchTerm}
-            placeholder={`${generalStrings.search_by} ${tableStrings.name}`}
+            placeholder={`${generalStrings.search_by} ${generalStrings.item_name} ${generalStrings.or} ${generalStrings.item_code}`}
           />
         </View>
         <View style={pageTopRightSectionContainer}>

--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -16,7 +16,7 @@ import { ToggleBar, DataTablePageView, SearchBar } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 import { BottomTextEditor } from '../widgets/bottomModals';
 
-import { buttonStrings, modalStrings, generalStrings, tableStrings } from '../localization';
+import { buttonStrings, modalStrings, generalStrings } from '../localization';
 import globalStyles from '../globalStyles';
 
 import { ROUTES } from '../navigation/constants';
@@ -119,7 +119,7 @@ export const StocktakeManage = ({
           <SearchBar
             onChangeText={onFilterData}
             value={searchTerm}
-            placeholder={`${generalStrings.search_by} ${tableStrings.item_name}, ${tableStrings.item_code}`}
+            placeholder={`${generalStrings.search_by} ${generalStrings.item_name} ${generalStrings.or} ${generalStrings.item_code}`}
           />
         </View>
 

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -22,7 +22,7 @@ import { ROUTES } from '../navigation/constants';
 import { UIDatabase } from '../database';
 import Settings from '../settings/MobileAppSettings';
 
-import { buttonStrings, modalStrings, generalStrings, tableStrings } from '../localization';
+import { buttonStrings, modalStrings, generalStrings } from '../localization';
 import globalStyles from '../globalStyles';
 
 import {
@@ -136,7 +136,7 @@ export const Stocktakes = ({
           <SearchBar
             onChangeText={onFilterData}
             value={searchTerm}
-            placeholder={`${generalStrings.search_by} ${tableStrings.name}`}
+            placeholder={`${generalStrings.search_by} ${generalStrings.name}`}
           />
         </View>
         <View style={pageTopRightSectionContainer}>

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -18,7 +18,7 @@ import { BottomConfirmModal } from '../widgets/bottomModals';
 import { PageButton, PageInfo, SearchBar, DataTablePageView } from '../widgets';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
-import { buttonStrings, modalStrings, generalStrings, tableStrings } from '../localization';
+import { buttonStrings, modalStrings, generalStrings } from '../localization';
 import globalStyles from '../globalStyles';
 
 import { ROUTES } from '../navigation/constants';
@@ -135,7 +135,7 @@ export const SupplierInvoice = ({
           <SearchBar
             onChangeText={onFilterData}
             value={searchTerm}
-            placeholder={`${generalStrings.search_by} ${tableStrings.name}`}
+            placeholder={`${generalStrings.search_by} ${generalStrings.item_name}`}
           />
         </View>
         <View style={pageTopRightSectionContainer}>

--- a/src/pages/SupplierInvoicesPage.js
+++ b/src/pages/SupplierInvoicesPage.js
@@ -19,7 +19,7 @@ import { DataTablePageModal } from '../widgets/modals';
 import { BottomConfirmModal } from '../widgets/bottomModals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 
-import { buttonStrings, modalStrings, generalStrings, tableStrings } from '../localization';
+import { buttonStrings, modalStrings, generalStrings } from '../localization';
 import globalStyles from '../globalStyles';
 import { ROUTES } from '../navigation/constants';
 
@@ -134,7 +134,7 @@ export const SupplierInvoices = ({
           <SearchBar
             onChangeText={onFilterData}
             value={searchTerm}
-            placeholder={`${generalStrings.search_by} ${tableStrings.invoice_number}`}
+            placeholder={`${generalStrings.search_by} ${generalStrings.invoice_number}`}
           />
         </View>
         <View style={pageTopRightSectionContainer}>

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -33,13 +33,7 @@ import { ROUTES } from '../navigation/constants';
 import { useRecordListener } from '../hooks';
 
 import globalStyles from '../globalStyles';
-import {
-  buttonStrings,
-  modalStrings,
-  programStrings,
-  generalStrings,
-  tableStrings,
-} from '../localization';
+import { buttonStrings, modalStrings, programStrings, generalStrings } from '../localization';
 import { UIDatabase } from '../database/index';
 import { SETTINGS_KEYS } from '../settings/index';
 
@@ -310,7 +304,7 @@ const SupplierRequisition = ({
           <SearchBar
             onChangeText={onFilterData}
             value={searchTerm}
-            placeholder={`${generalStrings.search_by} ${tableStrings.item_name}`}
+            placeholder={`${generalStrings.search_by} ${generalStrings.item_name} ${generalStrings.or} ${generalStrings.item_code}`}
           />
         </View>
         <View style={pageTopRightSectionContainer}>

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -23,7 +23,7 @@ import { createSupplierRequisition, gotoSupplierRequisition } from '../navigatio
 import { getItemLayout, PageActions, getPageDispatchers } from './dataTableUtilities';
 
 import globalStyles from '../globalStyles';
-import { buttonStrings, modalStrings, generalStrings, tableStrings } from '../localization';
+import { buttonStrings, modalStrings, generalStrings } from '../localization';
 
 /**
  * Renders a mSupply mobile page with a list of supplier requisitions.
@@ -152,7 +152,7 @@ export const SupplierRequisitions = ({
           <SearchBar
             onChangeText={onFilterData}
             value={searchTerm}
-            placeholder={`${generalStrings.search_by} ${tableStrings.requisition_number}`}
+            placeholder={`${generalStrings.search_by} ${generalStrings.requisition_number}`}
           />
         </View>
         <View style={pageTopRightSectionContainer}>

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -369,11 +369,10 @@ const supplierRequisitionInitialiser = requisition => {
   const usingIndicators = !!indicators.length;
 
   const [selectedIndicator] = indicators;
-  const { columns: indicatorColumns, rows: indicatorRows } = usingIndicators
-    ? getIndicatorData(selectedIndicator, period)
-    : {};
-  // ?
-  // : {};
+  const { columns: indicatorColumns, rows: indicatorRows } = getIndicatorData(
+    selectedIndicator,
+    period
+  );
 
   return {
     pageObject: requisition,

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -367,11 +367,13 @@ const supplierRequisitionInitialiser = requisition => {
       : sortedData.filter(item => item.isLessThanThresholdMOS);
 
   const usingIndicators = !!indicators.length;
+
   const [selectedIndicator] = indicators;
-  const { columns: indicatorColumns, rows: indicatorRows } = getIndicatorData(
-    selectedIndicator,
-    period
-  );
+  const { columns: indicatorColumns, rows: indicatorRows } = usingIndicators
+    ? getIndicatorData(selectedIndicator, period)
+    : {};
+  // ?
+  // : {};
 
   return {
     pageObject: requisition,


### PR DESCRIPTION
Fixes #1952 

## Change summary

- Changed the placeholders to be consistent and correct with the columns they're filtering on


## Testing

- [ ] Placeholder correctly states the columns it filters on and looks good on Customer Invoice Page
- [ ] Placeholder correctly states the columns it filters on and looks good on Customer Invoices Page
- [ ] Placeholder correctly states the columns it filters on and looks good on Supplier Invoice Page
- [ ] Placeholder correctly states the columns it filters on and looks good on Supplier Invoices Page
- [ ] Placeholder correctly states the columns it filters on and looks good on Customer Requisition Page
- [ ] Placeholder correctly states the columns it filters on and looks good on Customer Requisitions Page
- [ ] Placeholder correctly states the columns it filters on and looks good on Supplier Requisition Page
- [ ] Placeholder correctly states the columns it filters on and looks good on Supplier Requisitions Page
- [ ] Placeholder correctly states the columns it filters on and looks good on Stocktakes Page
- [ ] Placeholder correctly states the columns it filters on and looks good on Stocktake edit Page
- [ ] Placeholder correctly states the columns it filters on and looks good on Stocktake Manage Page
- [ ] Placeholder correctly states the columns it filters on and looks good on Stock Page

### Related areas to think about

I made new strings because it was easier. They're lower case because it's LESS SHOUTY AND DISTRACTING

@alainsussol  is my french correct? It might be different in the region I learnt french in:

```
    "no_reports": "Aucun rapport à afficher",
    "invoice_number": "numéro de facture",
    "requisition_number": "numéro de réquisition",
    "item_name": "nom de l'article",
    "item_code": "code de l'article",
    "customer": "cliente",
    "code": "code",
    "name": "nom",
    "or": "ou"
```
