### PR TITLE
Fix outgoing sync for payment and receipt transactions

### DIFF
--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -173,6 +173,8 @@ const generateSyncData = (settings, recordType, record) => {
       };
     }
     case 'Transaction': {
+      const isCashReconciliation = record.type === 'payment' || record.type === 'receipt';
+      const total = String(isCashReconciliation ? record.total : record.totalPrice);
       return {
         ID: record.id,
         name_ID: record.otherParty && record.otherParty.id,
@@ -183,11 +185,11 @@ const generateSyncData = (settings, recordType, record) => {
         status: STATUSES.translate(record.status, INTERNAL_TO_EXTERNAL),
         mode: record.mode,
         prescriber_ID: record.prescriber && record.prescriber.id,
-        total: String(record.totalPrice),
-        foreign_currency_total: String(record.totalPrice),
+        total,
+        foreign_currency_total: total,
         their_ref: record.theirRef,
         confirm_date: getDateString(record.confirmDate),
-        subtotal: String(record.totalPrice),
+        subtotal: total,
         user_ID: record.enteredBy && record.enteredBy.id,
         category_ID: record.category && record.category.id,
         confirm_time: getTimeString(record.confirmDate),


### PR DESCRIPTION
Fixes #2063.

## Change summary

Updated outgoing sync to correctly handle totals for  `payment` and `receipt` transactions (i.e. cash transactions with no associated `TransactionItem` or `TransactionBatch` records).

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a cash in transaction for a non-zero amount via the mobile cash register. Sync and open the transaction in the desktop cash register. The amount should be equal to that entered previously.
- [ ] Create a cash out transaction for a non-zero amount via the mobile cash register. Sync and open the transaction in the desktop cash register. The amount should be equal to that entered previously.

### Related areas to think about

N/A.