### PR TITLE
#2375 Patient creation diff

### DIFF
--- a/src/database/DataTypes/Currency.js
+++ b/src/database/DataTypes/Currency.js
@@ -1,0 +1,20 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+import Realm from 'realm';
+
+export class Currency extends Realm.Object {}
+
+Currency.schema = {
+  name: 'Abbreviation',
+  primaryKey: 'id',
+  properties: {
+    id: 'string',
+    rate: { type: 'double', default: 0 },
+    description: { type: 'string', default: 'placeholderCurrency' },
+    isDefaultCurrency: { type: 'boolean', default: false },
+    lastUpdate: { type: 'date', default: new Date() },
+  },
+};

--- a/src/database/DataTypes/Currency.js
+++ b/src/database/DataTypes/Currency.js
@@ -8,13 +8,13 @@ import Realm from 'realm';
 export class Currency extends Realm.Object {}
 
 Currency.schema = {
-  name: 'Abbreviation',
+  name: 'Currency',
   primaryKey: 'id',
   properties: {
     id: 'string',
     rate: { type: 'double', default: 0 },
     description: { type: 'string', default: 'placeholderCurrency' },
-    isDefaultCurrency: { type: 'boolean', default: false },
+    isDefaultCurrency: { type: 'bool', default: false },
     lastUpdate: { type: 'date', default: new Date() },
   },
 };

--- a/src/database/DataTypes/index.js
+++ b/src/database/DataTypes/index.js
@@ -49,3 +49,4 @@ export { Unit } from './Unit';
 export { Prescriber } from './Prescriber';
 export { Abbreviation } from './Abbreviation';
 export { ItemDirection } from './ItemDirection';
+export { Currency } from './Currency';

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -5,6 +5,7 @@
 
 import {
   Address,
+  Currency,
   Item,
   ItemBatch,
   ItemCategory,
@@ -185,6 +186,7 @@ export const schema = {
     Abbreviation,
     ItemDirection,
     User,
+    Currency,
   ],
   schemaVersion: 56,
 };

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -429,7 +429,7 @@ const createNumberSequence = (database, sequenceKey) =>
 const createNumberToReuse = (database, numberSequence, number) => {
   const alreadyReusing = database
     .objects('NumberToReuse')
-    .query('numberSequence == $0 && number == $1', numberSequence, number);
+    .filtered('numberSequence == $0 && number == $1', numberSequence, number);
 
   // If we are already reusing this number - shortcut return
   if (alreadyReusing.length) return;

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -302,6 +302,10 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
       cannotBeBlank: ['code', 'description'],
       canBeBlank: [],
     },
+    Currency: {
+      cannotBeBlank: [],
+      canBeBlank: [],
+    },
   };
 
   if (!requiredFields[recordType]) return false; // Unsupported record type
@@ -363,6 +367,16 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         comment: record?.comment,
         validityDays: parseNumber(record?.prescriptionValidityDays || 0),
         isActive: parseBoolean(record?.isActive || false),
+      });
+      return;
+    }
+    case 'Currency': {
+      database.update(recordType, {
+        id: record.ID,
+        rate: parseNumber(record.rate),
+        description: record.currency,
+        isDefaultCurrency: parseBoolean(record.is_home_currency ?? false),
+        lastUpdate: parseDate(record.date_updated),
       });
       return;
     }
@@ -932,6 +946,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
  * @param   {object}  syncRecord  Data representing the sync record.
  * @return  {none}
  */
+
 export const integrateRecord = (database, settings, syncRecord) => {
   // Ignore sync record if missing data, record type, sync type, or record ID.
   if (!syncRecord.RecordType || !syncRecord.SyncType) return;

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -376,7 +376,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         rate: parseNumber(record.rate),
         description: record.currency,
         isDefaultCurrency: parseBoolean(record.is_home_currency ?? false),
-        lastUpdate: parseDate(record.date_updated),
+        lastUpdate: parseDate(record.date_updated) ?? new Date(),
       });
       return;
     }

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -92,6 +92,8 @@ const generateSyncData = (settings, recordType, record) => {
         customer: String(record.isCustomer),
         address1: record.address?.line1,
         address2: record.address?.line2,
+        barcode: `*${record.code}*`,
+        charge_code: record.code,
       };
     }
     case 'NumberSequence': {

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -90,6 +90,8 @@ const generateSyncData = (settings, recordType, record) => {
         supplying_store_id: settings.get(THIS_STORE_ID),
         phone: record.phoneNumber,
         customer: String(record.isCustomer),
+        address1: record.address?.line1,
+        address2: record.address?.line2,
       };
     }
     case 'NumberSequence': {

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -78,6 +78,11 @@ const generateSyncData = (settings, recordType, record) => {
     case 'Name': {
       if (!record.isPatient) return false;
 
+      const defaultCurrency = UIDatabase.objects('Currency').filtered(
+        'isDefaultCurrency == $0',
+        true
+      )[0];
+
       return {
         id: record.id,
         type: record.type,
@@ -93,7 +98,8 @@ const generateSyncData = (settings, recordType, record) => {
         address1: record.address?.line1,
         address2: record.address?.line2,
         barcode: `*${record.code}*`,
-        charge_code: record.code,
+        'charge code': record.code,
+        currency_id: defaultCurrency?.id ?? '',
       };
     }
     case 'NumberSequence': {

--- a/src/sync/syncTranslators.js
+++ b/src/sync/syncTranslators.js
@@ -73,6 +73,7 @@ export const RECORD_TYPES = new SyncTranslator({
   Abbreviation: 'abbreviation',
   InsuranceProvider: 'insuranceProvider',
   InsurancePolicy: 'nameInsuranceJoin',
+  Currency: 'currency',
 });
 
 export const REQUISITION_TYPES = new SyncTranslator({


### PR DESCRIPTION
Fixes #2375 

## Change summary

- Add currency to sync to access the default currency. needed for transactions aswell
- Adds `charge code`, `barcode`, `currency_ID` and address' to outgoing sync

## Testing

- [ ] When syncing a patient to desktop - the billing address fields are correctly set.
- [ ] When syncing a patient to desktop - the charge code field is correctly set.
- [ ] When syncing a patient to desktop - the barcode field is correctly set.
- [ ] When syncing a patient to desktop - the currency_ID is correctly set.

### Related areas to think about

N/A
