### PR TITLE
#2162 Add additional sortable columns

### DIFF
--- a/src/pages/dataTableUtilities/constants.js
+++ b/src/pages/dataTableUtilities/constants.js
@@ -127,7 +127,6 @@ export const COLUMN_NAMES = {
   THEIR_STOCK_ON_HAND: 'theirStockOnHand',
   TOTAL: 'total',
   TOTAL_QUANTITY: 'totalQuantity',
-  TRANSACT_TYPE: 'transactType',
   UNIT: 'unit',
   EDIT_SUPPLIER: 'editSupplier',
 };

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -36,7 +36,7 @@ const PAGE_COLUMN_WIDTHS = {
   prescriberSelect: [3, 3, 1],
   itemSelect: [1, 3, 1],
   patientHistory: [1, 3, 1, 3],
-  [ROUTES.CASH_REGISTER]: [1, 2, 1, 1, 1, 1, 1],
+  [ROUTES.CASH_REGISTER]: [1, 2, 1, 1, 1.5, 2],
   supplierCredit: [1, 1, 1, 1],
 };
 
@@ -238,11 +238,10 @@ const PAGE_COLUMNS = {
   cashRegister: [
     COLUMN_NAMES.INVOICE_NUMBER,
     COLUMN_NAMES.PAYMENT_NAME,
-    COLUMN_NAMES.TRANSACT_TYPE,
     COLUMN_NAMES.CASH_REASON,
-    COLUMN_NAMES.COMMENT,
     COLUMN_NAMES.TOTAL,
     COLUMN_NAMES.CONFIRM_DATE,
+    COLUMN_NAMES.COMMENT,
   ],
 };
 
@@ -326,7 +325,7 @@ const COLUMNS = () => ({
     key: COLUMN_KEYS.OTHER_PARTY_NAME,
     title: tableStrings.name,
     alignText: 'left',
-    sortable: false,
+    sortable: true,
     editable: false,
   },
   [COLUMN_NAMES.FIRST_NAME]: {
@@ -385,21 +384,14 @@ const COLUMNS = () => ({
     type: COLUMN_TYPES.STRING,
     key: COLUMN_KEYS.REASON_TITLE,
     title: tableStrings.reason,
-    alignText: 'center',
-    sortable: false,
+    alignText: 'left',
+    sortable: true,
     editable: false,
   },
   [COLUMN_NAMES.STATUS]: {
     type: COLUMN_TYPES.STRING,
     key: COLUMN_KEYS.STATUS,
     title: tableStrings.status,
-    sortable: false,
-    editable: false,
-  },
-  [COLUMN_NAMES.TRANSACT_TYPE]: {
-    type: COLUMN_TYPES.STRING,
-    key: COLUMN_KEYS.TYPE,
-    title: tableStrings.type,
     sortable: false,
     editable: false,
   },
@@ -552,7 +544,7 @@ const COLUMNS = () => ({
     key: COLUMN_KEYS.TOTAL,
     title: tableStrings.total,
     alignTest: 'right',
-    sortable: false,
+    sortable: true,
     editable: false,
   },
 
@@ -624,7 +616,7 @@ const COLUMNS = () => ({
     key: COLUMN_KEYS.CONFIRM_DATE,
     title: tableStrings.confirm_date,
     alignText: 'left',
-    sortable: false,
+    sortable: true,
     editable: false,
   },
   [COLUMN_NAMES.CREATED_DATE]: {
@@ -753,7 +745,7 @@ const COLUMNS = () => ({
     type: COLUMN_TYPES.DROP_DOWN,
     key: COLUMN_KEYS.REASON_TITLE,
     title: tableStrings.reason,
-    alignText: 'center',
+    alignText: 'left',
     sortable: false,
     editable: false,
   },

--- a/src/utilities/sortDataBy.js
+++ b/src/utilities/sortDataBy.js
@@ -32,6 +32,9 @@ const sortKeyToType = {
   registrationCode: 'string',
   invoiceNumber: 'number',
   returnAmount: 'number',
+  total: 'number',
+  reasonTitle: 'string',
+  confirmDate: 'date',
 };
 
 /**


### PR DESCRIPTION
#### BRANCHED FROM #2162 



Fixes #2162 

## Change summary

- Removed the type column
- Added rest of the columns except for comments to be sortable.
- Moved comment column to the end to be consistent with other pages

<img width="1078" alt="image" src="https://user-images.githubusercontent.com/35858975/74069639-ba894f00-4a63-11ea-9c8f-654c35c0bb47.png">


## Testing

N/A

### Related areas to think about

N/A
