### PR TITLE
#2232 cash register balance filter payment types

### DIFF
--- a/dev_scripts/upload.sh
+++ b/dev_scripts/upload.sh
@@ -7,7 +7,7 @@
 
 BUGSNAG_URL=https://upload.bugsnag.com/react-native-source-map
 BUGSNAG_KEY=16a680e189b1e5f03f28665870f1401f
-APP_VERSION=4.0.0-rc3
+APP_VERSION=4.0.0-rc4
 
 PLATFORM=android
 DEV=false

--- a/src/localization/pageInfoStrings.json
+++ b/src/localization/pageInfoStrings.json
@@ -4,6 +4,7 @@
     "code": "Code",
     "comment": "Comment",
     "confirm_date": "Confirm Date",
+    "current_balance": "Cash Balance",
     "customer": "Customer",
     "entered_by": "Entered By",
     "entry_date": "Entry Date",
@@ -11,14 +12,14 @@
     "stocktake_name": "Stocktake Name",
     "supplier": "Supplier",
     "their_ref": "Their Ref",
-    "by_batch": "By batch",
-    "current_balance": "Current balance"
+    "by_batch": "By batch"
   },
   "fr": {
     "address": "Addresse",
     "code": "Code",
     "comment": "Commentaire",
     "confirm_date": "Date de confirmation",
+    "current_balance": "Solde de caisse actuel",
     "customer": "Client",
     "entered_by": "Entrée par",
     "entry_date": "Date d'entrée",
@@ -26,8 +27,7 @@
     "stocktake_name": "Nom du relevé d'inventaire",
     "supplier": "Fournisseur",
     "their_ref": "Leur référence",
-    "by_batch": "Par lot",
-    "current_balance": "Solde de caisse actuel"
+    "by_batch": "Par lot"
   },
   "gil": {
     "address": "Am tabo",

--- a/src/pages/CashRegisterPage.js
+++ b/src/pages/CashRegisterPage.js
@@ -10,7 +10,7 @@ import { View } from 'react-native';
 import { connect } from 'react-redux';
 
 import {
-  selectBalance,
+  selectCashRegisterInfoColumns,
   selectCashRegisterState,
   selectFilteredTransactions,
 } from '../selectors/cashRegister';
@@ -18,14 +18,14 @@ import {
 import { getItemLayout, getPageDispatchers } from './dataTableUtilities';
 
 import { DataTablePageView, PageButton, SearchBar } from '../widgets';
-import { SimpleLabel } from '../widgets/SimpleLabel';
 import { ToggleBar } from '../widgets/ToggleBar';
+import { PageInfo } from '../widgets/PageInfo';
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
 import { DataTablePageModal } from '../widgets/modals';
 
 import { ROUTES } from '../navigation/constants';
-import { buttonStrings, generalStrings, pageInfoStrings } from '../localization';
-import globalStyles, { WHITE } from '../globalStyles';
+import { buttonStrings, generalStrings, dispensingStrings } from '../localization';
+import globalStyles from '../globalStyles';
 
 export const CashRegister = ({
   dispatch,
@@ -37,7 +37,7 @@ export const CashRegister = ({
   keyExtractor,
   modalKey,
   columns,
-  currentBalance,
+  pageInfoColumns,
   transactionType,
   onFilterData,
   onSortColumn,
@@ -88,8 +88,16 @@ export const CashRegister = ({
 
   const toggles = useMemo(
     () => [
-      { text: 'Payments', onPress: onToggleTransactionType, isOn: transactionType === 'payment' },
-      { text: 'Receipts', onPress: onToggleTransactionType, isOn: transactionType === 'receipt' },
+      {
+        text: dispensingStrings.payments,
+        onPress: onToggleTransactionType,
+        isOn: transactionType === 'payment',
+      },
+      {
+        text: dispensingStrings.receipts,
+        onPress: onToggleTransactionType,
+        isOn: transactionType === 'receipt',
+      },
     ],
     [transactionType]
   );
@@ -105,7 +113,7 @@ export const CashRegister = ({
     <DataTablePageView>
       <View style={pageTopSectionContainer}>
         <View style={pageTopLeftSectionContainer}>
-          <ToggleBar toggles={toggles} />
+          <PageInfo columns={pageInfoColumns} isEditingDisabled={true} />
           <SearchBar
             onChangeText={onFilterData}
             value={searchTerm}
@@ -114,12 +122,7 @@ export const CashRegister = ({
         </View>
         <View style={pageTopRightSectionContainer}>
           <View style={verticalContainer}>
-            <SimpleLabel
-              label={pageInfoStrings.current_balance}
-              text={currentBalance}
-              textAlign="right"
-              textBackground={WHITE}
-            />
+            <ToggleBar toggles={toggles} />
             <AddNewTransactionButton />
           </View>
         </View>
@@ -151,9 +154,8 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
 const mapStateToProps = state => {
   const pageState = selectCashRegisterState(state);
   const data = selectFilteredTransactions(state);
-  const currentBalance = selectBalance(state);
-
-  return { ...pageState, data, currentBalance };
+  const pageInfoColumns = selectCashRegisterInfoColumns(state);
+  return { ...pageState, data, pageInfoColumns };
 };
 
 export const CashRegisterPage = connect(mapStateToProps, mapDispatchToProps)(CashRegister);
@@ -169,8 +171,8 @@ CashRegister.propTypes = {
   isAscending: PropTypes.bool.isRequired,
   modalKey: PropTypes.string.isRequired,
   keyExtractor: PropTypes.func.isRequired,
+  pageInfoColumns: PropTypes.object.isRequired,
   columns: PropTypes.array.isRequired,
-  currentBalance: PropTypes.string.isRequired,
   transactionType: PropTypes.string.isRequired,
   onFilterData: PropTypes.func.isRequired,
   onSortColumn: PropTypes.func.isRequired,

--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -94,6 +94,8 @@ export const CustomerRequisition = ({
     isFinalised,
   ]);
 
+  console.log(pageInfoColumns);
+
   const getCallback = useCallback(colKey => {
     switch (colKey) {
       case 'suppliedQuantity':

--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -51,9 +51,6 @@ const PER_PAGE_INFO_COLUMNS = {
     ['entryDate', 'enteredBy'],
     ['customer', 'transactionComment', 'prescriber'],
   ],
-  [ROUTES.CASH_REGISTER]: [
-    ['number', 'name', 'type', 'reason', 'comment', 'amount', 'confirmDate'],
-  ],
   stocktakeBatchEditModal: [['itemName']],
   stocktakeBatchEditModalWithReasons: [['itemName']],
   stocktakeBatchEditModalWithPrices: [['itemName']],

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -29,7 +29,6 @@ export const cashRegisterInitialiser = () => {
     modalKey: '',
     columns: getColumns(ROUTES.CASH_REGISTER),
     transactionType: 'payment',
-    getPageInfoColumns: getPageInfoColumns(ROUTES.CASH_REGISTER),
     route: ROUTES.CASH_REGISTER,
   };
 };

--- a/src/selectors/cashRegister.js
+++ b/src/selectors/cashRegister.js
@@ -4,8 +4,10 @@
  */
 
 import { createSelector } from 'reselect';
-
 import currency from '../localization/currency';
+import { CASH_TRANSACTION } from '../utilities/modules/dispensary/constants';
+
+const { PAYMENT_TYPES } = CASH_TRANSACTION;
 
 export const selectCashRegisterState = state => state.pages.cashRegister;
 
@@ -52,11 +54,19 @@ export const selectFilteredTransactions = createSelector(
     transactions.filter(({ otherParty }) => otherParty.name.includes(searchTerm))
 );
 
-export const selectPaymentsTotal = createSelector([selectPayments], payments =>
+export const selectCashPayments = createSelector([selectPayments], payments =>
+  payments.filter(payment => payment.paymentType?.code === PAYMENT_TYPES.CASH)
+);
+
+export const selectCashReceipts = createSelector([selectReceipts], receipts =>
+  receipts.filter(receipt => receipt.paymentType?.code === PAYMENT_TYPES.CASH)
+);
+
+export const selectPaymentsTotal = createSelector([selectCashPayments], payments =>
   payments.reduce((acc, { total }) => acc.add(total), currency(0))
 );
 
-export const selectReceiptsTotal = createSelector([selectReceipts], receipts =>
+export const selectReceiptsTotal = createSelector([selectCashReceipts], receipts =>
   receipts.reduce((acc, { total }) => acc.add(total), currency(0))
 );
 

--- a/src/selectors/cashRegister.js
+++ b/src/selectors/cashRegister.js
@@ -4,6 +4,7 @@
  */
 
 import { createSelector } from 'reselect';
+import { pageInfoStrings } from '../localization';
 import currency from '../localization/currency';
 import { CASH_TRANSACTION } from '../utilities/modules/dispensary/constants';
 
@@ -74,3 +75,12 @@ export const selectBalance = createSelector(
   [selectReceiptsTotal, selectPaymentsTotal],
   (receiptsTotal, paymentsTotal) => receiptsTotal.subtract(paymentsTotal).format()
 );
+
+export const selectCashRegisterInfoColumns = createSelector([selectBalance], currentBalance => [
+  [
+    {
+      title: `${pageInfoStrings.current_balance}:`,
+      info: currentBalance,
+    },
+  ],
+]);

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -112,6 +112,12 @@ const getOrCreateAddress = (database, line1, line2, line3, line4, zipCode) => {
   return createRecord(database, 'Address', { line1, line2, line3, line4, zipCode });
 };
 
+const getOrCreatePaymentType = (database, id, code, description) => {
+  const results = database.objects('PaymentType').filtered('id == $0', id);
+  if (results.length > 0) return results[0];
+  return database.update('PaymentType', { id, code, description });
+};
+
 /**
  * Ensure the given record has the right data to create an internal record of the given
  * |recordType|. Check only that it is a recognised record type, and that it contains values
@@ -767,6 +773,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         option: database.getOrCreate('Options', record.optionID),
         subtotal: parseFloat(record.subtotal),
         user1: record.user1,
+        paymentType: getOrCreatePaymentType(database, record.paymentTypeID),
       };
       const transaction = database.update(recordType, internalRecord);
       if (linkedRequisition) {

--- a/src/utilities/modules/dispensary/constants.js
+++ b/src/utilities/modules/dispensary/constants.js
@@ -14,3 +14,16 @@ export const CASH_TRANSACTION_TYPES = {
   CASH_IN: 'cash_in',
   CASH_OUT: 'cash_out',
 };
+
+export const CASH_TRANSACTION_PAYMENT_TYPES = {
+  CASH: 'cash',
+  CHEQUE: 'cheque',
+  CREDIT_CARD: 'credit_card',
+  MOBILE_PAYMENT: 'mobile_payment',
+};
+
+export const CASH_TRANSACTION = {
+  TYPES: CASH_TRANSACTION_TYPES,
+  PAYMENT_TYPES: CASH_TRANSACTION_PAYMENT_TYPES,
+  FIELD_KEYS: CASH_TRANSACTION_FIELD_KEYS,
+};


### PR DESCRIPTION
Fixes #2232.

## Change summary

Makes mobile cash register behaviour consistent with desktop.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Cash register balance is only effected by payments and receipts of `paymentType.code=='cash'`.

### Related areas to think about

N/A.