### PR TITLE
#2556 fix cash transaction toggle margin

### DIFF
--- a/src/widgets/modals/CashTransactionModal.js
+++ b/src/widgets/modals/CashTransactionModal.js
@@ -239,7 +239,7 @@ export const CashTransactionModal = ({ onConfirm }) => {
   return (
     <>
       <FlexRow justifyContent="center">
-        <View style={{ maxWidth: 300 }}>
+        <View style={localStyles.toggleBarContainerStyle}>
           <ToggleBar style={localStyles.toggleBarStyle} toggles={toggles} />
         </View>
       </FlexRow>
@@ -267,7 +267,6 @@ export const CashTransactionModal = ({ onConfirm }) => {
           <ChevronDownIcon />
         </View>
       </TouchableOpacity>
-
       <PressReason />
       <TouchableOpacity style={localStyles.containerStyle} onPress={onPressDescription}>
         <View style={localStyles.textContainerStyle}>
@@ -347,6 +346,10 @@ const localStyles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     minHeight: '10%',
+  },
+  toggleBarContainerStyle: {
+    marginTop: 50,
+    maxWidth: 300,
   },
   bottomModalContainerStyle: {
     height: 120,


### PR DESCRIPTION
Fixes #2556 

Branched off #2556 

## Change summary

Small style adjustment to increase vertical space between toggle and title.

## Testing

- [ ] When making a new cash transaction, there is a "good" amount of vertical space between the title and the "Cash in/out" toggle.

### Related areas to think about

N/A.
