### PR TITLE
#2221 Correct hasSelection field

### DIFF
--- a/src/pages/dataTableUtilities/reducer/rowReducers.js
+++ b/src/pages/dataTableUtilities/reducer/rowReducers.js
@@ -33,10 +33,12 @@ export const deselectRow = (state, action) => {
   const rowState = newDataState.get(rowKey);
   newDataState.set(rowKey, { ...rowState, isSelected: false });
 
+  const hasSelection = Array.from(newDataState).some(([, { isSelected }]) => isSelected);
+
   return {
     ...state,
     dataState: newDataState,
-    hasSelection: false,
+    hasSelection,
     allSelected: false,
     selectedRow: null,
   };


### PR DESCRIPTION
Fixes #2221 

## Change summary

- Checks if there is any selection before unsetting `hasSelection`

## Testing

- [ ] With two rows selected, unselecting one of them does not make the bottom modal dissapear

### Related areas to think about

N/A
