### PR TITLE
#2355 disable cash register if no payment types defined

### DIFF
--- a/src/reducers/ModulesReducer.js
+++ b/src/reducers/ModulesReducer.js
@@ -26,20 +26,20 @@ import { SYNC_TRANSACTION_COMPLETE } from '../sync/constants';
 const checkModule = key => UIDatabase.getSetting(key).toLowerCase() === 'true';
 
 const initialState = () => {
+  const usingInsurance = UIDatabase.objects('InsuranceProvider').length > 0;
+  const usingPaymentTypes = UIDatabase.objects('PaymentType').length > 0;
+  const usingPrescriptionCategories = UIDatabase.objects('PrescriptionCategory').length > 0;
+  const usingSupplierCreditCategories = UIDatabase.objects('SupplierCreditCategory').length > 0;
+
   const usingDashboard = checkModule(SETTINGS_KEYS.DASHBOARD_MODULE);
   const usingDispensary = checkModule(SETTINGS_KEYS.DISPENSARY_MODULE);
   const usingVaccines = checkModule(SETTINGS_KEYS.VACCINE_MODULE);
-  const usingCashRegister = checkModule(SETTINGS_KEYS.CASH_REGISTER_MODULE);
+  const usingCashRegister = checkModule(SETTINGS_KEYS.CASH_REGISTER_MODULE) && usingPaymentTypes;
   const usingPayments = checkModule(SETTINGS_KEYS.PAYMENT_MODULE);
   const usingSupplierCredits = checkModule(SETTINGS_KEYS.SUPPLIER_CREDIT_MODULE);
   const usingPatientTypes = checkModule(SETTINGS_KEYS.PATIENT_TYPES);
 
   const usingModules = usingDashboard || usingDispensary || usingVaccines || usingCashRegister;
-
-  const usingInsurance = UIDatabase.objects('InsuranceProvider').length > 0;
-  const usingPrescriptionCategories = UIDatabase.objects('PrescriptionCategory').length > 0;
-  const usingSupplierCreditCategories = UIDatabase.objects('SupplierCreditCategory').length > 0;
-  const usingPaymentTypes = UIDatabase.objects('PaymentType').length > 0;
 
   return {
     usingPayments,


### PR DESCRIPTION
Fixes #2355.

## Change summary

Disables cash register if no payment types defined.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] If `usesCashRegisterModule` is `true` but no payment types defined, cash register button is not displayed.
- [ ] If `usesCashRegisterModule` is `true` and at least one payment types defined, cash register button is displayed.

### Related areas to think about

Possibly needed for prescription functionality also?
