### PR TITLE
#2554 fix modal strings not centred

### DIFF
--- a/src/widgets/modals/ModalContainer.js
+++ b/src/widgets/modals/ModalContainer.js
@@ -165,6 +165,7 @@ const localStyles = StyleSheet.create({
     fontFamily: APP_FONT_FAMILY,
     color: 'white',
     fontSize: 20,
+    textAlign: 'center',
   },
   closeButtonContainer: {
     flex: 1,


### PR DESCRIPTION
Fixes #2554.

Branched from #2561.

## Change summary

Just a small style change to centre modal titles.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Modal titles are centred (e.g. create new patient, create new prescriber).

### Related areas to think about

N/A.