### PR TITLE
translations

### DIFF
--- a/src/localization/dispensingStrings.json
+++ b/src/localization/dispensingStrings.json
@@ -85,7 +85,7 @@
     "new": "Nouvelle",
     "not_enough_credit": "Crédit insuffisant",
     "patient": "Patient",
-    "patients": "Patients",
+    "patients": "Patient",
     "payment_amount": "Montant reçu",
     "payment": "Paiement",
     "payments": "Paiements",

--- a/src/localization/dispensingStrings.json
+++ b/src/localization/dispensingStrings.json
@@ -63,7 +63,7 @@
     "available_credit": "Crédit disponible",
     "cash_in": "Rentrées de fonds",
     "cash_out": "Sorties de fonds",
-    "change_required": "Montant rendu",
+    "change_required": "Montant à rendre",
     "choose_a_name": "Choisissez un nom",
     "choose_a_reason": "Choisissez une raison",
     "choose_a_payment_type": "Choisissez un type de paiement",
@@ -112,7 +112,7 @@
     "select_a_supplier_credit_category": "Sélectionnez une catégorie de crédit fournisseur",
     "patient_detail": "Détail du patient",
     "item_details": "Détail des articles",
-    "new_patient": "Patient nouvelle",
+    "new_patient": "Nouveau patient",
     "unable_to_create_withdrawl": "Impossible de créer un retrait supérieur au solde actuel",
     "inpatient": "hospitalisé",
     "outpatient": "Consul. externe"

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -54,7 +54,7 @@
     "cancel": "Annuler",
     "confirm": "Confirmer",
     "create": "Créer",
-    "create_cash_transaction": "Créer une nouvelle transaction en espèce",
+    "create_cash_transaction": "Créer une nouvelle transaction",
     "delete_these_invoices": "Êtes-vous sûr de vouloir supprimer ces factures ?",
     "delete_these_requisitions": "Êtes-vous sûr de vouloir supprimer ces réquisitions ?",
     "delete_these_stocktakes": "Êtes-vous sûr de vouloir supprimer ces relevé d'inventaires ?",

--- a/src/localization/navStrings.json
+++ b/src/localization/navStrings.json
@@ -33,7 +33,7 @@
     "finalise": "FINALISEZ",
     "finalised_cannot_be_edited": "FINALISÉ. NE PEUT ÊTRE MODIFIÉ",
     "invoice": "Facture",
-    "language": "LANGUE",
+    "language": "LANGAGE",
     "log_out": "SE DÉCONNECTER",
     "manage_stocktake": "Gérer les relevés d'inventaire",
     "new_stocktake": "Nouveau relevé d'inventaire",


### PR DESCRIPTION
Fixes #2549 

## Change summary

Just a few translations.
After it happened the first time, I couldn't recreate the wizard non-translating. Perhaps it memoed while I was logged in with an English user? 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

Check that the following changes have been made:

- [ ] Change Required: `Montant à rendre`
- [ ] New Patient: `Nouveau patient`
- [ ] Create Cash Transaction: `Créer une nouvelle transaction`
- [ ] Language button: `LANGAGE`
- [ ] Payment toggle: Paiment


