### PR TITLE
#2395 Stop making offset CC lines

### DIFF
--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -36,10 +36,13 @@ export class Name extends Realm.Object {
   }
 
   /**
-   * Returns all customer credits for this Name
+   * The customer credits for this name are the literal customer credit type transactions, as well
+   * as any customer invoices which are cancellations. These cancelled customer invoices are
+   * inverted customer invoices, which are equivallent to a customer credit.
    */
   get customerCredits() {
-    return this.transactions.filtered('type == $0', 'customer_credit');
+    const queryString = 'type == $0 || (type == $1 && isCancellation == $2)';
+    return this.transactions.filtered(queryString, 'customer_credit', 'customer_invoice', true);
   }
 
   /**

--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -49,7 +49,7 @@ export class Name extends Realm.Object {
    * Debit sources are customer invoices which are not cancellations - all outgoings.
    */
   get debitSources() {
-    const queryString = 'type == $0 && isCancellation == $2 && outstanding != 0';
+    const queryString = 'type == $0 && isCancellation == $1 && outstanding != 0';
     return this.transactions.filtered(queryString, 'customer_invoice', false);
   }
 

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -514,6 +514,7 @@ Transaction.schema = {
     insuranceDiscountRate: { type: 'double', optional: true },
     insuranceDiscountAmount: { type: 'double', optional: true },
     paymentType: { type: 'PaymentType', optional: true },
+    isCancellation: { type: 'bool', default: false },
   },
 };
 

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -361,22 +361,6 @@ const createCustomerRefundLine = (database, customerCredit, transactionBatch) =>
   return refundLine;
 };
 
-const createCustomerCreditLine = (database, customerCredit, total) => {
-  const receiptLine = database.create('TransactionBatch', {
-    id: generateUUID(),
-    total,
-    transaction: customerCredit,
-    type: 'cash_in',
-    note: 'credit',
-  });
-
-  customerCredit.outstanding += total;
-
-  database.save('Transaction', customerCredit);
-  database.save('TransactionBatch', receiptLine);
-  return receiptLine;
-};
-
 /**
  * Create a customer invoice associated with a given customer.
  *
@@ -846,8 +830,6 @@ export const createRecord = (database, type, ...args) => {
       return createOffsetCustomerCredit(database, ...args);
     case 'SupplierCredit':
       return createSupplierCredit(database, ...args);
-    case 'CustomerCreditLine':
-      return createCustomerCreditLine(database, ...args);
     case 'SupplierCreditLine':
       return createSupplierCreditLine(database, ...args);
     case 'InsurancePolicy':

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -213,13 +213,14 @@ const createReceipt = (database, user, name, amount, paymentType, description) =
   return receipt;
 };
 
-const createReceiptLine = (database, receipt, linkedTransaction, amount) => {
+const createReceiptLine = (database, receipt, linkedTransaction, amount, note) => {
   const receiptLine = database.create('TransactionBatch', {
     id: generateUUID(),
     total: amount,
     transaction: receipt,
     linkedTransaction,
     type: 'cash_in',
+    note,
   });
 
   database.save('TransactionBatch', receiptLine);

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -786,7 +786,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         subtotal: parseFloat(record.subtotal),
         user1: record.user1,
         paymentType: database.getOrCreate('PaymentType', record.paymentTypeID),
-        isCancellation: parseBoolean(record.is_cancellaton),
+        isCancellation: parseBoolean(record.is_cancellation),
       };
       const transaction = database.update(recordType, internalRecord);
       if (linkedRequisition) {

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -786,6 +786,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         subtotal: parseFloat(record.subtotal),
         user1: record.user1,
         paymentType: database.getOrCreate('PaymentType', record.paymentTypeID),
+        isCancellation: parseBoolean(record.is_cancellaton),
       };
       const transaction = database.update(recordType, internalRecord);
       if (linkedRequisition) {

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -222,7 +222,7 @@ const generateSyncData = (settings, recordType, record) => {
         paymentTypeID: record?.paymentType?.id ?? '',
         entry_time: getTimeString(record.entryDate),
         Date_order_written: getDateString(record.entryDate),
-        isCancellation: String(record?.isCancellation ?? false),
+        is_cancellation: String(record?.isCancellation ?? false),
         currency_ID: defaultCurrency?.id ?? '',
         currency_rate: String(defaultCurrency?.rate ?? ''),
         optionID: record.option?.id ?? '',

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -217,6 +217,7 @@ const generateSyncData = (settings, recordType, record) => {
         paymentTypeID: record?.paymentType?.id ?? '',
         entry_time: getTimeString(record.entryDate),
         Date_order_written: getDateString(record.entryDate),
+        isCancellation: String(record?.isCancellation ?? false),
       };
     }
     case 'TransactionBatch': {

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -95,7 +95,7 @@ export const pay = (
       if (outstandingCredit >= 0) return false;
 
       const amountToTake = Math.min(Math.abs(outstandingCredit), creditToAllocate);
-      createRecord(UIDatabase, 'ReceiptLine', receipt, creditSource, -amountToTake);
+      createRecord(UIDatabase, 'ReceiptLine', receipt, creditSource, -amountToTake, 'credit');
 
       creditToAllocate -= amountToTake;
 

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -7,27 +7,32 @@ import { createRecord } from '../../../database/utilities';
 import { UIDatabase } from '../../../database';
 
 /**
- * Helper method to pay off a prescription. Given a cash amount
- * a script and a patient, all receipts, credits and cash in
- * transactions will be created and the script will be finalised.
+ * Helper method to pay off a prescription. After payment, the script
+ * will be finalised.
  *
- * Paying a script has three paths: underpay, exactpay and overpay.
- * All payments create a Receipt with a ReceiptLine.
+ * Paying a script has three paths: exact cash* payment, credit payment and
+ * mixed cash+payment.
+ * * [cash payment really meaning the patient has paid some amount that is not
+ * credit]
  *
- * An underpayment creates a CustomerCreditLine and a ReceiptLine
- * for each source of credit (CustomerCredit) that credit was used from.
- * For example if a Patient has overpaid the last two prescriptions, then
- * there would be two sources of credit. If both sources were used to pay
- * off a script, a CustomerCreditLine is added to each CustomerCredit for
- * the amount used. A CustomerCredit can have many CustomerCreditLines If
- * only a fraction of credit is used at a time.
+ * Every payment starts with a Receipt.
+ * There are then two ReceiptLines created:
+ * If there is a cash payment portion: create a ReceiptLine with an amount equal.
+ * If there is a credit portion: create a ReceiptLine with the full amount of credit used.
  *
- * An overpayment creates a CashIn Transaction to the value of the
- * amount overpaid.
+ * Then the amount of credit used needs to be reduced from the credit sources*.
+ * * credit source: [Sources of credit are from customer_credit type Transactions, as well as
+ * cancelled customer invoices. These invoices will have their outstanding field < 0 - where the
+ * absolute value is the amount of credit the patient has from that source. I.e. a customer_credit
+ * transaction with an outstanding equal to -20 shows the patient has $20 of credit]
  *
- * When using credit, credit must not become negative.
- * A script must be paid off in full, no partial payments.
- * Any amount overpaid must be gained in credit.
+ * Using credit:
+ * - Credit must not become negative.
+ * - Credit must come from a credit source.
+ * - A script must be paid off in full, no partial payments.
+ *
+ * To use credit, iterate over each credit source and reduce the outstanding value by the amount
+ * of credit being used.
  *
  * @param {User} currentUser   The currently logged in user.
  * @param {Name} patient       A Name that is a patient
@@ -54,36 +59,38 @@ export const pay = (
 
   const { availableCredit } = patient;
 
-  // Determine if this is an under, exact or over payment
+  // Determine if the payment is using credit.
   const creditAmount = scriptTotal - cashAmount;
   const usingCredit = creditAmount > 0;
 
   if (creditAmount > availableCredit) throw new Error('Not enough credit');
 
-  // Create a Receipt and ReceiptLine for every payment path.
-
+  // Create a Receipt for every payment path.
   const receipt = createRecord(UIDatabase, 'Receipt', currentUser, patient, cashAmount, null, '');
 
-  createRecord(UIDatabase, 'ReceiptLine', receipt, script, cashAmount);
-  createRecord(UIDatabase, 'ReceiptLine', receipt, script, creditAmount);
+  // Create a receipt line for the full non-credit amount, if any.
+  if (cashAmount) createRecord(UIDatabase, 'ReceiptLine', receipt, script, cashAmount);
 
-  // When using credit, create a CustomerCreditLine and ReceiptLine for each
-  // source of credit being used.
   let creditToAllocate = creditAmount;
 
   if (usingCredit) {
-    // Iterate over all the patients CustomerCredits, taking credit
-    // from each with available credit, until all has been allocated.
-    patient.customerCredits.some(customerCredit => {
-      const creditFromCustomerCredit = customerCredit.outstanding;
+    // Create a receipt line for the full credit amount, if any.
+    createRecord(UIDatabase, 'ReceiptLine', receipt, script, creditAmount);
 
-      if (creditFromCustomerCredit >= 0) return false;
+    // Iterate over all the patients credit sources, taking credit from each with
+    // available credit, by reducing the outstanding value until all has been allocated.
+    patient.creditSources.some(creditSource => {
+      const { outstanding: outstandingCredit } = creditSource;
 
-      const amountToTake = Math.min(Math.abs(creditFromCustomerCredit), creditToAllocate);
+      if (outstandingCredit >= 0) return false;
 
-      createRecord(UIDatabase, 'ReceiptLine', receipt, customerCredit, -amountToTake);
+      const amountToTake = Math.min(Math.abs(outstandingCredit), creditToAllocate);
+      createRecord(UIDatabase, 'ReceiptLine', receipt, creditSource, -amountToTake);
 
       creditToAllocate -= amountToTake;
+
+      creditSource.outstanding -= amountToTake;
+      UIDatabase.save('Transaction', creditSource);
 
       return !creditToAllocate;
     });

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -65,10 +65,12 @@ export const pay = (
   const receipt = createRecord(UIDatabase, 'Receipt', currentUser, patient, cashAmount, null, '');
 
   createRecord(UIDatabase, 'ReceiptLine', receipt, script, cashAmount);
+  createRecord(UIDatabase, 'ReceiptLine', receipt, script, creditAmount);
 
   // When using credit, create a CustomerCreditLine and ReceiptLine for each
   // source of credit being used.
   let creditToAllocate = creditAmount;
+
   if (usingCredit) {
     // Iterate over all the patients CustomerCredits, taking credit
     // from each with available credit, until all has been allocated.
@@ -79,8 +81,6 @@ export const pay = (
 
       const amountToTake = Math.min(Math.abs(creditFromCustomerCredit), creditToAllocate);
 
-      createRecord(UIDatabase, 'CustomerCreditLine', customerCredit, amountToTake);
-      createRecord(UIDatabase, 'ReceiptLine', receipt, customerCredit, amountToTake);
       createRecord(UIDatabase, 'ReceiptLine', receipt, customerCredit, -amountToTake);
 
       creditToAllocate -= amountToTake;

--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -94,12 +94,12 @@ export const pay = (
 
       if (outstandingCredit >= 0) return false;
 
-      const amountToTake = Math.min(Math.abs(outstandingCredit), creditToAllocate);
-      createRecord(UIDatabase, 'ReceiptLine', receipt, creditSource, -amountToTake, 'credit');
+      const creditUsed = Math.min(Math.abs(outstandingCredit), creditToAllocate);
+      createRecord(UIDatabase, 'ReceiptLine', receipt, creditSource, -creditUsed, 'credit');
 
-      creditToAllocate -= amountToTake;
+      creditToAllocate -= creditUsed;
 
-      creditSource.outstanding -= amountToTake;
+      creditSource.outstanding -= creditUsed;
       UIDatabase.save('Transaction', creditSource);
 
       return !creditToAllocate;


### PR DESCRIPTION
Fixes #2395 

## Change summary

- Main change here is that we do no longer make customer credit lines when using credit.
- There was also a change on desktop, where cancelled customer invoices now become sources of credits. So have made the needed changes to handle that case.
- Also updated comments - hoping it's clearer

*Note: Does not address #2104 where I hope to do some refactoring on this method - just makes the logic 'correct'*

## Testing

*Correct behaviour for paying for a prescription is that there is a receipt where the total is equal to any amount paid (non-credit), with a receipt line for any non-credit amount paid. The receipt line links to the prescription. Then, there is a receipt line for the total amount of credit amount paid - this links to the prescription. Then, for any credit source used, another receipt line is created with an amount equal to the amount of credit taken from that source. These receipt lines link to the customer credits where they took credit from*

*Easiest way to test - is to sync the values to desktop and use record browser etc. It is far easier than using Realm Explorer in mobile*


*Receipt Lines created for linking to a credit source should have the note: "credit"*

- [ ] Paying for a prescription in full with non-credit creates a receipt and a receipt line, with correct values.
- [ ] Paying for a prescription in full with only credit creates a receipt and a receipt line, with correct values.
- [ ] Paying for a prescription in full with a mix of credit and cash amounts creates a receipt, a receipt line for the cash amount, a receipt line for the credit amount and a receipt line for the credit source.
- [ ] Paying for a prescription in full with a mix of credit (WHICH IS GAINED FROM MULTIPLE SOURCES) and a cash amount creates a receipt, a receipt line for the cash amount, a receipt line for the credit amount and a receipt line for EACH credit source. [i.e. create two cash in's for $10 each, getting $20 in total for a patient. Then, create a prescription for $25. Pay $5 and use the $20 credit)
- [ ] Repeat the above test while applying an insurance policy. All the values should still be correct.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
