### PR TITLE
#2380 Stop syncing with incompatible servers

### DIFF
--- a/src/authentication/SyncAuthenticator.js
+++ b/src/authentication/SyncAuthenticator.js
@@ -62,7 +62,7 @@ export class SyncAuthenticator {
     const [majorAppVersion] = appVersion.split('.');
     const { ServerVersion: serverVersion } = responseJson;
 
-    if (serverVersion >= SERVER_COMPATIBILITIES[majorAppVersion]) {
+    if (serverVersion < SERVER_COMPATIBILITIES[majorAppVersion]) {
       throw new Error(authStrings.incompatible_server);
     }
 

--- a/src/authentication/SyncAuthenticator.js
+++ b/src/authentication/SyncAuthenticator.js
@@ -7,7 +7,11 @@ import DeviceInfo from 'react-native-device-info';
 
 import { authenticateAsync, getAuthHeader, hashPassword } from 'sussol-utilities';
 
+import packageJson from '../../package.json';
+
+import { SERVER_COMPATIBILITIES } from '../sync/constants';
 import { SETTINGS_KEYS } from '../settings';
+import { authStrings } from '../localization';
 
 const {
   SUPPLYING_STORE_ID,
@@ -50,23 +54,27 @@ export class SyncAuthenticator {
 
     const authURL = `${serverURL}${AUTH_ENDPOINT}`;
 
-    try {
-      const responseJson = await authenticateAsync(authURL, username, passwordHash, {
-        ...this.extraHeaders,
-      });
-      this.settings.set(SYNC_URL, serverURL);
-      this.settings.set(SYNC_SITE_NAME, username);
-      this.settings.set(SYNC_SITE_PASSWORD_HASH, passwordHash);
-      this.settings.set(SYNC_SERVER_ID, responseJson.ServerID);
-      this.settings.set(SYNC_SITE_ID, responseJson.SiteID);
-      this.settings.set(THIS_STORE_ID, responseJson.StoreID);
-      this.settings.set(THIS_STORE_NAME_ID, responseJson.NameID);
-      this.settings.set(SUPPLYING_STORE_ID, responseJson.SupplyingStoreID);
-      this.settings.set(SUPPLYING_STORE_NAME_ID, responseJson.SupplyingStoreNameID);
-    } catch (error) {
-      // Pass error up
-      throw error;
+    const responseJson = await authenticateAsync(authURL, username, passwordHash, {
+      ...this.extraHeaders,
+    });
+
+    const { version: appVersion } = packageJson;
+    const [majorAppVersion] = appVersion.split('.');
+    const { ServerVersion: serverVersion } = responseJson;
+
+    if (serverVersion >= SERVER_COMPATIBILITIES[majorAppVersion]) {
+      throw new Error(authStrings.incompatible_server);
     }
+
+    this.settings.set(SYNC_URL, serverURL);
+    this.settings.set(SYNC_SITE_NAME, username);
+    this.settings.set(SYNC_SITE_PASSWORD_HASH, passwordHash);
+    this.settings.set(SYNC_SERVER_ID, responseJson.ServerID);
+    this.settings.set(SYNC_SITE_ID, responseJson.SiteID);
+    this.settings.set(THIS_STORE_ID, responseJson.StoreID);
+    this.settings.set(THIS_STORE_NAME_ID, responseJson.NameID);
+    this.settings.set(SUPPLYING_STORE_ID, responseJson.SupplyingStoreID);
+    this.settings.set(SUPPLYING_STORE_NAME_ID, responseJson.SupplyingStoreNameID);
   }
 
   /**

--- a/src/authentication/UserAuthenticator.js
+++ b/src/authentication/UserAuthenticator.js
@@ -74,7 +74,7 @@ export class UserAuthenticator {
         const [majorAppVersion] = appVersion.split('.');
         const { ServerVersion: serverVersion } = userJson;
 
-        if (serverVersion >= SERVER_COMPATIBILITIES[majorAppVersion]) {
+        if (serverVersion < SERVER_COMPATIBILITIES[majorAppVersion]) {
           throw new Error(authStrings.incompatible_server);
         }
 

--- a/src/localization/authStrings.json
+++ b/src/localization/authStrings.json
@@ -7,7 +7,8 @@
     "user_name": "User Name",
     "email": "E-mail Address",
     "invalid_username_or_password": "Invalid username or password",
-    "warning_sync_edit": "WARNING:\nThis will effect syncing for this store.\nMake sure you know what you doing!"
+    "warning_sync_edit": "WARNING:\nThis will effect syncing for this store.\nMake sure you know what you doing!",
+    "incompatible_server": "mSupply Server is not compatible with this application. Please contact your administrator."
   },
   "fr": {
     "logging_in": "Connexion en cours",

--- a/src/sync/constants.js
+++ b/src/sync/constants.js
@@ -3,6 +3,10 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
+export const SERVER_COMPATIBILITIES = {
+  4: 409,
+};
+
 export const INCREMENT_SYNC_PROGRESS = 'INCREMENT_SYNC_PROGRESS';
 export const SET_SYNC_ERROR = 'SET_SYNC_ERROR';
 export const SET_SYNC_PROGRESS = 'SET_SYNC_PROGRESS';


### PR DESCRIPTION
Fixes #2380 

See mSupply PR which is required to have been merged for this to do anything: https://github.com/sussol/msupply/pull/5681/files

## Change summary

- Don't like this at all - the user/sync authenticators aren't really extensible, so have just chucked it in - with the hope to refactor these one day.. :(

## Testing

- [ ] Mobile 4.0.0 cannot sync with any msupply server < 4.09 (current develop at the time on this PR)

### Related areas to think about

N/A