### PR TITLE
replace createAppContainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@react-native-community/datetimepicker": "^2.2.2",
     "@react-native-community/masked-view": "^0.1.7",
     "@react-native-community/slider": "^2.0.8",
+    "@react-navigation/bottom-tabs": "^5.1.1",
     "@react-navigation/compat": "^5.1.1",
     "@react-navigation/core": "^3.5.1",
     "@react-navigation/native": "^5.0.9",

--- a/src/globalStyles/pageStyles.js
+++ b/src/globalStyles/pageStyles.js
@@ -40,7 +40,11 @@ export const pageStyles = {
     justifyContent: 'flex-end',
     alignItems: 'flex-end',
   },
-  pageTopViewContainer: { paddingHorizontal: 10, paddingVertical: 10 },
+  pageTopViewContainer: {
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    backgroundColor: BLUE_WHITE,
+  },
 };
 
 export default pageStyles;

--- a/src/navigation/RootNavigator.js
+++ b/src/navigation/RootNavigator.js
@@ -24,7 +24,7 @@ const navigate = (screenName, screenProps) =>
 const replace = (screenName, screenProps) =>
   rootNavigatorRef.current?.dispatch(StackActions.replace(screenName, screenProps));
 
-const goBack = () => rootNavigatorRef.current?.goBack();
+const goBack = () => rootNavigatorRef.current?.dispatch(StackActions.pop());
 
 const canGoBack = () => !!rootNavigatorRef.current?.canGoBack();
 

--- a/src/navigation/utilities.js
+++ b/src/navigation/utilities.js
@@ -62,6 +62,7 @@ export const navigationMiddleware = () => next => action => {
     const { routeName, params } = action;
     RootNavigator.navigate(routeName, params);
   }
+
   if (type === 'Navigation/REPLACE') {
     const { routeName, params } = action;
     RootNavigator.replace(routeName, params);

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -41,9 +41,9 @@ const mapDispatchToProps = dispatch => {
 const mapStateToProps = (state, props) => mapParamsToProps(props);
 
 const mapParamsToProps = props => {
-  const { route } = props;
-  const { params } = route || {};
-  const { transaction } = params || {};
+  const { route = {} } = props;
+  const { params = {} } = route;
+  const { transaction } = params;
   return { transaction };
 };
 

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -38,7 +38,14 @@ const mapDispatchToProps = dispatch => {
   return { completePrescription };
 };
 
-const mapStateToProps = () => ({});
+const mapStateToProps = (state, props) => mapParamsToProps(props);
+
+const mapParamsToProps = props => {
+  const { route } = props;
+  const { params } = route || {};
+  const { transaction } = params || {};
+  return { transaction };
+};
 
 export const PrescriptionPage = connect(mapStateToProps, mapDispatchToProps)(Prescription);
 

--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -18,16 +18,19 @@ import { WizardActions } from '../actions/WizardActions';
 
 import { dispensingStrings } from '../localization';
 
-const tabs = [PrescriberSelect, ItemSelect, PrescriptionConfirmation];
-const titles = [
-  dispensingStrings.select_the_prescriber,
-  dispensingStrings.select_items,
-  dispensingStrings.finalise,
+const tabs = [
+  {
+    component: PrescriberSelect,
+    name: 'prescriber',
+    title: dispensingStrings.select_the_prescriber,
+  },
+  { component: ItemSelect, name: 'item', title: dispensingStrings.select_items },
+  { component: PrescriptionConfirmation, name: 'prescription', title: dispensingStrings.finalise },
 ];
 
 export const Prescription = ({ transaction, completePrescription }) => {
   useRecordListener(completePrescription, transaction, 'Transaction');
-  return <Wizard tabs={tabs} titles={titles} />;
+  return <Wizard tabs={tabs} />;
 };
 
 const mapDispatchToProps = dispatch => {

--- a/src/widgets/TabNavigator.js
+++ b/src/widgets/TabNavigator.js
@@ -1,17 +1,10 @@
 /* eslint-disable react/forbid-prop-types */
-import React, { useMemo, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { createAppContainer } from '@react-navigation/native';
-import { createBottomTabNavigator } from 'react-navigation-tabs';
-import { NavigationActions } from '@react-navigation/core';
+import { useNavigation } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
-const getTabNavigator = (routes, options) => {
-  const TabNavigator = createBottomTabNavigator(routes, options);
-  const Container = createAppContainer(TabNavigator);
-  return Container;
-};
-
-const DEFAULT_TAB_CONFIG = { navigationOptions: { tabBarVisible: false } };
+const DEFAULT_TAB_CONFIG = { options: { tabBarVisible: false } };
 
 /**
  * Simple TabNavigator component managing lazily loaded
@@ -23,26 +16,25 @@ const DEFAULT_TAB_CONFIG = { navigationOptions: { tabBarVisible: false } };
  * @prop {Number} currentTabIndex The index of the tab to show.
  */
 export const TabNavigator = ({ tabs, currentTabIndex }) => {
-  const navigatorRef = useRef(React.createRef());
-
-  // Create the tab navigator component dynamically. Will not re-calculate until unmounted.
-  const Container = useMemo(() => {
-    const tabsConfig = tabs.reduce(
-      (acc, value, index) => ({ ...acc, [index]: { ...DEFAULT_TAB_CONFIG, screen: value } }),
-      {}
-    );
-    const defaultNavigationConfig = { initialRouteName: String(currentTabIndex) };
-    return getTabNavigator(tabsConfig, defaultNavigationConfig);
-  }, []);
+  const navigatorRef = useRef(useNavigation());
+  const Tab = createBottomTabNavigator();
 
   // When `currentTabIndex` changes, dispatch an action to trigger a switch on the
   // base navigation component to the passed tab index.
-  useEffect(() => {
-    const navigationAction = NavigationActions.navigate({ routeName: String(currentTabIndex) });
-    navigatorRef.current.dispatch(navigationAction);
-  }, [currentTabIndex]);
+  useEffect(() => navigatorRef.current.navigate(String(currentTabIndex)), [currentTabIndex]);
 
-  return <Container ref={navigatorRef} />;
+  return (
+    <Tab.Navigator>
+      {tabs.map((tab, idx) => (
+        <Tab.Screen
+          {...DEFAULT_TAB_CONFIG}
+          name={`${idx}`}
+          key={tab.name}
+          component={tab.component}
+        />
+      ))}
+    </Tab.Navigator>
+  );
 };
 
 TabNavigator.propTypes = {

--- a/src/widgets/TabNavigator.js
+++ b/src/widgets/TabNavigator.js
@@ -5,6 +5,7 @@ import { useNavigation } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 const DEFAULT_TAB_CONFIG = { options: { tabBarVisible: false } };
+const Tab = createBottomTabNavigator();
 
 /**
  * Simple TabNavigator component managing lazily loaded
@@ -17,7 +18,6 @@ const DEFAULT_TAB_CONFIG = { options: { tabBarVisible: false } };
  */
 export const TabNavigator = ({ tabs, currentTabIndex }) => {
   const navigatorRef = useRef(useNavigation());
-  const Tab = createBottomTabNavigator();
 
   // When `currentTabIndex` changes, dispatch an action to trigger a switch on the
   // base navigation component to the passed tab index.

--- a/src/widgets/Tabs/PrescriberSelect.js
+++ b/src/widgets/Tabs/PrescriberSelect.js
@@ -141,7 +141,7 @@ const localStyles = StyleSheet.create({
 
 const mapDispatchToProps = dispatch => {
   const choosePrescriber = debounce(
-    prescriberID => dispatch(PrescriptionActions.assignPrescriber(prescriberID)),
+    prescriber => dispatch(PrescriptionActions.assignPrescriber(prescriber)),
     1000,
     true
   );

--- a/src/widgets/Wizard.js
+++ b/src/widgets/Wizard.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-named-as-default */
 /* eslint-disable react/forbid-prop-types */
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { StyleSheet, View } from 'react-native';
@@ -20,21 +20,25 @@ import { BACKGROUND_COLOR, BLUE_WHITE, SHADOW_BORDER } from '../globalStyles/col
  * to completion for completion. See TabNavigator and StepsTracker
  * for individual component implementation.
  */
-const WizardComponent = ({ tabs, currentTab, switchTab }) => (
-  <View style={localStyles.container}>
-    <View style={localStyles.stepperContainer}>
-      <Stepper
-        numberOfSteps={tabs.length}
-        currentStep={currentTab}
-        onPress={switchTab}
-        titles={tabs.map(tab => tab.title)}
-      />
+const WizardComponent = ({ tabs, currentTab, switchTab }) => {
+  const titles = useMemo(() => tabs.map(tab => tab.title), [tabs]);
+
+  return (
+    <View style={localStyles.container}>
+      <View style={localStyles.stepperContainer}>
+        <Stepper
+          numberOfSteps={tabs.length}
+          currentStep={currentTab}
+          onPress={switchTab}
+          titles={titles}
+        />
+      </View>
+      <DataTablePageView>
+        <TabNavigator tabs={tabs} currentTabIndex={currentTab} />
+      </DataTablePageView>
     </View>
-    <DataTablePageView>
-      <TabNavigator tabs={tabs} currentTabIndex={currentTab} />
-    </DataTablePageView>
-  </View>
-);
+  );
+};
 
 const localStyles = StyleSheet.create({
   container: { backgroundColor: BACKGROUND_COLOR, flex: 1 },

--- a/src/widgets/Wizard.js
+++ b/src/widgets/Wizard.js
@@ -20,14 +20,14 @@ import { BACKGROUND_COLOR, BLUE_WHITE, SHADOW_BORDER } from '../globalStyles/col
  * to completion for completion. See TabNavigator and StepsTracker
  * for individual component implementation.
  */
-const WizardComponent = ({ tabs, titles, currentTab, switchTab }) => (
+const WizardComponent = ({ tabs, currentTab, switchTab }) => (
   <View style={localStyles.container}>
     <View style={localStyles.stepperContainer}>
       <Stepper
         numberOfSteps={tabs.length}
         currentStep={currentTab}
         onPress={switchTab}
-        titles={titles}
+        titles={tabs.map(tab => tab.title)}
       />
     </View>
     <DataTablePageView>
@@ -48,7 +48,6 @@ const localStyles = StyleSheet.create({
 
 WizardComponent.propTypes = {
   tabs: PropTypes.array.isRequired,
-  titles: PropTypes.array.isRequired,
   switchTab: PropTypes.func.isRequired,
   currentTab: PropTypes.number.isRequired,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1036,6 +1036,14 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-2.0.8.tgz#c4a3c342638270e0adc942b51427ec17104a786d"
   integrity sha512-FZC3wjYzHQiD7jT7ALy3QNccyLj9zQBRiKGBFr/QvrWLkVg5orpIJ53aYFXm3eOkNvUV+wjhoI9uCkh3LCN2+A==
 
+"@react-navigation/bottom-tabs@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-5.1.1.tgz#04636a6b0c2105228f81d6b05aab285a1fcc7ff9"
+  integrity sha512-3eKoLgBsRKXFQoWv9co6bXr2DjlRDtgaS1XZ/2LpOs27lDthShGdVkWzTVaFZ6aGf6pOhUaeKtd8wX+jkUXk0A==
+  dependencies:
+    color "^3.1.2"
+    react-native-iphone-x-helper "^1.2.1"
+
 "@react-navigation/compat@^5.1.1":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@react-navigation/compat/-/compat-5.1.1.tgz#38b92becbe7358f089e08e14a6a94d605649c0dc"


### PR DESCRIPTION
Fixes #2537 

## Change summary

Replaces the call to `createAppContainer` with the declarative `Tab.Navigator`
This is working for the tabbing - but there is a subsequent problem with the `PrescriptionPage` which is now not receiving the `transaction` prop.

Have also modified the shape of the `tabs` supplied to the `TabNavigator` to bring in the title and pass in a name which is required by the `Tab.Screen` component.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Run through the dispensing wizard. Should all function correctly.

### Related areas to think about

No, I think that's about it.
