### PR TITLE
change prescriptioncategory from string to object

### DIFF
--- a/src/selectors/prescription.js
+++ b/src/selectors/prescription.js
@@ -103,8 +103,7 @@ export const selectPatientType = ({ prescription }) => {
   return user1 ?? '';
 };
 
-export const selectPrescriptionCategories = () =>
-  UIDatabase.objects('PrescriptionCategory').map(({ name }) => name);
+export const selectPrescriptionCategories = () => UIDatabase.objects('PrescriptionCategory');
 
 export const selectSelectedRows = createSelector(
   [selectPrescriptionItems, selectNumberOfItems],

--- a/src/widgets/PrescriptionExtra.js
+++ b/src/widgets/PrescriptionExtra.js
@@ -40,9 +40,13 @@ const PrescriptionExtraComponent = ({
   usingPatientTypes,
   usingPrescriptionCategories,
 }) => {
-  const onCategorySelection = React.useCallback(
-    (_, index) => onUpdateCategory(prescriptionCategories[index]),
-    []
+  const onCategorySelection = React.useCallback((_, index) => {
+    onUpdateCategory(prescriptionCategories[index]);
+  }, []);
+
+  const prescriptionCategoryNames = React.useMemo(
+    () => prescriptionCategories.map(({ name }) => name),
+    [prescriptionCategories]
   );
 
   const pageInfoColumns = React.useMemo(
@@ -70,7 +74,7 @@ const PrescriptionExtraComponent = ({
       )}
       {usingPrescriptionCategories && (
         <DropDown
-          values={prescriptionCategories}
+          values={prescriptionCategoryNames}
           selectedValue={categoryName}
           onValueChange={onCategorySelection}
         />
@@ -98,7 +102,7 @@ PrescriptionExtraComponent.propTypes = {
   comment: PropTypes.string.isRequired,
   categoryName: PropTypes.string.isRequired,
   patientType: PropTypes.string.isRequired,
-  prescriptionCategories: PropTypes.array.isRequired,
+  prescriptionCategories: PropTypes.object.isRequired,
   usingPatientTypes: PropTypes.bool.isRequired,
   usingPrescriptionCategories: PropTypes.bool.isRequired,
 };


### PR DESCRIPTION
Fixes #2138

## Change summary

Changed from saving a string to the `transactionCategory` to an object

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Reach the confirmation screen of a prescription and select a transaction category

