### PR TITLE
#2456 fix insurance policy provider editing

### DIFF
--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -191,7 +191,7 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     label: formInputStrings.policy_provider,
     options: UIDatabase.objects('InsuranceProvider'),
     optionKey: 'name',
-    isEditable: true,
+    isEditable: !seedObject,
   },
   [FORM_INPUT_KEYS.IS_ACTIVE]: {
     type: 'toggle',

--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -123,7 +123,7 @@ const FormControlComponent = ({
                 onValueChange={value => onUpdateForm(key, value)}
                 options={options}
                 optionKey={optionKey}
-                isDisabled={isDisabled}
+                isDisabled={!isEditable || isDisabled}
               />
             );
           }

--- a/src/widgets/FormInputs/FormDropdown.js
+++ b/src/widgets/FormInputs/FormDropdown.js
@@ -19,12 +19,12 @@ import { FlexColumn } from '../FlexColumn';
  * passed by `optionKey`.
  *
  * @prop {Bool}   isRequired    Indicator whether this input is required.
- * @prop {Bool}   isDisabled    Indicator whether this input is disabled.
  * @prop {String} label         Label to display for this input.
  * @prop {Func}   onValueChange Callback for when a selection has been made.
  * @prop {Array}  options       Array of options [{[optionKey], ..}, {..} ]
  * @prop {String} optionKey     Key of an object within options to display.
  * @prop {value}  value         The currently selected value.
+ * @prop {Bool}   isDisabled    Indicator whether this input is disabled.
  */
 export const FormDropdown = ({
   isRequired,
@@ -45,11 +45,11 @@ export const FormDropdown = ({
     <FlexColumn flex={1}>
       <FormLabel value={label} isRequired={isRequired} />
       <DropDown
-        enabled={!isDisabled}
         style={{ width: null, flex: 1 }}
         values={valueStrings}
         selectedValue={value[optionKey]}
         onValueChange={onValueChangeCallback}
+        isDisabled={isDisabled}
       />
     </FlexColumn>
   );


### PR DESCRIPTION
Fixes #2456.

Branched off #2433.

## Change summary

Brings mobile in-line with desktop by disabling editing of provider for saved insurance policies.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a new insurance policy.  The insurance provider can be changed.
- [ ] Reopen the saved insurance policy. The insurance provider cannot be changed.

### Related areas to think about

Still to do:

- Lock down policy type.
- Prevent duplicate policy numbers.

