### PR TITLE
#2189 Null background colour

### DIFF
--- a/src/widgets/PageButton.js
+++ b/src/widgets/PageButton.js
@@ -11,7 +11,7 @@ import { Button } from 'react-native-ui-components';
 
 import { debounce } from '../utilities';
 
-import globalStyles from '../globalStyles';
+import globalStyles, { WARMER_GREY } from '../globalStyles';
 
 // A generic button for use on pages
 export function PageButtonComponent(props) {
@@ -32,6 +32,7 @@ export function PageButtonComponent(props) {
       style={[...defaultButtonStyle, localStyles.button, style]}
       onPress={callback}
       textStyle={[...defaultTextStyle, textStyle]}
+      disabledColor={WARMER_GREY}
       {...buttonProps}
     />
   );


### PR DESCRIPTION
Fixes #2189 

## Change summary

- https://github.com/facebook/react-native/issues/24000
- Can't pass `null` to `backgroundColor` with RN & KitKat

## Testing

- [ ] Opening the new/edit prescriber modal doesn't crash the app
- [ ] Opening the new/edit patient modal doesn't crash the app

### Related areas to think about

N/A
