### PR TITLE
#2467 Reduce 'numberOfLines' to avoid text overlapping

### DIFF
--- a/src/widgets/PrescriptionInfo.js
+++ b/src/widgets/PrescriptionInfo.js
@@ -53,7 +53,7 @@ const PrescriptionInfoComponent = ({
         <FlexRow alignItems="center" justifyContent="">
           <FlexView flex={3}>
             <SimpleLabel label={dispensingStrings.patient} size="small" />
-            <SimpleLabel text={patientName} size="medium" />
+            <SimpleLabel text={patientName} size="medium" numberOfLines={1} />
           </FlexView>
 
           <FlexRow flex={1}>

--- a/src/widgets/SimpleLabel.js
+++ b/src/widgets/SimpleLabel.js
@@ -24,7 +24,17 @@ import {
  *
  */
 export const SimpleLabel = React.memo(
-  ({ label, text, size, labelAlign, textAlign, labelBackground, textBackground, bold }) => {
+  ({
+    label,
+    text,
+    size,
+    labelAlign,
+    textAlign,
+    labelBackground,
+    textBackground,
+    numberOfLines,
+    bold,
+  }) => {
     // Ensure null is set rather than any other nullish value as null is a node, but "" is not.
     const usingText = text || null;
     const usingLabel = label || null;
@@ -34,7 +44,7 @@ export const SimpleLabel = React.memo(
       <View style={containerStyle}>
         {usingLabel && (
           <Text
-            numberOfLines={2}
+            numberOfLines={numberOfLines}
             ellipsizeMode="tail"
             style={{
               ...labelStyle,
@@ -48,7 +58,7 @@ export const SimpleLabel = React.memo(
         )}
         {usingText && (
           <Text
-            numberOfLines={2}
+            numberOfLines={numberOfLines}
             ellipsizeMode="tail"
             style={{
               ...textStyle,
@@ -96,6 +106,7 @@ SimpleLabel.defaultProps = {
   label: '',
   labelAlign: 'left',
   textAlign: 'left',
+  numberOfLines: 2,
   labelBackground: 'transparent',
   textBackground: 'transparent',
   bold: false,
@@ -107,6 +118,7 @@ SimpleLabel.propTypes = {
   label: PropTypes.string,
   labelAlign: PropTypes.string,
   textAlign: PropTypes.string,
+  numberOfLines: PropTypes.number,
   labelBackground: PropTypes.string,
   textBackground: PropTypes.string,
   bold: PropTypes.bool,


### PR DESCRIPTION
Fixes #2467 

## Change summary

Reduced `numberOfLines` from 2 to 1, so now the patient's name is not longer taken 2 lines when too long. Anyway, the ellipse mode is still active and will act in case we are in presence of a name that is larger than the No. de chars allowed per line.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to `Dispensary`
- [ ] Create a new patient with a long name  (at least greater than 50 chars in total)
- [ ] Click on Dispense option for that patient
- [ ] See that the name fits in one line, it has ellipses at the end and it is not overlapping with the title: `Patient`.
- [ ] Click on ✏️ (Edit) icon and check that First Name and Last Name won't change.

Example:
![Screen Shot 2020-03-06 at 2 49 47 PM](https://user-images.githubusercontent.com/32987464/76042493-c2cc9f80-5fb9-11ea-9921-c3037cf8b70b.png)

### Related areas to think about

N/A.
