### PR TITLE
#1951 app crash on non indicators requisition

### DIFF
--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -206,7 +206,7 @@ const SupplierRequisition = ({
 
   const UseSuggestedQuantitiesButton = () => (
     <PageButton
-      style={usingIndicators ? globalStyles.wideButton : globalStyles.topButton}
+      style={program ? globalStyles.wideButton : globalStyles.topButton}
       text={buttonStrings.use_suggested_quantities}
       onPress={onSetRequestedToSuggested}
       isDisabled={isFinalised}
@@ -257,7 +257,7 @@ const SupplierRequisition = ({
           <UseSuggestedQuantitiesButton />
           <CreateAutomaticOrderButton />
         </View>
-        <View style={globalStyles.verticalContainer}>
+        <View style={verticalContainer}>
           <AddNewItemButton />
           <AddMasterListItemsButton />
         </View>
@@ -265,36 +265,41 @@ const SupplierRequisition = ({
     );
   }, [isFinalised]);
 
-  const ProgramButtons = useCallback(() => {
-    const { verticalContainer } = globalStyles;
+  const ProgramItemButtons = useCallback(() => (
+    <View style={globalStyles.verticalContainer}>
+      <UseSuggestedQuantitiesButton />
+      <ThresholdMOSToggle />
+    </View>
+  ));
 
-    const ProgramItemButtons = (
-      <>
-        <UseSuggestedQuantitiesButton isWide={true} />
-        <ThresholdMOSToggle />
-      </>
-    );
-
-    const { code: selectedIndicatorCode } = selectedIndicator;
+  const ProgramIndicatorButtons = useCallback(() => {
+    const selectedIndicatorCode = selectedIndicator?.code;
     const indicatorCodes = indicators.map(indicator => indicator.code);
-
-    const ProgramIndicatorButtons = (
+    return (
       <DropDown
         values={indicatorCodes}
         selectedValue={selectedIndicatorCode}
         onValueChange={onSelectIndicator}
       />
     );
+  }, [selectedIndicator, indicators]);
 
-    return (
-      <>
-        <View style={verticalContainer}>
+  const ProgramButtons = useCallback(() => {
+    if (usingIndicators) {
+      const Buttons = showIndicators ? ProgramIndicatorButtons : ProgramItemButtons;
+      return (
+        <View style={globalStyles.verticalContainer}>
           <ItemIndicatorToggle />
-          {showIndicators ? ProgramIndicatorButtons : ProgramItemButtons}
+          <Buttons />
         </View>
-      </>
+      );
+    }
+    return (
+      <View style={globalStyles.verticalContainer}>
+        <ProgramItemButtons />
+      </View>
     );
-  }, [showIndicators, selectedIndicator, showAll, isFinalised]);
+  }, [usingIndicators, showIndicators, selectedIndicator, showAll, isFinalised]);
 
   const {
     pageTopSectionContainer,

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -265,12 +265,15 @@ const SupplierRequisition = ({
     );
   }, [isFinalised]);
 
-  const ProgramItemButtons = useCallback(() => (
-    <View style={globalStyles.verticalContainer}>
-      <UseSuggestedQuantitiesButton />
-      <ThresholdMOSToggle />
-    </View>
-  ));
+  const ProgramItemButtons = useCallback(
+    () => (
+      <View style={globalStyles.verticalContainer}>
+        <UseSuggestedQuantitiesButton />
+        <ThresholdMOSToggle />
+      </View>
+    ),
+    [UseSuggestedQuantitiesButton, ThresholdMOSToggle]
+  );
 
   const ProgramIndicatorButtons = useCallback(() => {
     const selectedIndicatorCode = selectedIndicator?.code;

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -9,7 +9,6 @@ import { sortDataBy } from '../../utilities';
 import { recordKeyExtractor } from './utilities';
 import getColumns from './getColumns';
 import getPageInfoColumns from './getPageInfoColumns';
-import { getIndicatorData } from './getIndicatorTableData';
 
 import { ROUTES } from '../../navigation/constants';
 
@@ -355,7 +354,7 @@ const supplierInvoicesInitialiser = () => {
  * @returns  {object}
  */
 const supplierRequisitionInitialiser = requisition => {
-  const { isFinalised, program, period, items: backingData, indicators } = requisition;
+  const { isFinalised, program, items: backingData, indicators } = requisition;
 
   const usingPrograms = !!program;
   const route = program ? ROUTES.SUPPLIER_REQUISITION_WITH_PROGRAM : ROUTES.SUPPLIER_REQUISITION;
@@ -367,11 +366,9 @@ const supplierRequisitionInitialiser = requisition => {
       : sortedData.filter(item => item.isLessThanThresholdMOS);
 
   const usingIndicators = !!indicators.length;
-  const [selectedIndicator] = indicators;
-  const { columns: indicatorColumns, rows: indicatorRows } = getIndicatorData(
-    selectedIndicator,
-    period
-  );
+  const [selectedIndicator = null] = indicators;
+  const indicatorRows = selectedIndicator?.rows;
+  const indicatorColumns = selectedIndicator?.columns;
 
   return {
     pageObject: requisition,

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -329,14 +329,13 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       break;
     }
     case 'IndicatorValue': {
-      const recordValue = (record.value && JSON.parse(record.value))?.value;
       internalRecord = {
         id: record.ID,
         storeId: record.facility_ID,
         period: database.getOrCreate('Period', record.period_ID),
         column: database.getOrCreate('IndicatorAttribute', record.column_ID),
         row: database.getOrCreate('IndicatorAttribute', record.row_ID),
-        value: recordValue || '',
+        value: record.value || '',
       };
       database.update(recordType, internalRecord);
       break;

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -335,7 +335,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         period: database.getOrCreate('Period', record.period_ID),
         column: database.getOrCreate('IndicatorAttribute', record.column_ID),
         row: database.getOrCreate('IndicatorAttribute', record.row_ID),
-        value: record.value || '',
+        value: record.value ?? '',
       };
       database.update(recordType, internalRecord);
       break;


### PR DESCRIPTION
Fixes #1951.

Also includes a hotfix for #1958, which was found during replication.

## Change summary

Fixed up some incorrect booleans in `SupplierRequisitionPage` and `getPageInitialiser`. Still needs tidying up a bit, but the error is no longer replicable. 

Related prop type fixes to follow (see #1950).

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Can create a non-indicators program supplier requisition without any errors.
- [ ] Can create an indicators program supplier requisition without any errors.

### Related areas to think about

N/A.
