### PR TITLE
Remove finalised column from cash register page

### DIFF
--- a/src/pages/dataTableUtilities/constants.js
+++ b/src/pages/dataTableUtilities/constants.js
@@ -101,6 +101,7 @@ export const COLUMN_NAMES = {
   OUR_STOCK_ON_HAND: 'ourStockOnHand',
   PATIENT_EDIT: 'patientEdit',
   PATIENT_HISTORY: 'patientHistory',
+  PAYMENT_NAME: 'name',
   PRESCRIBER_EDIT: 'prescriberEdit',
   PRESCRIBER: 'prescriber',
   PRICE: 'price',

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -36,7 +36,7 @@ const PAGE_COLUMN_WIDTHS = {
   prescriberSelect: [3, 3, 1],
   itemSelect: [1, 3, 1],
   patientHistory: [1, 3, 1, 3],
-  [ROUTES.CASH_REGISTER]: [1, 1, 1, 1, 1, 1, 1],
+  [ROUTES.CASH_REGISTER]: [1, 2, 1, 1, 1, 1, 1],
   supplierCredit: [1, 1, 1, 1],
 };
 

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -36,7 +36,7 @@ const PAGE_COLUMN_WIDTHS = {
   prescriberSelect: [3, 3, 1],
   itemSelect: [1, 3, 1],
   patientHistory: [1, 3, 1, 3],
-  [ROUTES.CASH_REGISTER]: [1, 1, 1, 1, 1, 1, 1, 1],
+  [ROUTES.CASH_REGISTER]: [1, 1, 1, 1, 1, 1, 1],
   supplierCredit: [1, 1, 1, 1],
 };
 
@@ -239,7 +239,6 @@ const PAGE_COLUMNS = {
     COLUMN_NAMES.COMMENT,
     COLUMN_NAMES.TOTAL,
     COLUMN_NAMES.CONFIRM_DATE,
-    COLUMN_NAMES.STATUS,
   ],
 };
 

--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -52,7 +52,7 @@ const PER_PAGE_INFO_COLUMNS = {
     ['customer', 'transactionComment', 'prescriber'],
   ],
   [ROUTES.CASH_REGISTER]: [
-    ['number', 'name', 'type', 'reason', 'comment', 'amount', 'confirmDate', 'status'],
+    ['number', 'name', 'type', 'reason', 'comment', 'amount', 'confirmDate'],
   ],
   stocktakeBatchEditModal: [['itemName']],
   stocktakeBatchEditModalWithReasons: [['itemName']],


### PR DESCRIPTION
Fixes #2047.

## Change summary

Removes redundant cash register `"status"` column.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] The cash register page does not display transaction finalisation status.

### Related areas to think about

N/A.
