### PR TITLE
#2540 add patient api ui

### DIFF
--- a/src/actions/DispensaryActions.js
+++ b/src/actions/DispensaryActions.js
@@ -9,6 +9,7 @@ export const DISPENSARY_ACTIONS = {
   SWITCH: 'Dispensary/switch',
   REFRESH: 'Dispensary/refresh',
   LOOKUP_RECORD: 'Dispensary/lookupRecord',
+  CANCEL_LOOKUP_RECORD: 'Dispensary/cancelLookupRecord',
 };
 
 const filter = searchTerm => ({ type: DISPENSARY_ACTIONS.FILTER, payload: { searchTerm } });
@@ -20,10 +21,14 @@ const switchDataSet = () => ({ type: DISPENSARY_ACTIONS.SWITCH });
 const refresh = () => ({ type: DISPENSARY_ACTIONS.REFRESH });
 
 const lookupRecord = () => ({ type: DISPENSARY_ACTIONS.LOOKUP_RECORD });
+
+const cancelLookupRecord = () => ({ type: DISPENSARY_ACTIONS.CANCEL_LOOKUP_RECORD });
+
 export const DispensaryActions = {
   filter,
   sort,
   switchDataSet,
   refresh,
   lookupRecord,
+  cancelLookupRecord,
 };

--- a/src/actions/DispensaryActions.js
+++ b/src/actions/DispensaryActions.js
@@ -8,6 +8,7 @@ export const DISPENSARY_ACTIONS = {
   SORT: 'Dispensary/sort',
   SWITCH: 'Dispensary/switch',
   REFRESH: 'Dispensary/refresh',
+  LOOKUP_RECORD: 'Dispensary/lookupRecord',
 };
 
 const filter = searchTerm => ({ type: DISPENSARY_ACTIONS.FILTER, payload: { searchTerm } });
@@ -18,9 +19,11 @@ const switchDataSet = () => ({ type: DISPENSARY_ACTIONS.SWITCH });
 
 const refresh = () => ({ type: DISPENSARY_ACTIONS.REFRESH });
 
+const lookupRecord = () => ({ type: DISPENSARY_ACTIONS.LOOKUP_RECORD });
 export const DispensaryActions = {
   filter,
   sort,
   switchDataSet,
   refresh,
+  lookupRecord,
 };

--- a/src/localization/dispensingStrings.json
+++ b/src/localization/dispensingStrings.json
@@ -55,6 +55,8 @@
     "patient_detail": "Patient Detail",
     "item_details": "Item Details",
     "new_patient": "New patient",
+    "lookup_patient": "Lookup patient",
+    "lookup_prescriber": "Lookup prescriber",
     "unable_to_create_withdrawl": "Unable to create a withdrawl for more than the current balance.",
     "inpatient": "Inpatient",
     "outpatient": "Outpatient"

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -184,8 +184,12 @@ const Dispensing = ({
             viewStyle={localStyles.searchBar}
             placeholder={dispensingStrings.search_by_last_name_first_name}
           />
-          <PageButton text={lookupRecordText} onPress={lookupRecordAction} />
-          <PageButton text={newRecordText} onPress={newRecordAction} />
+          <PageButton
+            text={lookupRecordText}
+            onPress={lookupRecordAction}
+            style={localStyles.button}
+          />
+          <PageButton text={newRecordText} onPress={newRecordAction} style={localStyles.button} />
         </View>
         <DataTable
           data={data}
@@ -268,6 +272,9 @@ const localStyles = {
     marginHorizontal: 5,
     flex: 1,
     flexGrow: 1,
+  },
+  button: {
+    marginHorizontal: 2.5,
   },
 };
 

--- a/src/reducers/DispensaryReducer.js
+++ b/src/reducers/DispensaryReducer.js
@@ -76,6 +76,11 @@ export const DispensaryReducer = (state = initialState(), action) => {
     case DISPENSARY_ACTIONS.LOOKUP_RECORD: {
       return { ...state, isLookupModalOpen: true };
     }
+
+    case DISPENSARY_ACTIONS.CANCEL_LOOKUP_RECORD: {
+      return { ...state, isLookupModalOpen: false };
+    }
+
     default:
       return state;
   }

--- a/src/reducers/DispensaryReducer.js
+++ b/src/reducers/DispensaryReducer.js
@@ -16,6 +16,7 @@ const initialState = () => ({
   dataSet: 'patient',
   columns: getColumns(FORMS.PATIENT),
   data: UIDatabase.objects('Patient'),
+  isLookupModalOpen: false,
 });
 
 export const DispensaryReducer = (state = initialState(), action) => {
@@ -72,6 +73,9 @@ export const DispensaryReducer = (state = initialState(), action) => {
       return { ...state, data: newData };
     }
 
+    case DISPENSARY_ACTIONS.LOOKUP_RECORD: {
+      return { ...state, isLookupModalOpen: true };
+    }
     default:
       return state;
   }

--- a/src/selectors/dispensary.js
+++ b/src/selectors/dispensary.js
@@ -38,6 +38,11 @@ export const selectDataSetInUse = ({ dispensary }) => {
   return [usingPatientsDataSet, usingPrescribersDataSet];
 };
 
+export const selectLookupModalOpen = ({ dispensary }) => {
+  const { isLookupModalOpen } = dispensary;
+  return isLookupModalOpen;
+};
+
 export const selectFilteredData = createSelector(
   [selectData, selectSearchTerm, selectDataSetInUse],
   (data, searchTerm, [usingPatientsDataSet]) => {

--- a/src/widgets/modals/DispensaryLookup.js
+++ b/src/widgets/modals/DispensaryLookup.js
@@ -1,0 +1,10 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+
+const DispensaryLookup = () => <View />;
+export const DispensaryLookupModal = DispensaryLookup;

--- a/src/widgets/modals/index.js
+++ b/src/widgets/modals/index.js
@@ -10,3 +10,4 @@ export { DemoUserModal } from './DemoUserModal';
 export { FinaliseModal } from './FinaliseModal';
 export { LoginModal } from './LoginModal';
 export { ModalContainer } from './ModalContainer';
+export { DispensaryLookupModal } from './DispensaryLookup';


### PR DESCRIPTION
Fixes #2540.

Branches off #2567. 

## Change summary

Just a rough start to get things going. UI looks like this:

![#2540-add-patient-api-ui](https://user-images.githubusercontent.com/43223637/77365241-a2268700-6dba-11ea-9e03-cfbd13ce4eee.png)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When toggling patient/prescriber datasets, the lookup button updates correctly (`"Lookup patient/Lookup prescriber"`).
- [ ] When the `"Lookup patient"` button is pressed, an empty modal is opened with the same title.
- [ ] When the `"Lookup prescriber"` button is pressed, an empty modal is opened with the same title.
- [ ] When the modal is closed, the user is returned to the dispensary page without any change to the previous state.

### Related areas to think about

Still to do:

- Add modal: #2541.
- Add lookup logic: #2542.