### PR TITLE
multiline modal title

### DIFF
--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -232,12 +232,16 @@ const DataTablePageModalComponent = ({
     }
   };
 
+  const modalTitle = getModalTitle(modalKey);
+  const numberOfTitleLines = modalTitle.split('\n').length;
+
   return (
     <ModalContainer
       fullScreen={fullScreen}
       isVisible={isOpen}
       onClose={onClose}
-      title={getModalTitle(modalKey)}
+      title={modalTitle}
+      numberOfLines={numberOfTitleLines}
       {...ADDITIONAL_MODAL_PROPS[modalKey]}
     >
       <ModalContent />

--- a/src/widgets/modals/ModalContainer.js
+++ b/src/widgets/modals/ModalContainer.js
@@ -36,6 +36,7 @@ export const ModalContainer = ({
   children,
   noCancel,
   backgroundColor,
+  numberOfLines,
 }) => {
   const {
     contentContainer,
@@ -77,7 +78,7 @@ export const ModalContainer = ({
         <View style={flexSpacer} />
         {!!title && (
           <FlexView flex={2}>
-            <Text ellipsizeMode="tail" numberOfLines={1} style={titleFont}>
+            <Text ellipsizeMode="tail" numberOfLines={numberOfLines} style={titleFont}>
               {title}
             </Text>
           </FlexView>
@@ -116,6 +117,7 @@ ModalContainer.defaultProps = {
   noCancel: false,
   onClose: null,
   backgroundColor: DARKER_GREY,
+  numberOfLines: 1,
 };
 
 ModalContainer.propTypes = {
@@ -126,6 +128,7 @@ ModalContainer.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
   noCancel: PropTypes.bool,
   backgroundColor: PropTypes.string,
+  numberOfLines: PropTypes.number,
 };
 
 const localStyles = StyleSheet.create({


### PR DESCRIPTION
Fixes #2478 

## Change summary

Enabled specification of number of lines in a modal title and set this based on the number of line breaks in the title.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Check the warning message shown when editing the sync url: should show multiline
- [ ] Check other modal titles - long ones should be single line with ellipses

## Samples

![Screen Shot 2020-03-06 at 12 41 54 PM](https://user-images.githubusercontent.com/9192912/76036402-de7b7a00-5fa8-11ea-9a88-772518967f82.png)

![Screen Shot 2020-03-06 at 12 41 39 PM](https://user-images.githubusercontent.com/9192912/76036413-e4715b00-5fa8-11ea-8e01-e4079edcd531.png)
