### PR TITLE
#2006 add new cash transaction functionality

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -134,13 +134,13 @@ const createPatient = (database, patientDetails) => {
 };
 
 const createCashOut = (database, user, cashTransaction) => {
-  const { supplier, amount, reason, description } = cashTransaction;
+  const { name, amount, reason, description } = cashTransaction;
 
   // Create payment transaction.
-  const payment = createPayment(database, user, supplier, amount, reason, description);
+  const payment = createPayment(database, user, name, amount, reason, description);
 
   // Create customer invoice of same monetary value to offset payment transaction.
-  const customerInvoice = createOffsetCustomerInvoice(database, user, supplier, amount);
+  const customerInvoice = createOffsetCustomerInvoice(database, user, name, amount);
 
   // Create payment transaction batch.
   const paymentLine = createPaymentLine(database, payment, customerInvoice, amount);
@@ -149,13 +149,13 @@ const createCashOut = (database, user, cashTransaction) => {
 };
 
 const createCashIn = (database, user, cashTransaction) => {
-  const { supplier, amount, description } = cashTransaction;
+  const { name, amount, description } = cashTransaction;
 
   // Create receipt transaction.
-  const receipt = createReceipt(database, user, supplier, amount, description);
+  const receipt = createReceipt(database, user, name, amount, description);
 
   // Create customer credit transaction.
-  const customerCredit = createCustomerCredit(database, user, supplier, amount);
+  const customerCredit = createCustomerCredit(database, user, name, amount);
 
   // Create receipt transaction batch.
   const receiptLine = createReceiptLine(database, receipt, customerCredit, amount);
@@ -163,7 +163,7 @@ const createCashIn = (database, user, cashTransaction) => {
   return [receipt, customerCredit, receiptLine];
 };
 
-const createOffsetCustomerInvoice = (database, user, supplier, amount) => {
+const createOffsetCustomerInvoice = (database, user, name, amount) => {
   const { CUSTOMER_INVOICE_NUMBER } = NUMBER_SEQUENCE_KEYS;
   const currentDate = new Date();
   const invoice = database.create('Transaction', {
@@ -174,7 +174,7 @@ const createOffsetCustomerInvoice = (database, user, supplier, amount) => {
     type: 'customer_invoice',
     status: 'finalised',
     comment: 'Offset for a cash-only transaction',
-    otherParty: supplier,
+    otherParty: name,
     total: amount,
     outstanding: amount,
     enteredBy: user,
@@ -183,7 +183,7 @@ const createOffsetCustomerInvoice = (database, user, supplier, amount) => {
   return invoice;
 };
 
-const createReceipt = (database, user, supplier, amount, description) => {
+const createReceipt = (database, user, name, amount, description) => {
   const currentDate = new Date();
   const { CUSTOMER_INVOICE_NUMBER } = NUMBER_SEQUENCE_KEYS;
   const receipt = database.create('Transaction', {
@@ -194,7 +194,7 @@ const createReceipt = (database, user, supplier, amount, description) => {
     type: 'receipt',
     status: 'finalised',
     comment: description,
-    otherParty: supplier,
+    otherParty: name,
     enteredBy: user,
     total: amount,
   });
@@ -216,7 +216,7 @@ const createReceiptLine = (database, receipt, customerCredit, amount) => {
   return receiptLine;
 };
 
-const createPayment = (database, user, supplier, amount, reason, description) => {
+const createPayment = (database, user, name, amount, reason, description) => {
   const currentDate = new Date();
   const { CUSTOMER_INVOICE_NUMBER } = NUMBER_SEQUENCE_KEYS;
   const payment = database.create('Transaction', {
@@ -226,7 +226,7 @@ const createPayment = (database, user, supplier, amount, reason, description) =>
     confirmDate: currentDate,
     type: 'payment',
     status: 'finalised',
-    otherParty: supplier,
+    otherParty: name,
     enteredBy: user,
     total: amount,
     option: reason,
@@ -294,7 +294,7 @@ const createSupplierCredit = (database, user, supplierId, returnAmount) => {
   return supplierCredit;
 };
 
-const createCustomerCredit = (database, user, supplier, amount) => {
+const createCustomerCredit = (database, user, name, amount) => {
   const currentDate = new Date();
   const { CUSTOMER_INVOICE_NUMBER } = NUMBER_SEQUENCE_KEYS;
 
@@ -309,7 +309,7 @@ const createCustomerCredit = (database, user, supplier, amount) => {
     type: 'customer_credit',
     status: 'finalised',
     comment: 'Offset for a cash-only transaction',
-    otherParty: supplier,
+    otherParty: name,
     enteredBy: user,
     total: creditAmount,
     outstanding: creditAmount,

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -4,6 +4,7 @@
  */
 
 import { UIDatabase } from '../../../database/index';
+import { CASH_TRANSACTION_CODES } from '../../../utilities/modules/dispensary/constants';
 import { SETTINGS_KEYS } from '../../../settings';
 import Settings from '../../../settings/MobileAppSettings';
 import { createRecord } from '../../../database/utilities/index';
@@ -157,9 +158,10 @@ export const addItem = (item, addedItemType, route) => (dispatch, getState) => {
 export const addCashTransaction = (cashTransaction, route) => (dispatch, getState) => {
   const { user } = getState();
   const { currentUser } = user;
-  const { type } = cashTransaction;
+  const { type: transactionType } = cashTransaction;
+  const { code: transactionCode } = transactionType;
 
-  if (type.code === 'cash_in') {
+  if (transactionCode === CASH_TRANSACTION_CODES.CASH_IN) {
     // Create receipt transaction and associated customer credit and receipt transaction batch.
     UIDatabase.write(() => {
       const [payment] = createRecord(UIDatabase, 'CashIn', currentUser, cashTransaction);
@@ -167,7 +169,7 @@ export const addCashTransaction = (cashTransaction, route) => (dispatch, getStat
     });
   }
 
-  if (type.code === 'cash_out') {
+  if (transactionCode === CASH_TRANSACTION_CODES.CASH_OUT) {
     // Create payment transaction and associated customer invoice, payment transaction batch.
     UIDatabase.write(() => {
       const [payment] = createRecord(UIDatabase, 'CashOut', currentUser, cashTransaction);

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -164,9 +164,13 @@ export const addCashTransaction = (cashTransaction, route) => (dispatch, getStat
   }
 
   if (type.code === 'cash_out') {
-    // Create cash out transaction.
+    // Create payment transaction and associated customer invoice, payment batch transaction.
+    UIDatabase.write(() => {
+      const [payment] = createRecord(UIDatabase, 'CashOut', currentUser, cashTransaction);
+      dispatch(addRecord(payment, route));
+    });
   }
-}
+};
 
 /**
  * Creates a transaction batch which will be associated with the current stores

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -160,11 +160,15 @@ export const addCashTransaction = (cashTransaction, route) => (dispatch, getStat
   const { type } = cashTransaction;
 
   if (type.code === 'cash_in') {
-    // Create cash in transaction.
+    // Create receipt transaction and associated customer credit and receipt transaction batch.
+    UIDatabase.write(() => {
+      const [payment] = createRecord(UIDatabase, 'CashIn', currentUser, cashTransaction);
+      dispatch(addRecord(payment, route));
+    });
   }
 
   if (type.code === 'cash_out') {
-    // Create payment transaction and associated customer invoice, payment batch transaction.
+    // Create payment transaction and associated customer invoice, payment transaction batch.
     UIDatabase.write(() => {
       const [payment] = createRecord(UIDatabase, 'CashOut', currentUser, cashTransaction);
       dispatch(addRecord(payment, route));

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -155,13 +155,15 @@ export const addItem = (item, addedItemType, route) => (dispatch, getState) => {
  * @param {Object} cashTransaction Cash transaction object.
  */
 export const addCashTransaction = (cashTransaction, route) => (dispatch, getState) => {
-  const { name, transactionType, transactionAmount, reason, description } = cashTransaction;
+  const { user } = getState();
+  const { currentUser } = user;
+  const { type } = cashTransaction;
 
-  if (transactionType.code === 'cash_in') {
+  if (type.code === 'cash_in') {
     // Create cash in transaction.
   }
 
-  if (transactionType.code === 'cash_out') {
+  if (type.code === 'cash_out') {
     // Create cash out transaction.
   }
 }

--- a/src/utilities/modules/dispensary/constants.js
+++ b/src/utilities/modules/dispensary/constants.js
@@ -1,0 +1,20 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+export const CASH_TRANSACTION_KEYS = {
+  NAME: 'name',
+  TYPE: 'title',
+  REASON: 'title',
+};
+
+export const CASH_TRANSACTION_CODES = {
+  CASH_IN: 'cash_in',
+  CASH_OUT: ' cash_out',
+};
+
+export const CASH_TRANSACTION_TYPES = [
+  { [CASH_TRANSACTION_KEYS.TYPE]: 'Cash in', code: CASH_TRANSACTION_CODES.CASH_IN },
+  { [CASH_TRANSACTION_KEYS.TYPE]: 'Cash out', code: CASH_TRANSACTION_CODES.CASH_OUT },
+];

--- a/src/widgets/modals/CashTransactionModal.js
+++ b/src/widgets/modals/CashTransactionModal.js
@@ -8,6 +8,10 @@ import PropTypes from 'prop-types';
 import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 
 import { UIDatabase } from '../../database';
+import {
+  CASH_TRANSACTION_KEYS,
+  CASH_TRANSACTION_TYPES,
+} from '../../utilities/modules/dispensary/constants';
 
 import { BottomModalContainer, BottomTextEditor } from '../bottomModals';
 import { GenericChoiceList } from '../modalChildren';
@@ -21,11 +25,6 @@ const placeholderType = 'Choose a transaction type';
 const placeholderAmount = 'Enter transaction amount';
 const placeholderReason = 'Choose a reason';
 const placeholderDescription = 'Enter a description';
-
-const CASH_TRANSACTION_TYPES = [
-  { title: 'Cash in', code: 'cash_in' },
-  { title: 'Cash out', code: 'cash_out' },
-];
 
 export const CashTransactionModal = ({ onConfirm }) => {
   const [name, setName] = useState(null);
@@ -169,7 +168,7 @@ export const CashTransactionModal = ({ onConfirm }) => {
       >
         <GenericChoiceList
           data={names}
-          keyToDisplay="name"
+          keyToDisplay={CASH_TRANSACTION_KEYS.NAME}
           onPress={onSubmitName}
           highlightValue={name?.name}
         />
@@ -180,7 +179,7 @@ export const CashTransactionModal = ({ onConfirm }) => {
       >
         <GenericChoiceList
           data={CASH_TRANSACTION_TYPES}
-          keyToDisplay="title"
+          keyToDisplay={CASH_TRANSACTION_KEYS.TYPE}
           onPress={onSubmitType}
           highlightValue={type?.title}
         />
@@ -199,7 +198,7 @@ export const CashTransactionModal = ({ onConfirm }) => {
       >
         <GenericChoiceList
           data={reasons}
-          keyToDisplay="title"
+          keyToDisplay={CASH_TRANSACTION_KEYS.REASON}
           onPress={onSubmitReason}
           highlightValue={reason?.title}
         />

--- a/src/widgets/modals/CashTransactionModal.js
+++ b/src/widgets/modals/CashTransactionModal.js
@@ -16,61 +16,72 @@ import { PencilIcon, ChevronDownIcon } from '../icons';
 
 import globalStyles, { WARM_GREY, SUSSOL_ORANGE } from '../../globalStyles';
 
-const placeholderName = 'Choose a name';
-const placeholderTransactionType = 'Choose a transaction type';
-const placeholderTransactionAmount = 'Enter transaction amount';
+const placeholderSupplier = 'Choose a name';
+const placeholderType = 'Choose a transaction type';
+const placeholderAmount = 'Enter transaction amount';
 const placeholderReason = 'Choose a reason';
 const placeholderDescription = 'Enter a description';
 
-const CASH_TRANSACTION_TYPES = [{title: 'Cash in', code: 'cash_in'}, {title: 'Cash out', code: 'cash_out'}];
+const CASH_TRANSACTION_TYPES = [
+  { title: 'Cash in', code: 'cash_in' },
+  { title: 'Cash out', code: 'cash_out' },
+];
 
 export const CashTransactionModal = ({ onConfirm }) => {
-  const [name, setName] = useState(null);
-  const [transactionType, setTransactionType] = useState(null);
-  const [transactionAmount, setTransactionAmount] = useState(null);
+  const [supplier, setSupplier] = useState(null);
+  const [type, setType] = useState(null);
+  const [amount, setAmount] = useState(null);
   const [reason, setReason] = useState(null);
   const [description, setDescription] = useState(null);
 
   const [textBuffer, setTextBuffer] = useState('');
-  const [isNameModalOpen, setIsNameModalOpen] = useState(false);
-  const [isTransactionTypeModalOpen, setIsTransactionTypeModalOpen] = useState(false);
-  const [isTransactionAmountModalOpen, setIsTransactionAmountModalOpen] = useState(false);
+  const [isSupplierModalOpen, setIsSupplierModalOpen] = useState(false);
+  const [isTypeModalOpen, setIsTypeModalOpen] = useState(false);
+  const [isAmountModalOpen, setIsAmountModalOpen] = useState(false);
   const [isReasonModalOpen, setIsReasonModalOpen] = useState(false);
   const [isDescriptionModalOpen, setIsDescriptionModalOpen] = useState(false);
 
   const names = useMemo(() => UIDatabase.objects('Name'));
   const reasons = useMemo(() => UIDatabase.objects('Options'));
-  const isValidTransaction = useMemo(
-    () => !!name && !!transactionType && !!transactionAmount && !!reason,
-    [name, transactionType, transactionAmount, reason]
-  );
+  const isValidTransaction = useMemo(() => !!supplier && !!type && !!amount && !!reason, [
+    supplier,
+    type,
+    amount,
+    reason,
+  ]);
 
-  const onCreate = useCallback(() => onConfirm({ name, transactionType, transactionAmount, reason, description }), [name, transactionType, transactionAmount, reason, description]);
+  const onCreate = useCallback(() => onConfirm({ supplier, type, amount, reason, description }), [
+    supplier,
+    type,
+    amount,
+    reason,
+    description,
+  ]);
 
   const onChangeText = text => setTextBuffer(text);
 
   const resetBottomModal = () => {
-    setIsNameModalOpen(false);
-    setIsTransactionTypeModalOpen(false);
-    setIsTransactionAmountModalOpen(false);
+    setIsSupplierModalOpen(false);
+    setIsTypeModalOpen(false);
+    setIsAmountModalOpen(false);
     setIsReasonModalOpen(false);
     setIsDescriptionModalOpen(false);
   };
 
-  const onPressName = () => {
+  const onPressSupplier = () => {
     resetBottomModal();
-    setIsNameModalOpen(true);
+    setIsSupplierModalOpen(true);
   };
 
-  const onPressTransactionType = () => {
+  const onPressType = () => {
     resetBottomModal();
-    setIsTransactionTypeModalOpen(true);
+    setIsTypeModalOpen(true);
   };
 
-  const onPressTransactionAmount = () => {
+  const onPressAmount = () => {
     resetBottomModal();
-    setIsTransactionAmountModalOpen(true);
-    setTextBuffer(transactionAmount);
+    setIsAmountModalOpen(true);
+    setTextBuffer(amount);
   };
 
   const onPressReason = () => {
@@ -84,19 +95,19 @@ export const CashTransactionModal = ({ onConfirm }) => {
     setTextBuffer(description);
   };
 
-  const onSubmitName = ({ item }) => {
-    setName(item);
-    setIsNameModalOpen(false);
+  const onSubmitSupplier = ({ item }) => {
+    setSupplier(item);
+    setIsSupplierModalOpen(false);
   };
 
-  const onSubmitTransactionType = ({ item }) => {
-    setTransactionType(item);
-    setIsTransactionTypeModalOpen(false);
+  const onSubmitType = ({ item }) => {
+    setType(item);
+    setIsTypeModalOpen(false);
   };
 
-  const onSubmitTransactionAmount = () => {
-    setTransactionAmount(textBuffer);
-    setIsTransactionAmountModalOpen(false);
+  const onSubmitAmount = () => {
+    setAmount(parseFloat(textBuffer));
+    setIsAmountModalOpen(false);
   };
 
   const onSubmitReason = ({ item }) => {
@@ -111,29 +122,25 @@ export const CashTransactionModal = ({ onConfirm }) => {
 
   return (
     <View style={localStyles.modalContainerStyle}>
-      <TouchableOpacity style={localStyles.containerStyle} onPress={onPressName}>
+      <TouchableOpacity style={localStyles.containerStyle} onPress={onPressSupplier}>
         <View style={localStyles.textContainerStyle}>
-          <Text style={localStyles.textStyle}>{name?.name ?? placeholderName}</Text>
+          <Text style={localStyles.textStyle}>{supplier?.name ?? placeholderSupplier}</Text>
         </View>
         <View style={localStyles.iconContainerStyle}>
           <ChevronDownIcon />
         </View>
       </TouchableOpacity>
-      <TouchableOpacity style={localStyles.containerStyle} onPress={onPressTransactionType}>
+      <TouchableOpacity style={localStyles.containerStyle} onPress={onPressType}>
         <View style={localStyles.textContainerStyle}>
-          <Text style={localStyles.textStyle}>
-            {transactionType?.title ?? placeholderTransactionType}
-          </Text>
+          <Text style={localStyles.textStyle}>{type?.title ?? placeholderType}</Text>
         </View>
         <View style={localStyles.iconContainerStyle}>
           <ChevronDownIcon />
         </View>
       </TouchableOpacity>
-      <TouchableOpacity style={localStyles.containerStyle} onPress={onPressTransactionAmount}>
+      <TouchableOpacity style={localStyles.containerStyle} onPress={onPressAmount}>
         <View style={localStyles.textContainerStyle}>
-          <Text style={localStyles.textStyle}>
-            {transactionAmount ?? placeholderTransactionAmount}
-          </Text>
+          <Text style={localStyles.textStyle}>{amount ?? placeholderAmount}</Text>
         </View>
         <View style={localStyles.iconContainerStyle}>
           <PencilIcon />
@@ -156,34 +163,34 @@ export const CashTransactionModal = ({ onConfirm }) => {
         </View>
       </TouchableOpacity>
       <BottomModalContainer
-        isOpen={isNameModalOpen}
+        isOpen={isSupplierModalOpen}
         modalStyle={localStyles.bottomModalContainerStyle}
       >
         <GenericChoiceList
           data={names}
           keyToDisplay="name"
-          onPress={onSubmitName}
-          highlightValue={name?.name}
+          onPress={onSubmitSupplier}
+          highlightValue={supplier?.name}
         />
       </BottomModalContainer>
       <BottomModalContainer
-        isOpen={isTransactionTypeModalOpen}
+        isOpen={isTypeModalOpen}
         modalStyle={localStyles.bottomModalContainerStyle}
       >
         <GenericChoiceList
           data={CASH_TRANSACTION_TYPES}
           keyToDisplay="title"
-          onPress={onSubmitTransactionType}
-          highlightValue={transactionType?.title}
+          onPress={onSubmitType}
+          highlightValue={type?.title}
         />
       </BottomModalContainer>
       <BottomTextEditor
-        isOpen={isTransactionAmountModalOpen}
+        isOpen={isAmountModalOpen}
         buttonText="Confirm"
         value={textBuffer}
-        placeholder={placeholderTransactionAmount}
+        placeholder={placeholderAmount}
         onChangeText={onChangeText}
-        onConfirm={onSubmitTransactionAmount}
+        onConfirm={onSubmitAmount}
       />
       <BottomModalContainer
         isOpen={isReasonModalOpen}

--- a/src/widgets/modals/CashTransactionModal.js
+++ b/src/widgets/modals/CashTransactionModal.js
@@ -16,7 +16,7 @@ import { PencilIcon, ChevronDownIcon } from '../icons';
 
 import globalStyles, { WARM_GREY, SUSSOL_ORANGE } from '../../globalStyles';
 
-const placeholderSupplier = 'Choose a name';
+const placeholderName = 'Choose a name';
 const placeholderType = 'Choose a transaction type';
 const placeholderAmount = 'Enter transaction amount';
 const placeholderReason = 'Choose a reason';
@@ -28,14 +28,14 @@ const CASH_TRANSACTION_TYPES = [
 ];
 
 export const CashTransactionModal = ({ onConfirm }) => {
-  const [supplier, setSupplier] = useState(null);
+  const [name, setName] = useState(null);
   const [type, setType] = useState(null);
   const [amount, setAmount] = useState(null);
   const [reason, setReason] = useState(null);
   const [description, setDescription] = useState(null);
 
   const [textBuffer, setTextBuffer] = useState('');
-  const [isSupplierModalOpen, setIsSupplierModalOpen] = useState(false);
+  const [isNameModalOpen, setIsNameModalOpen] = useState(false);
   const [isTypeModalOpen, setIsTypeModalOpen] = useState(false);
   const [isAmountModalOpen, setIsAmountModalOpen] = useState(false);
   const [isReasonModalOpen, setIsReasonModalOpen] = useState(false);
@@ -43,15 +43,16 @@ export const CashTransactionModal = ({ onConfirm }) => {
 
   const names = useMemo(() => UIDatabase.objects('Name'));
   const reasons = useMemo(() => UIDatabase.objects('Options'));
-  const isValidTransaction = useMemo(() => !!supplier && !!type && !!amount && !!reason, [
-    supplier,
+
+  const isValidTransaction = useMemo(() => !!name && !!type && !!amount && !!reason, [
+    name,
     type,
     amount,
     reason,
   ]);
 
-  const onCreate = useCallback(() => onConfirm({ supplier, type, amount, reason, description }), [
-    supplier,
+  const onCreate = useCallback(() => onConfirm({ name, type, amount, reason, description }), [
+    name,
     type,
     amount,
     reason,
@@ -61,16 +62,16 @@ export const CashTransactionModal = ({ onConfirm }) => {
   const onChangeText = text => setTextBuffer(text);
 
   const resetBottomModal = () => {
-    setIsSupplierModalOpen(false);
+    setIsNameModalOpen(false);
     setIsTypeModalOpen(false);
     setIsAmountModalOpen(false);
     setIsReasonModalOpen(false);
     setIsDescriptionModalOpen(false);
   };
 
-  const onPressSupplier = () => {
+  const onPressName = () => {
     resetBottomModal();
-    setIsSupplierModalOpen(true);
+    setIsNameModalOpen(true);
   };
 
   const onPressType = () => {
@@ -95,9 +96,9 @@ export const CashTransactionModal = ({ onConfirm }) => {
     setTextBuffer(description);
   };
 
-  const onSubmitSupplier = ({ item }) => {
-    setSupplier(item);
-    setIsSupplierModalOpen(false);
+  const onSubmitName = ({ item }) => {
+    setName(item);
+    setIsNameModalOpen(false);
   };
 
   const onSubmitType = ({ item }) => {
@@ -122,9 +123,9 @@ export const CashTransactionModal = ({ onConfirm }) => {
 
   return (
     <View style={localStyles.modalContainerStyle}>
-      <TouchableOpacity style={localStyles.containerStyle} onPress={onPressSupplier}>
+      <TouchableOpacity style={localStyles.containerStyle} onPress={onPressName}>
         <View style={localStyles.textContainerStyle}>
-          <Text style={localStyles.textStyle}>{supplier?.name ?? placeholderSupplier}</Text>
+          <Text style={localStyles.textStyle}>{name?.name ?? placeholderName}</Text>
         </View>
         <View style={localStyles.iconContainerStyle}>
           <ChevronDownIcon />
@@ -163,14 +164,14 @@ export const CashTransactionModal = ({ onConfirm }) => {
         </View>
       </TouchableOpacity>
       <BottomModalContainer
-        isOpen={isSupplierModalOpen}
+        isOpen={isNameModalOpen}
         modalStyle={localStyles.bottomModalContainerStyle}
       >
         <GenericChoiceList
           data={names}
           keyToDisplay="name"
-          onPress={onSubmitSupplier}
-          highlightValue={supplier?.name}
+          onPress={onSubmitName}
+          highlightValue={name?.name}
         />
       </BottomModalContainer>
       <BottomModalContainer


### PR DESCRIPTION
Fixes #2006

## Change summary

Adds basic functionality for adding new cash transactions. Completes the MVP functionality, but lot left to tidy up and bits of `CashRegisterPage` UI and functionality still remaining. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Can create a new cash in transaction.
- [ ] Can create a new cash out transaction.

### Related areas to think about

- `CashRegisterPage`:
  - Add searchbar. 
  - Add toggle bar for receipts/payments.
  - Add total cash balance.
- `CashRegisterModal`
  - Add "cash in/cash out" toggle.
  - Update bottom modal components (size, keyboard etc.).
  - Disable reasons for cash in transactions. 
- Cash reconcilation functionality:
  - Sync out `payment` and `receipt` records.