### PR TITLE
#2318 Corrected countedQuantityEdit parameter

### DIFF
--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -203,7 +203,7 @@ export const editStocktakeBatchCountedQuantity = (value, rowKey, route) => (disp
   if (objectToEdit) {
     UIDatabase.write(() => {
       objectToEdit.countedTotalQuantity = parsePositiveInteger(value);
-      UIDatabase.save('StocktakeBatch', UIDatabase);
+      UIDatabase.save('StocktakeBatch', objectToEdit);
     });
   }
 


### PR DESCRIPTION
Fixes #2318 

## Change summary

- Adds the correct parameter to the `.save()`

## Testing

*Setup*
1. Create a stocktake - add some batches if none
2. Sync to desktop
3. Edit a stocktake batch
4. Try to sync

- [ ] on Step 4 - records should be sent to Desktop
- [ ] Repeat the above steps 1-3. Instead of step 4 - go to Realm Explorer and check the SyncQueue to see if the stocktake batch is in there.

### Related areas to think about

N/A
