### PR TITLE
#2062 cash in cash out totals incorrect

### DIFF
--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -450,6 +450,7 @@ export class Transaction extends Realm.Object {
     if (!this.isConfirmed) this.confirm(database);
 
     this.status = 'finalised';
+    this.total = this.totalPrice;
     database.save('Transaction', this);
   }
 }

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -120,6 +120,10 @@ export class Transaction extends Realm.Object {
     return this.type === 'payment' || this.type === 'receipt';
   }
 
+  get isCredit() {
+    return this.type === 'supplier_credit' || this.type === 'customer_credit';
+  }
+
   /**
    * Get if transaction is an external supplier invoice.
    *
@@ -454,9 +458,9 @@ export class Transaction extends Realm.Object {
     if (!this.isConfirmed) this.confirm(database);
 
     // Finding the totalPrice propogates through `TransactionItem` records down to the batch
-    // level, deriving the full cost of the Transaction. Cash transactions do not use the Item
-    // level, so the total can't be derived the same.
-    if (!this.isCashTransaction) {
+    // level, deriving the full cost of the Transaction. Cash transactions and credits are
+    // created finalised, having their total already set.
+    if (!this.isCashTransaction || !this.isCredit) {
       this.total = this.totalPrice;
     }
 

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -460,7 +460,7 @@ export class Transaction extends Realm.Object {
     // Finding the totalPrice propogates through `TransactionItem` records down to the batch
     // level, deriving the full cost of the Transaction. Cash transactions and credits are
     // created finalised, having their total already set.
-    if (!this.isCashTransaction || !this.isCredit) {
+    if (!(this.isCashTransaction || this.isCredit)) {
       this.total = this.totalPrice;
     }
 

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -175,9 +175,6 @@ const generateSyncData = (settings, recordType, record) => {
       };
     }
     case 'Transaction': {
-      const isCashReconciliation = record.type === 'payment' || record.type === 'receipt';
-      const total = String(isCashReconciliation ? record.total : record.totalPrice);
-
       return {
         ID: record.id,
         name_ID: record.otherParty && record.otherParty.id,
@@ -188,21 +185,18 @@ const generateSyncData = (settings, recordType, record) => {
         status: STATUSES.translate(record.status, INTERNAL_TO_EXTERNAL),
         mode: record.mode,
         prescriber_ID: record.prescriber && record.prescriber.id,
-        total,
-        foreign_currency_total: total,
+        total: String(record.total),
+        foreign_currency_total: String(record.total),
         their_ref: record.theirRef,
         confirm_date: getDateString(record.confirmDate),
-        subtotal: total,
+        subtotal: String(record.total),
         user_ID: record.enteredBy && record.enteredBy.id,
         category_ID: record.category && record.category.id,
         confirm_time: getTimeString(record.confirmDate),
         store_ID: settings.get(THIS_STORE_ID),
         linked_transaction_id: record.linkedTransaction?.id ?? '',
         user1: record.user1,
-        requisition_ID:
-          record.linkedRequisition && record.linkedRequisition.id
-            ? record.linkedRequisition.id
-            : undefined,
+        requisition_ID: record.linkedRequisition?.id ?? '',
         nameInsuranceJoinID: record?.insurancePolicy?.id,
         insuranceDiscountAmount: String(record?.insuranceDiscountAmount),
         insuranceDiscountRate: String(record?.insuranceDiscountRate),


### PR DESCRIPTION
Fixes #2062 

## Change summary

- Save the transaction total amount on a Transaction rather than trying to use the derived value for anything other than a `ps` or `rc`, 'sc', 'cc' when finalising. Avoiding regressions by keeping the same behaviour for the existing types. The only problem is for the `ci` created for a cash out which would technically get through and have it's `total` reset, but the finalise method isn't used for that type. I don't think that's a good enough reason, so I think this still needs some thinking - it is working for now though.. :(
- Can then use `total` field in `outgoingSync` for all cases.
- Using `total` field in all cases fixes this for the `cc` and `ci`

## Testing

N/A

### Related areas to think about

- There's probably so more nicer cleanup to do here. I think using a different method to determine the total for cash transactions would be nice? I.e. if no `Item`, try see if there are any `batch` or something like that.
