### PR TITLE
#2523 prevent applying inactive policies

### DIFF
--- a/src/selectors/insurance.js
+++ b/src/selectors/insurance.js
@@ -3,10 +3,20 @@
  * Sustainable Solutions (NZ) Ltd. 2020
  */
 
+export const selectInsurancePolicyIsActive = ({ insurancePolicy }) => {
+  const { isActive = true } = insurancePolicy ?? {};
+  return isActive;
+};
+
+export const selectInsurancePolicyDiscountRate = ({ insurancePolicy }) => {
+  const isActive = selectInsurancePolicyIsActive({ insurancePolicy });
+  const { discountRate = 0 } = isActive ? insurancePolicy ?? {} : {};
+  return discountRate;
+};
+
 export const selectInsuranceDiscountRate = ({ insurance }) => {
   const { selectedInsurancePolicy } = insurance;
-  const { discountRate = 0 } = selectedInsurancePolicy || {};
-  return discountRate;
+  return selectInsurancePolicyDiscountRate({ selectedInsurancePolicy });
 };
 
 export const selectInsuranceModalOpen = ({ insurance }) => {

--- a/src/selectors/insurance.js
+++ b/src/selectors/insurance.js
@@ -14,10 +14,8 @@ export const selectInsurancePolicyDiscountRate = ({ insurancePolicy }) => {
   return discountRate;
 };
 
-export const selectInsuranceDiscountRate = ({ insurance }) => {
-  const { selectedInsurancePolicy } = insurance;
-  return selectInsurancePolicyDiscountRate({ selectedInsurancePolicy });
-};
+export const selectInsuranceDiscountRate = ({ insurance }) =>
+  selectInsurancePolicyDiscountRate(insurance);
 
 export const selectInsuranceModalOpen = ({ insurance }) => {
   const { isCreatingInsurancePolicy, isEditingInsurancePolicy } = insurance;

--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -37,9 +37,11 @@ export const selectAvailableCredit = ({ patient }) =>
 export const selectPatientInsurancePolicies = ({ patient }) => {
   const { currentPatient } = patient;
   const { policies } = currentPatient;
-  return policies;
+  return policies.map(policy => {
+    const { isActive, policyNumber } = policy;
+    return isActive ? policy : { ...policy, policyNumber: `${policyNumber} (inactive)` };
+  });
 };
-
 export const selectPatientModalOpen = ({ patient }) => {
   const { isCreating, isEditing } = patient;
   const { viewingHistory } = patient;

--- a/src/selectors/payment.js
+++ b/src/selectors/payment.js
@@ -5,6 +5,7 @@
 
 import currency from '../localization/currency';
 import { UIDatabase } from '../database';
+import { selectInsurancePolicyDiscountRate } from './insurance';
 
 export const selectPrescriptionSubTotal = ({ payment }) => {
   const { transaction } = payment;
@@ -17,8 +18,9 @@ export const selectDiscountAmount = ({ payment }) => {
   const { insurancePolicy } = payment;
   const subtotal = selectPrescriptionSubTotal({ payment });
 
-  const insuranceDiscountRate = insurancePolicy ? (insurancePolicy.discountRate || 100) / 100 : 0;
-  const discountAmount = currency(subtotal).multiply(insuranceDiscountRate);
+  const insuranceDiscountRate = selectInsurancePolicyDiscountRate({ insurancePolicy });
+  const insuranceDiscountMultiplier = insuranceDiscountRate ? insuranceDiscountRate / 100 : 0;
+  const discountAmount = currency(subtotal).multiply(insuranceDiscountMultiplier);
 
   return discountAmount;
 };

--- a/src/widgets/PaymentSummary.js
+++ b/src/widgets/PaymentSummary.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/forbid-prop-types */
 /**
  * mSupply Mobile
- * Sustainable Solutions (NZ) Ltd. 2019
+ * Sustainable Solutions (NZ) Ltd. 2020
  */
 
 import React from 'react';
@@ -109,9 +109,14 @@ const PaymentSummaryComponent = ({
   usingInsurance,
   usingPaymentTypes,
 }) => {
-  const policyNumbers = React.useMemo(() => insurancePolicies.map(policy => policy.policyNumber), [
-    insurancePolicies,
-  ]);
+  const policyNumbers = React.useMemo(
+    () =>
+      insurancePolicies.map(policy => {
+        const { policyNumber } = policy;
+        return policyNumber;
+      }),
+    [insurancePolicies]
+  );
 
   const onSelectPolicy = React.useCallback(
     (_, index) => {
@@ -234,7 +239,7 @@ PaymentSummaryComponent.propTypes = {
   paymentAmount: PropTypes.object.isRequired,
   creditOverflow: PropTypes.bool,
   isComplete: PropTypes.bool.isRequired,
-  insurancePolicies: PropTypes.object.isRequired,
+  insurancePolicies: PropTypes.array.isRequired,
   choosePolicy: PropTypes.func.isRequired,
   selectedInsurancePolicy: PropTypes.object,
   editPolicy: PropTypes.func.isRequired,

--- a/src/widgets/PaymentSummary.js
+++ b/src/widgets/PaymentSummary.js
@@ -109,14 +109,9 @@ const PaymentSummaryComponent = ({
   usingInsurance,
   usingPaymentTypes,
 }) => {
-  const policyNumbers = React.useMemo(
-    () =>
-      insurancePolicies.map(policy => {
-        const { policyNumber } = policy;
-        return policyNumber;
-      }),
-    [insurancePolicies]
-  );
+  const policyNumbers = React.useMemo(() => insurancePolicies.map(policy => policy.policyNumber), [
+    insurancePolicies,
+  ]);
 
   const onSelectPolicy = React.useCallback(
     (_, index) => {


### PR DESCRIPTION
Fixes #2523.

## Change summary

- Update insurance policy selectors to display if policies active or not. 
- Do not apply discount rate for inactive policies.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When viewing an inactive policy in the dropdown, `"(inactive)"` is appended to the policy name.
- [ ] If an inactive policy is selected, the insurance discount rate is `"0%"`.
- [ ] If an inactive policy is selected, the insurance discount amount is `"0.00"`.
- [ ] If an inactive policy is selected, the insurance discount is not applied to the subtotal or total.

### Related areas to think about

N/A.
