### PR TITLE
#2213 fix incorrect customer requisition indicators

### DIFF
--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -155,7 +155,15 @@ export class Requisition extends Realm.Object {
    */
   get indicators() {
     if (this.isRequest) return this.program?.activeIndicators;
-    if (this.isResponse) return this.period?.indicators;
+    if (this.isResponse) {
+      const periodIndicators = this.period?.indicators;
+      const programIndicators = this.program?.indicators;
+      const indicators = periodIndicators.reduce((acc, indicator) => {
+        const isValidIndicator = !!programIndicators.find(({ id }) => id === indicator.id);
+        return isValidIndicator ? [...acc, indicator] : acc;
+      }, []);
+      return indicators;
+    }
     return null;
   }
 

--- a/src/database/utilities/getIndicatorData.js
+++ b/src/database/utilities/getIndicatorData.js
@@ -87,10 +87,8 @@ const getIndicatorsByValues = indicatorValues => {
       acc.some(indicatorId => indicatorId === indicator.id) ? acc : [...acc, indicator.id],
     []
   );
-  const indicators = UIDatabase.objects('ProgramIndicator').filtered(
-    indicatorIds.map(indicatorId => `id == "${indicatorId}"`).join(' OR ')
-  );
-  return indicators;
+  const query = indicatorIds.map(indicatorId => `id == "${indicatorId}"`).join(' OR ');
+  return query ? UIDatabase.objects('ProgramIndicator').filtered(query) : [];
 };
 
 export {


### PR DESCRIPTION
Fixes #2213.

## Change summary

Fixes response requisition indicator getters.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Open a customer requisition not associated with any indicators. No crash.
- [ ] Open a customer requisition for a period which has indicator values for another program. The indicator values do not appear.

### Related areas to think about

N/A.
