### PR TITLE
#2345 add amount_outstanding to transaction outgoing sync

### DIFF
--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -188,6 +188,7 @@ const generateSyncData = (settings, recordType, record) => {
         mode: record.mode,
         prescriber_ID: record.prescriber && record.prescriber.id,
         total: String(record.total),
+        amount_outstanding: String(record.outstanding),
         foreign_currency_total: String(record.total),
         service_price: String(record.servicePrice),
         their_ref: record.theirRef,


### PR DESCRIPTION
Fixes #2345.

## Change summary

Adds `amount_outstanding` to outgoing sync.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

### Setup

- [ ] Create a cash in or cash out (receipt or payment) record using the cash register and sync to desktop. 
- [ ] On desktop, view the offset customer invoice (cash in) or customer credit (cash out) transaction.
- [ ] Enter the debugger and view the current `[transact]` record.

### Tests

- [ ] The `amount_outstanding` for the offset transaction for a cash in or cash out is synced from mobile (`[transact]amount_outstanding == [transact]total`).

### Related areas to think about

Following desktop behaviour, the `payment` and `receipt` transactions always have `amount_outstanding == 0`.
