### PR TITLE
#2273 Missing TransactionBatch when syncing

### DIFF
--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -17,7 +17,7 @@ import {
   TRANSACTION_BATCH_TYPES,
   TRANSACTION_TYPES,
 } from './syncTranslators';
-import { CHANGE_TYPES } from '../database';
+import { UIDatabase, CHANGE_TYPES } from '../database';
 import { SETTINGS_KEYS } from '../settings';
 
 const { THIS_STORE_ID, SYNC_URL, SYNC_SITE_NAME } = SETTINGS_KEYS;
@@ -286,13 +286,26 @@ export const generateSyncJson = (database, settings, syncOutRecord) => {
   } else {
     // Get the record the |syncOutRecord| refers to from the database.
     const recordResults = database.objects(recordType).filtered('id == $0', recordId);
+
     if (!recordResults || recordResults.length === 0) {
       // No such record
-      throw new Error(`${recordType} with id = ${recordId} missing`);
-    } else if (recordResults.length > 1) {
-      // Duplicate records
-      throw new Error(`Multiple ${recordType} records with id = ${recordId}`);
+      const error = new Error(`${recordType} with id = ${recordId} missing`);
+      bugsnagClient.notify(error, content => {
+        content.syncSite = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_SITE_NAME);
+        content.record = syncOutRecord;
+      });
+      throw error;
     }
+    if (recordResults.length > 1) {
+      // Duplicate records
+      const error = new Error(`Multiple ${recordType} records with id = ${recordId}`);
+      bugsnagClient.notify(error, content => {
+        content.syncSite = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_SITE_NAME);
+        content.record = syncOutRecord;
+      });
+      throw error;
+    }
+
     const record = recordResults[0];
 
     // Generate the appropriate data for the sync object to carry, representing the

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -95,7 +95,7 @@ export const StocktakeBatchModalComponent = ({ stocktakeItem, reduxDispatch }) =
       reduxDispatch(PageActions.refreshRow(stocktakeItem.id, ROUTES.STOCKTAKE_EDITOR));
     });
   const onEditDate = (date, rowKey, columnKey) =>
-    dispatch(PageActions.editTransactionBatchExpiryDate(date, rowKey, columnKey));
+    dispatch(PageActions.editStocktakeBatchExpiryDate(date, rowKey, columnKey));
 
   const toggles = useCallback(getPageInfoColumns(pageObject, dispatch, PageActions), []);
 


### PR DESCRIPTION
Fixes #2273 

## Change summary

- Steps to reproduce the error:

1. Create a Stocktake with > 1 line.
2. Go to the batch editing of a line, and add a batch.
3. Edit the quantity of the batch.
4. Leave the Stocktake and Sync.
5. Go back to the Stocktake, and go to the batch you edited previously
6. ONLY edit the expiry date [NOTE: This cell saves on LOSING FOCUS]
7. Leave the Stocktake and go sync again.


Why:

- Used the wrong action for updating the `ExpiryDate`. All this did was make the `database.save()` method, use `database.save("TransactionBatch", ...)` rather than `database.save("StocktakeBatch", ...)`. 
- When `.save()` is called, we trigger the `SyncQueue` event handler for the pass parameters (In this instance, `recordType = "TransactionBatch`, and the actual record is the `StocktakeBatch`. 
- The `SyncQueue` first looks for (any) record in the `SyncOut` queue which has the `ID` of the object we are trying to save [Note: Doesn't look for TYPE + ID, JUST ID)
- If it finds it, it updates it - otherwise, it creates a `SyncOut`.
- If there is already a `StocktakeBatch` record in the `SyncOut` for the `StocktakeBatch` we edited the date of, then it would just update it (i.e. after creation, after editing quantity).
- Otherwise, when we revisit after syncing, there is no `SyncOut`, so we create a new one where the `RecordType` is `TransactionBatch`
- Then, when we sync, that is where we check both ID AND TYPE - and we can't find the `TransactionBatch` with the ID, as it is really a `StocktakeBatch`



## Testing

Using the reproduction steps above - make sure you can recreate the problem on the current MASTER. Then, try the steps again on this branch and we can ensure it does not happen again.

### Related areas to think about

Left the error throwing as even though this may really hurt some data in the future by completely stopping sync, I think this is a good case of error throwing. If we did not have it we wouldn't have found this for a long time, potentially which could have potentially caused some more unintended consequences!


The bugsnag adding is ugly, yeah