### PR TITLE
#2341 only allow editing of patients from this store

### DIFF
--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -120,6 +120,7 @@ Name.schema = {
     isPatient: { type: 'bool', default: false },
     policies: { type: 'linkingObjects', objectType: 'InsurancePolicy', property: 'patient' },
     female: { type: 'bool', default: false },
+    thisStoresPatient: { type: 'bool', default: false },
   },
 };
 

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -28,7 +28,7 @@ import { DispensaryActions } from '../actions/DispensaryActions';
 import { selectDataSetInUse, selectSortedData } from '../selectors/dispensary';
 import { selectPrescriberModalOpen, selectCanEditPrescriber } from '../selectors/prescriber';
 import { selectInsuranceModalOpen } from '../selectors/insurance';
-import { selectPatientModalOpen } from '../selectors/patient';
+import { selectPatientModalOpen, selectCanEditPatient } from '../selectors/patient';
 
 import globalStyles from '../globalStyles';
 import { dispensingStrings } from '../localization';
@@ -52,6 +52,7 @@ const Dispensing = ({
   patientEditModalOpen,
   currentPatient,
   patientHistoryModalOpen,
+  canEditPatient,
 
   // Patient callback
   editPatient,
@@ -175,6 +176,7 @@ const Dispensing = ({
         isVisible={patientEditModalOpen}
       >
         <FormControl
+          isDisabled={!canEditPatient}
           onSave={savePatient}
           onCancel={cancelPatientEdit}
           inputConfig={getFormInputConfig('patient', currentPatient)}
@@ -241,6 +243,7 @@ const mapStateToProps = state => {
 
   const prescriberModalOpen = selectPrescriberModalOpen(state);
   const canEditPrescriber = selectCanEditPrescriber(state);
+  const canEditPatient = selectCanEditPatient(state);
   const [patientEditModalOpen, patientHistoryModalOpen] = selectPatientModalOpen(state);
   const insuranceModalOpen = selectInsuranceModalOpen(state);
   const data = selectSortedData(state);
@@ -259,6 +262,7 @@ const mapStateToProps = state => {
     patientEditModalOpen,
     currentPatient,
     patientHistoryModalOpen,
+    canEditPatient,
     // Prescriber
     currentPrescriber,
     prescriberModalOpen,
@@ -320,6 +324,7 @@ Dispensing.propTypes = {
   savePatient: PropTypes.func.isRequired,
   cancelPatientEdit: PropTypes.func.isRequired,
   currentPatient: PropTypes.object,
+  canEditPatient: PropTypes.bool.isRequired,
   currentPrescriber: PropTypes.object,
   canEditPrescriber: PropTypes.bool,
   editPrescriber: PropTypes.func.isRequired,

--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -45,3 +45,10 @@ export const selectPatientModalOpen = ({ patient }) => {
   const { viewingHistory } = patient;
   return [isCreating || isEditing, viewingHistory];
 };
+
+export const selectCanEditPatient = ({ patient }) => {
+  const { currentPatient } = patient;
+  const { thisStoresPatient } = currentPatient ?? {};
+
+  return thisStoresPatient ?? true;
+};

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -535,6 +535,9 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
     case 'Name': {
       const isPatient = record.type === 'patient';
       const name = isPatient ? `${record.last}, ${record.first}` : record.name;
+
+      const thisStoresPatient = record.supplying_store_id === settings.get(THIS_STORE_ID);
+
       internalRecord = {
         id: record.ID,
         name,
@@ -554,6 +557,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         isSupplier: parseBoolean(record.supplier),
         isManufacturer: parseBoolean(record.manufacturer),
         supplyingStoreId: record.supplying_store_id,
+        thisStoresPatient,
         isPatient,
         firstName: record.first,
         lastName: record.last,

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -534,13 +534,13 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
     }
     case 'Name': {
       const isPatient = record.type === 'patient';
-      const name = isPatient ? `${record.last}, ${record.first}` : record.name;
-
       const thisStoresPatient = record.supplying_store_id === settings.get(THIS_STORE_ID);
+
+      if (isPatient && !thisStoresPatient) break;
 
       internalRecord = {
         id: record.ID,
-        name,
+        name: record.name,
         code: record.code,
         phoneNumber: record.phone,
         billingAddress: getOrCreateAddress(

--- a/src/widgets/FormInputs/FormToggle.js
+++ b/src/widgets/FormInputs/FormToggle.js
@@ -5,12 +5,13 @@
  */
 
 import React from 'react';
-
+import { StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
 import { FormLabel } from './FormLabel';
 import { ToggleBar } from '../ToggleBar';
 import { FlexView } from '../FlexView';
+import { WARMER_GREY, SUSSOL_ORANGE } from '../../globalStyles';
 
 /**
  * Form input of a toggle selection. Multiple toggles can be rendered, with
@@ -49,13 +50,31 @@ export const FormToggle = ({
       <ToggleBar
         isDisabled={isDisabled}
         toggles={toggles}
-        style={{ marginTop: 20 }}
-        toggleOnStyle={{ flex: 1 }}
-        toggleOffStyle={{ flex: 1 }}
+        style={localStyles.toggleMargin}
+        toggleOnStyle={localStyles.toggleOnStyle}
+        toggleOffStyle={localStyles.toggleOffStyle}
+        toggleOnDisabledStyle={localStyles.toggleOnDisabledStyle}
       />
     </FlexView>
   );
 };
+
+const localStyles = StyleSheet.create({
+  toggleMargin: { marginTop: 20 },
+  toggleOnStyle: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: SUSSOL_ORANGE,
+  },
+  toggleOffStyle: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  toggleOnDisabledStyle: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: WARMER_GREY,
+  },
+});
 
 FormToggle.defaultProps = {
   isRequired: false,

--- a/src/widgets/ToggleBar/ToggleBar.js
+++ b/src/widgets/ToggleBar/ToggleBar.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/forbid-prop-types */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
@@ -40,6 +41,7 @@ export const ToggleBarComponent = props => {
     textOnStyle,
     toggles,
     isDisabled,
+    toggleOnDisabledStyle,
     ...containerProps
   } = props;
 
@@ -47,9 +49,7 @@ export const ToggleBarComponent = props => {
     if (buttons.length === 0) return [];
     const renderOutput = [];
 
-    const defaultOnStyle = isDisabled
-      ? localStyles.toggleOnDisabledStyle
-      : localStyles.toggleOnStyle;
+    const defaultOnStyle = isDisabled ? toggleOnDisabledStyle : toggleOnStyle;
 
     buttons.forEach((button, i) => {
       const currentTextStyle = button.isOn
@@ -110,8 +110,8 @@ const localStyles = StyleSheet.create({
   toggleOnDisabledStyle: {
     alignItems: 'center',
     justifyContent: 'center',
-    width: 142,
     backgroundColor: WARMER_GREY,
+    width: 142,
   },
 });
 
@@ -124,6 +124,7 @@ ToggleBarComponent.propTypes = {
   textOffStyle: Text.propTypes.style,
   textOnStyle: Text.propTypes.style,
   isDisabled: PropTypes.bool,
+  toggleOnDisabledStyle: PropTypes.object,
 };
 
 ToggleBarComponent.defaultProps = {
@@ -132,5 +133,6 @@ ToggleBarComponent.defaultProps = {
   toggleOnStyle: localStyles.toggleOnStyle,
   textOffStyle: globalStyles.toggleText,
   textOnStyle: globalStyles.toggleTextSelected,
+  toggleOnDisabledStyle: localStyles.toggleOnDisabledStyle,
   isDisabled: false,
 };


### PR DESCRIPTION
Fixes #2341 

## Change summary

- Makes patients editable only if theyre from the mobile store.
- Rejects any patients not from the mobile store in incoming sync.

## Testing

- [ ] Patients are not editable if they're not created in the mobile store
- [ ] Patients are editable which have been created in this mobile store

### Related areas to think about

N/A
