### PR TITLE
#2099 Store insurance details

### DIFF
--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -479,6 +479,8 @@ Transaction.schema = {
     option: { type: 'Options', optional: true },
     linkedTransaction: { type: 'Transaction', optional: true },
     user1: { type: 'string', optional: true },
+    insuranceDiscountRate: { type: 'double', optional: true },
+    insuranceDiscountAmount: { type: 'double', optional: true },
   },
 };
 

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -203,6 +203,9 @@ const generateSyncData = (settings, recordType, record) => {
           record.linkedRequisition && record.linkedRequisition.id
             ? record.linkedRequisition.id
             : undefined,
+        nameInsuranceJoinID: record?.insurancePolicy?.id,
+        insuranceDiscountAmount: String(record?.insuranceDiscountAmount),
+        insuranceDiscountRate: String(record?.insuranceDiscountRate),
       };
     }
     case 'TransactionBatch': {

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -36,7 +36,16 @@ import { UIDatabase } from '../../../database';
  * @param {Number} scriptTotal The total amount of the script.
  */
 
-export const pay = (currentUser, patient, script, cashAmount, scriptTotal) => {
+export const pay = (
+  currentUser,
+  patient,
+  script,
+  cashAmount,
+  scriptTotal,
+  subtotal,
+  discountAmount,
+  discountRate
+) => {
   if (!patient.isPatient) throw new Error('Patient is not a patient');
   if (!script.isPrescription) throw new Error('Script is not a script');
   if (!(script.items.length > 0)) throw new Error('Script is empty');
@@ -80,5 +89,9 @@ export const pay = (currentUser, patient, script, cashAmount, scriptTotal) => {
   if (usingCredit && creditToAllocate > 0) throw new Error('Credit not fully allocated');
 
   // Ensure the script is finalised once paid.
+  script.subtotal = subtotal;
+  script.total = subtotal;
+  script.insuranceDiscountAmount = discountAmount;
+  script.insuranceDiscountRate = discountRate;
   script.finalise(UIDatabase);
 };

--- a/src/widgets/DetailRow.js
+++ b/src/widgets/DetailRow.js
@@ -9,6 +9,7 @@ import { View } from 'react-native';
 import PropTypes from 'prop-types';
 
 import { SimpleLabel } from './SimpleLabel';
+import { FlexView } from './FlexView';
 
 /**
  * Simple layout component render sequential SimpleLabel components
@@ -22,9 +23,9 @@ export const DetailRow = ({ details }) => {
   const Details = React.useCallback(
     () =>
       details.map(({ label, text }) => (
-        <View key={label} style={{ flex: 1 }}>
+        <FlexView key={`${label}${text}`} flex={1}>
           <SimpleLabel label={label} size="small" text={text} />
-        </View>
+        </FlexView>
       )),
     [details]
   );

--- a/src/widgets/Tabs/PrescriberSelect.js
+++ b/src/widgets/Tabs/PrescriberSelect.js
@@ -153,6 +153,7 @@ const mapStateToProps = state => {
 PrescriberSelectComponent.defaultProps = {
   searchTerm: '',
   isComplete: false,
+  currentPrescriber: null,
 };
 
 PrescriberSelectComponent.propTypes = {
@@ -166,7 +167,7 @@ PrescriberSelectComponent.propTypes = {
   sortKey: PropTypes.string.isRequired,
   isAscending: PropTypes.bool.isRequired,
   onCancelPrescription: PropTypes.func.isRequired,
-  currentPrescriber: PropTypes.func.isRequired,
+  currentPrescriber: PropTypes.func,
 };
 
 export const PrescriberSelect = connect(

--- a/src/widgets/Tabs/PrescriberSelect.js
+++ b/src/widgets/Tabs/PrescriberSelect.js
@@ -167,7 +167,7 @@ PrescriberSelectComponent.propTypes = {
   sortKey: PropTypes.string.isRequired,
   isAscending: PropTypes.bool.isRequired,
   onCancelPrescription: PropTypes.func.isRequired,
-  currentPrescriber: PropTypes.func,
+  currentPrescriber: PropTypes.object,
 };
 
 export const PrescriberSelect = connect(


### PR DESCRIPTION
Fixes #2099 

## Change summary

- Correctly assigns insurance details to a finalise prescription. I've made #2104 to refactor this code to be less weird/horrible as the amount of parameters is very msupplyesque but it works so going with it for now
- Added insurance stuff to outgoing sync including the historic insurance details
- Fixed a couple of prop type and key warnings

Basically, this makes syncing prescriptions with insurance correct

I.e. I can now get this in desktop after syncing a prescription with a payment of $10, with 25% insurance 🎉 

<img width="963" alt="image" src="https://user-images.githubusercontent.com/35858975/73616285-69014e80-4676-11ea-9eda-31197c24c745.png">


## Testing

N/A

### Related areas to think about

N/A
