### PR TITLE
Add comments of example to import/export

### DIFF
--- a/dev_scripts/translation.js
+++ b/dev_scripts/translation.js
@@ -7,6 +7,23 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
+/*
+Example for exporting strings:
+------------------------------
+yarn translation export [selectedLanguage]
+
+# selectedLanguage options: fr, gil, tl, la, pt
+
+Example for importing strings:
+------------------------------
+yarn translation import [selectedLanguage]
+
+# selectedLanguage options: fr, gil, tl, la, pt
+# It should match with the language of the tsv file to be imported
+
+More info here: https://github.com/openmsupply/mobile/wiki/Scripts
+*/
+
 const fs = require('fs');
 
 const localizationFiles = [];


### PR DESCRIPTION
Fixes #2409

## Change summary

Added comments in file `dev_scripts\translation.js` of example to import and export translations 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Open `dev_scripts\translation.js`
- [ ] Check added comments are clear enough to run the scripts.
- [ ] Revise the added link to the wiki docs is working

### Related areas to think about

@joshxg 
Is this what you had in mind? Otherwise please let me know 😄