### PR TITLE
Add correct fields to patient creation

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -134,6 +134,7 @@ const createPatient = (database, patientDetails) => {
     code: uniqueCode,
     supplyingStoreId: thisStoreId,
     isCustomer: true,
+    thisStoresPatient: true,
     name: fullName,
   });
 


### PR DESCRIPTION
Fixes #2429 

## Change summary

- Correctly adds the field being checked to see if a patient is a home store

## Testing

- [ ] Can edit patients on the mobile store after creating them

### Related areas to think about

N/A
