### PR TITLE
#2020 add cash register transaction type toggle

### DIFF
--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -4,7 +4,7 @@
  */
 
 import { UIDatabase } from '../../../database/index';
-import { CASH_TRANSACTION_CODES } from '../../../utilities/modules/dispensary/constants';
+import { CASH_TRANSACTION_TYPES } from '../../../utilities/modules/dispensary/constants';
 import { SETTINGS_KEYS } from '../../../settings';
 import Settings from '../../../settings/MobileAppSettings';
 import { createRecord } from '../../../database/utilities/index';
@@ -159,9 +159,8 @@ export const addCashTransaction = (cashTransaction, route) => (dispatch, getStat
   const { user } = getState();
   const { currentUser } = user;
   const { type: transactionType } = cashTransaction;
-  const { code: transactionCode } = transactionType;
 
-  if (transactionCode === CASH_TRANSACTION_CODES.CASH_IN) {
+  if (transactionType === CASH_TRANSACTION_TYPES.CASH_IN) {
     // Create receipt transaction and associated customer credit and receipt transaction batch.
     UIDatabase.write(() => {
       const [payment] = createRecord(UIDatabase, 'CashIn', currentUser, cashTransaction);
@@ -169,7 +168,7 @@ export const addCashTransaction = (cashTransaction, route) => (dispatch, getStat
     });
   }
 
-  if (transactionCode === CASH_TRANSACTION_CODES.CASH_OUT) {
+  if (transactionType === CASH_TRANSACTION_TYPES.CASH_OUT) {
     // Create payment transaction and associated customer invoice, payment transaction batch.
     UIDatabase.write(() => {
       const [payment] = createRecord(UIDatabase, 'CashOut', currentUser, cashTransaction);

--- a/src/utilities/modules/dispensary/constants.js
+++ b/src/utilities/modules/dispensary/constants.js
@@ -9,12 +9,7 @@ export const CASH_TRANSACTION_KEYS = {
   REASON: 'title',
 };
 
-export const CASH_TRANSACTION_CODES = {
+export const CASH_TRANSACTION_TYPES = {
   CASH_IN: 'cash_in',
-  CASH_OUT: ' cash_out',
+  CASH_OUT: 'cash_out',
 };
-
-export const CASH_TRANSACTION_TYPES = [
-  { [CASH_TRANSACTION_KEYS.TYPE]: 'Cash in', code: CASH_TRANSACTION_CODES.CASH_IN },
-  { [CASH_TRANSACTION_KEYS.TYPE]: 'Cash out', code: CASH_TRANSACTION_CODES.CASH_OUT },
-];


### PR DESCRIPTION
Fixes #2020.

## Change summary

Replaces type choice list bottom modal with toggle bar.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Can toggle between creating a cash in/out transaction.
- [ ] Cash in transactions do not prompt the user for a reason.
- [ ] Cash out transactions prompt the user for a reason.

### Related areas to think about

N/A.