### PR TITLE
#2471 fix prescription record not saving new insurance policy

### DIFF
--- a/src/actions/InsuranceActions.js
+++ b/src/actions/InsuranceActions.js
@@ -54,7 +54,10 @@ const update = completedForm => (dispatch, getState) => {
     });
   }
 
-  dispatch(save(insurancePolicy));
+  batch(() => {
+    dispatch(save(insurancePolicy));
+    dispatch(select(insurancePolicy));
+  });
 };
 
 const select = insurancePolicy => (dispatch, getState) => {


### PR DESCRIPTION
Fixes #2471.

## Change summary

Update insurance policy `update` thunk to also dispatch `select` action, ensuring prescription record is updated with new policy. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

### Setup

- Create a new prescription.
- Create a new insurance policy.
- Save the prescription without updating insurance policy dropdown.
- Sync to desktop.
- Open the synced prescription transaction in desktop. 
- Navigate to the `"Payment"` tab.

### Test cases

- [ ] The insurance policy is correctly listed in the dropdown (bottom right of form, above `"Invoice Total"`).

### Related areas to think about

N/A.
