### PR TITLE
#2501 add is_edited field to outgoing stocktake batch sync

### DIFF
--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -184,6 +184,7 @@ const generateSyncData = (settings, recordType, record) => {
         Batch: record.batch,
         item_ID: record.itemId,
         optionID: record.option && record.option.id,
+        is_edited: record.hasBeenCounted,
       };
     }
     case 'Transaction': {


### PR DESCRIPTION
Fixes #2501.

## Change summary

Adds `is_edited` to `stocktakeBatch` outgoing sync.

## Testing

### Setup

- Using mobile, create a new stocktake.
 - Enter a quantity different than its snapshot quantity. 
- Sync to desktop.
- Open the stocktake in desktop.

### Test cases 

- [ ] The entered quantity is shown correctly (i.e. the same as entered on mobile).

### Related areas to think about

N/A.