### PR TITLE
#1992 undefined objects in cell actions

### DIFF
--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -44,12 +44,14 @@ export const editBatchName = (value, rowKey, objectType, route) => (dispatch, ge
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  const { batch } = objectToEdit;
+  if (objectToEdit) {
+    const { batch } = objectToEdit;
 
-  if (value !== batch) {
-    UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
+    if (value !== batch) {
+      UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
 
-    dispatch(refreshRow(rowKey, route));
+      dispatch(refreshRow(rowKey, route));
+    }
   }
 };
 
@@ -81,12 +83,14 @@ export const editExpiryDate = (newDate, rowKey, objectType, route) => (dispatch,
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => {
-    objectToEdit.expiryDate = newDate;
-    UIDatabase.save(objectType, objectToEdit);
-  });
+  if (objectToEdit) {
+    UIDatabase.write(() => {
+      objectToEdit.expiryDate = newDate;
+      UIDatabase.save(objectType, objectToEdit);
+    });
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -109,11 +113,13 @@ export const editTotalQuantity = (value, rowKey, route) => (dispatch, getState) 
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => {
-    objectToEdit.setTotalQuantity(UIDatabase, parsePositiveInteger(value));
-  });
+  if (objectToEdit) {
+    UIDatabase.write(() => {
+      objectToEdit.setTotalQuantity(UIDatabase, parsePositiveInteger(value));
+    });
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -128,7 +134,11 @@ export const editSuppliedQuantity = (value, rowKey, route) => (dispatch, getStat
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => objectToEdit.setSuppliedQuantity(UIDatabase, parsePositiveInteger(value)));
+  if (objectToEdit) {
+    UIDatabase.write(() =>
+      objectToEdit.setSuppliedQuantity(UIDatabase, parsePositiveInteger(value))
+    );
+  }
 
   dispatch(refreshRow(rowKey, route));
 };
@@ -145,12 +155,14 @@ export const editRequiredQuantity = (value, rowKey, objectType, route) => (dispa
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => {
-    objectToEdit.requiredQuantity = parsePositiveInteger(value);
-    UIDatabase.save(objectType, objectToEdit);
-  });
+  if (objectToEdit) {
+    UIDatabase.write(() => {
+      objectToEdit.requiredQuantity = parsePositiveInteger(value);
+      UIDatabase.save(objectType, objectToEdit);
+    });
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -170,7 +182,9 @@ export const editCountedQuantity = (value, rowKey, route) => (dispatch, getState
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  objectToEdit.setCountedTotalQuantity(UIDatabase, parsePositiveInteger(value));
+  if (objectToEdit) {
+    objectToEdit.setCountedTotalQuantity(UIDatabase, parsePositiveInteger(value));
+  }
 
   dispatch(refreshRow(rowKey, route));
 };
@@ -186,10 +200,12 @@ export const editStocktakeBatchCountedQuantity = (value, rowKey, route) => (disp
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => {
-    objectToEdit.countedTotalQuantity = parsePositiveInteger(value);
-    UIDatabase.save('StocktakeBatch', UIDatabase);
-  });
+  if (objectToEdit) {
+    UIDatabase.write(() => {
+      objectToEdit.countedTotalQuantity = parsePositiveInteger(value);
+      UIDatabase.save('StocktakeBatch', UIDatabase);
+    });
+  }
 
   dispatch(refreshRow(rowKey, route));
 };
@@ -204,7 +220,9 @@ export const removeReason = (rowKey, route) => (dispatch, getState) => {
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  objectToEdit.removeReason(UIDatabase);
+  if (objectToEdit) {
+    objectToEdit.removeReason(UIDatabase);
+  }
 
   dispatch(refreshRow(rowKey, route));
 };

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -44,12 +44,14 @@ export const editBatchName = (value, rowKey, objectType, route) => (dispatch, ge
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  const { batch } = objectToEdit;
+  if (objectToEdit) {
+    const { batch } = objectToEdit;
 
-  if (value !== batch) {
-    UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
+    if (value !== batch) {
+      UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
 
-    dispatch(refreshRow(rowKey, route));
+      dispatch(refreshRow(rowKey, route));
+    }
   }
 };
 
@@ -81,12 +83,14 @@ export const editExpiryDate = (newDate, rowKey, objectType, route) => (dispatch,
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => {
-    objectToEdit.expiryDate = newDate;
-    UIDatabase.save(objectType, objectToEdit);
-  });
+  if (objectToEdit) {
+    UIDatabase.write(() => {
+      objectToEdit.expiryDate = newDate;
+      UIDatabase.save(objectType, objectToEdit);
+    });
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -109,11 +113,13 @@ export const editTotalQuantity = (value, rowKey, route) => (dispatch, getState) 
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => {
-    objectToEdit.setTotalQuantity(UIDatabase, parsePositiveInteger(value));
-  });
+  if (objectToEdit) {
+    UIDatabase.write(() => {
+      objectToEdit.setTotalQuantity(UIDatabase, parsePositiveInteger(value));
+    });
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -128,9 +134,13 @@ export const editSuppliedQuantity = (value, rowKey, route) => (dispatch, getStat
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => objectToEdit.setSuppliedQuantity(UIDatabase, parsePositiveInteger(value)));
+  if (objectToEdit) {
+    UIDatabase.write(() =>
+      objectToEdit.setSuppliedQuantity(UIDatabase, parsePositiveInteger(value))
+    );
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -145,12 +155,14 @@ export const editRequiredQuantity = (value, rowKey, objectType, route) => (dispa
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => {
-    objectToEdit.requiredQuantity = parsePositiveInteger(value);
-    UIDatabase.save(objectType, objectToEdit);
-  });
+  if (objectToEdit) {
+    UIDatabase.write(() => {
+      objectToEdit.requiredQuantity = parsePositiveInteger(value);
+      UIDatabase.save(objectType, objectToEdit);
+    });
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -170,9 +182,11 @@ export const editCountedQuantity = (value, rowKey, route) => (dispatch, getState
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  objectToEdit.setCountedTotalQuantity(UIDatabase, parsePositiveInteger(value));
+  if (objectToEdit) {
+    objectToEdit.setCountedTotalQuantity(UIDatabase, parsePositiveInteger(value));
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -186,12 +200,14 @@ export const editStocktakeBatchCountedQuantity = (value, rowKey, route) => (disp
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  UIDatabase.write(() => {
-    objectToEdit.countedTotalQuantity = parsePositiveInteger(value);
-    UIDatabase.save('StocktakeBatch', UIDatabase);
-  });
+  if (objectToEdit) {
+    UIDatabase.write(() => {
+      objectToEdit.countedTotalQuantity = parsePositiveInteger(value);
+      UIDatabase.save('StocktakeBatch', UIDatabase);
+    });
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**
@@ -204,9 +220,11 @@ export const removeReason = (rowKey, route) => (dispatch, getState) => {
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  objectToEdit.removeReason(UIDatabase);
+  if (objectToEdit) {
+    objectToEdit.removeReason(UIDatabase);
 
-  dispatch(refreshRow(rowKey, route));
+    dispatch(refreshRow(rowKey, route));
+  }
 };
 
 /**

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -44,14 +44,12 @@ export const editBatchName = (value, rowKey, objectType, route) => (dispatch, ge
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    const { batch } = objectToEdit;
+  const { batch } = objectToEdit;
 
-    if (value !== batch) {
-      UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
+  if (value !== batch) {
+    UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
 
-      dispatch(refreshRow(rowKey, route));
-    }
+    dispatch(refreshRow(rowKey, route));
   }
 };
 
@@ -83,14 +81,12 @@ export const editExpiryDate = (newDate, rowKey, objectType, route) => (dispatch,
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    UIDatabase.write(() => {
-      objectToEdit.expiryDate = newDate;
-      UIDatabase.save(objectType, objectToEdit);
-    });
+  UIDatabase.write(() => {
+    objectToEdit.expiryDate = newDate;
+    UIDatabase.save(objectType, objectToEdit);
+  });
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**
@@ -113,13 +109,11 @@ export const editTotalQuantity = (value, rowKey, route) => (dispatch, getState) 
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    UIDatabase.write(() => {
-      objectToEdit.setTotalQuantity(UIDatabase, parsePositiveInteger(value));
-    });
+  UIDatabase.write(() => {
+    objectToEdit.setTotalQuantity(UIDatabase, parsePositiveInteger(value));
+  });
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**
@@ -134,13 +128,9 @@ export const editSuppliedQuantity = (value, rowKey, route) => (dispatch, getStat
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    UIDatabase.write(() =>
-      objectToEdit.setSuppliedQuantity(UIDatabase, parsePositiveInteger(value))
-    );
+  UIDatabase.write(() => objectToEdit.setSuppliedQuantity(UIDatabase, parsePositiveInteger(value)));
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**
@@ -155,14 +145,12 @@ export const editRequiredQuantity = (value, rowKey, objectType, route) => (dispa
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    UIDatabase.write(() => {
-      objectToEdit.requiredQuantity = parsePositiveInteger(value);
-      UIDatabase.save(objectType, objectToEdit);
-    });
+  UIDatabase.write(() => {
+    objectToEdit.requiredQuantity = parsePositiveInteger(value);
+    UIDatabase.save(objectType, objectToEdit);
+  });
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**
@@ -182,11 +170,9 @@ export const editCountedQuantity = (value, rowKey, route) => (dispatch, getState
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    objectToEdit.setCountedTotalQuantity(UIDatabase, parsePositiveInteger(value));
+  objectToEdit.setCountedTotalQuantity(UIDatabase, parsePositiveInteger(value));
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**
@@ -200,14 +186,12 @@ export const editStocktakeBatchCountedQuantity = (value, rowKey, route) => (disp
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    UIDatabase.write(() => {
-      objectToEdit.countedTotalQuantity = parsePositiveInteger(value);
-      UIDatabase.save('StocktakeBatch', UIDatabase);
-    });
+  UIDatabase.write(() => {
+    objectToEdit.countedTotalQuantity = parsePositiveInteger(value);
+    UIDatabase.save('StocktakeBatch', UIDatabase);
+  });
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**
@@ -220,11 +204,9 @@ export const removeReason = (rowKey, route) => (dispatch, getState) => {
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
 
-  if (objectToEdit) {
-    objectToEdit.removeReason(UIDatabase);
+  objectToEdit.removeReason(UIDatabase);
 
-    dispatch(refreshRow(rowKey, route));
-  }
+  dispatch(refreshRow(rowKey, route));
 };
 
 /**


### PR DESCRIPTION
Fixes #1992 

## Change summary

- This actually occurs when you're mid-editing a cell and navigate back.
- You basically have to be spamming a cell with text and clicking back at the same time, so not tooo bad

## Testing

- [ ] Edit a cell by repeat spamming constantly, and then with your other hand navigate back - the app should not crash.

### Related areas to think about

I mean, the codes not pretty but 🤷‍♂ 

Ideally, there would be a `ERROR` action which would be dispatched in the else - which wouldn't do anything, but potentially logs in the future
