### PR TITLE
#2031 Remove patient/prescriber row onPress

### DIFF
--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -100,7 +100,6 @@ const Dispensing = ({
           getCallback={getCellCallbacks}
           columns={columns}
           rowIndex={index}
-          onPress={usingPatientsDataSet ? editPatient : editPrescriber}
         />
       );
     },


### PR DESCRIPTION
Fixes #2031 

## Change summary

- Removes the `onPress` for patients and prescribers as they have a column with a button for this now and this `onPress` was crashing the app

## Testing

N/A

### Related areas to think about

N/A
