### PR TITLE
Add use of stack action over goBack

### DIFF
--- a/src/navigation/RootNavigator.js
+++ b/src/navigation/RootNavigator.js
@@ -24,7 +24,7 @@ const navigate = (screenName, screenProps) =>
 const replace = (screenName, screenProps) =>
   rootNavigatorRef.current?.dispatch(StackActions.replace(screenName, screenProps));
 
-const goBack = () => rootNavigatorRef.current?.goBack();
+const goBack = () => rootNavigatorRef.current?.dispatch(StackActions.pop());
 
 const canGoBack = () => !!rootNavigatorRef.current?.canGoBack();
 

--- a/src/navigation/utilities.js
+++ b/src/navigation/utilities.js
@@ -62,6 +62,7 @@ export const navigationMiddleware = () => next => action => {
     const { routeName, params } = action;
     RootNavigator.navigate(routeName, params);
   }
+
   if (type === 'Navigation/REPLACE') {
     const { routeName, params } = action;
     RootNavigator.replace(routeName, params);


### PR DESCRIPTION
@mark-prins 

Was going to merge your PR but thought I'd have another quick look and realized this was a pretty nice fix to be able to navigate back?

So when you navigate back or click cancel, the stack navigator will go back, rather than the tab navigator which was the previous behaviour 