### PR TITLE
Add resetting of insurance

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -701,7 +701,7 @@ const createSupplierInvoice = (database, supplier, user) => {
  */
 const createTransactionBatch = (database, transactionItem, itemBatch, isAddition = true) => {
   const { item, batch, expiryDate, packSize, costPrice, sellPrice, donor } = itemBatch;
-  const { transaction } = transactionItem || {};
+  const { transaction, note } = transactionItem || {};
 
   const transactionBatch = database.create('TransactionBatch', {
     id: generateUUID(),
@@ -709,6 +709,7 @@ const createTransactionBatch = (database, transactionItem, itemBatch, isAddition
     itemName: item.name,
     itemBatch,
     batch,
+    note,
     expiryDate,
     packSize,
     numberOfPacks: 0,

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -36,7 +36,7 @@ const PAGE_COLUMN_WIDTHS = {
   prescriberSelect: [3, 3, 1],
   itemSelect: [1, 3, 1],
   patientHistory: [1, 3, 1, 3],
-  [ROUTES.CASH_REGISTER]: [1, 2, 1, 1, 1, 1.5, 2],
+  [ROUTES.CASH_REGISTER]: [1, 2, 1, 1, 1, 2, 2],
   supplierCreditFromItem: [1, 1, 1, 1],
   supplierCreditFromInvoice: [1, 1, 1, 1],
 };

--- a/src/reducers/InsuranceReducer.js
+++ b/src/reducers/InsuranceReducer.js
@@ -4,6 +4,7 @@
  */
 
 import { INSURANCE_ACTIONS } from '../actions/InsuranceActions';
+import { ROUTES } from '../navigation/index';
 
 const initialState = () => ({
   currentInsurancePolicy: null,
@@ -16,6 +17,13 @@ export const InsuranceReducer = (state = initialState(), action) => {
   const { type } = action;
 
   switch (type) {
+    case 'Navigation/NAVIGATE': {
+      const { routeName } = action;
+      if (routeName !== ROUTES.PRESCRIPTION) return state;
+
+      return initialState();
+    }
+
     case INSURANCE_ACTIONS.CLOSE: {
       return {
         ...state,

--- a/src/selectors/cashRegister.js
+++ b/src/selectors/cashRegister.js
@@ -49,7 +49,9 @@ export const selectToggledTransactions = createSelector(
 export const selectFilteredTransactions = createSelector(
   [selectToggledTransactions, selectSearchTerm],
   (transactions, searchTerm) =>
-    transactions.filter(({ otherParty }) => otherParty.name.includes(searchTerm))
+    transactions.filter(({ otherParty }) =>
+      otherParty.name.toLowerCase().includes(searchTerm.toLowerCase())
+    )
 );
 
 export const selectPaymentsTotal = createSelector([selectPayments], payments =>

--- a/src/selectors/dispensary.js
+++ b/src/selectors/dispensary.js
@@ -60,5 +60,5 @@ export const selectFilteredData = createSelector(
 
 export const selectSortedData = createSelector(
   [selectFilteredData, selectIsAscending, selectSortKey],
-  (data, isAscending, sortKey) => data.sorted(sortKey, isAscending)
+  (data, isAscending, sortKey) => data.sorted(sortKey, !isAscending)
 );

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -80,6 +80,7 @@ export const pay = (
       const amountToTake = Math.min(Math.abs(creditFromCustomerCredit), creditToAllocate);
 
       createRecord(UIDatabase, 'CustomerCreditLine', customerCredit, amountToTake);
+      createRecord(UIDatabase, 'ReceiptLine', receipt, customerCredit, amountToTake);
       createRecord(UIDatabase, 'ReceiptLine', receipt, customerCredit, -amountToTake);
 
       creditToAllocate -= amountToTake;


### PR DESCRIPTION
Fixes #2253 

## Change summary

- Correctly resets insurance policies when navigating to a prescription (ignore navigating away, doens't matter)

## Testing

- [ ] After creating a prescription with a policy applied, the next prescription does not have a policy auto-applied

### Related areas to think about

N/A
