### PR TITLE
#2476 modal titles not centred

### DIFF
--- a/src/localization/navStrings.json
+++ b/src/localization/navStrings.json
@@ -41,7 +41,7 @@
     "stocktakes": "Relevés d'inventaire",
     "stocktake": "Relevé d'inventaire",
     "supplier_invoices": "Factures fournisseurs",
-    "supplier_requisitions": "Factures réquisitions",
+    "supplier_requisitions": "Réquisitions fournisseur",
     "settings": "Réglages",
     "database_contents": "Contenus de la base de données",
     "dispensary": "Dispensaire",

--- a/src/widgets/modals/ModalContainer.js
+++ b/src/widgets/modals/ModalContainer.js
@@ -168,6 +168,7 @@ const localStyles = StyleSheet.create({
     fontFamily: APP_FONT_FAMILY,
     color: 'white',
     fontSize: 20,
+    textAlign: 'center',
   },
   closeButtonContainer: {
     flex: 1,


### PR DESCRIPTION
Fixes #2476 

## Change summary

Centred. Took the issue on so that I could fix a French translation - we had the `Supplier Requisitions` button showing `Invoices requisitions`

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Open a modal and see if centred
- [ ] Check the french translation of the supplier requisitions button

