### PR TITLE
#2274 Corrected locale support for languages

### DIFF
--- a/src/localization/utilities.js
+++ b/src/localization/utilities.js
@@ -26,8 +26,17 @@ const DATE_CONFIGS = {
   [LANGUAGE_CODES.FRENCH]: french,
 };
 
+const SUPPORTED_DATE_LOCALES = {
+  DEFAULT: 'en-nz',
+  [LANGUAGE_CODES.ENGLISH]: 'en-nz',
+  [LANGUAGE_CODES.FRENCH]: 'fr',
+};
+
 export const setDateLocale = languageCode =>
-  moment.updateLocale(languageCode, DATE_CONFIGS[languageCode] || DATE_CONFIGS.DEFAULT);
+  moment.updateLocale(
+    SUPPORTED_DATE_LOCALES[languageCode] ?? SUPPORTED_DATE_LOCALES.DEFAULT,
+    DATE_CONFIGS[languageCode] ?? DATE_CONFIGS.DEFAULT
+  );
 
 export function setCurrentLanguage(language) {
   authStrings.setLanguage(language);


### PR DESCRIPTION
Fixes #2274 

## Change summary

- Bit of a tricky one - only crashed on an APK
- `moment` does a require internally which is async. When using RN, it does doesn't bubble correctly if the file isn't found and just throws an error instead of handling it correctly. I.e. tries to require `'gb'` instead of `'en-nz'` - instead of being caught and discarding (intended behaviour), the error isn't caught and crashes the app!

## Testing

- [ ] Changing the current language on a built APK does not crash the app

### Related areas to think about

The other languages we support (Kiribati, Tetum, Laos) don't seem to be in the locales supported by `moment` which is sucks a bit - https://github.com/moment/moment/tree/develop/src/locale  however maybe I'm wrong! Also would be cool to contribute !