### PR TITLE
#1982 Validate dashboard's reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@react-native-community/async-storage": "^1.6.2",
     "@react-navigation/core": "^3.5.1",
+    "ajv": "^6.11.0",
     "bugsnag-react-native": "2.23.2",
     "prop-types": "^15.7.2",
     "react": "16.9.0",

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -556,14 +556,13 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       const { ID: id, title, type, json } = record;
       try {
         const parsedData = JSON.parse(json);
-        const shouldSetData = checkIsObject(parsedData);
-        const validatedReport = validateReport(parsedData, type);
-        if (validatedReport) {
+        const shouldSetData = checkIsObject(parsedData) ? validateReport(parsedData, type) : false;
+        if (shouldSetData) {
           internalRecord = {
             id,
             title,
             type,
-            _data: shouldSetData ? JSON.stringify(parsedData.data) : null,
+            _data: JSON.stringify(parsedData.data),
           };
           database.update(recordType, internalRecord);
         }

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -14,7 +14,7 @@ import {
 import { CHANGE_TYPES, generateUUID } from '../database';
 import { deleteRecord } from '../database/utilities';
 import { SETTINGS_KEYS } from '../settings';
-import { checkIsObject, validateReport } from '../utilities';
+import { validateReport } from '../utilities';
 
 const { THIS_STORE_ID, THIS_STORE_TAGS, THIS_STORE_CUSTOM_DATA } = SETTINGS_KEYS;
 
@@ -556,8 +556,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       const { ID: id, title, type, json } = record;
       try {
         const parsedData = JSON.parse(json);
-        const shouldSetData = checkIsObject(parsedData) ? validateReport(parsedData, type) : false;
-        if (shouldSetData) {
+        if (validateReport(parsedData, type)) {
           internalRecord = {
             id,
             title,

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -14,7 +14,7 @@ import {
 import { CHANGE_TYPES, generateUUID } from '../database';
 import { deleteRecord } from '../database/utilities';
 import { SETTINGS_KEYS } from '../settings';
-import { checkIsObject } from '../utilities';
+import { checkIsObject, validateReport } from '../utilities';
 
 const { THIS_STORE_ID, THIS_STORE_TAGS, THIS_STORE_CUSTOM_DATA } = SETTINGS_KEYS;
 
@@ -557,13 +557,16 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       try {
         const parsedData = JSON.parse(json);
         const shouldSetData = checkIsObject(parsedData);
-        internalRecord = {
-          id,
-          title,
-          type,
-          _data: shouldSetData ? JSON.stringify(parsedData.data) : null,
-        };
-        database.update(recordType, internalRecord);
+        const validatedReport = validateReport(parsedData, type);
+        if (validatedReport) {
+          internalRecord = {
+            id,
+            title,
+            type,
+            _data: shouldSetData ? JSON.stringify(parsedData.data) : null,
+          };
+          database.update(recordType, internalRecord);
+        }
       } catch (error) {
         // Throw to parent, for now
         throw error;

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -18,6 +18,7 @@ export { backupValidation } from './fileSystem';
 export { debounce } from './underscoreMethods';
 export { getModalTitle, MODAL_KEYS } from './getModalTitle';
 export { checkIsObject } from './checkIsObject';
+export { validateReport } from './validateReport';
 // eslint-disable-next-line import/no-cycle
 export {
   checkForCustomerInvoiceError,

--- a/src/utilities/validateReport.js
+++ b/src/utilities/validateReport.js
@@ -24,6 +24,7 @@ const tableReportSchema = {
         },
         formatters: {
           type: 'array',
+          items: { type: 'string' },
         },
       },
       required: ['header', 'rows', 'formatters'],
@@ -40,20 +41,26 @@ const otherReportSchema = {
     data: {
       type: 'array',
       items: {
-        label: { type: 'string' },
-        values: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              x: { type: ['string', 'number'] },
-              y: { type: ['string', 'number'] },
-            },
-            required: ['x', 'y'],
+        type: 'object',
+        properties: {
+          label: { type: 'string' },
+          values: {
+            type: 'array',
+            items: { $ref: '#/definitions/plotValues' },
           },
         },
         required: ['label', 'values'],
       },
+    },
+  },
+  definitions: {
+    plotValues: {
+      type: 'object',
+      properties: {
+        x: { type: ['string', 'number'] },
+        y: { type: ['string', 'number'] },
+      },
+      required: ['x', 'y'],
     },
   },
   required: ['name', 'data'],

--- a/src/utilities/validateReport.js
+++ b/src/utilities/validateReport.js
@@ -9,6 +9,15 @@
 import Ajv from 'ajv';
 
 // Expected json structure for Table reports
+/**
+ *   {
+ *      data: {
+ *        header: [...],
+ *        rows: [...],
+ *        formatters: [...],
+ *      },
+ *   }
+ */
 const tableReportSchema = {
   type: 'object',
   properties: {
@@ -17,6 +26,7 @@ const tableReportSchema = {
       properties: {
         header: {
           type: 'array',
+          items: { type: 'string' },
         },
         rows: {
           type: 'array',
@@ -27,14 +37,31 @@ const tableReportSchema = {
           items: { type: 'string' },
         },
       },
-      required: ['header', 'rows', 'formatters'],
+      required: ['header', 'rows'],
     },
   },
   required: ['data'],
 };
 
 // Expected json structure for BarChart, LineChart or PieChart reports
-const otherReportSchema = {
+/**
+{
+   "name": reportName,
+   "data":[
+      {
+         "label": labelValue,
+         "values":[
+            {
+               "x":"xValue",
+               "y":"yValue"
+            }
+         ]
+      }
+   ]
+}
+*/
+
+const defaultReportSchema = {
   type: 'object',
   properties: {
     name: { type: 'string' },
@@ -66,22 +93,14 @@ const otherReportSchema = {
   required: ['name', 'data'],
 };
 
+const REPORTS_SCHEMAS = {
+  Table: tableReportSchema,
+  PieChart: defaultReportSchema,
+  LineChart: defaultReportSchema,
+  BarChart: defaultReportSchema,
+};
+
 export const validateReport = (parsedData, type) => {
   const ajv = new Ajv({ coerceTypes: true });
-  switch (type) {
-    case 'Table': {
-      return ajv.validate(tableReportSchema, parsedData);
-    }
-    case 'BarChart': {
-      return ajv.validate(otherReportSchema, parsedData);
-    }
-    case 'LineChart': {
-      return ajv.validate(otherReportSchema, parsedData);
-    }
-    case 'PieChart': {
-      return ajv.validate(otherReportSchema, parsedData);
-    }
-    default:
-      return null;
-  }
+  return ajv.validate(REPORTS_SCHEMAS[type] || {}, parsedData);
 };

--- a/src/utilities/validateReport.js
+++ b/src/utilities/validateReport.js
@@ -1,0 +1,80 @@
+/**
+ * Check if the given parameter is a valid Report based
+ * on its data structure and type and return a boolean.
+ *
+ * @param   {object}  parsedData  The data to check.
+ * @param   {string}  type        Type of Report to check.
+ */
+
+import Ajv from 'ajv';
+
+// Expected json structure for Table reports
+const tableReportSchema = {
+  type: 'object',
+  properties: {
+    data: {
+      type: 'object',
+      properties: {
+        header: {
+          type: 'array',
+        },
+        rows: {
+          type: 'array',
+          items: { type: 'array' },
+        },
+        formatters: {
+          type: 'array',
+        },
+      },
+      required: ['header', 'rows', 'formatters'],
+    },
+  },
+  required: ['data'],
+};
+
+// Expected json structure for BarChart, LineChart or PieChart reports
+const otherReportSchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    data: {
+      type: 'array',
+      items: {
+        label: { type: 'string' },
+        values: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              x: { type: ['string', 'number'] },
+              y: { type: ['string', 'number'] },
+            },
+            required: ['x', 'y'],
+          },
+        },
+        required: ['label', 'values'],
+      },
+    },
+  },
+  required: ['name', 'data'],
+};
+
+export const validateReport = (parsedData, type) => {
+  const ajv = new Ajv({ coerceTypes: true });
+  switch (type) {
+    case 'Table': {
+      return ajv.validate(tableReportSchema, parsedData);
+    }
+    case 'BarChart': {
+      return ajv.validate(otherReportSchema, parsedData);
+    }
+    case 'LineChart': {
+      return ajv.validate(otherReportSchema, parsedData);
+    }
+    case 'PieChart': {
+      return ajv.validate(otherReportSchema, parsedData);
+    }
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
Fixes #1982

## Change summary

Because `dashboard_store_reports` coming from desktop can have a different data structure or report type as the expected, a report validation was added. Basically here we use the report type to contrast the data structure with a known validated json schema (using an external dependency named [ajv](https://www.npmjs.com/package/ajv)).

## Setup

Instructions to generate reports:

1. Make Dashboard feature visible in main page:

- [ ]  In Desktop go to: **Special -> Stores -> Select the current store -> Custom Fields** and add the following: 
<img width="542" alt="Screen Shot 2020-01-25 at 11 44 09 AM" src="https://user-images.githubusercontent.com/32987464/73109505-2bab0b80-3f68-11ea-952b-a16d971a00e6.png">

- [ ] Sync
- [ ] Check that the `Dashboard` button in visible in mobile and can navigate to its corresponding page.

2. Add reports

- [ ] In Desktop go to: **Admin -> Dashboard**
- [ ] Select one of the reports and click on `Duplicate`
- [ ] Open the Duplicated report and add the following properties:
<img width="529" alt="Screen Shot 2020-01-25 at 11 54 42 AM" src="https://user-images.githubusercontent.com/32987464/73109968-9c065c80-3f69-11ea-8e98-9b6168e95fc2.png">

- [ ] Go to `json` tab and click on `Run Report`
- [ ] Now duplicate this created report (make 3 copies) and modify its reportType property to `BarChart`, `PieChart` and `Table`
- [ ] Run all reports (click on `json` tab -> `Run Report` in each of them)

3. Edit json structures of each generated report
- [ ] Download all json structures [here](https://drive.google.com/drive/folders/11YO89TChF6rTW36emyQGpnHCdkZ8-P5R?usp=sharing)
- [ ] In Desktop go to Design Mode, execute the method `record_browser` (see image below):
<img width="522" alt="Screen Shot 2020-01-25 at 12 05 58 PM" src="https://user-images.githubusercontent.com/32987464/73110429-3c10b580-3f6b-11ea-868f-67b6c13f6c77.png">

- [ ] Look for `dashboard_store_report` and click on `All records`
- [ ] Click on Next to navigate through all previously created records one by one
- [ ] For each report, edit the field: `json` with its corresponding structure (previously download)
- [ ] After editing, click on `Update` and then `Save` (repeat the process for each report).
<img width="491" alt="Screen Shot 2020-01-25 at 12 11 36 PM" src="https://user-images.githubusercontent.com/32987464/73111528-6fedda00-3f6f-11ea-889e-ad88418b2533.png">

- [ ] In mobile, Sync again and go to `DashboardPage`
- [ ] See the reports

## Testing

Steps to reproduce or otherwise test the changes of this PR:

Many more test cases can be added in order to test this properly, but anyway I _think_ the following are the main ones:

Test 1 - Edit json structure to make the invalid

- [ ] Edit the json structure of all reports (check previous steps above).
Example: remove "label" and its value of TableReport, delete one "x" or "y" property and its values of a PieChart, delete "name" and its value of a BarChart, etc.
- [ ] Sync in mobile
- [ ] Check that the modified report/s is/are plot correct- means modifications were rejected
- [ ] Make as many changes an possible in the json structure of each reporta and repeat the process. 

Test 1 - Edit data in reports without changing the structure

- [ ] Edit some data of all reports (check previous steps above).
Example: change value of a "x" or "y" property in PieChart/BarChart/LineChart, modify a row value or header value in TableReport.
- [ ] Sync in mobile
- [ ] Check that the modified report/s is/are correct - means modifications were accepted

### Related areas to think about

I _believe_ all expected errors were taking into account while defining which are the required parameters, but maybe I'm missing some 😅