### PR TITLE
#2414 Save a TransactionBatch after editing

### DIFF
--- a/src/database/DataTypes/TransactionBatch.js
+++ b/src/database/DataTypes/TransactionBatch.js
@@ -81,6 +81,8 @@ export class TransactionBatch extends Realm.Object {
       this.itemBatch.totalQuantity += inventoryDifference;
       database.save('ItemBatch', this.itemBatch);
     }
+
+    database.save('TransactionBatch', this);
   }
 
   /**

--- a/src/sync/SyncQueue.js
+++ b/src/sync/SyncQueue.js
@@ -83,6 +83,7 @@ export class SyncQueue {
           } else {
             existingSyncOutRecord.changeTime = new Date().getTime();
             existingSyncOutRecord.changeType = changeType;
+            existingSyncOutRecord.recordType = recordType;
             this.database.save('SyncOut', existingSyncOutRecord);
           }
           break;


### PR DESCRIPTION
Fixes #2414 

## Change summary

- Just saves a `TransactionBatch` after editing..!

## Testing

- [ ] After editing a `TransactionBatch` in an SI - the record on the server is updated also

### Related areas to think about

N/A
