### PR TITLE
#2134 align total subtotal with desktop

### DIFF
--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -57,6 +57,10 @@ export class Transaction extends Realm.Object {
     database.delete('TransactionItem', this.items);
   }
 
+  get total() {
+    return this.subtotal - this.insuranceDiscountAmount;
+  }
+
   /**
    * Get if transaction is finalised.
    *
@@ -461,7 +465,7 @@ export class Transaction extends Realm.Object {
     // level, deriving the full cost of the Transaction. Cash transactions and credits are
     // created finalised, having their total already set.
     if (!(this.isCashTransaction || this.isCredit)) {
-      this.total = this.totalPrice;
+      this.subtotal = this.totalPrice;
     }
 
     this.status = 'finalised';
@@ -488,7 +492,7 @@ Transaction.schema = {
     mode: { type: 'string', default: 'store' },
     prescriber: { type: 'Prescriber', optional: true },
     linkedRequisition: { type: 'Requisition', optional: true },
-    total: { type: 'float', optional: true },
+    subtotal: { type: 'float', optional: true },
     outstanding: { type: 'float', optional: true },
     insurancePolicy: { type: 'InsurancePolicy', optional: true },
     option: { type: 'Options', optional: true },

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -181,7 +181,7 @@ const createOffsetCustomerInvoice = (database, user, name, amount) => {
     status: 'finalised',
     comment: 'Offset for a cash-only transaction',
     otherParty: name,
-    total: amount,
+    subtotal: amount,
     outstanding: amount,
     enteredBy: user,
   });
@@ -202,7 +202,7 @@ const createReceipt = (database, user, name, amount, description) => {
     comment: description,
     otherParty: name,
     enteredBy: user,
-    total: amount,
+    subtotal: amount,
   });
 
   database.save('Transaction', receipt);
@@ -234,7 +234,7 @@ const createPayment = (database, user, name, amount, reason, description) => {
     status: 'finalised',
     otherParty: name,
     enteredBy: user,
-    total: amount,
+    subtotal: amount,
     option: reason,
     comment: description,
   });
@@ -293,7 +293,7 @@ const createSupplierCredit = (database, user, supplierId, returnAmount) => {
     status: 'finalised',
     comment: '',
     otherParty: database.get('Name', supplierId),
-    total: returnAmount,
+    subtotal: returnAmount,
     enteredBy: user,
   });
 
@@ -317,7 +317,7 @@ const createCustomerCredit = (database, user, name, amount) => {
     comment: 'Offset for a cash-only transaction',
     otherParty: name,
     enteredBy: user,
-    total: creditAmount,
+    subtotal: creditAmount,
     outstanding: creditAmount,
   });
 

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -742,7 +742,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         otherParty,
         linkedRequisition,
         option: database.getOrCreate('Options', record.optionID),
-        total: parseFloat(record.total),
+        subtotal: parseFloat(record.subtotal),
         user1: record.user1,
       };
       const transaction = database.update(recordType, internalRecord);

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -189,7 +189,7 @@ const generateSyncData = (settings, recordType, record) => {
         foreign_currency_total: String(record.total),
         their_ref: record.theirRef,
         confirm_date: getDateString(record.confirmDate),
-        subtotal: String(record.total),
+        subtotal: String(record.subtotal),
         user_ID: record.enteredBy && record.enteredBy.id,
         category_ID: record.category && record.category.id,
         confirm_time: getTimeString(record.confirmDate),

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -90,7 +90,6 @@ export const pay = (
 
   // Ensure the script is finalised once paid.
   script.subtotal = subtotal;
-  script.total = subtotal;
   script.insuranceDiscountAmount = discountAmount;
   script.insuranceDiscountRate = discountRate;
   script.finalise(UIDatabase);


### PR DESCRIPTION
Fixes #2134

## Change summary

Aligning with desktop here in the wiki: https://wiki.sussol.net/doku.php/msupply:specifications:customers:receipts_payments where `subtotal` is the real subtotal and `total` is the subtotal less tax and discounts. Since we only use insurance discount and no tax in mobile, the total is really just `subtotal - insuranceDiscountAmount`. Saving both `subtotal` and `total` and `insuranceDiscountAmount` is overkill - so decided to go with just `subtotal`. I think removing `insuranceDiscountAmount` is probably a good idea also. `insuranceDiscountRate` is also not needed - but "keeping for now".. (My new motto ? :( )

- Renamed `Transaction.total` -> `Transaction.subtotal`
- Added a `total` getter calculating the new total value

## Testing

N/A

### Related areas to think about

N/A
