### PR TITLE
#2572 fix incorrect daily usage conditional

### DIFF
--- a/src/utilities/dailyUsage.js
+++ b/src/utilities/dailyUsage.js
@@ -45,10 +45,8 @@ export const dailyUsage = item => {
   const itemAddedDate = moment(addedDate);
   const dateNow = moment();
   const lookbackDate = moment(dateNow).subtract(amcLookback * 30, 'days');
-
-  const addedRecently = itemAddedDate.isBefore(lookbackDate);
-
-  const startDate = amcEnforceLookback || !addedRecently ? lookbackDate : itemAddedDate;
+  const useLookbackDate = amcEnforceLookback || itemAddedDate.isBefore(lookbackDate);
+  const startDate = useLookbackDate ? lookbackDate : itemAddedDate;
 
   const numberOfUsageDays = moment.duration(dateNow.diff(startDate)).asDays();
 


### PR DESCRIPTION
Fixes #2572.

## Change summary

Minor fix to lookback date conditional logic. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

The correct lookback logic as as follows:

- If the enforce lookback period preference is enabled, monthly consumption is always calculated as far back as that period (e.g. if the lookback period is six months, even if an item was first used last month, the consumption will be calculated as if the usage since then was actually over six months of dispensing).
- Otherwise, monthly consumption is calculated based on the most recent of the lookback period or the date when the item was first added (so that if an item has only recently been added, it's consumption will not be underrepresented). 

- [ ] The lookback date is correctly applied when calculating monthly consumption.

### Related areas to think about

N/A.
