### PR TITLE
#2379 cash transaction missing fields

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -172,6 +172,7 @@ const createCashIn = (database, user, cashTransaction) => {
 
 const createOffsetCustomerInvoice = (database, payment) => {
   const { CUSTOMER_INVOICE_NUMBER } = NUMBER_SEQUENCE_KEYS;
+
   const currentDate = new Date();
   const invoice = database.create('Transaction', {
     id: generateUUID(),
@@ -186,6 +187,7 @@ const createOffsetCustomerInvoice = (database, payment) => {
     outstanding: payment.subtotal,
     enteredBy: payment.enteredBy,
     linkedTransaction: payment,
+    paymentType: payment?.paymentType,
   });
 
   return invoice;
@@ -321,6 +323,7 @@ const createOffsetCustomerCredit = (database, receipt) => {
     subtotal: -receipt.subtotal,
     outstanding: -receipt.subtotal,
     linkedTransaction: receipt,
+    paymentType: receipt?.paymentType,
   });
 
   database.save('Transaction', customerCredit);

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -186,7 +186,6 @@ const createOffsetCustomerInvoice = (database, payment) => {
     subtotal: payment.subtotal,
     outstanding: payment.subtotal,
     enteredBy: payment.enteredBy,
-    linkedTransaction: payment,
     paymentType: payment?.paymentType,
   });
 
@@ -322,7 +321,6 @@ const createOffsetCustomerCredit = (database, receipt) => {
     enteredBy: receipt.enteredBy,
     subtotal: -receipt.subtotal,
     outstanding: -receipt.subtotal,
-    linkedTransaction: receipt,
     paymentType: receipt?.paymentType,
   });
 

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -214,6 +214,7 @@ const generateSyncData = (settings, recordType, record) => {
         Date_order_written: getDateString(record.entryDate),
         currency_ID: defaultCurrency?.id ?? '',
         currency_rate: String(defaultCurrency?.rate ?? ''),
+        optionID: record.option?.id ?? '',
       };
     }
     case 'TransactionBatch': {


### PR DESCRIPTION
Fixes #2379 

## Change summary

- Removes the linked transaction from the CC/CI's to the receipt - doesn't happen on desktop
- Adds the payment type to the CC/CI offsets


## Testing

*Cash in transaction*
- [ ] The offset customer credit created from a cash in transaction has the payment type of the cash in transaction when synced to desktop
- [ ] The offset customer credit created from a cash in transaction has no linked transaction when synced to desktop
*Cash out transaction*
- [ ] The offset customer invoice created from a cash out transaction has the payment type of the cash out transaction when synced to desktop
- [ ] The offset customer invoice created from a cash out transaction has no linked transaction out  when synced to desktop
- [ ] The offset customer invoice created from a cash out transaction has the reason type of the cash out transaction when synced to desktop


### Related areas to think about

N/A
