### PR TITLE
#2309 show scs in si list

### DIFF
--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -20,6 +20,7 @@ const translateToCoreDatabaseType = type => {
     case 'CustomerCredit':
     case 'Payment':
     case 'CashTransaction':
+    case 'SupplierTransaction':
       return 'Transaction';
     case 'CashTransactionName':
     case 'Customer':
@@ -123,6 +124,20 @@ class UIDatabase {
           null,
           'finalised'
         );
+      case 'SupplierTransaction': {
+        const queryString =
+          // eslint-disable-next-line no-multi-str
+          '((type == $0 AND mode == $2) OR (type == $1 AND status == $3))\
+           AND otherParty.type != $4';
+        return results.filtered(
+          queryString,
+          'supplier_invoice',
+          'supplier_credit',
+          'store',
+          'finalised',
+          'inventory_adjustment'
+        );
+      }
       case 'SupplierInvoice':
         return results.filtered(
           'type == $0 AND mode == $1 AND otherParty.type != $2',

--- a/src/localization/tableStrings.json
+++ b/src/localization/tableStrings.json
@@ -69,7 +69,9 @@
     "total": "TOTAL",
     "type": "TYPE",
     "unit": "UNIT",
-    "value": "VALUE"
+    "value": "VALUE",
+    "supplier_credit": "Crédit fournisseur",
+    "supplier_invoice": "Facture fournisseur"
   },
   "fr": {
     "actual_quantity": "QUANTITÉ\nRÉELLE",

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -56,6 +56,7 @@ export const SupplierInvoice = ({
   route,
   onEditSellPrice,
   onEditTransactionBatchName,
+  isSupplierInvoice,
 }) => {
   // Listen for this transaction being finalised, so data can be refreshed and kept consistent.
   useRecordListener(refreshData, pageObject, 'Transaction');
@@ -147,7 +148,7 @@ export const SupplierInvoice = ({
           />
         </View>
         <View style={pageTopRightSectionContainer}>
-          {!isFinalised ? (
+          {(!isFinalised && isSupplierInvoice) || (isFinalised && !isSupplierInvoice) ? (
             <PageButton
               text={buttonStrings.new_item}
               onPress={onSelectNewItem}
@@ -198,7 +199,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 const mapStateToProps = state => {
   const { pages } = state;
   const { supplierInvoice } = pages;
-  return supplierInvoice;
+
+  const { pageObject } = supplierInvoice ?? {};
+
+  const { isSupplierInvoice } = pageObject ?? {};
+
+  return { ...supplierInvoice, isSupplierInvoice };
 };
 
 export const SupplierInvoicePage = connect(mapStateToProps, mapDispatchToProps)(SupplierInvoice);
@@ -239,4 +245,5 @@ SupplierInvoice.propTypes = {
   onEditSellPrice: PropTypes.func.isRequired,
   refund: PropTypes.func.isRequired,
   onEditTransactionBatchName: PropTypes.func.isRequired,
+  isSupplierInvoice: PropTypes.bool.isRequired,
 };

--- a/src/pages/dataTableUtilities/constants.js
+++ b/src/pages/dataTableUtilities/constants.js
@@ -70,6 +70,7 @@ export const COLUMN_KEYS = {
 };
 
 export const COLUMN_NAMES = {
+  TRANSACTION_TYPE: 'transactionType',
   AVAILABLE_QUANTITY: 'availableQuantity',
   BATCH_NAME: 'batch',
   BATCHES: 'batches',

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -109,7 +109,7 @@ const PAGE_COLUMNS = {
     COLUMN_NAMES.INVOICE_NUMBER,
     COLUMN_NAMES.SUPPLIER,
     COLUMN_NAMES.ENTRY_DATE,
-    COLUMN_NAMES.STATUS,
+    COLUMN_NAMES.TRANSACTION_TYPE,
     COLUMN_NAMES.COMMENT,
     COLUMN_NAMES.REMOVE,
   ],
@@ -299,6 +299,15 @@ const COLUMNS = () => ({
   },
 
   // STRING COLUMNS
+
+  [COLUMN_NAMES.TRANSACTION_TYPE]: {
+    type: COLUMN_TYPES.STRING,
+    key: COLUMN_KEYS.TYPE,
+    title: tableStrings.type,
+    alignText: 'left',
+    sortable: true,
+    editable: false,
+  },
 
   [COLUMN_NAMES.OTHER_PARTY_NAME]: {
     type: COLUMN_TYPES.STRING,

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -367,7 +367,7 @@ const supplierInvoiceInitialiser = transaction => {
  * @returns  {object}
  */
 const supplierInvoicesInitialiser = () => {
-  const backingData = UIDatabase.objects('SupplierInvoice');
+  const backingData = UIDatabase.objects('SupplierTransaction');
 
   const filteredData = backingData.filtered('status != $0', 'finalised').slice();
   const sortedData = sortDataBy(filteredData, 'serialNumber', false);

--- a/src/utilities/formatStatus.js
+++ b/src/utilities/formatStatus.js
@@ -9,4 +9,15 @@ export const formatStatus = status => {
   }
 };
 
+export const formatType = type => {
+  switch (type) {
+    case 'supplier_credit':
+      return tableStrings.supplier_credit;
+    case 'supplier_invoice':
+      return tableStrings.supplier_invoice;
+    default:
+      return '';
+  }
+};
+
 export default formatStatus;

--- a/src/utilities/sortDataBy.js
+++ b/src/utilities/sortDataBy.js
@@ -36,6 +36,7 @@ const sortKeyToType = {
   total: 'number',
   reasonTitle: 'string',
   confirmDate: 'date',
+  type: 'string',
 };
 
 /**

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -36,6 +36,7 @@ import { formatStatus } from '../../utilities';
 
 import { COLUMN_TYPES, COLUMN_NAMES } from '../../pages/dataTableUtilities';
 import { generalStrings, tableStrings } from '../../localization/index';
+import { formatType } from '../../utilities/formatStatus';
 
 /**
  * Wrapper component for a mSupply DataTable page row.
@@ -175,7 +176,9 @@ const DataTableRow = React.memo(
 
             case COLUMN_TYPES.STRING: {
               const value = rowData[columnKey];
-              const displayValue = columnKey === 'status' ? formatStatus(value) : value;
+              let displayValue = columnKey === 'status' ? formatStatus(value) : value;
+              displayValue = columnKey === 'type' ? formatType(displayValue) : displayValue;
+
               return (
                 <Cell
                   key={columnKey}

--- a/src/widgets/DropdownRow.js
+++ b/src/widgets/DropdownRow.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import { DropDown } from './DropDown';
 import { FlexRow } from './FlexRow';
 
-import { SUSSOL_ORANGE, APP_FONT_FAMILY } from '../globalStyles';
+import { LIGHT_GREY, SUSSOL_ORANGE, APP_FONT_FAMILY } from '../globalStyles';
 
 /**
  * Layout component rendering a Dropdown and a TextInput.
@@ -48,6 +48,7 @@ export const DropdownRow = ({
       underlineColorAndroid={SUSSOL_ORANGE}
       style={localStyles.textInputStyle}
       placeholder={placeholder}
+      placeholderTextColor={LIGHT_GREY}
     />
   </FlexRow>
 );


### PR DESCRIPTION
Fixes #2309

## Change summary

- SI's page now shows SC's also
- Added a `TYPE` column to differentiate
- Only shows finalised SC's (they're auto-finalised when creating in mobile)

![image](https://user-images.githubusercontent.com/35858975/74494886-26bff300-4f3b-11ea-8b09-9d14cbaa9e98.png)

![image](https://user-images.githubusercontent.com/35858975/74494890-2a537a00-4f3b-11ea-9264-4856f33bb39f.png)

## Testing

- [ ] After creating an SC it shows in the SI list

### Related areas to think about

- I don't like this implementation. The column is redundant.
- Need to add code to only use the `TYPE` column when using supplier credits (should they just be available to everyone...?)
- I think just having a `Supplier Credit` page is better


