### PR TITLE
#2340 prescribers editable only from this store

### DIFF
--- a/src/database/DataTypes/Prescriber.js
+++ b/src/database/DataTypes/Prescriber.js
@@ -17,6 +17,7 @@ Prescriber.schema = {
     mobileNumber: { type: 'string', optional: true },
     emailAddress: { type: 'string', optional: true },
     transactions: { type: 'linkingObjects', objectType: 'Transaction', property: 'prescriber' },
+    fromThisStore: { type: 'bool', default: false },
   },
 };
 

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -95,6 +95,7 @@ const createPrescriber = (database, prescriberDetails) => {
     ...prescriberDetails,
     address,
     // Defaults:
+    fromThisStore: true,
     isVisible: true,
     isActive: true,
   });

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -26,7 +26,7 @@ import { InsuranceActions } from '../actions/InsuranceActions';
 import { DispensaryActions } from '../actions/DispensaryActions';
 
 import { selectDataSetInUse, selectSortedData } from '../selectors/dispensary';
-import { selectPrescriberModalOpen } from '../selectors/prescriber';
+import { selectPrescriberModalOpen, selectCanEditPrescriber } from '../selectors/prescriber';
 import { selectInsuranceModalOpen } from '../selectors/insurance';
 import { selectPatientModalOpen } from '../selectors/patient';
 
@@ -41,6 +41,7 @@ const Dispensing = ({
   searchTerm,
   usingPatientsDataSet,
   usingPrescribersDataSet,
+
   // Misc. Callbacks
   filter,
   sort,
@@ -51,6 +52,7 @@ const Dispensing = ({
   patientEditModalOpen,
   currentPatient,
   patientHistoryModalOpen,
+
   // Patient callback
   editPatient,
   createPatient,
@@ -61,6 +63,8 @@ const Dispensing = ({
   // Prescriber variables
   currentPrescriber,
   prescriberModalOpen,
+  canEditPrescriber,
+
   // Prescriber callbacks
   editPrescriber,
   createPrescriber,
@@ -183,6 +187,7 @@ const Dispensing = ({
         isVisible={prescriberModalOpen}
       >
         <FormControl
+          isDisabled={!canEditPrescriber}
           onSave={savePrescriber}
           onCancel={cancelPrescriberEdit}
           inputConfig={getFormInputConfig('prescriber', currentPrescriber)}
@@ -235,6 +240,7 @@ const mapStateToProps = state => {
   const { isCreatingInsurancePolicy, selectedInsurancePolicy } = insurance;
 
   const prescriberModalOpen = selectPrescriberModalOpen(state);
+  const canEditPrescriber = selectCanEditPrescriber(state);
   const [patientEditModalOpen, patientHistoryModalOpen] = selectPatientModalOpen(state);
   const insuranceModalOpen = selectInsuranceModalOpen(state);
   const data = selectSortedData(state);
@@ -256,6 +262,7 @@ const mapStateToProps = state => {
     // Prescriber
     currentPrescriber,
     prescriberModalOpen,
+    canEditPrescriber,
     // Insurance
     insuranceModalOpen,
     selectedInsurancePolicy,
@@ -294,6 +301,7 @@ Dispensing.defaultProps = {
   currentPatient: null,
   currentPrescriber: null,
   selectedInsurancePolicy: null,
+  canEditPrescriber: false,
 };
 
 Dispensing.propTypes = {
@@ -313,6 +321,7 @@ Dispensing.propTypes = {
   cancelPatientEdit: PropTypes.func.isRequired,
   currentPatient: PropTypes.object,
   currentPrescriber: PropTypes.object,
+  canEditPrescriber: PropTypes.bool,
   editPrescriber: PropTypes.func.isRequired,
   createPrescriber: PropTypes.func.isRequired,
   cancelPrescriberEdit: PropTypes.func.isRequired,

--- a/src/selectors/prescriber.js
+++ b/src/selectors/prescriber.js
@@ -45,5 +45,13 @@ export const selectSortedPrescribers = createSelector(
 
 export const selectPrescriberModalOpen = ({ prescriber }) => {
   const { isCreatingPrescriber, isEditingPrescriber } = prescriber;
+
   return isCreatingPrescriber || isEditingPrescriber;
+};
+
+export const selectCanEditPrescriber = ({ prescriber }) => {
+  const { currentPrescriber } = prescriber;
+  const { fromThisStore } = currentPrescriber ?? {};
+
+  return fromThisStore ?? true;
 };

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -869,6 +869,8 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       break;
     }
     case 'Prescriber': {
+      const fromThisStore = record.store_ID === settings.get(THIS_STORE_ID);
+
       database.update(recordType, {
         id: record.ID,
         firstName: record.first_name,
@@ -880,6 +882,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         phoneNumber: record.phone,
         mobileNumber: record.mobile,
         emailAddress: record.email,
+        fromThisStore,
       });
       break;
     }

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -258,6 +258,9 @@ const generateSyncData = (settings, recordType, record) => {
       };
     }
     case 'Prescriber': {
+      // Only sync out prescribers from this store.
+      if (!record.fromThisStore) return null;
+
       return {
         ID: record.id,
         last_name: record.lastName,

--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -17,7 +17,7 @@ import { formInputStrings } from '../localization';
  *
  * FormInputConfig have the following structure:
  * {
- *     type: 'text' : A ValidationTextInput component
+ *     type: 'text' : A FormTextInput component
  *     initialValue : The value to seed the form input component with.
  *     key: A key for the underlying record.
  *     isRequired : Indicator whether this input is required to be filled for completion.

--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -32,6 +32,7 @@ import { FormActions } from '../actions/FormActions';
  * @param {func}  completedForm   Object containing key:value pairs of valid inputs from the form.
  * @param {func}  initialiseForm  Dispatcher to initialise the redux state with the correct config.
  * @param {func}  onSave          Callback to invoke on saving the form, passing back completedForm.
+ * @param {bool}  isDisabled      Indicator whether this Form is disabled.
  * @param {Array} inputConfig     Configuration array of input config objects.
  *                                See { getFormInputConfig } from src/utilities/formInputConfigs.
  */
@@ -43,6 +44,7 @@ const FormControlComponent = ({
   initialiseForm,
   onSave,
   inputConfig,
+  isDisabled,
 }) => {
   const [refs, setRefs] = React.useState([]);
   React.useEffect(() => {
@@ -80,6 +82,7 @@ const FormControlComponent = ({
                 onChangeText={value => onUpdateForm(key, value)}
                 label={label}
                 invalidMessage={invalidMessage}
+                isDisabled={isDisabled}
               />
             );
           }
@@ -95,6 +98,7 @@ const FormControlComponent = ({
                 onValidate={validator}
                 invalidMessage={invalidMessage}
                 onSubmit={nextFocus(index, key)}
+                isDisabled={isDisabled}
               />
             );
           }
@@ -109,6 +113,7 @@ const FormControlComponent = ({
                 onValueChange={value => onUpdateForm(key, value)}
                 options={options}
                 optionKey={optionKey}
+                isDisabled={isDisabled}
               />
             );
           }
@@ -123,6 +128,7 @@ const FormControlComponent = ({
                 key={key}
                 label={label}
                 isRequired={isRequired}
+                isDisabled={isDisabled}
               />
             );
           }
@@ -139,6 +145,7 @@ const FormControlComponent = ({
                 key={key}
                 label={label}
                 isRequired={isRequired}
+                isDisabled={isDisabled}
               />
             );
           }
@@ -161,7 +168,7 @@ const FormControlComponent = ({
         <PageButton
           onPress={onSaveCompletedForm}
           style={localStyles.saveButton}
-          isDisabled={!canSaveForm}
+          isDisabled={!canSaveForm || isDisabled}
           textStyle={localStyles.saveButtonTextStyle}
           text={generalStrings.save}
         />
@@ -196,6 +203,7 @@ const mapStateToProps = state => {
 
 FormControlComponent.defaultProps = {
   completedForm: null,
+  isDisabled: false,
 };
 
 FormControlComponent.propTypes = {
@@ -206,6 +214,7 @@ FormControlComponent.propTypes = {
   onUpdateForm: PropTypes.func.isRequired,
   inputConfig: PropTypes.array.isRequired,
   onCancelPressed: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
 };
 
 export const FormControl = connect(mapStateToProps, mapDispatchToProps)(FormControlComponent);

--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -6,17 +6,17 @@ import { View, ScrollView, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import { ValidationTextInput } from './ValidationTextInput';
 import { PageButton } from './PageButton';
+import { FormTextInput } from './FormInputs/FromTextInput';
+import { FormDateInput } from './FormInputs/FormDateInput';
+import { FormToggle } from './FormInputs/FormToggle';
+import { FormDropdown } from './FormInputs/FormDropdown';
+import { FormSlider } from './FormInputs/FormSlider';
 
 import globalStyles, { SUSSOL_ORANGE, WHITE } from '../globalStyles';
 import { modalStrings, generalStrings } from '../localization';
 import { selectCanSaveForm, selectCompletedForm } from '../selectors/form';
 import { FormActions } from '../actions/FormActions';
-import { FormDateInput } from './FormDateInput';
-import { FormToggle } from './FormInputs/FormToggle';
-import { FormDropdown } from './FormInputs/FormDropdown';
-import { FormSlider } from './FormInputs/FormSlider';
 
 /**
  * Component which will manage and control a set of user inputs of a form.
@@ -70,7 +70,7 @@ const FormControlComponent = ({
         switch (type) {
           case 'text': {
             return (
-              <ValidationTextInput
+              <FormTextInput
                 ref={refs[index]}
                 onSubmit={nextFocus(index, key)}
                 key={key}

--- a/src/widgets/FormInputs/FormDateInput.js
+++ b/src/widgets/FormInputs/FormDateInput.js
@@ -19,6 +19,23 @@ import { CircleButton } from '../CircleButton';
 import { FormLabel } from './FormLabel';
 import { FormInvalidMessage } from './FormInvalidMessage';
 
+/**
+ * Form input for entering dates. Renders a TextInput as well as a button, opening a
+ * native Date picker.
+ *
+ * @prop {Date}   value                    A date or moment - The initial date.
+ * @prop {Bool}   isRequired               Indicator whether this date is required.
+ * @prop {Bool}   isDisabled               Indicator whether this input is disabled.
+ * @prop {Func}   onValidate               Callback to validate the input.
+ * @prop {Func}   onChangeDate             Callback for date changes[called only with a valid date].
+ * @prop {Func}   onSubmit                 Callback after submitting a date from text.
+ * @prop {String} label                    Label for the input
+ * @prop {String} placeholder              Placeholder text for the text input.
+ * @prop {String} placeholderTextColor     Colour of the placeholder text.
+ * @prop {String} underlineColorAndroid    Underline colour of the text input.
+ * @prop {String} invalidMessage           Message to the user when the current input is invalid.
+ * @prop {Object} textInputStyle           Style object to override the underlying text input.
+ */
 export const FormDateInput = React.forwardRef(
   (
     {
@@ -33,6 +50,7 @@ export const FormDateInput = React.forwardRef(
       placeholderTextColor,
       underlineColorAndroid,
       onSubmit,
+      isDisabled,
     },
     ref
   ) => {
@@ -101,8 +119,13 @@ export const FormDateInput = React.forwardRef(
               autoCorrect={false}
               onChangeText={onChangeTextCallback}
               onSubmitEditing={onSubmitEditing}
+              editable={!isDisabled}
             />
-            <CircleButton IconComponent={CalendarIcon} onPress={openDatePicker} />
+            <CircleButton
+              IconComponent={CalendarIcon}
+              onPress={openDatePicker}
+              isDisabled={isDisabled}
+            />
           </FlexRow>
 
           {datePickerOpen && (
@@ -136,6 +159,7 @@ FormDateInput.defaultProps = {
   onValidate: null,
   invalidMessage: '',
   onSubmit: null,
+  isDisabled: false,
 };
 
 FormDateInput.propTypes = {
@@ -150,4 +174,5 @@ FormDateInput.propTypes = {
   placeholderTextColor: PropTypes.string,
   underlineColorAndroid: PropTypes.string,
   onSubmit: PropTypes.func,
+  isDisabled: PropTypes.isDisabled,
 };

--- a/src/widgets/FormInputs/FormDateInput.js
+++ b/src/widgets/FormInputs/FormDateInput.js
@@ -10,14 +10,14 @@ import moment from 'moment';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import PropTypes from 'prop-types';
 
-import { FlexColumn } from './FlexColumn';
-import { FlexRow } from './FlexRow';
+import { FlexColumn } from '../FlexColumn';
+import { FlexRow } from '../FlexRow';
 
-import { APP_FONT_FAMILY, SUSSOL_ORANGE, DARKER_GREY } from '../globalStyles';
-import { CalendarIcon } from './icons';
-import { CircleButton } from './CircleButton';
-import { FormLabel } from './FormInputs/FormLabel';
-import { FormInvalidMessage } from './FormInputs/FormInvalidMessage';
+import { APP_FONT_FAMILY, SUSSOL_ORANGE, DARKER_GREY } from '../../globalStyles';
+import { CalendarIcon } from '../icons';
+import { CircleButton } from '../CircleButton';
+import { FormLabel } from './FormLabel';
+import { FormInvalidMessage } from './FormInvalidMessage';
 
 export const FormDateInput = React.forwardRef(
   (

--- a/src/widgets/FormInputs/FormDropdown.js
+++ b/src/widgets/FormInputs/FormDropdown.js
@@ -12,14 +12,40 @@ import { DropDown } from '../DropDown';
 import { FormLabel } from './FormLabel';
 import { FlexColumn } from '../FlexColumn';
 
-export const FormDropdown = ({ isRequired, label, onValueChange, options, optionKey, value }) => {
+/**
+ * Form input rendering a native drop down with a selection of choices
+ * passed in through `options` where each element is an object. Each element
+ * is displayed to the user represented by the value retrived from the field
+ * passed by `optionKey`.
+ *
+ * @prop {Bool}   isRequired    Indicator whether this input is required.
+ * @prop {Bool}   isDisabled    Indicator whether this input is disabled.
+ * @prop {String} label         Label to display for this input.
+ * @prop {Func}   onValueChange Callback for when a selection has been made.
+ * @prop {Array}  options       Array of options [{[optionKey], ..}, {..} ]
+ * @prop {String} optionKey     Key of an object within options to display.
+ * @prop {value}  value         The currently selected value.
+ */
+export const FormDropdown = ({
+  isRequired,
+  label,
+  onValueChange,
+  options,
+  optionKey,
+  value,
+  isDisabled,
+}) => {
   const valueStrings = options.map(({ [optionKey]: valueString }) => valueString);
-  const onValueChangeCallback = (_, index) => onValueChange(options[index]);
+  const onValueChangeCallback = React.useCallback((_, index) => onValueChange(options[index]), [
+    options,
+    onValueChange,
+  ]);
 
   return (
     <FlexColumn flex={1}>
       <FormLabel value={label} isRequired={isRequired} />
       <DropDown
+        enabled={!isDisabled}
         style={{ width: null, flex: 1 }}
         values={valueStrings}
         selectedValue={value[optionKey]}
@@ -31,6 +57,7 @@ export const FormDropdown = ({ isRequired, label, onValueChange, options, option
 
 FormDropdown.defaultProps = {
   isRequired: false,
+  isDisabled: false,
 };
 
 FormDropdown.propTypes = {
@@ -40,4 +67,5 @@ FormDropdown.propTypes = {
   value: PropTypes.object.isRequired,
   label: PropTypes.string.isRequired,
   isRequired: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 };

--- a/src/widgets/FormInputs/FormSlider.js
+++ b/src/widgets/FormInputs/FormSlider.js
@@ -12,11 +12,31 @@ import { FormLabel } from './FormLabel';
 import { FlexView } from '../FlexView';
 import { Slider } from '../Slider';
 
+/**
+ * Form input for a slider and smaller text input to enter numbers.
+ * The maximum and minimum values will put a range on the input for both
+ * slider and text input where the callback will only be triggered
+ * when values are valid. When sliding, the callback is only triggered
+ * at the end of a slide, regardless of the value changing, or not.
+ *
+ * @prop {String} label         Label for this form input
+ * @prop {Bool}   isRequired    Indicator whether this input is required for the form.
+ * @prop {Bool}   isDisabled    Indicator whether this input is disabled for the form.
+ * @prop {Number} minimumValue  The upper bound number of the slider.
+ * @prop {Number} maximumValue  The lower bound number of the slider.
+ * @prop {Number} step          The increment step for the slider.
+ * @prop {Number} value         The current value of the input.
+ * @prop {Func}   onValueChange Callback for value changes. For sliding- will be called on press up.
+ */
 export const FormSlider = React.forwardRef(
-  ({ label, isRequired, minimumValue, maximumValue, step, value, onValueChange }, ref) => (
+  (
+    { label, isRequired, minimumValue, maximumValue, step, value, onValueChange, isDisabled },
+    ref
+  ) => (
     <FlexView flex={1}>
       <FormLabel value={label} isRequired={isRequired} />
       <Slider
+        isDisabled={isDisabled}
         ref={ref}
         onEndEditing={onValueChange}
         minimumValue={minimumValue}
@@ -32,6 +52,7 @@ FormSlider.defaultProps = {
   isRequired: false,
   minimumValue: 0,
   maximumValue: 100,
+  isDisabled: false,
 };
 
 FormSlider.propTypes = {
@@ -42,4 +63,5 @@ FormSlider.propTypes = {
   step: PropTypes.number.isRequired,
   value: PropTypes.number.isRequired,
   onValueChange: PropTypes.func.isRequired,
+  isDisabled: PropTypes.isDisabled,
 };

--- a/src/widgets/FormInputs/FormToggle.js
+++ b/src/widgets/FormInputs/FormToggle.js
@@ -12,7 +12,27 @@ import { FormLabel } from './FormLabel';
 import { ToggleBar } from '../ToggleBar';
 import { FlexView } from '../FlexView';
 
-export const FormToggle = ({ label, options, optionLabels, value, onValueChange, isRequired }) => {
+/**
+ * Form input of a toggle selection. Multiple toggles can be rendered, with
+ * just one being selected.
+ *
+ * @prop {String} label         Label for this form input.
+ * @prop {Array}  options       The underlying options to select from.
+ * @prop {Array}  optionLabels  Array of labels for options i.e. ["Yes", "No"]
+ * @prop {String} value         The current selected value.
+ * @prop {Func}   onValueChange Callback after a toggle selection.
+ * @prop {Bool}   isRequired    Indicator whether this form input is required.
+ * @prop {Bool}   isDisabled    Indicator whether this form input is disabled.
+ */
+export const FormToggle = ({
+  label,
+  options,
+  optionLabels,
+  value,
+  onValueChange,
+  isRequired,
+  isDisabled,
+}) => {
   const toggles = React.useMemo(
     () =>
       options.map((option, index) => ({
@@ -27,6 +47,7 @@ export const FormToggle = ({ label, options, optionLabels, value, onValueChange,
     <FlexView flex={1}>
       <FormLabel value={label} isRequired={isRequired} />
       <ToggleBar
+        isDisabled={isDisabled}
         toggles={toggles}
         style={{ marginTop: 20 }}
         toggleOnStyle={{ flex: 1 }}
@@ -38,6 +59,7 @@ export const FormToggle = ({ label, options, optionLabels, value, onValueChange,
 
 FormToggle.defaultProps = {
   isRequired: false,
+  isDisabled: false,
 };
 
 FormToggle.propTypes = {
@@ -47,4 +69,5 @@ FormToggle.propTypes = {
   value: PropTypes.any.isRequired,
   label: PropTypes.string.isRequired,
   isRequired: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 };

--- a/src/widgets/FormInputs/FromTextInput.js
+++ b/src/widgets/FormInputs/FromTextInput.js
@@ -21,6 +21,8 @@ import { SUSSOL_ORANGE, APP_FONT_FAMILY, DARKER_GREY } from '../../globalStyles'
  * @prop {String} value                 The initial value of the input.
  * @prop {Object} labelStyle            Style of the label.
  * @prop {Object} textInputStyle        Style of the underlying TextInput.
+ * @prop {Func}   onSubmit              Callback from submitting - component holds internal state.
+ * @prop {Bool}   isDisabled            Indicator whether this component is disabled.
  */
 export const FormTextInput = React.forwardRef(
   (
@@ -36,6 +38,7 @@ export const FormTextInput = React.forwardRef(
       value,
       textInputStyle,
       onSubmit,
+      isDisabled,
     },
     ref
   ) => {
@@ -89,6 +92,7 @@ export const FormTextInput = React.forwardRef(
               autoCorrect={false}
               onChangeText={onChangeTextCallback}
               onSubmitEditing={onSubmitEditing}
+              editable={!isDisabled}
             />
             <FormInvalidMessage message={invalidMessage} isValid={isValid} />
           </View>
@@ -114,6 +118,7 @@ FormTextInput.defaultProps = {
   textInputStyle: localStyles.textInputStyle,
   onValidate: null,
   onSubmit: null,
+  isDisabled: false,
 };
 
 FormTextInput.propTypes = {
@@ -128,4 +133,5 @@ FormTextInput.propTypes = {
   invalidMessage: PropTypes.string,
   textInputStyle: PropTypes.object,
   onSubmit: PropTypes.func,
+  isDisabled: PropTypes.bool,
 };

--- a/src/widgets/FormInputs/FromTextInput.js
+++ b/src/widgets/FormInputs/FromTextInput.js
@@ -3,10 +3,10 @@ import React from 'react';
 import { View, TextInput, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
-import { FormLabel } from './FormInputs/FormLabel';
-import { FormInvalidMessage } from './FormInputs/FormInvalidMessage';
+import { FormLabel } from './FormLabel';
+import { FormInvalidMessage } from './FormInvalidMessage';
 
-import { SUSSOL_ORANGE, APP_FONT_FAMILY, DARKER_GREY } from '../globalStyles';
+import { SUSSOL_ORANGE, APP_FONT_FAMILY, DARKER_GREY } from '../../globalStyles';
 
 /**
  * Uncontrolled wrapper component around a TextInput with validation
@@ -22,7 +22,7 @@ import { SUSSOL_ORANGE, APP_FONT_FAMILY, DARKER_GREY } from '../globalStyles';
  * @prop {Object} labelStyle            Style of the label.
  * @prop {Object} textInputStyle        Style of the underlying TextInput.
  */
-export const ValidationTextInput = React.forwardRef(
+export const FormTextInput = React.forwardRef(
   (
     {
       placeholder,
@@ -104,7 +104,7 @@ const localStyles = StyleSheet.create({
   textInputStyle: { flex: 1, fontFamily: APP_FONT_FAMILY },
 });
 
-ValidationTextInput.defaultProps = {
+FormTextInput.defaultProps = {
   placeholder: '',
   placeholderTextColor: SUSSOL_ORANGE,
   underlineColorAndroid: DARKER_GREY,
@@ -116,7 +116,7 @@ ValidationTextInput.defaultProps = {
   onSubmit: null,
 };
 
-ValidationTextInput.propTypes = {
+FormTextInput.propTypes = {
   placeholder: PropTypes.string,
   placeholderTextColor: PropTypes.string,
   underlineColorAndroid: PropTypes.string,

--- a/src/widgets/Slider.js
+++ b/src/widgets/Slider.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import { StyleSheet, View, Text, TextInput } from 'react-native';
 
 import RNSlider from '@react-native-community/slider';
-import { SUSSOL_ORANGE, WARMER_GREY, FINALISED_RED } from '../globalStyles/index';
-import { roundNumber } from '../utilities/index';
+import { SUSSOL_ORANGE, WARMER_GREY } from '../globalStyles';
+import { roundNumber } from '../utilities';
 
 /**
  * Component rendering a slider with an additional TextInput in a row.
@@ -15,8 +15,7 @@ import { roundNumber } from '../utilities/index';
  * The callback on value changes is invoked when sliding has finished and when
  * a valid number is entered into the TextInput.
  *
- * @prop {Number} minimumValue           The lower bound of valid values.
- * @prop {Number} maximumValue           The upper bound of valid values.
+ * @prop {Bool}   isDisabled             Indicator whether this component is disabled.
  * @prop {String} minimumTrackTintColour The colour of the track lower than the slider.
  * @prop {String} maximumTrackTintColour The colour of the track greater than the slider.
  * @prop {String} thumbTintColour        The colour of the slider thumb
@@ -24,6 +23,8 @@ import { roundNumber } from '../utilities/index';
  * @prop {Number} step                   The steps of the slider. i.e. 0.25 for [.0, .25,.5,.75]
  * @prop {Number} value                  The current value of the input.
  * @prop {Number} onEndEditing           The callback on editing.
+ * @prop {Number} minimumValue           The lower bound of valid values.
+ * @prop {Number} maximumValue           The upper bound of valid values.
  *
  */
 export const Slider = React.forwardRef(
@@ -38,6 +39,7 @@ export const Slider = React.forwardRef(
       step,
       value,
       onEndEditing,
+      isDisabled,
     },
     ref
   ) => {
@@ -100,6 +102,7 @@ export const Slider = React.forwardRef(
       <View style={mainContainerStyle}>
         <View style={rowStyle}>
           <RNSlider
+            disabled={isDisabled}
             style={sliderStyle}
             value={currentValue}
             step={step}
@@ -114,8 +117,9 @@ export const Slider = React.forwardRef(
 
           <TextInput
             ref={ref}
+            enabled={!isDisabled}
             style={textInputStyle}
-            underlineColorAndroid={isValid ? WARMER_GREY : FINALISED_RED}
+            underlineColorAndroid={WARMER_GREY}
             value={currentStringValue}
             onChangeText={setString}
             selectTextOnFocus
@@ -155,6 +159,7 @@ Slider.defaultProps = {
   fractionDigits: 2,
   step: 0.25,
   value: 20,
+  isDisabled: false,
 };
 
 Slider.propTypes = {
@@ -167,4 +172,5 @@ Slider.propTypes = {
   step: PropTypes.number,
   value: PropTypes.number,
   onEndEditing: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
 };

--- a/src/widgets/ToggleBar/ToggleBar.js
+++ b/src/widgets/ToggleBar/ToggleBar.js
@@ -7,7 +7,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { StyleSheet, Text, TouchableOpacity, ViewPropTypes, View } from 'react-native';
-import globalStyles, { SUSSOL_ORANGE } from '../../globalStyles';
+import globalStyles, { WARMER_GREY, SUSSOL_ORANGE } from '../../globalStyles';
 
 /**
  * Renders a bar of multiple toggling buttons, defined by the array 'toggles' passed in.
@@ -39,6 +39,7 @@ export const ToggleBarComponent = props => {
     textOffStyle,
     textOnStyle,
     toggles,
+    isDisabled,
     ...containerProps
   } = props;
 
@@ -46,16 +47,19 @@ export const ToggleBarComponent = props => {
     if (buttons.length === 0) return [];
     const renderOutput = [];
 
+    const defaultOnStyle = isDisabled
+      ? localStyles.toggleOnDisabledStyle
+      : localStyles.toggleOnStyle;
+
     buttons.forEach((button, i) => {
       const currentTextStyle = button.isOn
         ? [localStyles.textOnStyle, textOnStyle]
         : [localStyles.textOffStyle, textOffStyle];
-      const currentToggleStyle = button.isOn
-        ? [localStyles.toggleOnStyle, toggleOnStyle]
-        : [localStyles.toggleOffStyle, toggleOffStyle];
+      const currentToggleStyle = button.isOn ? defaultOnStyle : toggleOffStyle;
+      const Container = isDisabled ? View : TouchableOpacity;
 
       renderOutput.push(
-        <TouchableOpacity
+        <Container
           // TODO: use key which is not index.
           // eslint-disable-next-line react/no-array-index-key
           key={i}
@@ -63,7 +67,7 @@ export const ToggleBarComponent = props => {
           onPress={button.onPress}
         >
           <Text style={currentTextStyle}>{button.text}</Text>
-        </TouchableOpacity>
+        </Container>
       );
     });
 
@@ -80,24 +84,6 @@ export const ToggleBarComponent = props => {
 export const ToggleBar = React.memo(ToggleBarComponent);
 
 export default ToggleBar;
-
-ToggleBarComponent.propTypes = {
-  style: ViewPropTypes.style,
-  // eslint-disable-next-line react/require-default-props, react/forbid-prop-types
-  toggles: PropTypes.array,
-  toggleOffStyle: ViewPropTypes.style,
-  toggleOnStyle: ViewPropTypes.style,
-  textOffStyle: Text.propTypes.style,
-  textOnStyle: Text.propTypes.style,
-};
-
-ToggleBarComponent.defaultProps = {
-  style: globalStyles.toggleBar,
-  toggleOffStyle: globalStyles.toggleOption,
-  toggleOnStyle: globalStyles.toggleOptionSelected,
-  textOffStyle: globalStyles.toggleText,
-  textOnStyle: globalStyles.toggleTextSelected,
-};
 
 const localStyles = StyleSheet.create({
   container: {
@@ -121,4 +107,30 @@ const localStyles = StyleSheet.create({
     width: 142,
     backgroundColor: SUSSOL_ORANGE,
   },
+  toggleOnDisabledStyle: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 142,
+    backgroundColor: WARMER_GREY,
+  },
 });
+
+ToggleBarComponent.propTypes = {
+  style: ViewPropTypes.style,
+  // eslint-disable-next-line react/require-default-props, react/forbid-prop-types
+  toggles: PropTypes.array,
+  toggleOffStyle: ViewPropTypes.style,
+  toggleOnStyle: ViewPropTypes.style,
+  textOffStyle: Text.propTypes.style,
+  textOnStyle: Text.propTypes.style,
+  isDisabled: PropTypes.bool,
+};
+
+ToggleBarComponent.defaultProps = {
+  style: globalStyles.toggleBar,
+  toggleOffStyle: localStyles.toggleOffStyle,
+  toggleOnStyle: localStyles.toggleOnStyle,
+  textOffStyle: globalStyles.toggleText,
+  textOnStyle: globalStyles.toggleTextSelected,
+  isDisabled: false,
+};

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -37,7 +37,7 @@ export { TableShortcuts } from './TableShortcuts';
 export { TabNavigator } from './TabNavigator';
 export { TextInput } from './TextInput';
 export { ToggleBar } from './ToggleBar';
-export { ValidationTextInput } from './ValidationTextInput';
+export { FormTextInput } from './FormInputs/FromTextInput';
 export { Wizard } from './Wizard';
 
 export * from './icons';


### PR DESCRIPTION
Fixes #2340 

## Change summary

- Adds `fromThisStore` to `Prescriber` following the same pattern as `NameStoreJoin`
- Disables editing of a prescriber if the prescriber is not `fromThisStore`
- In the unlikely event of trying to sync a prescriber out: don't!

## Testing

- [ ] Cannot edit a prescriber that hasn't been created on the mobile store

### Related areas to think about

N/A
