### PR TITLE
#2378 missing rc fields

### DIFF
--- a/src/localization/dispensingStrings.json
+++ b/src/localization/dispensingStrings.json
@@ -1,5 +1,6 @@
 {
   "gb": {
+    "receipt_for_invoice": "Receipt for invoice(s)",
     "available_credit": "Available credit",
     "cash_in": "Cash In",
     "cash_out": "Cash out",

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -177,6 +177,11 @@ const generateSyncData = (settings, recordType, record) => {
       };
     }
     case 'Transaction': {
+      const defaultCurrency = UIDatabase.objects('Currency').filtered(
+        'isDefaultCurrency == $0',
+        true
+      )[0];
+
       return {
         ID: record.id,
         name_ID: record.otherParty && record.otherParty.id,
@@ -207,6 +212,8 @@ const generateSyncData = (settings, recordType, record) => {
         paymentTypeID: record?.paymentType?.id ?? '',
         entry_time: getTimeString(record.entryDate),
         Date_order_written: getDateString(record.entryDate),
+        currency_ID: defaultCurrency?.id ?? '',
+        currency_rate: String(defaultCurrency?.rate ?? ''),
       };
     }
     case 'TransactionBatch': {

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -5,6 +5,7 @@
 
 import { createRecord } from '../../../database/utilities';
 import { UIDatabase } from '../../../database';
+import { dispensingStrings } from '../../../localization';
 
 /**
  * Helper method to pay off a prescription. Given a cash amount
@@ -61,8 +62,16 @@ export const pay = (
   if (creditAmount > availableCredit) throw new Error('Not enough credit');
 
   // Create a Receipt and ReceiptLine for every payment path.
-
-  const receipt = createRecord(UIDatabase, 'Receipt', currentUser, patient, cashAmount, null, '');
+  const receiptDescription = `${dispensingStrings.receipt_for_invoice} ${script.serialNumber}`;
+  const receipt = createRecord(
+    UIDatabase,
+    'Receipt',
+    currentUser,
+    patient,
+    cashAmount,
+    null,
+    receiptDescription
+  );
 
   createRecord(UIDatabase, 'ReceiptLine', receipt, script, cashAmount);
 


### PR DESCRIPTION
Fixes #2378 

## Change summary

- Adds `currency_id` and `currency_rate` to transactions when syncing - the default for the data file.
- Adds a comment to the receipt for a prescription

## Testing

- [ ] After paying for a prescription, the receipt correctly has the `currency_id` field set.
- [ ] After paying for a prescription, the receipt correctly has the `currency_rate` field set.
- [ ] After paying for a prescription, the receipt correctly has the `comment` field set with "Receipt(s) from invoice X"

### Related areas to think about

N/A