### PR TITLE
#2490 show program name

### DIFF
--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -180,15 +180,18 @@ const PAGE_INFO_ROWS = (pageObject, dispatch, route) => ({
   },
 });
 
-const getPageInfoColumns = page => {
+const getPageInfoColumns = (page, isProgramBased) => {
   const pageInfoColumns = PER_PAGE_INFO_COLUMNS[page];
 
   if (!pageInfoColumns) return null;
+
   return (pageObjectParameter, dispatch, route) => {
     const pageInfoRows = PAGE_INFO_ROWS(pageObjectParameter, dispatch, route);
-    return pageInfoColumns.map(pageInfoColumn =>
-      pageInfoColumn.map(pageInfoKey => pageInfoRows[pageInfoKey])
-    );
+    return pageInfoColumns.map((pageInfoColumn, idx) => {
+      const columnArray =
+        isProgramBased && idx === 0 ? ['program', ...pageInfoColumn] : pageInfoColumn;
+      return columnArray.map(pageInfoKey => pageInfoRows[pageInfoKey]);
+    });
   };
 };
 

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -298,7 +298,7 @@ const stocktakeEditorInitialiser = stocktake => {
     modalValue: null,
     route: ROUTES.STOCKTAKE_EDITOR,
     columns: getColumns(customCode),
-    getPageInfoColumns: getPageInfoColumns(customCode),
+    getPageInfoColumns: getPageInfoColumns(customCode, !!stocktake.program),
   };
 };
 


### PR DESCRIPTION
Fixes #2490 

## Change summary

Added program name to the top row of program based stocktakes.
I didn't want to add `STOCKTAKE_EDITOR_WITH_PROGRAM` and `STOCKTAKE_EDITOR_WITH_REASONS_WITH_PROGRAM` as that would give us four variants for the stocktake edit page. Instead I've added the parameter to allow insertion of the program name. Feel free to rip apart this approach.. and if you have better options I'd love to hear them.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create or find a program based stocktake. Observe the program name is shown when editing
- [ ] Create or find a non-program based stocktake: this should load correctly and display as now
- [ ] Check other pages, esp. the program based supplier requisitions


