### PR TITLE
#2227 add gender to patient registration

### DIFF
--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -119,6 +119,7 @@ Name.schema = {
     isManufacturer: { type: 'bool', default: false },
     isPatient: { type: 'bool', default: false },
     policies: { type: 'linkingObjects', objectType: 'InsurancePolicy', property: 'patient' },
+    female: { type: 'bool', default: false },
   },
 };
 

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -186,7 +186,7 @@ export const schema = {
     ItemDirection,
     User,
   ],
-  schemaVersion: 13,
+  schemaVersion: 14,
 };
 
 export default schema;

--- a/src/localization/formInputStrings.json
+++ b/src/localization/formInputStrings.json
@@ -63,7 +63,7 @@
     "unique_personal_policy": "Doit être un no de police personnelle unique entre 0 et 50 caractères",
     "yes": "Oui",
     "is_required": "Est requis",
-    "gender": "Gender",
+    "gender": "Sexe",
     "female": "Femme",
     "male": "Homme"
   },

--- a/src/localization/formInputStrings.json
+++ b/src/localization/formInputStrings.json
@@ -28,7 +28,10 @@
     "registration_code": "Registration code",
     "unique_personal_policy": "Must be a unique personal policy number between 0 and 50 characters.",
     "yes": "Yes",
-    "is_required": "Is required"
+    "is_required": "Is required",
+    "gender": "Gender",
+    "female": "Female",
+    "male": "Male"
   },
   "fr": {
     "address_one": "Addresse 1",
@@ -59,7 +62,10 @@
     "registration_code": "Code d'enregistrement",
     "unique_personal_policy": "Doit être un no de police personnelle unique entre 0 et 50 caractères",
     "yes": "Oui",
-    "is_required": "Est requis"
+    "is_required": "Est requis",
+    "gender": "Gender",
+    "female": "Femme",
+    "male": "Homme"
   },
   "gil": {},
   "tl": {},

--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -88,6 +88,14 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     },
     label: formInputStrings.date_of_birth,
   },
+  [FORM_INPUT_KEYS.GENDER]: {
+    type: 'toggle',
+    initialValue: 'false',
+    key: 'female',
+    options: [true, false],
+    optionLabels: [formInputStrings.female, formInputStrings.male],
+    label: formInputStrings.gender,
+  },
   [FORM_INPUT_KEYS.EMAIL]: {
     type: 'text',
     initialValue: '',
@@ -203,6 +211,7 @@ const FORM_CONFIGS = {
     FORM_INPUT_KEYS.FIRST_NAME,
     FORM_INPUT_KEYS.LAST_NAME,
     FORM_INPUT_KEYS.DATE_OF_BIRTH,
+    FORM_INPUT_KEYS.GENDER,
     FORM_INPUT_KEYS.EMAIL,
     FORM_INPUT_KEYS.PHONE,
     FORM_INPUT_KEYS.ADDRESS_ONE,

--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -90,7 +90,7 @@ const FORM_INPUT_CONFIGS = seedObject => ({
   },
   [FORM_INPUT_KEYS.GENDER]: {
     type: 'toggle',
-    initialValue: 'false',
+    initialValue: false,
     key: 'female',
     options: [true, false],
     optionLabels: [formInputStrings.female, formInputStrings.male],


### PR DESCRIPTION
Fixes #2227 

## Change summary

Added a toggle for male/female - a strictly non-pc implementation of gender, in line with the current mSupply option. Uses the boolean *female* field

Created the PR because I made the changes during UAT. feel free to discard this PR and implement it properly

## Testing

- [ ] Edit patient. set gender. reload patient, check value.

### Related areas to think about

Should really be a drop down with more options, this should do for now though.
