### PR TITLE
#2332 Display MenuPage Grid only when theres buttons to show

### DIFF
--- a/src/reducers/ModulesReducer.js
+++ b/src/reducers/ModulesReducer.js
@@ -34,13 +34,7 @@ const initialState = () => {
   const usingSupplierCredits = checkModule(SETTINGS_KEYS.SUPPLIER_CREDIT_MODULE);
   const usingPatientTypes = checkModule(SETTINGS_KEYS.PATIENT_TYPES);
 
-  const usingModules =
-    usingDashboard ||
-    usingDispensary ||
-    usingVaccines ||
-    usingCashRegister ||
-    usingPayments ||
-    usingSupplierCredits;
+  const usingModules = usingDashboard || usingDispensary || usingVaccines || usingCashRegister;
 
   const usingInsurance = UIDatabase.objects('InsuranceProvider').length > 0;
   const usingPrescriptionCategories = UIDatabase.objects('PrescriptionCategory').length > 0;


### PR DESCRIPTION
Fixes #2332 

## Change summary

- Display the `ModuleLayout` on the `MenuPage` only when there are buttons to display (Vaccines, dispensary, cashregister, dashboard)

## Testing

N/A

### Related areas to think about

N/A
