### PR TITLE
#2360 Silently ignoring record types which can't be translated

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -824,6 +824,10 @@ export const integrateRecord = (database, settings, syncRecord) => {
   const changeType = SYNC_TYPES.translate(syncType, EXTERNAL_TO_INTERNAL);
   const internalRecordType = RECORD_TYPES.translate(recordType, EXTERNAL_TO_INTERNAL);
 
+  // If there is no translation available, then the app does not handle the record type.
+  // Shortcut return here and silently ignore it.
+  if (!internalRecordType) return;
+
   switch (changeType) {
     case CHANGE_TYPES.CREATE:
     case CHANGE_TYPES.UPDATE:


### PR DESCRIPTION
Fixes #2360 

## Change summary

- Silently ignores any record type which isn't supported by mobile earlier in the call chain.
- Does get ignored in `createOrUpdateRecord` but not in `deleteRecords` or `mergeRecords`!

## Testing

- [ ] Create a merge record for `Location` on your server and sync it to mobile. Pulling records is possible

### Related areas to think about

N/A
