### PR TITLE
#2609 add patient api search form

### DIFF
--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -5,12 +5,12 @@
  */
 import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { batch, connect } from 'react-redux';
 import { View } from 'react-native';
 
 import { ToggleBar, DataTablePageView, SearchBar, PageButton } from '../widgets';
 import { DataTable, DataTableRow, DataTableHeaderRow } from '../widgets/DataTable';
-import { DispensaryLookupModal } from '../widgets/modals/DispensaryLookup';
+import { SearchForm } from '../widgets/modals/SearchForm';
 import { PatientHistoryModal } from '../widgets/modals/PatientHistory';
 import { FormControl } from '../widgets/FormControl';
 import { ModalContainer } from '../widgets/modals/ModalContainer';
@@ -21,6 +21,7 @@ import { createPrescription } from '../navigation/actions';
 import { UIDatabase } from '../database';
 import { getFormInputConfig } from '../utilities/formInputConfigs';
 
+import { FormActions } from '../actions/FormActions';
 import { PatientActions } from '../actions/PatientActions';
 import { PrescriberActions } from '../actions/PrescriberActions';
 import { InsuranceActions } from '../actions/InsuranceActions';
@@ -254,7 +255,7 @@ const Dispensing = ({
         fullScreen
         isVisible={isLookupModalOpen}
       >
-        <DispensaryLookupModal />
+        <SearchForm dataSource={usingPatientsDataSet ? 'patient' : 'prescriber'} />
       </ModalContainer>
     </>
   );
@@ -324,7 +325,11 @@ const mapDispatchToProps = dispatch => ({
   switchDataset: () => dispatch(DispensaryActions.switchDataSet()),
 
   lookupRecord: () => dispatch(DispensaryActions.lookupRecord()),
-  cancelLookupRecord: () => dispatch(DispensaryActions.cancelLookupRecord()),
+  cancelLookupRecord: () =>
+    batch(() => {
+      dispatch(DispensaryActions.cancelLookupRecord());
+      dispatch(FormActions.resetForm());
+    }),
 
   editPatient: patient => dispatch(PatientActions.editPatient(UIDatabase.get('Name', patient))),
   createPatient: () => dispatch(PatientActions.createPatient()),

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -17,143 +17,145 @@ import { TouchableOpacity } from 'react-native-gesture-handler';
 import { queryPatientApi, queryPrescriberApi } from '../../utilities/network/lookupApi';
 
 const RECORD_TYPES = {
-    PATIENT: 'patient',
-    PRESCRIBER: 'prescriber',
-}
+  PATIENT: 'patient',
+  PRESCRIBER: 'prescriber',
+};
 
 const FORM_CONFIGS = {
-    [RECORD_TYPES.PATIENT]: 'searchPatient',
-    [RECORD_TYPES.PRESCRIBER]: 'searchPrescriber',
-}
+  [RECORD_TYPES.PATIENT]: 'searchPatient',
+  [RECORD_TYPES.PRESCRIBER]: 'searchPrescriber',
+};
 
 const LIST_CONFIGS = {
-    [RECORD_TYPES.PATIENT]: [ 'firstName', 'lastName', 'dateOfBirth' ],
-    [RECORD_TYPES.PRESCRIBER]: [ 'firstName', 'lastName', 'registrationCode' ],
-}
+  [RECORD_TYPES.PATIENT]: ['firstName', 'lastName', 'dateOfBirth'],
+  [RECORD_TYPES.PRESCRIBER]: ['firstName', 'lastName', 'registrationCode'],
+};
 
 const SearchListItemColumn = ({ value, type }) => (
-    <View style={localStyles.columnContainer}>
-        <Text style={localStyles.text}>
-            {type === 'date' ? value.toDateString() : value}
-        </Text>
-    </View>
+  <View style={localStyles.columnContainer}>
+    <Text style={localStyles.text}>{type === 'date' ? value.toDateString() : value}</Text>
+  </View>
 );
 
 const SearchListItem = ({ listItem, listConfig }) => {
-    const onPress = item => console.log(item);
-    const columns = listConfig.map(({ key, type}) => {
-        const value = listItem[key];
-        return <SearchListItemColumn key={key} value={value} type={type}/>;
-    });
-    return (
-        <TouchableOpacity onPress={onPress} style={localStyles.rowContainer}>
-            {columns}
-        </TouchableOpacity>
+  const onPress = item => console.log(item);
+  const columns = listConfig.map(({ key, type }) => {
+    const value = listItem[key];
+    return <SearchListItemColumn key={key} value={value} type={type} />;
+  });
+  return (
+    <TouchableOpacity onPress={onPress} style={localStyles.rowContainer}>
+      {columns}
+    </TouchableOpacity>
+  );
+};
+
+export const SearchForm = ({ dataSource }) => {
+  const [data, setData] = useState([]);
+
+  if (!RECORD_TYPES.includes(dataSource)) return null;
+
+  const configKey = useMemo(() => FORM_CONFIGS[dataSource], [dataSource]);
+  const formConfig = useMemo(() => getFormInputConfig(configKey), [configKey]);
+
+  const listConfig = useMemo(() => {
+    const keys = LIST_CONFIGS[dataSource];
+    const keyTypes = keys.reduce(
+      (acc, key) => ({ ...acc, [key]: formConfig.find(config => config.key === key)?.type }),
+      {}
     );
-}
+    return keys.map(key => ({ key, type: keyTypes[key] }));
+  }, [formConfig]);
 
-export const SearchForm = ({dataSource}) => {
-    const [data, setData] = useState([]);
+  const renderItem = useMemo(
+    () => ({ item }) => <SearchListItem key={item.id} listItem={item} listConfig={listConfig} />,
+    [listConfig]
+  );
 
-    if (!RECORD_TYPES.includes(dataSource)) return null;
-
-    const configKey = useMemo(() => FORM_CONFIGS[dataSource], [dataSource]);
-    const formConfig = useMemo(() => getFormInputConfig(configKey), [configKey]);
-
-    const listConfig = useMemo(() => {
-        const keys = LIST_CONFIGS[dataSource];
-        const keyTypes = keys.reduce((acc, key) => ({ ...acc, [key]: formConfig.find(config => config.key === key)?.type }), {});
-        return keys.map(key => ({ key, type: keyTypes[key] }));
-    }, [formConfig]);
-
-    const renderItem = useMemo(() => ({item}) => <SearchListItem key={item.id} listItem={item} listConfig={listConfig}/>, [listConfig]);
-
-    const lookupRecords = useMemo(() => params => {
-        switch (dataSource) {
-            case RECORD_TYPES.PATIENT: {
-                queryPatientApi(params).then(patientData => setData(patientData));
-                break;
-            }
-            case RECORD_TYPES.PRESCRIBER: {
-                queryPrescriberApi(params).then(prescriberData => setData(prescriberData));
-                break;
-            }
-            default: queryPatientApi(params);
+  const lookupRecords = useMemo(
+    () => params => {
+      switch (dataSource) {
+        case RECORD_TYPES.PATIENT: {
+          queryPatientApi(params).then(patientData => setData(patientData));
+          break;
         }
-    }, []);
+        case RECORD_TYPES.PRESCRIBER: {
+          queryPrescriberApi(params).then(prescriberData => setData(prescriberData));
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    []
+  );
 
-    return (
-        <View style={localStyles.container}>
-            <View style={localStyles.formContainer}>
-                <FormControl
-                    isDisabled={false}
-                    isSearchForm={true}
-                    onSave={lookupRecords}
-                    onCancel={() => null}
-                    inputConfig={formConfig}
-                />
-            </View>
-            <View style={localStyles.verticalSeparator}></View>
-            <View style={localStyles.listContainer}>
-                <FlatList
-                    data={data}
-                    keyExtractor={record => record.id}
-                    renderItem={renderItem}
-                />
-            </View>
-        </View>
-    );
-  };
-  
+  return (
+    <View style={localStyles.container}>
+      <View style={localStyles.formContainer}>
+        <FormControl
+          isDisabled={false}
+          isSearchForm={true}
+          onSave={lookupRecords}
+          onCancel={() => null}
+          inputConfig={formConfig}
+        />
+      </View>
+      <View style={localStyles.verticalSeparator}></View>
+      <View style={localStyles.listContainer}>
+        <FlatList data={data} keyExtractor={record => record.id} renderItem={renderItem} />
+      </View>
+    </View>
+  );
+};
+
 SearchForm.propTypes = {
-    dataSource: PropTypes.string.isRequired,
+  dataSource: PropTypes.string.isRequired,
 };
 
 SearchListItem.propTypes = {
-    listItem: PropTypes.object.isRequired,
-    listConfig: PropTypes.array.isRequired,
-}
+  listItem: PropTypes.object.isRequired,
+  listConfig: PropTypes.array.isRequired,
+};
 
 SearchListItemColumn.propTypes = {
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]).isRequired,
-    type: PropTypes.string.isRequired,
-}
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]).isRequired,
+  type: PropTypes.string.isRequired,
+};
 
-  
 const localStyles = StyleSheet.create({
-    container: {
-        height: 720,
-        marginVertical: 20,
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        backgroundColor: 'white',
-    },
-    formContainer: {
-      flex: 1,
-      flexDirection: 'row',
-      backgroundColor: 'white',
-      alignItems: 'stretch',
-    },
-    verticalSeparator: {
-        width: 10,
-        backgroundColor: DARK_GREY,
-    },
-    listContainer: {
-      flex: 3,
-      flexDirection: 'row',
-      backgroundColor: 'white',
-
-    },
-    rowContainer: {
-        flexDirection: 'row', 
-        justifyContent: 'space-around',
-        marginVertical: 10,
-    },
-    columnContainer: {
-        marginHorizontal: 10,
-    },        
-    text: {
-        fontSize: 20,
-        fontFamily: APP_FONT_FAMILY,
-      },
-  });
+  container: {
+    height: 720,
+    marginVertical: 20,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    backgroundColor: 'white',
+  },
+  formContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    backgroundColor: 'white',
+    alignItems: 'stretch',
+  },
+  verticalSeparator: {
+    width: 10,
+    backgroundColor: DARK_GREY,
+  },
+  listContainer: {
+    flex: 3,
+    flexDirection: 'row',
+    backgroundColor: 'white',
+  },
+  rowContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginVertical: 10,
+  },
+  columnContainer: {
+    marginHorizontal: 10,
+  },
+  text: {
+    fontSize: 20,
+    fontFamily: APP_FONT_FAMILY,
+  },
+});

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -1,0 +1,159 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+import React, { useMemo, useState } from 'react';
+import { View, StyleSheet, FlatList, Text } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { FormControl } from '../FormControl';
+
+import { getFormInputConfig } from '../../utilities/formInputConfigs';
+
+import { APP_FONT_FAMILY, DARK_GREY } from '../../globalStyles';
+import { TouchableOpacity } from 'react-native-gesture-handler';
+import { queryPatientApi, queryPrescriberApi } from '../../utilities/network/lookupApi';
+
+const RECORD_TYPES = {
+    PATIENT: 'patient',
+    PRESCRIBER: 'prescriber',
+}
+
+const FORM_CONFIGS = {
+    [RECORD_TYPES.PATIENT]: 'searchPatient',
+    [RECORD_TYPES.PRESCRIBER]: 'searchPrescriber',
+}
+
+const LIST_CONFIGS = {
+    [RECORD_TYPES.PATIENT]: [ 'firstName', 'lastName', 'dateOfBirth' ],
+    [RECORD_TYPES.PRESCRIBER]: [ 'firstName', 'lastName', 'registrationCode' ],
+}
+
+const SearchListItemColumn = ({ value, type }) => (
+    <View style={localStyles.columnContainer}>
+        <Text style={localStyles.text}>
+            {type === 'date' ? value.toDateString() : value}
+        </Text>
+    </View>
+);
+
+const SearchListItem = ({ listItem, listConfig }) => {
+    const onPress = item => console.log(item);
+    const columns = listConfig.map(({ key, type}) => {
+        const value = listItem[key];
+        return <SearchListItemColumn key={key} value={value} type={type}/>;
+    });
+    return (
+        <TouchableOpacity onPress={onPress} style={localStyles.rowContainer}>
+            {columns}
+        </TouchableOpacity>
+    );
+}
+
+export const SearchForm = ({dataSource}) => {
+    const [data, setData] = useState([]);
+
+    if (!RECORD_TYPES.includes(dataSource)) return null;
+
+    const configKey = useMemo(() => FORM_CONFIGS[dataSource], [dataSource]);
+    const formConfig = useMemo(() => getFormInputConfig(configKey), [configKey]);
+
+    const listConfig = useMemo(() => {
+        const keys = LIST_CONFIGS[dataSource];
+        const keyTypes = keys.reduce((acc, key) => ({ ...acc, [key]: formConfig.find(config => config.key === key)?.type }), {});
+        return keys.map(key => ({ key, type: keyTypes[key] }));
+    }, [formConfig]);
+
+    const renderItem = useMemo(() => ({item}) => <SearchListItem key={item.id} listItem={item} listConfig={listConfig}/>, [listConfig]);
+
+    const lookupRecords = useMemo(() => params => {
+        switch (dataSource) {
+            case RECORD_TYPES.PATIENT: {
+                queryPatientApi(params).then(patientData => setData(patientData));
+                break;
+            }
+            case RECORD_TYPES.PRESCRIBER: {
+                queryPrescriberApi(params).then(prescriberData => setData(prescriberData));
+                break;
+            }
+            default: queryPatientApi(params);
+        }
+    }, []);
+
+    return (
+        <View style={localStyles.container}>
+            <View style={localStyles.formContainer}>
+                <FormControl
+                    isDisabled={false}
+                    isSearchForm={true}
+                    onSave={lookupRecords}
+                    onCancel={() => null}
+                    inputConfig={formConfig}
+                />
+            </View>
+            <View style={localStyles.verticalSeparator}></View>
+            <View style={localStyles.listContainer}>
+                <FlatList
+                    data={data}
+                    keyExtractor={record => record.id}
+                    renderItem={renderItem}
+                />
+            </View>
+        </View>
+    );
+  };
+  
+SearchForm.propTypes = {
+    dataSource: PropTypes.string.isRequired,
+};
+
+SearchListItem.propTypes = {
+    listItem: PropTypes.object.isRequired,
+    listConfig: PropTypes.array.isRequired,
+}
+
+SearchListItemColumn.propTypes = {
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]).isRequired,
+    type: PropTypes.string.isRequired,
+}
+
+  
+const localStyles = StyleSheet.create({
+    container: {
+        height: 720,
+        marginVertical: 20,
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        backgroundColor: 'white',
+    },
+    formContainer: {
+      flex: 1,
+      flexDirection: 'row',
+      backgroundColor: 'white',
+      alignItems: 'stretch',
+    },
+    verticalSeparator: {
+        width: 10,
+        backgroundColor: DARK_GREY,
+    },
+    listContainer: {
+      flex: 3,
+      flexDirection: 'row',
+      backgroundColor: 'white',
+
+    },
+    rowContainer: {
+        flexDirection: 'row', 
+        justifyContent: 'space-around',
+        marginVertical: 10,
+    },
+    columnContainer: {
+        marginHorizontal: 10,
+    },        
+    text: {
+        fontSize: 20,
+        fontFamily: APP_FONT_FAMILY,
+      },
+  });


### PR DESCRIPTION
Fixes #2609.

Branched off #2612.

## Change summary

Adds basic search form for retrieving and displaying patient/prescriber records. 

Uses a combo of `FormControl` and `FlatList` to provide a search interface and list for rendering results. Still just minimal functionality and UI, but gives a good idea of the basic design.

## Testing

N/A.

### Related areas to think about

N/A.
