### PR TITLE
#2183 Override visibility only when record is for a patient

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -535,7 +535,6 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         type: NAME_TYPES.translate(record.type, EXTERNAL_TO_INTERNAL),
         isCustomer: parseBoolean(record.customer),
         isSupplier: parseBoolean(record.supplier),
-        isVisible: isPatient, // Patients default visibility to true, regardless of nameStoreJoin.
         isManufacturer: parseBoolean(record.manufacturer),
         supplyingStoreId: record.supplying_store_id,
         isPatient,
@@ -543,6 +542,9 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         lastName: record.last,
         dateOfBirth: parseDate(record.date_of_birth),
       };
+
+      if (isPatient) internalRecord.isVisible = true;
+
       database.update(recordType, internalRecord);
       break;
     }


### PR DESCRIPTION
Fixes #2183 

## Change summary

- Name visibility was being overridden for everyone, not just patients
- I think this only started being a problem recently - maybe the order of `[Name]` records and `[NameStoreJoin]` from the server swapped? Regardless it should be changed

## Testing

- [ ] When syncing from desktop, all `Name` records should be correctly visible or invisible

### Related areas to think about

N/A