### PR TITLE
#2164 cancelling throws

### DIFF
--- a/src/widgets/PageButton.js
+++ b/src/widgets/PageButton.js
@@ -9,11 +9,18 @@ import PropTypes from 'prop-types';
 import { StyleSheet, Text, ViewPropTypes } from 'react-native';
 import { Button } from 'react-native-ui-components';
 
+import { debounce } from '../utilities';
+
 import globalStyles from '../globalStyles';
 
 // A generic button for use on pages
 export function PageButtonComponent(props) {
-  const { style, textStyle, isDisabled, ...buttonProps } = props;
+  const { style, textStyle, isDisabled, debounceTimer, onPress, ...buttonProps } = props;
+
+  const callback = React.useCallback(debounce(onPress, debounceTimer, true), [
+    onPress,
+    debounceTimer,
+  ]);
 
   const defaultButtonStyle = [globalStyles.button];
   if (isDisabled) defaultButtonStyle.push(globalStyles.disabledButton);
@@ -23,6 +30,7 @@ export function PageButtonComponent(props) {
     <Button
       isDisabled={isDisabled}
       style={[...defaultButtonStyle, localStyles.button, style]}
+      onPress={callback}
       textStyle={[...defaultTextStyle, textStyle]}
       {...buttonProps}
     />
@@ -49,6 +57,7 @@ PageButtonComponent.propTypes = {
   onPress: PropTypes.func,
   text: PropTypes.string,
   isDisabled: PropTypes.bool,
+  debounceTimer: PropTypes.number,
 };
 
 const localStyles = StyleSheet.create({

--- a/src/widgets/PageButtonWithOnePress.js
+++ b/src/widgets/PageButtonWithOnePress.js
@@ -1,0 +1,9 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+import { withOnePress } from './withOnePress';
+import { PageButton } from './PageButton';
+
+export const PageButtonWithOnePress = withOnePress(PageButton);

--- a/src/widgets/Tabs/ItemSelect.js
+++ b/src/widgets/Tabs/ItemSelect.js
@@ -32,6 +32,7 @@ import { SearchBar } from '../SearchBar';
 
 import { dispensingStrings, generalStrings } from '../../localization';
 import globalStyles from '../../globalStyles';
+import { PageButtonWithOnePress } from '../PageButtonWithOnePress';
 
 const { pageTopViewContainer } = globalStyles;
 
@@ -88,8 +89,12 @@ const ItemSelectComponent = ({
           <PrescriptionCart isDisabled={isComplete} />
 
           <FlexRow justifyContent="flex-end">
-            <PageButton text="Cancel" onPress={onDelete} style={{ marginRight: 7 }} />
-            <PageButton text="Next" onPress={canProceed ? nextTab : showToast} />
+            <PageButtonWithOnePress text="Cancel" onPress={onDelete} style={{ marginRight: 7 }} />
+            <PageButton
+              debounceTimer={1000}
+              text="Next"
+              onPress={canProceed ? nextTab : showToast}
+            />
           </FlexRow>
         </FlexColumn>
       </FlexRow>

--- a/src/widgets/Tabs/PrescriberSelect.js
+++ b/src/widgets/Tabs/PrescriberSelect.js
@@ -24,6 +24,7 @@ import { getItemLayout, getColumns } from '../../pages/dataTableUtilities';
 import { selectSortedPrescribers } from '../../selectors/prescriber';
 import { dispensingStrings } from '../../localization';
 import globalStyles from '../../globalStyles';
+import { PageButtonWithOnePress } from '../PageButtonWithOnePress';
 
 /**
  * Layout component used for a tab within the prescription wizard.
@@ -107,12 +108,13 @@ const PrescriberSelectComponent = ({
       />
 
       <FlexRow justifyContent="flex-end" alignItems="flex-end">
-        <PageButton
+        <PageButtonWithOnePress
           text="Cancel"
           onPress={() => onCancelPrescription()}
           style={{ marginRight: 7 }}
         />
         <PageButton
+          debounceTimer={1000}
           text="OK"
           onPress={() => choosePrescriber(currentPrescriber)}
           isDisabled={!currentPrescriber}

--- a/src/widgets/Tabs/PrescriptionConfirmation.js
+++ b/src/widgets/Tabs/PrescriptionConfirmation.js
@@ -11,7 +11,6 @@ import { connect } from 'react-redux';
 import { PrescriptionSummary } from '../PrescriptionSummary';
 import { PrescriptionInfo } from '../PrescriptionInfo';
 import { FlexView } from '../FlexView';
-import { PageButton } from '../PageButton';
 import { FlexRow } from '../FlexRow';
 
 import { UIDatabase } from '../../database';
@@ -34,6 +33,7 @@ import { selectInsuranceDiscountRate } from '../../selectors/insurance';
 import { selectPrescriptionIsFinalised } from '../../selectors/prescription';
 
 import globalStyles from '../../globalStyles';
+import { PageButtonWithOnePress } from '../PageButtonWithOnePress';
 
 const { pageTopViewContainer } = globalStyles;
 const mapStateToProps = state => {
@@ -121,13 +121,18 @@ const PrescriptionConfirmationComponent = ({
           {usingPayments && <PaymentSummary />}
 
           <FlexRow justifyContent="flex-end">
-            <PageButton
+            <PageButtonWithOnePress
               text="Cancel"
               onPress={onDelete}
               isDisabled={isFinalised}
+              debounceTimer={3000}
               style={{ marginRight: 7 }}
             />
-            <PageButton isDisabled={!canConfirm} text="Complete" onPress={confirmPrescription} />
+            <PageButtonWithOnePress
+              isDisabled={!canConfirm}
+              text="Complete"
+              onPress={confirmPrescription}
+            />
           </FlexRow>
         </FlexColumn>
       </FlexRow>

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -3,41 +3,42 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
+export { BarChart } from './BarChart';
 export { Button, ProgressBar } from 'react-native-ui-components';
 export { DataTablePageView } from './DataTablePageView';
+export { DropDown } from './DropDown';
 export { ExpiryDateInput } from './ExpiryDateInput';
+export { FinaliseButton } from './FinaliseButton';
+export { Flag } from './Flag';
 export { FlexColumn } from './FlexColumn';
 export { FlexRow } from './FlexRow';
 export { FlexView } from './FlexView';
-export { FinaliseButton } from './FinaliseButton';
-export { Flag } from './Flag';
 export { IconCell } from './IconCell';
 export { InfoBadge } from './InfoBadge';
+export { LineChart } from './LineChart';
 export { NavigationBar } from './NavigationBar';
 export { OnePressButton } from './OnePressButton';
 export { PageButton } from './PageButton';
+export { PageButtonWithOnePress } from './PageButtonWithOnePress';
 export { PageInfo } from './PageInfo';
+export { PieChart } from './PieChart';
+export { ReportTable } from './ReportTable';
+export { ResultRow } from './ResultRow';
 export { SearchBar } from './SearchBar';
 export { SimpleTable } from './SimpleTable';
-export { Step } from './Step';
-export { Spinner } from './Spinner';
-export { StepperInput } from './StepperInput';
-export { Stepper } from './Stepper';
 export { Slider } from './Slider';
+export { Spinner } from './Spinner';
+export { Step } from './Step';
+export { Stepper } from './Stepper';
+export { StepperInput } from './StepperInput';
 export { SyncState } from './SyncState';
-export { TabNavigator } from './TabNavigator';
 export { TableShortcut } from './TableShortcuts';
 export { TableShortcuts } from './TableShortcuts';
+export { TabNavigator } from './TabNavigator';
 export { TextInput } from './TextInput';
 export { ToggleBar } from './ToggleBar';
 export { ValidationTextInput } from './ValidationTextInput';
 export { Wizard } from './Wizard';
-export { DropDown } from './DropDown';
-export { ResultRow } from './ResultRow';
-export { BarChart } from './BarChart';
-export { LineChart } from './LineChart';
-export { PieChart } from './PieChart';
-export { ReportTable } from './ReportTable';
 
 export * from './icons';
 


### PR DESCRIPTION
Fixes #2164 

## Change summary

Problem was pressing the button twice+. Can't just debounce, as the component is unmounted and collected, so the debounce functionality doesn't work as there is no reference to the previously invoked debounce, so for the cancel button, you need the one press functionality, which works well. Wouldn't work for the next tab buttons as you can go back to them constantly and the state doesn't reset.


## Testing

N/A

### Related areas to think about

N/A

