### PR TITLE
#2246 Correctly apply TransactionItem's note to TransactionBatch

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -701,7 +701,7 @@ const createSupplierInvoice = (database, supplier, user) => {
  */
 const createTransactionBatch = (database, transactionItem, itemBatch, isAddition = true) => {
   const { item, batch, expiryDate, packSize, costPrice, sellPrice, donor } = itemBatch;
-  const { transaction } = transactionItem || {};
+  const { transaction, note } = transactionItem || {};
 
   const transactionBatch = database.create('TransactionBatch', {
     id: generateUUID(),
@@ -709,6 +709,7 @@ const createTransactionBatch = (database, transactionItem, itemBatch, isAddition
     itemName: item.name,
     itemBatch,
     batch,
+    note,
     expiryDate,
     packSize,
     numberOfPacks: 0,

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -80,6 +80,7 @@ export const pay = (
       const amountToTake = Math.min(Math.abs(creditFromCustomerCredit), creditToAllocate);
 
       createRecord(UIDatabase, 'CustomerCreditLine', customerCredit, amountToTake);
+      createRecord(UIDatabase, 'ReceiptLine', receipt, customerCredit, amountToTake);
       createRecord(UIDatabase, 'ReceiptLine', receipt, customerCredit, -amountToTake);
 
       creditToAllocate -= amountToTake;


### PR DESCRIPTION
Fixes #2246 

## Change summary

- Correctly apply an items note to a batch

## Testing

- [ ] After adding a direction to an item in a prescription, it is displayed in the confirmation page

### Related areas to think about

N/A
