### PR TITLE
#2218 SupplierCredit crash

### DIFF
--- a/src/actions/SupplierCreditActions.js
+++ b/src/actions/SupplierCreditActions.js
@@ -41,7 +41,7 @@ const create = () => (dispatch, getState) => {
     const { id: supplierId } = itemBatch.itemBatch?.supplier || {};
     const suppliersGroup = groupings[supplierId];
 
-    if (suppliersGroup) return { ...groupings, [supplierId]: suppliersGroup.push(itemBatch) };
+    if (suppliersGroup) return { ...groupings, [supplierId]: [...suppliersGroup, itemBatch] };
     return { ...groupings, [supplierId]: [itemBatch] };
   }, {});
 

--- a/src/localization/dispensingStrings.json
+++ b/src/localization/dispensingStrings.json
@@ -94,7 +94,7 @@
     "select_a_patient_type": "Sélectionner un type de patient",
     "select_a_prescription_category": "Sélectionner une catégorie de prescription",
     "select_the_prescriber": "Sélectionnez le prescripteur",
-    "subtotal": "Sous-total",
+    "subtotal": "Total",
     "supplier": "Fournisseur",
     "total": "Part du client",
     "type": "Type",

--- a/src/localization/tableStrings.json
+++ b/src/localization/tableStrings.json
@@ -84,7 +84,7 @@
     "confirm_date": "DATE DE CONFIRMATION",
     "cost_price": "PRIX D'ACHAT",
     "created_date": "DATE CRÉEE",
-    "current_stock": "STOCK ACTUEL",
+    "current_stock": "SDU",
     "customer": "CLIENT",
     "delete": "SUPPRIMER",
     "department": "Départment",


### PR DESCRIPTION
Fixes #2218 

## Change summary

- Attempt #2!
- Pushing returns the count.. not the array.. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push :) heheehe.....

## Testing

- [ ] Creating a `SupplierCredit` where there are more than one batch being returned to the same supplied does not crash the app
- [ ] Creating a `SupplierCredit` from a `SupplierInvoice`, where all batches are having all amounts returned does not crash the app

### Related areas to think about

Where to start...........
