### PR TITLE
#2333 Remove item code column for supplier credits

### DIFF
--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -37,16 +37,15 @@ const PAGE_COLUMN_WIDTHS = {
   itemSelect: [1, 3, 1],
   patientHistory: [1, 3, 1, 3],
   [ROUTES.CASH_REGISTER]: [1, 2, 1, 1, 1, 2, 2],
-  supplierCreditFromItem: [1, 1, 1, 1, 1, 1],
+  supplierCreditFromItem: [1, 1, 1, 1, 1],
   supplierCreditFromInvoice: [1, 1, 1, 1, 1, 1],
 };
 
 const PAGE_COLUMNS = {
   supplierCreditFromItem: [
-    COLUMN_NAMES.ITEM_CODE,
-    COLUMN_NAMES.EXPIRY_DATE,
     COLUMN_NAMES.BATCH_NAME,
     COLUMN_NAMES.OTHER_PARTY_NAME,
+    COLUMN_NAMES.EXPIRY_DATE,
     COLUMN_NAMES.TOTAL_QUANTITY,
     COLUMN_NAMES.RETURN_AMOUNT,
   ],

--- a/src/selectors/supplierCredit.js
+++ b/src/selectors/supplierCredit.js
@@ -38,6 +38,12 @@ export const selectItemName = ({ supplierCredit }) => {
   return name;
 };
 
+export const selectItemCode = ({ supplierCredit }) => {
+  const { item } = supplierCredit;
+  const { code } = item || {};
+  return code;
+};
+
 export const selectType = ({ supplierCredit }) => {
   const { type } = supplierCredit;
   return type;
@@ -51,10 +57,10 @@ export const selectInvoice = ({ supplierCredit }) => {
 };
 
 export const selectTitle = createSelector(
-  [selectType, selectInvoice, selectItemName],
-  (type, invoice, itemName) => {
+  [selectType, selectInvoice, selectItemName, selectItemCode],
+  (type, invoice, itemName, itemCode) => {
     if (type === 'supplierCreditFromItem') {
-      return `${dispensingStrings.available_credits_for} ${itemName}`;
+      return `${dispensingStrings.available_credits_for} ${itemName} (${itemCode})`;
     }
     const { serialNumber, otherPartyName } = invoice;
     return `${dispensingStrings.supplier_credit_for_supplier_invoice} ${serialNumber} ${generalStrings.to} ${otherPartyName}`;


### PR DESCRIPTION
Fixes #2333 

## Change summary

- Removed the item code column for a supplier credit modal opened from a particular item.
- Added the code into the title

## Testing

N/A

### Related areas to think about

N/A
