### PR TITLE
#2546 fix demo store error message

### DIFF
--- a/src/widgets/modals/DemoUserModal.js
+++ b/src/widgets/modals/DemoUserModal.js
@@ -19,6 +19,13 @@ import { authStrings, generalStrings, demoUserModalStrings } from '../../localiz
 import globalStyles, { SUSSOL_ORANGE, GREY, WARM_GREY } from '../../globalStyles';
 import { ModalContainer } from './ModalContainer';
 
+const STATUS = {
+  SUBMIT: 'submit',
+  SUBMITTING: 'submitting',
+  SUBMITTED: 'submitted',
+  ERROR: 'error',
+};
+
 export class DemoUserModal extends React.Component {
   constructor(props) {
     super(props);
@@ -209,9 +216,9 @@ export class DemoUserModal extends React.Component {
               />
             </View>
           </View>
-          <ModalContainer fullScreen={true} isVisible={isOpen}>
+          <ModalContainer fullScreen={true} isVisible={status === STATUS.SUBMITTED}>
             <ConfirmForm
-              isOpen={status === 'submitted'}
+              isOpen={status === STATUS.SUBMITTED}
               questionText={demoUserModalStrings.confirm_modal_body}
               onConfirm={this.onDemoSubmittedModalClose}
               confirmText="Close"

--- a/src/widgets/modals/DemoUserModal.js
+++ b/src/widgets/modals/DemoUserModal.js
@@ -31,7 +31,7 @@ export class DemoUserModal extends React.Component {
     super(props);
     this.demoSiteRequest = new DemoSiteRequest();
     this.state = {
-      status: 'submit', // submit, submitting, submitted, error
+      status: STATUS.SUBMIT,
       error: '',
       username: '',
       password: '',
@@ -50,16 +50,16 @@ export class DemoUserModal extends React.Component {
     const { username, email, password, repeatPassword } = this.state;
 
     if (this.canAttemptSubmit) {
-      this.setState({ status: 'submitting' });
+      this.setState({ status: STATUS.SUBMITTING });
       try {
         await this.demoSiteRequest.createActivationURL(username, email, password, repeatPassword);
-        this.setState({ status: 'submitted' });
+        this.setState({ status: STATUS.SUBMITTED });
       } catch (error) {
-        this.setState({ status: 'error', error: error.message });
+        this.setState({ status: STATUS.ERROR, error: error.message });
         if (!error.message.startsWith('Invalid username or password')) {
           // After ten seconds of displaying the error, re-enable the button
           this.errorTimeoutId = setTimeout(() => {
-            this.setState({ status: 'submit' });
+            this.setState({ status: STATUS.SUBMIT });
             this.errorTimeoutId = null;
           }, 10 * 1000);
         }
@@ -72,7 +72,7 @@ export class DemoUserModal extends React.Component {
 
     // Reset state, close modals and go back to FirstUsePage
     this.setState({
-      status: 'submit',
+      status: STATUS.SUBMIT,
       username: '',
       password: '',
       repeatPassword: '',
@@ -85,7 +85,7 @@ export class DemoUserModal extends React.Component {
     const { status, username, password, email, repeatPassword } = this.state;
 
     return (
-      status === 'submit' &&
+      status === STATUS.SUBMIT &&
       username.length > 0 &&
       password.length > 0 &&
       email.length > 0 &&
@@ -97,11 +97,11 @@ export class DemoUserModal extends React.Component {
     const { status, error } = this.state;
 
     switch (status) {
-      case 'submitting':
+      case STATUS.SUBMITTING:
         return generalStrings.submitting;
-      case 'submitted':
+      case STATUS.SUBMITTED:
         return generalStrings.submitted;
-      case 'error':
+      case STATUS.ERROR:
         return error;
       default:
         return generalStrings.submit;
@@ -111,13 +111,14 @@ export class DemoUserModal extends React.Component {
   // Handlers to set state of form variables on input onChange trigger
   // Extracting into local methods because calling an anonymous function in onChange would
   // re-render the input fields each time render() is called, causing slight performance hit
-  handleOnChangeEmail = text => this.setState({ email: text, status: 'submit' });
+  handleOnChangeEmail = text => this.setState({ email: text, status: STATUS.SUBMIT });
 
-  handleOnChangeUsername = text => this.setState({ username: text, status: 'submit' });
+  handleOnChangeUsername = text => this.setState({ username: text, status: STATUS.SUBMIT });
 
-  handleOnChangePassword = text => this.setState({ password: text, status: 'submit' });
+  handleOnChangePassword = text => this.setState({ password: text, status: STATUS.SUBMIT });
 
-  handleOnChangeRepeatPassword = text => this.setState({ repeatPassword: text, status: 'submit' });
+  handleOnChangeRepeatPassword = text =>
+    this.setState({ repeatPassword: text, status: STATUS.SUBMIT });
 
   render() {
     const { isOpen, onClose } = this.props;
@@ -157,7 +158,7 @@ export class DemoUserModal extends React.Component {
                 placeholderTextColor={SUSSOL_ORANGE}
                 underlineColorAndroid={SUSSOL_ORANGE}
                 value={username}
-                editable={status !== 'submitting'}
+                editable={status !== STATUS.SUBMITTING}
                 returnKeyType="next"
                 selectTextOnFocus
                 onChangeText={this.handleOnChangeUsername}
@@ -170,7 +171,7 @@ export class DemoUserModal extends React.Component {
                 placeholderTextColor={SUSSOL_ORANGE}
                 underlineColorAndroid={SUSSOL_ORANGE}
                 value={email}
-                editable={status !== 'submitting'}
+                editable={status !== STATUS.SUBMITTING}
                 returnKeyType="next"
                 selectTextOnFocus
                 onChangeText={this.handleOnChangeEmail}
@@ -184,7 +185,7 @@ export class DemoUserModal extends React.Component {
                 underlineColorAndroid={SUSSOL_ORANGE}
                 value={password}
                 secureTextEntry
-                editable={status !== 'submitting'}
+                editable={status !== STATUS.SUBMITTING}
                 returnKeyType="next"
                 selectTextOnFocus
                 onChangeText={this.handleOnChangePassword}
@@ -198,7 +199,7 @@ export class DemoUserModal extends React.Component {
                 underlineColorAndroid={SUSSOL_ORANGE}
                 value={repeatPassword}
                 secureTextEntry
-                editable={status !== 'submitting'}
+                editable={status !== STATUS.SUBMITTING}
                 returnKeyType="next"
                 selectTextOnFocus
                 onChangeText={this.handleOnChangeRepeatPassword}


### PR DESCRIPTION
Fixes #2546.

## Change summary

Fixes demo store `ModalContainer` prop `isVisible`. Was preventing users from entering details to request demo store.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When requesting a demo store, the user is prompted to enter username, email etc. details. 
- [ ] After submitting credentials, the user is presented with a confirmation message (`"One step closer to creating your Demo Store...."`). 

### Related areas to think about

N/A.
