### PR TITLE
Add refresh to editing in stocktakebatchmodal

### DIFF
--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -44,12 +44,14 @@ export const editBatchName = (value, rowKey, objectType, route) => (dispatch, ge
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  const { batch } = objectToEdit;
+  if (objectToEdit) {
+    const { batch } = objectToEdit;
 
-  if (value !== batch) {
-    UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
+    if (value !== batch) {
+      UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
 
-    dispatch(refreshRow(rowKey, route));
+      dispatch(refreshRow(rowKey, route));
+    }
   }
 };
 
@@ -81,12 +83,14 @@ export const editExpiryDate = (newDate, rowKey, objectType, route) => (dispatch,
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => {
-    objectToEdit.expiryDate = newDate;
-    UIDatabase.save(objectType, objectToEdit);
-  });
+  if (objectToEdit) {
+    UIDatabase.write(() => {
+      objectToEdit.expiryDate = newDate;
+      UIDatabase.save(objectType, objectToEdit);
+    });
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -109,11 +113,13 @@ export const editTotalQuantity = (value, rowKey, route) => (dispatch, getState) 
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => {
-    objectToEdit.setTotalQuantity(UIDatabase, parsePositiveInteger(value));
-  });
+  if (objectToEdit) {
+    UIDatabase.write(() => {
+      objectToEdit.setTotalQuantity(UIDatabase, parsePositiveInteger(value));
+    });
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -128,9 +134,13 @@ export const editSuppliedQuantity = (value, rowKey, route) => (dispatch, getStat
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => objectToEdit.setSuppliedQuantity(UIDatabase, parsePositiveInteger(value)));
+  if (objectToEdit) {
+    UIDatabase.write(() =>
+      objectToEdit.setSuppliedQuantity(UIDatabase, parsePositiveInteger(value))
+    );
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -145,12 +155,14 @@ export const editRequiredQuantity = (value, rowKey, objectType, route) => (dispa
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => {
-    objectToEdit.requiredQuantity = parsePositiveInteger(value);
-    UIDatabase.save(objectType, objectToEdit);
-  });
+  if (objectToEdit) {
+    UIDatabase.write(() => {
+      objectToEdit.requiredQuantity = parsePositiveInteger(value);
+      UIDatabase.save(objectType, objectToEdit);
+    });
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -170,9 +182,11 @@ export const editCountedQuantity = (value, rowKey, route) => (dispatch, getState
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  objectToEdit.setCountedTotalQuantity(UIDatabase, parsePositiveInteger(value));
+  if (objectToEdit) {
+    objectToEdit.setCountedTotalQuantity(UIDatabase, parsePositiveInteger(value));
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -186,12 +200,14 @@ export const editStocktakeBatchCountedQuantity = (value, rowKey, route) => (disp
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => {
-    objectToEdit.countedTotalQuantity = parsePositiveInteger(value);
-    UIDatabase.save('StocktakeBatch', UIDatabase);
-  });
+  if (objectToEdit) {
+    UIDatabase.write(() => {
+      objectToEdit.countedTotalQuantity = parsePositiveInteger(value);
+      UIDatabase.save('StocktakeBatch', UIDatabase);
+    });
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -204,9 +220,11 @@ export const removeReason = (rowKey, route) => (dispatch, getState) => {
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  objectToEdit.removeReason(UIDatabase);
+  if (objectToEdit) {
+    objectToEdit.removeReason(UIDatabase);
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -44,14 +44,12 @@ export const editBatchName = (value, rowKey, objectType, route) => (dispatch, ge
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    const { batch } = objectToEdit;
+  const { batch } = objectToEdit;
 
-    if (value !== batch) {
-      UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
+  if (value !== batch) {
+    UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
 
-      dispatch(refreshRow(rowKey, route));
-    }
+    dispatch(refreshRow(rowKey, route));
   }
 };
 
@@ -83,14 +81,12 @@ export const editExpiryDate = (newDate, rowKey, objectType, route) => (dispatch,
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    UIDatabase.write(() => {
-      objectToEdit.expiryDate = newDate;
-      UIDatabase.save(objectType, objectToEdit);
-    });
+  UIDatabase.write(() => {
+    objectToEdit.expiryDate = newDate;
+    UIDatabase.save(objectType, objectToEdit);
+  });
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**
@@ -113,13 +109,11 @@ export const editTotalQuantity = (value, rowKey, route) => (dispatch, getState) 
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    UIDatabase.write(() => {
-      objectToEdit.setTotalQuantity(UIDatabase, parsePositiveInteger(value));
-    });
+  UIDatabase.write(() => {
+    objectToEdit.setTotalQuantity(UIDatabase, parsePositiveInteger(value));
+  });
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**
@@ -134,13 +128,9 @@ export const editSuppliedQuantity = (value, rowKey, route) => (dispatch, getStat
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    UIDatabase.write(() =>
-      objectToEdit.setSuppliedQuantity(UIDatabase, parsePositiveInteger(value))
-    );
+  UIDatabase.write(() => objectToEdit.setSuppliedQuantity(UIDatabase, parsePositiveInteger(value)));
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**
@@ -155,14 +145,12 @@ export const editRequiredQuantity = (value, rowKey, objectType, route) => (dispa
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    UIDatabase.write(() => {
-      objectToEdit.requiredQuantity = parsePositiveInteger(value);
-      UIDatabase.save(objectType, objectToEdit);
-    });
+  UIDatabase.write(() => {
+    objectToEdit.requiredQuantity = parsePositiveInteger(value);
+    UIDatabase.save(objectType, objectToEdit);
+  });
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**
@@ -182,11 +170,9 @@ export const editCountedQuantity = (value, rowKey, route) => (dispatch, getState
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    objectToEdit.setCountedTotalQuantity(UIDatabase, parsePositiveInteger(value));
+  objectToEdit.setCountedTotalQuantity(UIDatabase, parsePositiveInteger(value));
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**
@@ -200,14 +186,12 @@ export const editStocktakeBatchCountedQuantity = (value, rowKey, route) => (disp
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    UIDatabase.write(() => {
-      objectToEdit.countedTotalQuantity = parsePositiveInteger(value);
-      UIDatabase.save('StocktakeBatch', UIDatabase);
-    });
+  UIDatabase.write(() => {
+    objectToEdit.countedTotalQuantity = parsePositiveInteger(value);
+    UIDatabase.save('StocktakeBatch', UIDatabase);
+  });
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**
@@ -220,11 +204,9 @@ export const removeReason = (rowKey, route) => (dispatch, getState) => {
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    objectToEdit.removeReason(UIDatabase);
+  objectToEdit.removeReason(UIDatabase);
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**


### PR DESCRIPTION
Fixes #1994 

## Change summary

- Connects `StocktakeBatchModal` to redux. Could just pass a prop for the dispatch, but this modal should be changed a bit to use redux anyway as we move closer to using redux for a lot more, so it is the easier and more long term solution
- Connected so that it has access to the redux dispatch function, which means we can dispatch a refresh on the underlying `StocktakeItem` when we edit within the modal.
- The `Batch` from redux uses `react` api to force the interface to update once for both dispatches, rather than twice

## Testing

- [ ] With a line in a stocktake, open the batch editor and edit the quantity in a/some batches. The changes are reflected when the modal is closed, in the underlying line for those batches.
- [ ] Enable some "reasons" -- [mSupply Desktop-Preferences-OptionsTab-Enable/create BOTH a POSITIVE and NEGATIVE reason and sync, two of each] -- and now edit the reason to be a different reason. This change should be reflected the same as above.

### Related areas to think about

This is a pretty dirty hack, but moves forward to a way to easily change up the modal to be a bit nicer and stop using `usePageReducer`
