### PR TITLE
#2050 Delete unfinalised prescriptions

### DIFF
--- a/src/actions/PrescriptionActions.js
+++ b/src/actions/PrescriptionActions.js
@@ -5,6 +5,7 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 import { batch } from 'react-redux';
+import { NavigationActions } from 'react-navigation';
 
 import { UIDatabase, createRecord } from '../database';
 
@@ -16,6 +17,23 @@ export const PRESCRIPTION_ACTIONS = {
   FILTER: 'Prescription/filter',
   OPEN_COMMENT_MODAL: 'Prescription/openCommentModal',
   CLOSE_COMMENT_MODAL: 'Prescription/closeCommentModal',
+  DELETE: 'Prescription/delete',
+};
+
+const deletePrescription = () => ({ type: PRESCRIPTION_ACTIONS.DELETE });
+
+const cancelPrescription = () => (dispatch, getState) => {
+  const { prescription } = getState();
+  const { transaction } = prescription;
+
+  UIDatabase.write(() => {
+    UIDatabase.delete('Transaction', transaction);
+  });
+
+  batch(() => {
+    dispatch(NavigationActions.back());
+    dispatch(deletePrescription());
+  });
 };
 
 const editTransactionCategory = newValue => (dispatch, getState) => {
@@ -191,4 +209,6 @@ export const PrescriptionActions = {
   editComment,
   editPatientType,
   editTransactionCategory,
+  cancelPrescription,
+  deletePrescription,
 };

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -57,7 +57,7 @@ const AUTHENTICATION_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 class MSupplyMobileAppContainer extends React.Component {
   handleBackEvent = debounce(
     () => {
-      const { dispatch, prevRouteName } = this.props;
+      const { dispatch, prevRouteName, currentRouteName } = this.props;
       const { syncModalIsOpen } = this.state;
 
       // If finalise or sync modals are open, close them rather than navigating.
@@ -340,6 +340,7 @@ const mapStateToProps = state => {
   }
 
   return {
+    currentRouteName,
     currentTitle,
     prevRouteName: prevRouteNameSelector(state),
     finaliseItem,
@@ -373,6 +374,7 @@ MSupplyMobileAppContainer.propTypes = {
   closeSupplierCreditModal: PropTypes.func.isRequired,
   supplierCreditModalOpen: PropTypes.bool.isRequired,
   creditItemName: PropTypes.string,
+  currentRouteName: PropTypes.string.isRequired,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(MSupplyMobileAppContainer);

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -46,9 +46,10 @@ import { UserActions } from './actions';
 import { debounce } from './utilities';
 import { prevRouteNameSelector } from './navigation/selectors';
 import { SupplierCredit } from './widgets/modalChildren/SupplierCredit';
-import ModalContainer from './widgets/modals/ModalContainer';
+import { ModalContainer } from './widgets/modals/ModalContainer';
 import { SupplierCreditActions } from './actions/SupplierCreditActions';
 import { selectItemName } from './selectors/supplierCredit';
+import { PrescriptionActions } from './actions/PrescriptionActions';
 
 const SYNC_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 const AUTHENTICATION_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
@@ -58,14 +59,27 @@ class MSupplyMobileAppContainer extends React.Component {
     () => {
       const { dispatch, prevRouteName } = this.props;
       const { syncModalIsOpen } = this.state;
+
       // If finalise or sync modals are open, close them rather than navigating.
       if (syncModalIsOpen) {
         this.setState({ syncModalIsOpen: false });
         return true;
       }
       // If we are on base screen (e.g. home), back button should close app as we can't go back.
-      if (!this.getCanNavigateBack()) BackHandler.exitApp();
-      else dispatch({ ...NavigationActions.back(), payload: { prevRouteName } });
+      if (!this.getCanNavigateBack()) {
+        BackHandler.exitApp();
+      } else {
+        dispatch({ ...NavigationActions.back(), payload: { prevRouteName } });
+      }
+      if (currentRouteName === ROUTES.PRESCRIPTION) {
+        UIDatabase.write(() => {
+          UIDatabase.delete(
+            'Transaction',
+            UIDatabase.objects('Prescription').filtered('status != $0', 'finalised')
+          );
+          dispatch(PrescriptionActions.deletePrescription());
+        });
+      }
 
       return true;
     },
@@ -118,6 +132,7 @@ class MSupplyMobileAppContainer extends React.Component {
 
   getCanNavigateBack = () => {
     const { navigationState } = this.props;
+
     return navigationState.index !== 0;
   };
 

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -30,18 +30,6 @@ import { ROUTES } from './constants';
  *
  */
 
-export const gotoPatients = () =>
-  NavigationActions.navigate({
-    routeName: ROUTES.PATIENTS,
-    params: { title: 'Patients' },
-  });
-
-export const gotoPrescribers = () =>
-  NavigationActions.navigate({
-    routeName: ROUTES.PRESCRIBERS,
-    params: { title: 'Prescribers' },
-  });
-
 /**
  * Action creator which first creates a prescription, and then navigates to it
  * for editing.
@@ -92,11 +80,21 @@ export const gotoPrescriptions = () =>
     params: { title: 'Prescriptions' },
   });
 
-export const gotoDispensingPage = () =>
-  NavigationActions.navigate({
-    routeName: ROUTES.DISPENSARY,
-    params: { title: 'Dispensary' },
+export const gotoDispensingPage = () => dispatch => {
+  UIDatabase.write(() => {
+    UIDatabase.delete(
+      'Transaction',
+      UIDatabase.objects('Prescription').filtered('status != $0', 'finalised')
+    );
   });
+
+  dispatch(
+    NavigationActions.navigate({
+      routeName: ROUTES.DISPENSARY,
+      params: { title: 'Dispensary' },
+    })
+  );
+};
 
 /**
  * Pushes the Settings page route onto the main navigation stack.
@@ -132,13 +130,21 @@ export const gotoRealmExplorer = () =>
 /**
  * Pushes the Customer Invoices route onto the main navigation stack.
  */
-export const gotoCustomerInvoices = () =>
-  NavigationActions.navigate({
-    routeName: ROUTES.CUSTOMER_INVOICES,
-    params: {
-      title: navStrings.customer_invoices,
-    },
+export const gotoCustomerInvoices = () => dispatch => {
+  UIDatabase.write(() => {
+    UIDatabase.delete(
+      'Transaction',
+      UIDatabase.objects('Prescription').filtered('status != $0', 'finalised')
+    );
   });
+
+  dispatch(
+    NavigationActions.navigate({
+      routeName: ROUTES.CUSTOMER_INVOICES,
+      params: { title: navStrings.customer_invoices },
+    })
+  );
+};
 
 /**
  * Pushes the Customer Requisitions route onto the main navigation stack.

--- a/src/reducers/PagesReducer.js
+++ b/src/reducers/PagesReducer.js
@@ -17,7 +17,7 @@ export const PagesReducer = (state = {}, action) => {
   switch (type) {
     case 'Navigation/BACK': {
       const { payload } = action;
-      const { prevRouteName } = payload;
+      const { prevRouteName } = payload || {};
       return { ...state, currentRoute: prevRouteName };
     }
     case 'Navigation/REPLACE':

--- a/src/reducers/PaymentReducer.js
+++ b/src/reducers/PaymentReducer.js
@@ -9,6 +9,7 @@ import { PAYMENT_ACTIONS } from '../actions/PaymentActions';
 import { WIZARD_ACTIONS } from '../actions/WizardActions';
 import { selectPrescriptionTotal } from '../selectors/payment';
 import { INSURANCE_ACTIONS } from '../actions/InsuranceActions';
+import { PRESCRIPTION_ACTIONS } from '../actions/PrescriptionActions';
 
 const initialState = () => ({
   transaction: null,
@@ -29,6 +30,10 @@ export const PaymentReducer = (state = initialState(), action) => {
       if (routeName !== ROUTES.PRESCRIPTION) return state;
       const { transaction } = params;
       return { ...state, transaction };
+    }
+
+    case PRESCRIPTION_ACTIONS.DELETE: {
+      return { ...state, transaction: null };
     }
 
     case WIZARD_ACTIONS.NEXT_TAB: {

--- a/src/reducers/PrescriptionReducer.js
+++ b/src/reducers/PrescriptionReducer.js
@@ -47,6 +47,9 @@ export const PrescriptionReducer = (state = initialState(), action) => {
       return { ...state, commentModalOpen: false };
     }
 
+    case PRESCRIPTION_ACTIONS.DELETE:
+      return { ...state, transaction: null };
+
     default: {
       return state;
     }

--- a/src/selectors/prescription.js
+++ b/src/selectors/prescription.js
@@ -8,22 +8,22 @@ import { UIDatabase } from '../database';
 
 export const selectHasItemsAndQuantity = ({ prescription }) => {
   const { transaction } = prescription;
-  const { totalQuantity, items } = transaction;
+  const { totalQuantity = 0, items = [] } = transaction || {};
   const hasItems = items.length > 0;
   const hasQuantity = totalQuantity > 0;
   return hasItems && hasQuantity;
 };
 
 export const selectPrescriptionPatient = ({ prescription }) => {
-  const { transaction = {} } = prescription;
-  const { otherParty } = transaction;
+  const { transaction } = prescription;
+  const { otherParty } = transaction || {};
 
   return otherParty;
 };
 
 export const selectPrescriptionPrescriber = ({ prescription }) => {
-  const { transaction = {} } = prescription;
-  const { prescriber } = transaction;
+  const { transaction } = prescription;
+  const { prescriber } = transaction || {};
 
   return prescriber;
 };
@@ -71,7 +71,7 @@ export const selectFilteredAndSortedItems = createSelector(
 
 export const selectSelectedRows = ({ prescription }) => {
   const { transaction } = prescription;
-  const { items } = transaction;
+  const { items = [] } = transaction || {};
 
   return items.reduce((acc, { item }) => ({ ...acc, [item.id]: true }), {});
 };
@@ -85,14 +85,14 @@ export const selectTransactionCategoryName = ({ prescription }) => {
 
 export const selectTransactionComment = ({ prescription }) => {
   const { transaction } = prescription;
-  const { comment } = transaction;
-  return comment;
+  const { comment } = transaction || {};
+  return comment ?? '';
 };
 
 export const selectPatientType = ({ prescription }) => {
   const { transaction } = prescription;
-  const { user1 } = transaction;
-  return user1 || '';
+  const { user1 } = transaction || {};
+  return user1 ?? '';
 };
 
 export const selectPrescriptionCategories = () =>

--- a/src/utilities/underscoreMethods.js
+++ b/src/utilities/underscoreMethods.js
@@ -14,7 +14,8 @@ export function debounce(func, wait, immediate) {
 
     const later = () => {
       timeout = null;
-      if (!immediate) func.apply(context, args);
+      if (!immediate) return func.apply(context, args);
+      return null;
     };
 
     const callNow = immediate && !timeout;
@@ -23,6 +24,8 @@ export function debounce(func, wait, immediate) {
 
     timeout = setTimeout(later, wait);
 
-    if (callNow) func.apply(context, args);
+    if (callNow) return func.apply(context, args);
+
+    return timeout;
   };
 }

--- a/src/widgets/PrescriptionCart.js
+++ b/src/widgets/PrescriptionCart.js
@@ -77,8 +77,8 @@ const localStyles = StyleSheet.create({
 
 const mapStateToProps = state => {
   const { prescription } = state;
-  const { transaction } = prescription;
-  return { items: transaction.items };
+  const { transaction } = prescription || {};
+  return { items: transaction?.items ?? [] };
 };
 
 export const PrescriptionCart = connect(mapStateToProps)(PrescriptionCartComponent);

--- a/src/widgets/PrescriptionSummary.js
+++ b/src/widgets/PrescriptionSummary.js
@@ -23,7 +23,7 @@ export const PrescriptionSummary = ({ transaction }) => (
   <View style={localStyles.containerStyle}>
     <Text style={localStyles.titleStyle}>Item Details</Text>
     <FlatList
-      data={transaction.items}
+      data={transaction?.items ?? []}
       ItemSeparatorComponent={Separator}
       renderItem={PrescriptionSummaryRow}
     />

--- a/src/widgets/Tabs/ItemSelect.js
+++ b/src/widgets/Tabs/ItemSelect.js
@@ -50,6 +50,7 @@ const ItemSelectComponent = ({
   filterItems,
   items,
   selectedRows,
+  onDelete,
 }) => {
   const columns = React.useMemo(() => getColumns('itemSelect'), []);
 
@@ -70,12 +71,10 @@ const ItemSelectComponent = ({
         <FlexColumn flex={15}>
           <PrescriptionCart isDisabled={isComplete} />
 
-          <PageButton
-            isDisabled={!canProceed}
-            text="Next"
-            onPress={nextTab}
-            style={{ alignSelf: 'flex-end' }}
-          />
+          <FlexRow justifyContent="flex-end">
+            <PageButton text="Cancel" onPress={onDelete} />
+            <PageButton isDisabled={!canProceed} text="Next" onPress={nextTab} />
+          </FlexRow>
         </FlexColumn>
       </FlexRow>
     </>
@@ -87,13 +86,13 @@ const mapDispatchToProps = dispatch => {
   const nextTab = () => dispatch(WizardActions.nextTab());
   const updateQuantity = (id, quantity) => dispatch(PrescriptionActions.editQuantity(id, quantity));
   const filterItems = searchTerm => dispatch(PrescriptionActions.filter(searchTerm));
-  return { filterItems, nextTab, chooseItem, updateQuantity };
+  const onDelete = () => dispatch(PrescriptionActions.cancelPrescription());
+  return { onDelete, filterItems, nextTab, chooseItem, updateQuantity };
 };
 
 const mapStateToProps = state => {
   const { wizard } = state;
   const { isComplete } = wizard;
-
   const itemSearchTerm = selectItemSearchTerm(state);
   const items = selectFilteredAndSortedItems(state);
   const selectedRows = selectSelectedRows(state);
@@ -111,6 +110,7 @@ ItemSelectComponent.propTypes = {
   filterItems: PropTypes.func.isRequired,
   items: PropTypes.array.isRequired,
   selectedRows: PropTypes.object.isRequired,
+  onDelete: PropTypes.func.isRequired,
 };
 
 export const ItemSelect = connect(mapStateToProps, mapDispatchToProps)(ItemSelectComponent);

--- a/src/widgets/Tabs/PrescriberSelect.js
+++ b/src/widgets/Tabs/PrescriberSelect.js
@@ -12,9 +12,11 @@ import { connect } from 'react-redux';
 import { SearchBar } from '../SearchBar';
 import { PageButton } from '../PageButton';
 import { FlexRow } from '../FlexRow';
+import { FlexView } from '../FlexView';
 import { PrescriptionInfo } from '../PrescriptionInfo';
 import { DataTable, DataTableRow, DataTableHeaderRow } from '../DataTable';
 
+import { selectPrescriptionPrescriber } from '../../selectors/prescription';
 import { debounce } from '../../utilities';
 import { PrescriberActions } from '../../actions/PrescriberActions';
 import { PrescriptionActions } from '../../actions/PrescriptionActions';
@@ -36,6 +38,7 @@ import { selectSortedAndFilteredPrescribers } from '../../selectors/prescriber';
  */
 const PrescriberSelectComponent = ({
   choosePrescriber,
+  onCancelPrescription,
   prescribers,
   onFilterData,
   onSortData,
@@ -44,6 +47,7 @@ const PrescriberSelectComponent = ({
   isAscending,
   createPrescriber,
   isComplete,
+  currentPrescriber,
 }) => {
   const columns = React.useMemo(() => getColumns('prescriberSelect'), []);
 
@@ -78,7 +82,7 @@ const PrescriberSelectComponent = ({
   );
 
   return (
-    <>
+    <FlexView>
       <PrescriptionInfo />
       <FlexRow>
         <SearchBar
@@ -88,6 +92,7 @@ const PrescriberSelectComponent = ({
         />
         <PageButton text="Add Prescriber" onPress={createPrescriber} />
       </FlexRow>
+
       <DataTable
         data={prescribers}
         renderRow={renderRow}
@@ -95,7 +100,16 @@ const PrescriberSelectComponent = ({
         keyExtractor={item => item.id}
         getItemLayout={getItemLayout}
       />
-    </>
+
+      <FlexRow justifyContent="flex-end" alignItems="flex-end">
+        <PageButton text="Cancel" onPress={() => onCancelPrescription()} />
+        <PageButton
+          text="OK"
+          onPress={() => choosePrescriber(currentPrescriber)}
+          isDisabled={!currentPrescriber}
+        />
+      </FlexRow>
+    </FlexView>
   );
 };
 
@@ -118,8 +132,9 @@ const mapDispatchToProps = dispatch => {
   const onFilterData = searchTerm => dispatch(PrescriberActions.filterData(searchTerm));
   const onSortData = sortKey => dispatch(PrescriberActions.sortData(sortKey));
   const createPrescriber = () => dispatch(PrescriberActions.createPrescriber());
+  const onCancelPrescription = () => dispatch(PrescriptionActions.cancelPrescription());
 
-  return { onSortData, choosePrescriber, onFilterData, createPrescriber };
+  return { onSortData, onCancelPrescription, choosePrescriber, onFilterData, createPrescriber };
 };
 
 const mapStateToProps = state => {
@@ -127,9 +142,10 @@ const mapStateToProps = state => {
   const { searchTerm, sortKey, isAscending } = prescriber;
   const { isComplete } = wizard;
 
+  const currentPrescriber = selectPrescriptionPrescriber(state);
   const prescribers = selectSortedAndFilteredPrescribers(state);
 
-  return { prescribers, searchTerm, isComplete, sortKey, isAscending };
+  return { prescribers, searchTerm, isComplete, sortKey, isAscending, currentPrescriber };
 };
 
 PrescriberSelectComponent.defaultProps = {
@@ -147,6 +163,8 @@ PrescriberSelectComponent.propTypes = {
   onSortData: PropTypes.func.isRequired,
   sortKey: PropTypes.string.isRequired,
   isAscending: PropTypes.bool.isRequired,
+  onCancelPrescription: PropTypes.func.isRequired,
+  currentPrescriber: PropTypes.func.isRequired,
 };
 
 export const PrescriberSelect = connect(

--- a/src/widgets/Tabs/PrescriptionConfirmation.js
+++ b/src/widgets/Tabs/PrescriptionConfirmation.js
@@ -24,6 +24,7 @@ import { PrescriptionExtra } from '../PrescriptionExtra';
 import { FlexColumn } from '../FlexColumn';
 
 import { useLoadingIndicator } from '../../hooks/useLoadingIndicator';
+import { PrescriptionActions } from '../../actions/PrescriptionActions';
 
 const mapStateToProps = state => {
   const { payment, wizard, modules } = state;
@@ -40,7 +41,8 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   const openFinaliseModal = () => dispatch(FinaliseActions.openModal());
-  return { openFinaliseModal };
+  const onDelete = () => dispatch(PrescriptionActions.cancelPrescription());
+  return { onDelete, openFinaliseModal };
 };
 
 const PrescriptionConfirmationComponent = ({
@@ -50,6 +52,7 @@ const PrescriptionConfirmationComponent = ({
   paymentAmount,
   canConfirm,
   usingPayments,
+  onDelete,
 }) => {
   const runWithLoadingIndicator = useLoadingIndicator();
 
@@ -74,12 +77,10 @@ const PrescriptionConfirmationComponent = ({
         <FlexColumn flex={1}>
           {usingPayments && <PaymentSummary />}
 
-          <PageButton
-            style={{ alignSelf: 'flex-end' }}
-            isDisabled={!canConfirm}
-            text="Complete"
-            onPress={confirmPrescription}
-          />
+          <FlexRow justifyContent="flex-end">
+            <PageButton text="Cancel" onPress={onDelete} />
+            <PageButton isDisabled={!canConfirm} text="Complete" onPress={confirmPrescription} />
+          </FlexRow>
         </FlexColumn>
       </FlexRow>
     </FlexView>
@@ -93,6 +94,7 @@ PrescriptionConfirmationComponent.propTypes = {
   paymentAmount: PropTypes.object.isRequired,
   canConfirm: PropTypes.bool.isRequired,
   usingPayments: PropTypes.bool.isRequired,
+  onDelete: PropTypes.func.isRequired,
 };
 
 export const PrescriptionConfirmation = connect(


### PR DESCRIPTION
## BRANCHED FROM #2046 

Fixes #2050  

## Change summary

- Adds a delete prescription action and defensive code against possible re-renders without a `Transaction` in state
- Added code which will delete the prescription when 1) new cancel button is clicked 2) hardware back button is pressed 3) navigation bar back button is pressed 4) navigating to the dispensary page or Customer invoices page

## Testing

N/A

### Related areas to think about

N/A
