### PR TITLE
#1906 enforce indicator types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
     "import/prefer-default-export": "off",
     "indent": ["error", 2, { "SwitchCase": 1 }],
     "max-len": ["error", { "code": 100, "ignoreTemplateLiterals": true }],
+    "no-underscore-dangle": "off",
     "no-confusing-arrow": "off",
     "no-param-reassign": "off",
     "no-use-before-define": ["error", { "variables": false }],

--- a/src/database/DataTypes/IndicatorValue.js
+++ b/src/database/DataTypes/IndicatorValue.js
@@ -4,6 +4,12 @@
  */
 
 import Realm from 'realm';
+import {
+  INDICATOR_CODES,
+  INDICATOR_COLUMN_CODES,
+  INDICATOR_VALUE_TYPES,
+} from '../utilities/constants';
+import { parsePositiveInteger } from '../../utilities';
 
 /**
  * An abstract object which contains metadata describing an indicator row or column.
@@ -19,9 +25,25 @@ export class IndicatorValue extends Realm.Object {
   get indicator() {
     return this.row.indicator ?? this.column.indicator;
   }
-}
 
-export default IndicatorValue;
+  get value() {
+    return this._value;
+  }
+
+  get valueType() {
+    if (this.indicator.code === INDICATOR_CODES.REGIMEN) {
+      return this.column.code === INDICATOR_COLUMN_CODES.REGIMEN_VALUE
+        ? this.row.valueType
+        : INDICATOR_VALUE_TYPES.STRING;
+    }
+    return this.column.valueType;
+  }
+
+  set value(value) {
+    this._value =
+      this.valueType === INDICATOR_VALUE_TYPES.STRING ? value : String(parsePositiveInteger(value));
+  }
+}
 
 IndicatorValue.schema = {
   name: 'IndicatorValue',
@@ -32,6 +54,6 @@ IndicatorValue.schema = {
     period: 'Period',
     column: 'IndicatorAttribute',
     row: 'IndicatorAttribute',
-    value: 'string',
+    _value: 'string',
   },
 };

--- a/src/database/utilities/constants.js
+++ b/src/database/utilities/constants.js
@@ -21,3 +21,9 @@ export const NUMBER_SEQUENCE_KEYS = {
   STOCKTAKE_SERIAL_NUMBER: 'stocktake_serial_number',
   SUPPLIER_INVOICE_NUMBER: 'supplier_invoice_serial_number',
 };
+
+export {
+  INDICATOR_CODES,
+  INDICATOR_COLUMN_CODES,
+  INDICATOR_VALUE_TYPES,
+} from './indicatorConstants';

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -107,7 +107,7 @@ const createIndicatorValue = (database, row, column, period) => {
     row,
     column,
     period,
-    value,
+    _value: value,
   });
   row.addIndicatorValue(indicatorValue);
   column.addIndicatorValue(indicatorValue);

--- a/src/database/utilities/getIndicatorData.js
+++ b/src/database/utilities/getIndicatorData.js
@@ -23,7 +23,7 @@ const createIndicatorValue = (row, column, period) => {
  */
 const updateIndicatorValue = (indicatorValue, value) => {
   UIDatabase.write(() => {
-    UIDatabase.update('IndicatorValue', { ...indicatorValue, value });
+    indicatorValue.value = value;
   });
 };
 

--- a/src/database/utilities/indicatorConstants.js
+++ b/src/database/utilities/indicatorConstants.js
@@ -1,0 +1,13 @@
+export const INDICATOR_CODES = {
+  HIV: 'HIV',
+  REGIMEN: 'REGIMEN',
+};
+
+export const INDICATOR_COLUMN_CODES = {
+  REGIMEN_VALUE: 'regimen_value',
+  REGIMEN_COMMENT: 'regimen_comment',
+};
+
+export const INDICATOR_VALUE_TYPES = {
+  STRING: 'string',
+};

--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -14,6 +14,7 @@ import { MODAL_KEYS } from '../utilities';
 
 import { DataTablePageModal } from '../widgets/modals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
+import { DATA_TABLE_DEFAULTS } from '../widgets/DataTable/constants';
 import {
   DataTablePageView,
   DropDown,
@@ -273,6 +274,11 @@ export const CustomerRequisition = ({
         keyExtractor={keyExtractor}
         getItemLayout={getItemLayout}
         columns={columns}
+        windowSize={
+          showIndicators
+            ? DATA_TABLE_DEFAULTS.WINDOW_SIZE_SMALL
+            : DATA_TABLE_DEFAULTS.WINDOW_SIZE_MEDIUM
+        }
       />
       <DataTablePageModal
         fullScreen={false}

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -14,6 +14,7 @@ import { MODAL_KEYS } from '../utilities';
 import { DataTablePageModal } from '../widgets/modals';
 import { BottomConfirmModal } from '../widgets/bottomModals';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
+import { DATA_TABLE_DEFAULTS } from '../widgets/DataTable/constants';
 import {
   DataTablePageView,
   DropDown,
@@ -30,6 +31,7 @@ import {
   selectIndicatorTableRows,
 } from './dataTableUtilities/selectors/indicatorSelectors';
 import { getItemLayout, getPageDispatchers, PageActions } from './dataTableUtilities';
+
 import { ROUTES } from '../navigation/constants';
 
 import { useRecordListener } from '../hooks';
@@ -326,6 +328,11 @@ const SupplierRequisition = ({
         keyExtractor={keyExtractor}
         getItemLayout={getItemLayout}
         columns={columns}
+        windowSize={
+          showIndicators
+            ? DATA_TABLE_DEFAULTS.WINDOW_SIZE_SMALL
+            : DATA_TABLE_DEFAULTS.WINDOW_SIZE_MEDIUM
+        }
       />
       <BottomConfirmModal
         isOpen={hasSelection}

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -132,7 +132,6 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
   const requiredFields = {
     IndicatorAttribute: {
       canBeBlank: [
-        'code',
         'description',
         'index',
         'is_required',
@@ -141,7 +140,7 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
         'axis',
         'is_active',
       ],
-      cannotBeBlank: ['indicator_ID'],
+      cannotBeBlank: ['code', 'indicator_ID'],
     },
     IndicatorValue: {
       cannotBeBlank: ['facility_ID', 'period_ID', 'column_ID', 'row_ID'],
@@ -337,7 +336,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         period: database.getOrCreate('Period', record.period_ID),
         column: indicatorColumn,
         row: indicatorRow,
-        value: record.value ?? '',
+        _value: record.value ?? '',
       });
       indicatorRow.addIndicatorValue(indicatorValue);
       indicatorColumn.addIndicatorValue(indicatorValue);

--- a/src/widgets/DataTable/DataTable.js
+++ b/src/widgets/DataTable/DataTable.js
@@ -14,6 +14,7 @@ import {
   View,
 } from 'react-native';
 import RefContext from './RefContext';
+import DATA_TABLE_DEFAULTS from './constants';
 
 /**
  * Base DataTable component. Wrapper around VirtualizedList, providing
@@ -149,14 +150,14 @@ DataTable.propTypes = {
 };
 
 DataTable.defaultProps = {
-  renderHeader: null,
-  footerHeight: 200,
+  renderHeader: DATA_TABLE_DEFAULTS.RENDER_HEADER,
+  footerHeight: DATA_TABLE_DEFAULTS.FOOTER_HEIGHT,
   style: defaultStyles.virtualizedList,
   getItem: (items, index) => items[index],
   getItemCount: items => items.length,
-  initialNumToRender: 10,
-  removeClippedSubviews: true,
-  windowSize: 3,
+  initialNumToRender: DATA_TABLE_DEFAULTS.INITIAL_NUM_TO_RENDER,
+  removeClippedSubviews: DATA_TABLE_DEFAULTS.REMOVE_CLIPPED_SUBVIEWS,
+  windowSize: DATA_TABLE_DEFAULTS.WINDOW_SIZE_MEDIUM,
   columns: [],
 };
 

--- a/src/widgets/DataTable/TextInputCell.js
+++ b/src/widgets/DataTable/TextInputCell.js
@@ -90,6 +90,7 @@ const TextInputCell = React.memo(
           underlineColorAndroid={underlineColor}
           keyboardType={keyboardType}
           blurOnSubmit={false}
+          selectTextOnFocus
         />
       </View>
     );

--- a/src/widgets/DataTable/constants.js
+++ b/src/widgets/DataTable/constants.js
@@ -1,0 +1,14 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+export const DATA_TABLE_DEFAULTS = {
+  RENDER_HEADER: null,
+  FOOTER_HEIGHT: 200,
+  INITIAL_NUM_TO_RENDER: 10,
+  REMOVE_CLIPPED_SUBVIEWS: true,
+  WINDOW_SIZE_SMALL: 1,
+  WINDOW_SIZE_MEDIUM: 3,
+  WINDOW_SIZE_LARGE: 5,
+};

--- a/src/widgets/DataTable/index.js
+++ b/src/widgets/DataTable/index.js
@@ -9,6 +9,7 @@ import DataTable from './DataTable';
 import DataTableHeaderRow from './DataTableHeaderRow';
 import DataTableRow from './DataTableRow';
 import TouchableNoFeedback from './TouchableNoFeedback';
+import DATA_TABLE_DEFAULTS from './constants';
 
 export {
   DataTable,
@@ -22,4 +23,5 @@ export {
   HeaderCell,
   DataTableRow,
   TouchableNoFeedback,
+  DATA_TABLE_DEFAULTS,
 };


### PR DESCRIPTION
Fixes #1906.

## Change summary

Adds type enforcement to indicator data entry.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] HIV input cells can only be set to positive integer values.
- [ ] HIV input cell values are persisted after reopening requisition.
- [ ] Requisition value input cells can only be set to the row data type.
- [ ] Requisition comment input cells can be any string.

### Related areas to think about

Currently, indicators only supports string and numerical (interpreted as positive integer) data. Would be good in future to add support for negative integers, real numbers, booleans etc.
