### PR TITLE
#2440 Correct fetching of columns

### DIFF
--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -177,6 +177,7 @@ const stockInitialiser = () => {
     isAscending: true,
     selectedRow: null,
     route: ROUTES.STOCK,
+    columns: getColumns(ROUTES.STOCK),
   };
 };
 


### PR DESCRIPTION
Fixes #2440 

## Change summary

- Removed the columns in a previous PR accidentally. This adds them back!

## Testing

- [ ] Can navigate to the stock page without the app crashing instantly

### Related areas to think about

N/A
