### PR TITLE
#1954 fix supplier requisition showing inactive indicators

### DIFF
--- a/src/database/DataTypes/MasterList.js
+++ b/src/database/DataTypes/MasterList.js
@@ -27,6 +27,14 @@ export class MasterList extends Realm.Object {
   }
 
   /**
+   * Get all indicators currently active on this master list.
+   * @returns {Array.<ProgramIndicator>}
+   */
+  get activeIndicators() {
+    return this.program?.indicators.filter(indicator => indicator.isActive);
+  }
+
+  /**
    * Returns this master lists programSettings, which is stored
    * as a stringified object as an object
    */
@@ -70,14 +78,6 @@ export class MasterList extends Realm.Object {
   addIndicatorIfUnique(programIndicator) {
     if (this.indicators.filtered('id == $0', programIndicator.id).length > 0) return;
     this.addIndicator(programIndicator);
-  }
-
-  /**
-   * Get all indicators currently active on this master list.
-   * @returns {Array.<ProgramIndicator>}
-   */
-  getActiveIndicators() {
-    return this.program?.indicators.filter(indicator => indicator.isActive);
   }
 
   /**

--- a/src/database/DataTypes/MasterList.js
+++ b/src/database/DataTypes/MasterList.js
@@ -73,6 +73,14 @@ export class MasterList extends Realm.Object {
   }
 
   /**
+   * Get all indicators currently active on this master list.
+   * @returns {Array.<ProgramIndicator>}
+   */
+  getActiveIndicators() {
+    return this.program?.indicators.filter(indicator => indicator.isActive);
+  }
+
+  /**
    * Find the current stores matching store tag object in this master lists program settings.
    * Program settings is a JSON object held as a string - example below.
    * @param  {string}  tags   Current stores tags field

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -145,7 +145,7 @@ export class Requisition extends Realm.Object {
    * @returns {Array.<ProgramIndicator>}
    */
   get indicators() {
-    return this.program?.getActiveindicators();
+    return this.program?.activeindicators;
   }
 
   /**

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -140,8 +140,12 @@ export class Requisition extends Realm.Object {
     return (this.otherStoreName && this.otherStoreName.name) || '';
   }
 
+  /**
+   * Get all indicators associated with this requisition.
+   * @returns {Array.<ProgramIndicator>}
+   */
   get indicators() {
-    return this.program?.indicators;
+    return this.program?.getActiveindicators();
   }
 
   /**


### PR DESCRIPTION
Fixes #1954. Branches off #1960.

## Change summary

Fixes inactive indicators being displayed. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Supplier requisitions for active HIV programs display HIV indicator values.
- [ ] Supplier requisitions for inactive HIV programs do not display HIV indicator values (disable `"Is HIV program"` -> resync -> create a new supplier requisition).

### Related areas to think about

N/A.
