### PR TITLE
#2195 Clinicians not syncing storeID

### DIFF
--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -76,6 +76,8 @@ const generateSyncData = (settings, recordType, record) => {
       };
     }
     case 'Name': {
+      if (!record.isPatient) return false;
+
       return {
         id: record.id,
         type: record.type,
@@ -264,6 +266,7 @@ const generateSyncData = (settings, recordType, record) => {
         active: record.isActive,
         address1: record.address?.line1,
         address2: record.address?.line2,
+        store_ID: settings.get(THIS_STORE_ID),
       };
     }
     default:


### PR DESCRIPTION
Fixes #2195 

## Change summary

- Sync a clinicians store ID in outgoing sync
- Only sync out patients

## Testing

N/A

### Related areas to think about

N/A