### PR TITLE
#2112 list all batches not items

### DIFF
--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -114,12 +114,19 @@ class MSupplyMobileAppContainer extends React.Component {
 
   componentDidMount = () => {
     BackHandler.addEventListener('hardwareBackPress', this.handleBackEvent);
-    AppState.addEventListener('change', this.onAppStateChange);
+
+    if (!__DEV__) {
+      AppState.addEventListener('change', this.onAppStateChange);
+    }
   };
 
   componentWillUnmount = () => {
     BackHandler.removeEventListener('hardwareBackPress', this.handleBackEvent);
-    AppState.removeEventListener('change', this.onAppStateChange);
+
+    if (!__DEV__) {
+      AppState.removeEventListener('change', this.onAppStateChange);
+    }
+
     this.scheduler.clearAll();
   };
 

--- a/src/selectors/payment.js
+++ b/src/selectors/payment.js
@@ -4,14 +4,12 @@
  */
 
 import currency from '../localization/currency';
+import { UIDatabase } from '../database';
 
 export const selectPrescriptionSubTotal = ({ payment }) => {
   const { transaction } = payment;
-  const { items = [] } = transaction || {};
-  const total = items.reduce(
-    (acc, { totalPrice }) => currency(totalPrice || 0).add(acc),
-    currency(0)
-  );
+  const batches = transaction?.getTransactionBatches(UIDatabase) || [];
+  const total = batches.reduce((acc, { totalPrice }) => acc.add(totalPrice), currency(0));
   return total;
 };
 

--- a/src/widgets/PrescriptionSummary.js
+++ b/src/widgets/PrescriptionSummary.js
@@ -8,9 +8,12 @@ import React from 'react';
 import { View, Text, StyleSheet, FlatList } from 'react-native';
 import PropTypes from 'prop-types';
 
+import { UIDatabase } from '../database';
+
 import { Separator } from './Separator';
 import { PrescriptionSummaryRow } from './PrescriptionSummaryRow';
 
+import { recordKeyExtractor } from '../pages/dataTableUtilities';
 import { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../globalStyles';
 
 /**
@@ -23,9 +26,10 @@ export const PrescriptionSummary = ({ transaction }) => (
   <View style={localStyles.containerStyle}>
     <Text style={localStyles.titleStyle}>Item Details</Text>
     <FlatList
-      data={transaction?.items ?? []}
+      data={transaction?.getTransactionBatches(UIDatabase) ?? []}
       ItemSeparatorComponent={Separator}
       renderItem={PrescriptionSummaryRow}
+      keyExtractor={recordKeyExtractor}
     />
   </View>
 );

--- a/src/widgets/PrescriptionSummaryRow.js
+++ b/src/widgets/PrescriptionSummaryRow.js
@@ -13,6 +13,7 @@ import { SimpleLabel } from './SimpleLabel';
 import { TouchableNoFeedback } from './DataTable';
 
 import { dispensingStrings } from '../localization';
+import currency from '../localization/currency';
 
 /**
  * Simple layout component for primary use within the PrescriptionSummary
@@ -24,7 +25,7 @@ import { dispensingStrings } from '../localization';
  * @param {Object} item A TransactionItem record to display details for.
  */
 export const PrescriptionSummaryRow = ({ item }) => {
-  const { itemName, itemCode, totalQuantity, note } = item;
+  const { itemName, itemCode, totalQuantity, note, totalPrice } = item;
 
   const details = [{ label: 'Code', text: itemCode }];
 
@@ -35,6 +36,8 @@ export const PrescriptionSummaryRow = ({ item }) => {
       <DetailRow details={details} />
       <View style={localStyles.marginFive} />
       <SimpleLabel label={dispensingStrings.directions} text={note} />
+      <View style={localStyles.marginFive} />
+      <SimpleLabel label="Price" text={currency(totalPrice).format()} />
     </TouchableNoFeedback>
   );
 };


### PR DESCRIPTION
Fixes #2112 

## Change summary

- In the summary, display all batches and the total cost for that batch, rather than just an item by itself, for cases where you need to dispense over multiple batches

## Testing

N/A

### Related areas to think about

N/A
