### PR TITLE
Add missing entry time and date order written fields to outgoing sync

### DIFF
--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -205,6 +205,8 @@ const generateSyncData = (settings, recordType, record) => {
         insuranceDiscountAmount: String(record?.insuranceDiscountAmount),
         insuranceDiscountRate: String(record?.insuranceDiscountRate),
         paymentTypeID: record?.paymentType?.id ?? '',
+        entry_time: getTimeString(record.entryDate),
+        Date_order_written: getDateString(record.entryDate),
       };
     }
     case 'TransactionBatch': {


### PR DESCRIPTION
Fixes #2377 

## Change summary

- Adds `entry_time` and `Date_order_written` to `outgoingSyncUtils`
- ignoring colour 🤷‍♂ 

## Testing

- [ ] When syncing a `Transaction` the `entry_time` is correct on the server.
- [ ] When syncing a `Transaction` the `Date_order_written` is correct on the server (and equal to `entry_time`.

### Related areas to think about

N/A