### PR TITLE
#2162 fix cash register not filtering reasons

### DIFF
--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -28,6 +28,8 @@ const translateToCoreDatabaseType = type => {
     case 'ExternalSupplier':
     case 'Patient':
       return 'Name';
+    case 'CashTransactionReason':
+      return 'Options';
     case 'RequestRequisition':
     case 'ResponseRequisition':
       return 'Requisition';
@@ -135,6 +137,8 @@ class UIDatabase {
         return results
           .filtered('isVisible == true && id != $0', thisStoreNameId)
           .filtered('isSupplier == true || isCustomer == true || isPatient == true');
+      case 'CashTransactionReason':
+        return results.filtered('type == $0', 'newCashOutTransaction');
       case 'CustomerCredit':
         return results.filtered('type == $0', 'customer_credit');
       case 'Policy':

--- a/src/widgets/modals/CashTransactionModal.js
+++ b/src/widgets/modals/CashTransactionModal.js
@@ -42,7 +42,7 @@ export const CashTransactionModal = ({ onConfirm }) => {
   const [isDescriptionModalOpen, setIsDescriptionModalOpen] = useState(false);
 
   const names = useMemo(() => UIDatabase.objects('CashTransactionName'));
-  const reasons = useMemo(() => UIDatabase.objects('Options'));
+  const reasons = useMemo(() => UIDatabase.objects('CashTransactionReason'));
   const type = useMemo(
     () => (isCashIn ? CASH_TRANSACTION_TYPES.CASH_IN : CASH_TRANSACTION_TYPES.CASH_OUT),
     [isCashIn]

--- a/src/widgets/modals/CashTransactionModal.js
+++ b/src/widgets/modals/CashTransactionModal.js
@@ -60,11 +60,13 @@ export const CashTransactionModal = ({ onConfirm }) => {
     [name, type, amount, reason, description]
   );
 
-  const onChangeText = useMemo(() => text => setDescriptionBuffer(text));
-  const onChangeAmount = useMemo(() => value => setAmountBuffer(value));
+  const onChangeText = useMemo(() => text => setDescriptionBuffer(text), []);
+  const onChangeAmount = useMemo(() => value => setAmountBuffer(value), []);
 
-  const renderNameLeftText = useCallback(({ firstName, lastName, name: fullName, isPatient }) =>
-    isPatient ? `${lastName}, ${firstName}` : `${fullName}`
+  const renderNameLeftText = useCallback(
+    ({ firstName, lastName, name: fullName, isPatient }) =>
+      isPatient ? `${lastName}, ${firstName}` : `${fullName}`,
+    []
   );
 
   const renderNameRightText = useCallback(({ isCustomer, isSupplier, isPatient, dateOfBirth }) => {
@@ -80,7 +82,7 @@ export const CashTransactionModal = ({ onConfirm }) => {
       return dispensingStrings.supplier;
     }
     return '';
-  });
+  }, []);
 
   const resetBottomModal = () => {
     setIsNameModalOpen(false);

--- a/src/widgets/modals/CashTransactionModal.js
+++ b/src/widgets/modals/CashTransactionModal.js
@@ -41,8 +41,8 @@ export const CashTransactionModal = ({ onConfirm }) => {
   const [isReasonModalOpen, setIsReasonModalOpen] = useState(false);
   const [isDescriptionModalOpen, setIsDescriptionModalOpen] = useState(false);
 
-  const names = useMemo(() => UIDatabase.objects('CashTransactionName'));
-  const reasons = useMemo(() => UIDatabase.objects('CashTransactionReason'));
+  const names = useMemo(() => UIDatabase.objects('CashTransactionName'), []);
+  const reasons = useMemo(() => UIDatabase.objects('CashTransactionReason'), []);
   const type = useMemo(
     () => (isCashIn ? CASH_TRANSACTION_TYPES.CASH_IN : CASH_TRANSACTION_TYPES.CASH_OUT),
     [isCashIn]


### PR DESCRIPTION
Fixes #2162.

## Change summary

Fixes cash register reason filtering.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Cash out transaction reasons only display `Options` records with type `"newCashOutTransaction"`.

### Related areas to think about

N/A.