### PR TITLE
#2021 TransactionBatch outgoing sync

### DIFF
--- a/src/actions/PatientActions.js
+++ b/src/actions/PatientActions.js
@@ -5,7 +5,7 @@
 
 import { batch } from 'react-redux';
 
-import { UIDatabase, generateUUID } from '../database';
+import { createRecord, UIDatabase } from '../database';
 import { DispensaryActions } from './DispensaryActions';
 
 export const PATIENT_ACTIONS = {
@@ -32,22 +32,16 @@ const patientUpdate = completedForm => (dispatch, getState) => {
   const { currentPatient } = patient;
 
   if (currentPatient) {
+    const { addressOne, addressTwo } = completedForm;
+    const { billingAddress } = currentPatient;
+
     UIDatabase.write(() => {
-      UIDatabase.update('Name', {
-        ...currentPatient,
-        ...completedForm,
-        isPatient: true,
-        isVisible: true,
-      });
+      UIDatabase.update('Address', { ...billingAddress, line1: addressOne, line2: addressTwo });
+      UIDatabase.update('Name', { ...currentPatient, ...completedForm });
     });
   } else {
     UIDatabase.write(() => {
-      UIDatabase.update('Name', {
-        ...completedForm,
-        id: generateUUID(),
-        isPatient: true,
-        isVisible: true,
-      });
+      createRecord(UIDatabase, 'Patient', completedForm);
     });
   }
 

--- a/src/actions/PrescriberActions.js
+++ b/src/actions/PrescriberActions.js
@@ -5,7 +5,7 @@
 
 import { batch } from 'react-redux';
 
-import { UIDatabase, generateUUID } from '../database';
+import { createRecord, UIDatabase } from '../database';
 import { DispensaryActions } from './DispensaryActions';
 
 export const PRESCRIBER_ACTIONS = {
@@ -37,19 +37,15 @@ const updatePrescriber = completedForm => (dispatch, getState) => {
   const { currentPrescriber } = prescriber;
 
   if (currentPrescriber) {
+    const { addressOne, addressTwo } = completedForm;
+    const { address } = currentPrescriber;
+
     UIDatabase.write(() => {
-      UIDatabase.update('Prescriber', {
-        ...currentPrescriber,
-        ...completedForm,
-      });
+      UIDatabase.update('Address', { ...address, line1: addressOne, line2: addressTwo });
+      UIDatabase.update('Prescriber', { ...currentPrescriber, ...completedForm });
     });
   } else {
-    UIDatabase.write(() => {
-      UIDatabase.update('Prescriber', {
-        id: generateUUID(),
-        ...completedForm,
-      });
-    });
+    UIDatabase.write(() => createRecord(UIDatabase, 'Prescriber', completedForm));
   }
 
   batch(() => {

--- a/src/context/LoadingIndicatorContext.js
+++ b/src/context/LoadingIndicatorContext.js
@@ -1,0 +1,11 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+import React from 'react';
+
+/**
+ * Simple context used for passing the loading indicator prop down from the root.
+ */
+export const LoadingIndicatorContext = React.createContext();

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -477,6 +477,7 @@ Transaction.schema = {
     outstanding: { type: 'float', optional: true },
     insurancePolicy: { type: 'InsurancePolicy', optional: true },
     option: { type: 'Options', optional: true },
+    linkedTransaction: { type: 'Transaction', optional: true },
   },
 };
 

--- a/src/database/DataTypes/TransactionBatch.js
+++ b/src/database/DataTypes/TransactionBatch.js
@@ -85,6 +85,7 @@ export class TransactionBatch extends Realm.Object {
   setTotalQuantity(database, quantity) {
     const difference = quantity - this.totalQuantity;
     this.numberOfPacks = this.packSize ? quantity / this.packSize : 0;
+    this.total = this.totalPrice;
 
     if (this.transaction.isConfirmed) {
       const inventoryDifference = this.transaction.isIncoming ? difference : -difference;

--- a/src/database/DataTypes/TransactionItem.js
+++ b/src/database/DataTypes/TransactionItem.js
@@ -212,8 +212,13 @@ export class TransactionItem extends Realm.Object {
       // until no remainder left.
       for (let index = 0; index < itemBatchesToAdd.length && remainder !== 0; index += 1) {
         // Create the new transaction batch and attach it to this transaction item.
-        const newBatch = createRecord(database, 'TransactionBatch', this, itemBatchesToAdd[index]);
-
+        const newBatch = createRecord(
+          database,
+          'TransactionBatch',
+          this,
+          itemBatchesToAdd[index],
+          this.transaction.isIncoming
+        );
         // Apply as much of the remainder to it as possible.
         remainder = this.allocateDifferenceToBatch(database, remainder, newBatch);
       }

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -69,30 +69,6 @@ const createInsurancePolicy = (database, policyValues) => {
   return policy;
 };
 
-/**
- * Creates a prescriber record. prescriberDetails can have the shape:
- * {
- *     firstName, lastName, registrationCode, line1, line2, isVisible,
- *     isActive, phoneNumber, mobileNumber, emailAddress
- * }
- */
-const createPrescriber = (database, prescriberDetails) => {
-  const { line1, line2 } = prescriberDetails;
-  const address = createAddress({ line1, line2 });
-
-  const prescriber = database.create('Prescriber', {
-    id: generateUUID(),
-    ...prescriberDetails,
-    address,
-
-    // Defaults:
-    isVisible: true,
-    isActive: true,
-  });
-
-  database.save('Prescriber', prescriber);
-};
-
 const createAddress = (database, { line1, line2, line3, line4, zipCode } = {}) =>
   database.create('Address', {
     id: generateUUID(),
@@ -104,25 +80,45 @@ const createAddress = (database, { line1, line2, line3, line4, zipCode } = {}) =
   });
 
 /**
+ * Creates a prescriber record. prescriberDetails can have the shape:
+ * {
+ *     firstName, lastName, registrationCode, line1, line2, isVisible,
+ *     isActive, phoneNumber, mobileNumber, emailAddress
+ * }
+ */
+const createPrescriber = (database, prescriberDetails) => {
+  const { addressOne, addressTwo } = prescriberDetails;
+  const address = createAddress(database, { line1: addressOne, line2: addressTwo });
+
+  const prescriber = database.create('Prescriber', {
+    id: generateUUID(),
+    ...prescriberDetails,
+    address,
+    // Defaults:
+    isVisible: true,
+    isActive: true,
+  });
+
+  database.save('Prescriber', prescriber);
+};
+
+/**
  * Creates a patient record. Patient details passed can be in the shape:
  *  {
  *    firstName, lastName, dateOfBirth, code, emailAddress,
- *    phoneNumber, line1, line2,
+ *    phoneNumber, addressOne, addressTwo, country
  *  }
  */
 const createPatient = (database, patientDetails) => {
-  const { dateOfBirth, line1, line2 } = patientDetails;
-
-  const billingAddress = createAddress(database, { line1, line2 });
-  const parsedDateOfBirth = moment(dateOfBirth, 'DD-MM-YYYY').toDate();
+  const { dateOfBirth, addressOne, addressTwo } = patientDetails;
+  const billingAddress = createAddress(database, { line1: addressOne, line2: addressTwo });
   const thisStoreId = database.getSetting(SETTINGS_KEYS.THIS_STORE_ID);
 
   const patient = database.create('Name', {
     id: generateUUID(),
     ...patientDetails,
     billingAddress,
-    dateOfBirth: parsedDateOfBirth,
-    // Defaults:
+    dateOfBirth,
     isVisible: true,
     isPatient: true,
     type: 'patient',

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -203,12 +203,12 @@ const createReceipt = (database, user, name, amount, description) => {
   return receipt;
 };
 
-const createReceiptLine = (database, receipt, customerCredit, amount) => {
+const createReceiptLine = (database, receipt, linkedTransaction, amount) => {
   const receiptLine = database.create('TransactionBatch', {
     id: generateUUID(),
     total: amount,
     transaction: receipt,
-    linkedTransaction: customerCredit,
+    linkedTransaction,
     type: 'cash_in',
   });
 

--- a/src/hooks/useLoadingIndicator.js
+++ b/src/hooks/useLoadingIndicator.js
@@ -1,0 +1,12 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+import React from 'react';
+import { LoadingIndicatorContext } from '../context/LoadingIndicatorContext';
+
+/**
+ * Simple custom hook to return the runWithLoadingIndicator function.
+ */
+export const useLoadingIndicator = () => React.useContext(LoadingIndicatorContext);

--- a/src/localization/currency.js
+++ b/src/localization/currency.js
@@ -10,16 +10,10 @@ const CURRENCY_CONFIGS = {
   DEFAULT: {
     decimal: '.',
     separator: ',',
-    pattern: '!#',
-    symbol: '$',
-    formatWithSymbol: true,
   },
   [LANGUAGE_CODES.FRENCH]: {
     decimal: ',',
     separator: '.',
-    pattern: '#!',
-    symbol: 'CFA',
-    formatWithSymbol: true,
   },
 };
 

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -41,6 +41,7 @@ import Database from './database/BaseDatabase';
 import { UIDatabase } from './database';
 
 import globalStyles, { textStyles, SUSSOL_ORANGE } from './globalStyles';
+import { LoadingIndicatorContext } from './context/LoadingIndicatorContext';
 import { UserActions } from './actions';
 import { debounce } from './utilities';
 import { prevRouteNameSelector } from './navigation/selectors';
@@ -239,61 +240,63 @@ class MSupplyMobileAppContainer extends React.Component {
     }
 
     return (
-      <View style={globalStyles.appBackground}>
-        <NavigationBar
-          routeName={this.getCurrentRouteName(navigationState)}
-          onPressBack={this.getCanNavigateBack() ? this.handleBackEvent : null}
-          LeftComponent={this.getCanNavigateBack() ? this.renderPageTitle : null}
-          CentreComponent={this.renderLogo}
-          RightComponent={
-            finaliseItem && finaliseItem?.visibleButton
-              ? this.renderFinaliseButton
-              : this.renderSyncState
-          }
-        />
-        <ReduxNavigator
-          state={navigationState}
-          dispatch={dispatch}
-          screenProps={{
-            database: UIDatabase,
-            settings: Settings,
-            currentUser,
-            routeName: navigationState.routes[navigationState.index].routeName,
-            runWithLoadingIndicator: this.runWithLoadingIndicator,
-            isInAdminMode,
-          }}
-        />
-        <FinaliseModal
-          database={UIDatabase}
-          isOpen={finaliseModalOpen}
-          onClose={closeFinaliseModal}
-          finaliseItem={finaliseItem}
-          user={currentUser}
-          runWithLoadingIndicator={this.runWithLoadingIndicator}
-        />
-        <SyncModal
-          database={UIDatabase}
-          isOpen={syncModalIsOpen}
-          state={syncState}
-          onPressManualSync={this.synchronise}
-          onClose={() => this.setState({ syncModalIsOpen: false })}
-        />
-        <LoginModal
-          authenticator={this.userAuthenticator}
-          settings={Settings}
-          isAuthenticated={!!currentUser}
-          onAuthentication={this.onAuthentication}
-        />
-        {isLoading && this.renderLoadingIndicator()}
-        <ModalContainer
-          isVisible={supplierCreditModalOpen}
-          onClose={closeSupplierCreditModal}
-          title={`Available Credits for ${creditItemName}`}
-          fullScreen
-        >
-          <SupplierCredit />
-        </ModalContainer>
-      </View>
+      <LoadingIndicatorContext.Provider value={this.runWithLoadingIndicator}>
+        <View style={globalStyles.appBackground}>
+          <NavigationBar
+            routeName={this.getCurrentRouteName(navigationState)}
+            onPressBack={this.getCanNavigateBack() ? this.handleBackEvent : null}
+            LeftComponent={this.getCanNavigateBack() ? this.renderPageTitle : null}
+            CentreComponent={this.renderLogo}
+            RightComponent={
+              finaliseItem && finaliseItem?.visibleButton
+                ? this.renderFinaliseButton
+                : this.renderSyncState
+            }
+          />
+          <ReduxNavigator
+            state={navigationState}
+            dispatch={dispatch}
+            screenProps={{
+              database: UIDatabase,
+              settings: Settings,
+              currentUser,
+              routeName: navigationState.routes[navigationState.index].routeName,
+              runWithLoadingIndicator: this.runWithLoadingIndicator,
+              isInAdminMode,
+            }}
+          />
+          <FinaliseModal
+            database={UIDatabase}
+            isOpen={finaliseModalOpen}
+            onClose={closeFinaliseModal}
+            finaliseItem={finaliseItem}
+            user={currentUser}
+            runWithLoadingIndicator={this.runWithLoadingIndicator}
+          />
+          <SyncModal
+            database={UIDatabase}
+            isOpen={syncModalIsOpen}
+            state={syncState}
+            onPressManualSync={this.synchronise}
+            onClose={() => this.setState({ syncModalIsOpen: false })}
+          />
+          <LoginModal
+            authenticator={this.userAuthenticator}
+            settings={Settings}
+            isAuthenticated={!!currentUser}
+            onAuthentication={this.onAuthentication}
+          />
+          {isLoading && this.renderLoadingIndicator()}
+          <ModalContainer
+            isVisible={supplierCreditModalOpen}
+            onClose={closeSupplierCreditModal}
+            title={`Available Credits for ${creditItemName}`}
+            fullScreen
+          >
+            <SupplierCredit />
+          </ModalContainer>
+        </View>
+      </LoadingIndicatorContext.Provider>
     );
   }
 }

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -100,7 +100,6 @@ const Dispensing = ({
           getCallback={getCellCallbacks}
           columns={columns}
           rowIndex={index}
-          onPress={usingPatientsDataSet ? editPatient : editPrescriber}
         />
       );
     },

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -52,7 +52,7 @@ export const pay = (currentUser, patient, script, cashAmount) => {
   if (creditAmount > availableCredit) throw new Error('Not enough credit');
 
   // Create a Receipt and ReceiptLine for every payment path.
-  const receipt = createRecord(UIDatabase, 'Receipt', currentUser, patient, cashAmount, script);
+  const receipt = createRecord(UIDatabase, 'Receipt', currentUser, patient, cashAmount, '');
   createRecord(UIDatabase, 'ReceiptLine', receipt, script, cashAmount);
 
   // When using credit, create a CustomerCreditLine and ReceiptLine for each

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -37,11 +37,9 @@ import { UIDatabase } from '../../../database';
 
 export const pay = (currentUser, patient, script, cashAmount) => {
   if (!patient.isPatient) throw new Error('Patient is not a patient');
-
   if (!script.isPrescription) throw new Error('Script is not a script');
   if (!(script.items.length > 0)) throw new Error('Script is empty');
   if (script.isFinalised) throw new Error('Script is finalised');
-
   if (cashAmount < 0) throw new Error('Cash amount is negative');
 
   const { total } = script;

--- a/src/widgets/CurrencyInputRow.js
+++ b/src/widgets/CurrencyInputRow.js
@@ -78,7 +78,6 @@ export const CurrencyInputRow = ({
       </FlexView>
 
       <FlexRow flex={3}>
-        <SimpleLabel label="$" size="large" />
         <TextInput
           ref={refsArray.current[0]}
           value={dollarAmount}

--- a/src/widgets/NumberLabelRow.js
+++ b/src/widgets/NumberLabelRow.js
@@ -21,14 +21,10 @@ import { FlexView } from './FlexView';
  * @prop {String} text         Left hand side text value.
  * @prop {Number} number       Right hand side number value.
  * @prop {Number} total        Total value - displays text / total rather than just total.
- * @prop {Bool}   isCurrency   Indicator whether to append `$` to each number value.
  * @prop {Bool}   isPercentage Indicator whether to append `%` to each number value.
  */
-export const NumberLabelRow = ({ size, text, number, total, isCurrency, isPercentage }) => {
-  const withCurrency = textInput => (isCurrency ? `$${textInput}` : textInput);
-  const withTotalText = total
-    ? `${withCurrency(number)} / ${withCurrency(total)}`
-    : withCurrency(number);
+export const NumberLabelRow = ({ size, text, number, total, isPercentage }) => {
+  const withTotalText = total ? `${number} / ${total}` : number;
   const withPercentage = isPercentage ? `${withTotalText}%` : `${withTotalText}`;
 
   return (
@@ -45,7 +41,6 @@ export const NumberLabelRow = ({ size, text, number, total, isCurrency, isPercen
 
 NumberLabelRow.defaultProps = {
   total: 0,
-  isCurrency: false,
   isPercentage: false,
   size: 'small',
 };
@@ -55,6 +50,5 @@ NumberLabelRow.propTypes = {
   text: PropTypes.string.isRequired,
   number: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   total: PropTypes.number,
-  isCurrency: PropTypes.bool,
   isPercentage: PropTypes.bool,
 };

--- a/src/widgets/PaymentSummary.js
+++ b/src/widgets/PaymentSummary.js
@@ -156,13 +156,8 @@ const PaymentSummaryComponent = ({
           </FlexView>
 
           <FlexView flex={0.25}>
-            <NumberLabelRow text="Available Credit" isCurrency number={availableCredit.format()} />
-            <NumberLabelRow
-              size="small"
-              text="Credit used"
-              isCurrency
-              number={creditUsed.format()}
-            />
+            <NumberLabelRow text="Available Credit" number={availableCredit.format()} />
+            <NumberLabelRow size="small" text="Credit used" number={creditUsed.format()} />
 
             <Text style={localStyles.errorMessageStyle}>
               {creditOverflow ? 'Not enough credit!' : ''}
@@ -172,17 +167,17 @@ const PaymentSummaryComponent = ({
 
         <FlexView flex={1}>
           <Separator marginBottom={20} />
-          <NumberLabelRow text="Sub total" isCurrency number={subtotal.format()} />
+          <NumberLabelRow text="Sub total" number={subtotal.format()} />
 
-          <NumberLabelRow text="Insurance discount rate" isPercentage number={discountRate} />
-          <NumberLabelRow
-            text="Insurance discount amount"
-            isCurrency
-            number={discountAmount.format()}
-          />
-          <NumberLabelRow text="Change required" isCurrency number={changeRequired.format()} />
+          {usingInsurance && (
+            <NumberLabelRow text="Insurance discount rate" isPercentage number={discountRate} />
+          )}
+          {usingInsurance && (
+            <NumberLabelRow text="Insurance discount amount" number={discountAmount.format()} />
+          )}
+          <NumberLabelRow text="Change required" number={changeRequired.format()} />
           <Separator length="50%" marginTop={20} marginBottom={20} />
-          <NumberLabelRow size="large" text="Total" isCurrency number={total.format()} />
+          <NumberLabelRow size="large" text="Total" number={total.format()} />
         </FlexView>
       </FlexView>
     </ScrollView>

--- a/src/widgets/Tabs/PrescriptionConfirmation.js
+++ b/src/widgets/Tabs/PrescriptionConfirmation.js
@@ -21,6 +21,8 @@ import { PaymentSummary } from '../PaymentSummary';
 import { selectCurrentUser } from '../../selectors/user';
 import { selectCurrentPatient } from '../../selectors/patient';
 
+import { useLoadingIndicator } from '../../hooks/useLoadingIndicator';
+
 const mapStateToProps = state => {
   const { payment, wizard, modules } = state;
   const { transaction, paymentValid, paymentAmount } = payment;
@@ -29,7 +31,7 @@ const mapStateToProps = state => {
   const { usingPayments } = modules;
   const currentPatient = selectCurrentPatient(state);
   const currentUser = selectCurrentUser(state);
-  const canConfirm = paymentValid || isComplete;
+  const canConfirm = paymentValid && !isComplete;
 
   return { transaction, canConfirm, paymentAmount, currentUser, currentPatient, usingPayments };
 };
@@ -47,11 +49,16 @@ const PrescriptionConfirmationComponent = ({
   canConfirm,
   usingPayments,
 }) => {
-  const confirmPrescription = React.useCallback(
+  const runWithLoadingIndicator = useLoadingIndicator();
+
+  const confirm = React.useCallback(
     () =>
       UIDatabase.write(() => pay(currentUser, currentPatient, transaction, paymentAmount.value)),
-    []
+    [currentUser, currentPatient, transaction, paymentAmount.value]
   );
+
+  const confirmPrescription = React.useCallback(() => runWithLoadingIndicator(confirm), [confirm]);
+
   return (
     <FlexView flex={1}>
       <PrescriptionInfo />


### PR DESCRIPTION
Fixes #2021 

## Change summary

- Makes a few changes to `outgoingSyncUtils` to allow for `TransactionBatch` records to sync if they don't have an `ItemBatch`. Was using `safeGet` and it wasn't safe.
- Also added the `total` field being used when setting a quantity on a batch.
- Added `price_extension` and `foriegn_currency_..` to come from the `total` field. This is so it's historic and not changing with the `ItemBatch` and also because the payment lines don't have an `ItemBatch`!
- Removed the `safeGet` method because it wasn't used anymore and there doesn't seem to be any point to it now with optional chaining and null coals

## Testing

N/A

### Related areas to think about

N/A