### PR TITLE
#2339 store id to prescriber

### DIFF
--- a/src/database/DataTypes/Prescriber.js
+++ b/src/database/DataTypes/Prescriber.js
@@ -17,6 +17,7 @@ Prescriber.schema = {
     mobileNumber: { type: 'string', optional: true },
     emailAddress: { type: 'string', optional: true },
     transactions: { type: 'linkingObjects', objectType: 'Transaction', property: 'prescriber' },
+    fromThisStore: { type: 'bool', default: false },
   },
 };
 

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -869,6 +869,8 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       break;
     }
     case 'Prescriber': {
+      const fromThisStore = record.store_ID === settings.get(THIS_STORE_ID);
+
       database.update(recordType, {
         id: record.ID,
         firstName: record.first_name,
@@ -880,6 +882,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         phoneNumber: record.phone,
         mobileNumber: record.mobile,
         emailAddress: record.email,
+        fromThisStore,
       });
       break;
     }

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -258,6 +258,9 @@ const generateSyncData = (settings, recordType, record) => {
       };
     }
     case 'Prescriber': {
+      // Only sync out prescribers from this store.
+      if (!record.fromThisStore) return null;
+
       return {
         ID: record.id,
         last_name: record.lastName,


### PR DESCRIPTION
Fixes #2339 

## Change summary

- Adds `fromThisStore` to `Prescriber`
- Disallows outgoing syncing of `Prescribers` from other stores
- Thought this was a better overall solution than the one described in the issue

## Testing

N/A

### Related areas to think about

N/A
