### PR TITLE
#1950 fix supplier requisition prop types

### DIFF
--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -141,7 +141,7 @@ export class Requisition extends Realm.Object {
   }
 
   get indicators() {
-    return this.program?.indicators.slice() || [];
+    return this.program?.indicators;
   }
 
   /**

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -392,6 +392,10 @@ SupplierRequisition.defaultProps = {
   showAll: false,
   usingIndicators: false,
   showIndicators: false,
+  selectedIndicator: null,
+  indicators: null,
+  indicatorColumns: null,
+  indicatorRows: null,
 };
 
 SupplierRequisition.propTypes = {
@@ -412,10 +416,10 @@ SupplierRequisition.propTypes = {
   showAll: PropTypes.bool,
   usingIndicators: PropTypes.bool,
   showIndicators: PropTypes.bool,
-  selectedIndicator: PropTypes.object.isRequired,
-  indicators: PropTypes.array.isRequired,
-  indicatorColumns: PropTypes.object.isRequired,
-  indicatorRows: PropTypes.object.isRequired,
+  selectedIndicator: PropTypes.object,
+  indicators: PropTypes.object,
+  indicatorColumns: PropTypes.object,
+  indicatorRows: PropTypes.object,
   modalValue: PropTypes.any,
   refreshData: PropTypes.func.isRequired,
   onSelectNewItem: PropTypes.func.isRequired,

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -365,8 +365,8 @@ const supplierRequisitionInitialiser = requisition => {
       ? sortedData
       : sortedData.filter(item => item.isLessThanThresholdMOS);
 
-  const usingIndicators = !!indicators.length;
-  const [selectedIndicator = null] = indicators;
+  const usingIndicators = !!indicators;
+  const [selectedIndicator = null] = indicators || [];
   const indicatorRows = selectedIndicator?.rows;
   const indicatorColumns = selectedIndicator?.columns;
 


### PR DESCRIPTION
Fixes #1950. Branches off #1959.

## Change summary

Fixes supplier requisition warnings caused by undefined indicator props.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Navigating to a program supplier requisition without indicators does not cause any prop type warnings to be shown.

### Related areas to think about

N/A.
