### PR TITLE
#2525 reduce size of supplier credit bottom flex row component

### DIFF
--- a/src/widgets/modalChildren/SupplierCredit.js
+++ b/src/widgets/modalChildren/SupplierCredit.js
@@ -96,7 +96,7 @@ const SupplierCreditComponent = ({
         getItemLayout={getItemLayout}
         columns={columns}
       />
-      <FlexRow flex={1} alignItems="flex-end" justifyContent="flex-end">
+      <FlexRow alignItems="flex-end" justifyContent="flex-end">
         <PageButton text={modalStrings.confirm} onPress={onSave} style={{ margin: 7 }} />
       </FlexRow>
     </View>


### PR DESCRIPTION
Fixes #2525.

## Change summary

Just a small tweak to the `FlexRow` at the bottom of `SupplierCredit` component.

## Testing

### Setup

- Make a new supplier invoice with a large number of item batches (>= 15).
- Add a quantity to each item batch.
- Finalise the invoice.
- Click `"New supplier credit"`.

Steps to reproduce or otherwise test the changes of this PR:

- [ ] The data table fits the screen correctly, i.e. no large white space at the bottom of the page (except for when scrolling right to the bottom, which is consistent with other data table pages).

### Related areas to think about

N/A.