### PR TITLE
#2579 Item methods [D4]

### DIFF
--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -282,14 +282,14 @@ export class Item extends Realm.Object {
   closedVialWastage(fromDate) {
     if (!this.isVaccine || !fromDate) return 0;
 
-    const customerCreditTransactionItems = this.transactionItems.filtered(
+    const supplierCreditTransactionItems = this.transactionItems.filtered(
       'transaction.confirmDate > $0 && transaction.type == $1 && transaction.otherParty.name == $2',
       fromDate,
       'supplier_credit',
       'inventory_adjustment'
     );
 
-    const totalDosesPossible = customerCreditTransactionItems.reduce(
+    const totalDosesPossible = supplierCreditTransactionItems.reduce(
       (dosesPossible, { batches }) => dosesPossible + batches.sum('numberOfPacks') * this.doses,
       0
     );

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -169,13 +169,12 @@ export class Item extends Realm.Object {
   }
 
   /**
-   * @return {Date} The date of the most recent confirmed requisition for this item.
+   * @return {Date} The date of the most recent finalised requisition for this item.
    */
   get lastRequisitionDate() {
-    const mostRecentRequisitionItem = this.requisitionItems.sorted(
-      'requisition.entryDate',
-      true
-    )[0];
+    const mostRecentRequisitionItem = this.requisitionItems
+      .filtered("requisition.status == 'finalised'")
+      .sorted('requisition.entryDate', true)[0];
 
     return mostRecentRequisitionItem?.requisition?.confirmDate;
   }

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -173,7 +173,7 @@ export class Item extends Realm.Object {
    */
   get lastRequisitionDate() {
     const mostRecentRequisitionItem = this.requisitionItems.sorted(
-      'requisition.confirmDate',
+      'requisition.entryDate',
       true
     )[0];
 

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -169,6 +169,18 @@ export class Item extends Realm.Object {
   }
 
   /**
+   * @return {Date} The date of the most recent confirmed requisition for this item.
+   */
+  get lastRequisitionDate() {
+    const mostRecentRequisitionItem = this.requisitionItems.sorted(
+      'requisition.confirmDate',
+      true
+    )[0];
+
+    return mostRecentRequisitionItem?.requisition?.confirmDate;
+  }
+
+  /**
    * Add batch to item.
    *
    * @param  {ItemBatch}  itemBatch
@@ -228,6 +240,63 @@ export class Item extends Realm.Object {
 
     return this.totalQuantity + reductions - additions;
   }
+
+  /**
+   * A vaccine item can have multiple doses per 'unit' or 'pack'. For example, you can have
+   * a single vaccine which has two doses. Once a vaccine has been opened, the doses must be
+   * given quickly. When recording outgoing stock, the doses and quantity (or number of packs)
+   * are recorded seperately. The amount of open vial wastage (that is, the amount of doses
+   * which are left in a vial and wasted) is the difference between the total number of 'packs'
+   * that are outgoing, multiplied by the amount of doses in each pack and the total number of
+   * doses actually given.
+   *
+   * @param  {Date} fromDate The date to calculate the open vial wastage from.
+   * @return {Number} the number of DOSES wasted.
+   */
+  openVialWastage(fromDate) {
+    if (!this.isVaccine || !fromDate) return 0;
+
+    const customerInvoiceTransactionItems = this.transactionItems.filtered(
+      "transaction.confirmDate > $0 && transaction.type == 'customer_invoice",
+      fromDate
+    );
+
+    const totalDosesPossible = customerInvoiceTransactionItems.reduce(
+      (dosesPossible, { batches }) => dosesPossible + batches.sum('numberOfPacks') * this.doses,
+      0
+    );
+
+    const totalDosesGiven = customerInvoiceTransactionItems.reduce(
+      (dosesGiven, { batches }) => dosesGiven + batches.sum('doses'),
+      0
+    );
+
+    return totalDosesPossible - totalDosesGiven;
+  }
+
+  /**
+   * Closed vial wastage differs from open vial wastage in that closed vial wastage
+   * is 'standard wastage'.
+   * @param {Date} fromDate
+   * @param {Number} the number of DOSES wasted.
+   */
+  closedVialWastage(fromDate) {
+    if (!this.isVaccine || !fromDate) return 0;
+
+    const customerCreditTransactionItems = this.transactionItems.filtered(
+      'transaction.confirmDate > $0 && transaction.type == $1 && transaction.otherParty.name == $2',
+      fromDate,
+      'supplier_credit',
+      'inventory_adjustment'
+    );
+
+    const totalDosesPossible = customerCreditTransactionItems.reduce(
+      (dosesPossible, { batches }) => dosesPossible + batches.sum('numberOfPacks') * this.doses,
+      0
+    );
+
+    return totalDosesPossible;
+  }
 }
 
 Item.schema = {
@@ -247,9 +316,11 @@ Item.schema = {
     crossReferenceItem: { type: 'Item', optional: true },
     unit: { type: 'Unit', optional: true },
     defaultRestrictedLocationType: { type: 'LocationType', optional: true },
-    directions: { type: 'linkingObjects', objectType: 'ItemDirection', property: 'item' },
     doses: { type: 'double', default: 0 },
     isVaccine: { type: 'bool', default: false },
+    directions: { type: 'linkingObjects', objectType: 'ItemDirection', property: 'item' },
+    requisitionItems: { type: 'linkingObjects', objectType: 'RequisitionItem', property: 'item' },
+    transactionItems: { type: 'linkingObjects', objectType: 'TransactionItem', property: 'item' },
   },
 };
 

--- a/src/database/DataTypes/ItemBatch.js
+++ b/src/database/DataTypes/ItemBatch.js
@@ -21,6 +21,18 @@ import Realm from 'realm';
  * @property  {List.<TransactionBatch>}  transactionBatches
  */
 export class ItemBatch extends Realm.Object {
+  get isInBreach() {
+    return this.location?.isInBreach() ?? false;
+  }
+
+  get currentVvmStatus() {
+    return this.vaccineVialMonitorStatusLogs.sorted('timestamp', true)[0];
+  }
+
+  get vvmStatusName() {
+    return this.currentVvmStatus?.description ?? '';
+  }
+
   get otherPartyName() {
     return this.supplier?.name || '';
   }
@@ -110,6 +122,28 @@ export class ItemBatch extends Realm.Object {
    */
   toString() {
     return `${this.itemName} - Batch ${this.batch}`;
+  }
+
+  /**
+   * @param  {VaccineVialMonitorStatus} newVvmStatus
+   * @return {Bool} Indicator whether the new vvm status should be applied to this batch.
+   */
+  shouldApplyVvmStatus(newVvmStatus) {
+    const { id: newStatusId } = newVvmStatus;
+    const { id: currentStatusId } = this.currentVvmStatus;
+
+    return newStatusId !== currentStatusId;
+  }
+
+  /**
+   * @param  {Location} newLocation
+   * @return {Bool} Indicator whether the new location should be applied to this batch.
+   */
+  shouldApplyLocation(newLocation) {
+    const { id: newLocationId } = newLocation;
+    const { id: currentLocationId } = this.location;
+
+    return newLocationId !== currentLocationId;
   }
 }
 

--- a/src/database/DataTypes/Location.js
+++ b/src/database/DataTypes/Location.js
@@ -5,7 +5,44 @@
 
 import Realm from 'realm';
 
-export class Location extends Realm.Object {}
+export class Location extends Realm.Object {
+  get mostRecentTemperatureLog() {
+    return this.temperatureLogs.sorted('timestamp', true)[0];
+  }
+
+  get mostRecentTemperatureBreach() {
+    return this.breaches.sorted('startTimestamp', true)[0];
+  }
+
+  /**
+   * This location is currently experiencing a temperature breach
+   * if the most recent breach for the location has no end timestamp.
+   */
+  get isInBreach() {
+    const hasBeenInABreach = this.mostRecentTemperatureBreach;
+    return hasBeenInABreach && !hasBeenInABreach.endTimestamp;
+  }
+
+  get currentTemperature() {
+    const { temperature } = this.mostRecentTemperatureLog;
+    return temperature;
+  }
+
+  batchesAtTime(database, timestamp = new Date()) {
+    const locationMovements = this.locationMovements.filtered(
+      'inTime <= $0 && (outTime > $0 || outTime == null)',
+      timestamp
+    );
+    const queryString = locationMovements.map(({ id }) => `id == "${id}"`).join(' OR ');
+
+    return database.objects('ItemBatch').filtered(queryString);
+  }
+
+  totalStock(database) {
+    const batches = this.batchesAtTime(database);
+    return batches.sum('numberOfPacks') ?? 0;
+  }
+}
 
 Location.schema = {
   name: 'Location',

--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -228,9 +228,13 @@ export class Stocktake extends Realm.Object {
     return this.additions;
   }
 
+  get hasValidDoses() {
+    return this.items.every(({ hasValidDoses }) => hasValidDoses);
+  }
+
   get canFinalise() {
     const finaliseStatus = { success: true, message: modalStrings.finalise_stocktake };
-    if (!this.hasSomeCountedItems) {
+    if (!this.hasSomeCountedItems || !this.hasValidDoses) {
       finaliseStatus.success = false;
       finaliseStatus.errorMessage = modalStrings.stocktake_no_counted_items;
     }

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -30,8 +30,37 @@ export class StocktakeBatch extends Realm.Object {
     }
   }
 
+  get currentLocationName() {
+    return this.location?.description ?? '';
+  }
+
+  get currentVvmStatusName() {
+    return this.vaccineVialMonitorStatus?.description ?? '';
+  }
+
+  get isInBreach() {
+    return this.itemBatch?.isInBreach ?? false;
+  }
+
   get otherPartyName() {
     return this.supplier?.name ?? '';
+  }
+
+  /**
+   * @return {Bool} Indicator if this batch has a valid number of doses.
+   */
+  get hasValidDoses() {
+    const { item } = this.itemBatch;
+    const { doses: dosesPerVial } = item;
+
+    const maximumDosesPossible = this.snapshotTotalQuantity * dosesPerVial;
+    const minimumDosesPossible = this.snapshotTotalQuantity;
+
+    const tooManyDoses = this.doses > maximumDosesPossible;
+    const tooLittleDoses = this.doses < minimumDosesPossible;
+    const justRightDoses = !tooManyDoses && !tooLittleDoses;
+
+    return justRightDoses;
   }
 
   /**

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -23,6 +23,10 @@ export class StocktakeItem extends Realm.Object {
     database.delete('StocktakeBatch', this.batches);
   }
 
+  get hasValidDoses() {
+    return this.batches.every(({ hasValidDoses }) => hasValidDoses);
+  }
+
   /**
    * Get snapshot of total quantity of item.
    *

--- a/src/database/DataTypes/TemperatureBreach.js
+++ b/src/database/DataTypes/TemperatureBreach.js
@@ -4,8 +4,61 @@
  */
 
 import Realm from 'realm';
+import moment from 'moment';
 
-export class TemperatureBreach extends Realm.Object {}
+export class TemperatureBreach extends Realm.Object {
+  get maximumTemperature() {
+    return this.temperatureLogs.max('temperature');
+  }
+
+  get minimumTemperature() {
+    return this.temperatureLogs.min('temperature');
+  }
+
+  get temperatureExposure() {
+    const { maximumTemperature, minimumTemperature } = this;
+    return { maximumTemperature, minimumTemperature };
+  }
+
+  get duration() {
+    return moment
+      .duration(moment(this.endTimestamp).diff(moment(this.startTimestamp)))
+      .asMilliseconds();
+  }
+
+  affectedBatches(database) {
+    return this.location.batchesAtTime(database, this.endTimestamp);
+  }
+
+  numberOfAffectedBatches(database) {
+    return this.affectedBatches(database)?.length ?? 0;
+  }
+
+  affectedQuantity(database) {
+    const affectedBatches = this.affectedBatches(database);
+
+    if (!affectedBatches?.length) return 0;
+
+    const itemBatchQuery = affectedBatches.map(({ id }) => `itemBatch.id == "${id}"`).join(' OR ');
+    const transactionBatches = database.objects('TransactionBatch').filtered(itemBatchQuery);
+
+    const incomingStock = transactionBatches.filtered(
+      'transaction.confirmDate < $0 && (transaction.type == $1 || transaction.type == $2)',
+      this.endTimestamp,
+      'supplier_invoice',
+      'customer_credit'
+    );
+
+    const outgoingStock = transactionBatches.filtered(
+      'transaction.confirmDate < $0 && (transaction.type == $1 || transaction.type == $2)',
+      this.endTimestamp,
+      'customer_invoice',
+      'supplier_credit'
+    );
+
+    return incomingStock.sum('numberOfPacks') ?? 0 - outgoingStock.sum('numberOfPacks') ?? 0;
+  }
+}
 
 TemperatureBreach.schema = {
   name: 'TemperatureBreach',

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -459,6 +459,10 @@ export class Transaction extends Realm.Object {
     return batchName;
   }
 
+  get hasValidDoses() {
+    return this.items.every(({ hasValidDoses }) => hasValidDoses);
+  }
+
   get canFinaliseCustomerInvoice() {
     const finaliseStatus = { success: true, message: modalStrings.finalise_customer_invoice };
 
@@ -470,6 +474,11 @@ export class Transaction extends Realm.Object {
     if (!this.totalQuantity) {
       finaliseStatus.success = false;
       finaliseStatus.message = modalStrings.record_stock_to_issue_before_finalising;
+    }
+
+    if (!this.hasValidDoses) {
+      finaliseStatus.success = false;
+      finaliseStatus.message = modalStrings.some_item_have_invalid_doses;
     }
 
     return finaliseStatus;

--- a/src/database/DataTypes/TransactionBatch.js
+++ b/src/database/DataTypes/TransactionBatch.js
@@ -37,6 +37,35 @@ export class TransactionBatch extends Realm.Object {
     }
   }
 
+  get currentLocationName() {
+    return this.location?.description ?? '';
+  }
+
+  get currentVvmStatusName() {
+    return this.vaccineVialMonitorStatus?.description ?? '';
+  }
+
+  get isInBreach() {
+    return this.itemBatch?.isInBreach ?? false;
+  }
+
+  /**
+   * @return {Bool} Indicator if this batch has a valid number of doses.
+   */
+  get hasValidDoses() {
+    const { item } = this.itemBatch;
+    const { doses: dosesPerVial } = item;
+
+    const maximumDosesPossible = this.snapshotTotalQuantity * dosesPerVial;
+    const minimumDosesPossible = this.snapshotTotalQuantity;
+
+    const tooManyDoses = this.doses > maximumDosesPossible;
+    const tooLittleDoses = this.doses < minimumDosesPossible;
+    const justRightDoses = !tooManyDoses && !tooLittleDoses;
+
+    return justRightDoses;
+  }
+
   /**
    * Returns either the prescriber name who prescribed the medicine
    * to a patient, or an empty string.

--- a/src/database/DataTypes/TransactionItem.js
+++ b/src/database/DataTypes/TransactionItem.js
@@ -22,6 +22,10 @@ export class TransactionItem extends Realm.Object {
     database.delete('TransactionBatch', this.batches);
   }
 
+  get hasValidDoses() {
+    return this.batches.every(({ hasValidDoses }) => hasValidDoses);
+  }
+
   /**
    * Get id of item associated with this transaction item.
    *

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -750,6 +750,85 @@ const createTransactionItem = (database, transaction, item, initialQuantity = 0)
   return transactionItem;
 };
 
+const createLocation = (database, description, code, locationType) => {
+  const location = database.create('Location', {
+    id: generateUUID(),
+    description,
+    code,
+    locationType,
+  });
+
+  return location;
+};
+
+const createSensor = (database, macAddress, batteryLevel, location) => {
+  const sensor = database.create('Sensor', {
+    id: generateUUID(),
+    macAddress,
+    batteryLevel,
+    location,
+  });
+
+  return sensor;
+};
+
+const createLocationMovement = (database, itemBatch, location) => {
+  const locationMovement = database.create('LocationMovement', {
+    id: generateUUID(),
+    itemBatch,
+    location,
+    enterTimestamp: new Date(),
+  });
+
+  itemBatch.location = location;
+  database.save('ItemBatch', itemBatch);
+
+  return locationMovement;
+};
+
+const createVvmStatusLog = (database, itemBatch, status) => {
+  const vvmStatus = database.create('VaccineVialMonitorStatus', {
+    id: generateUUID(),
+    itemBatch,
+    status,
+    timestamp: new Date(),
+  });
+
+  return vvmStatus;
+};
+
+const createSensorLog = (database, temperature, timestamp, sensor) => {
+  const sensorLog = database.create('SensorLog', {
+    id: generateUUID(),
+    temperature,
+    timestamp,
+    sensor,
+  });
+
+  return sensorLog;
+};
+
+const createTemperatureLog = (database, temperature, timestamp, location) => {
+  const temperatureLog = database.create('TemperatureLog', {
+    id: generateUUID(),
+    temperature,
+    timestamp,
+    location,
+  });
+
+  return temperatureLog;
+};
+
+const createTemperatureBreach = (database, startTimestamp, location) => {
+  const temperatureLog = database.create('SensorLog', {
+    id: generateUUID(),
+    startTimestamp,
+    location,
+  });
+
+  return temperatureLog;
+};
+
 /**
  * Create a Message record. This will be sent to the server and requests tables
  * when an app is upgraded from some version to another.
@@ -853,6 +932,20 @@ export const createRecord = (database, type, ...args) => {
       return createPrescriber(database, ...args);
     case 'UpgradeMessage':
       return createUpgradeMessage(database, ...args);
+    case 'Location':
+      return createLocation(database, ...args);
+    case 'Sensor':
+      return createSensor(database, ...args);
+    case 'LocationMovement':
+      return createLocationMovement(database, ...args);
+    case 'VaccineVialMonitorStatus':
+      return createVvmStatusLog(database, ...args);
+    case 'SensorLog':
+      return createSensorLog(database, ...args);
+    case 'TemperatureLog':
+      return createTemperatureLog(database, ...args);
+    case 'TemperatureBreach':
+      return createTemperatureBreach(database, ...args);
     default:
       throw new Error(`Cannot create a record with unsupported type: ${type}`);
   }

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -46,7 +46,8 @@
     "customer_no_masterlist_available": "This customer has no master lists!",
     "supplier_no_masterlist_available": "Your store has no master lists!",
     "emergency_orders_can_only_have": "Emergency orders can only have",
-    "items_remove_some": "items! Remove some before you can finalise"
+    "items_remove_some": "items! Remove some before you can finalise",
+    "some_item_have_invalid_doses": "This invoice has items with an invalid amount of doses!"
   },
   "fr": {
     "add_at_least_one_item_before_finalising": "Vous devez ajouter au moins un article avant de finaliser",


### PR DESCRIPTION
#### NOTE: Branched from #2580 

Fixes #2579 

## Change summary

- Adds `Item` methods!

## Testing

N/A

### Related areas to think about

- Don't like the use of reduce but since this should always be a pretty small amount of transactions (since the most recent requisition, so either monthly - or if not ordering monthly, should probably have a small amount of transactions), it should be ok. Would be possible to just use `UIDatabase` but I think leaving it like this and seeing if there is a performance problem later is the better decision
- I think it might be better to use only finalised requisitions however the last implementation didn't, so have left it

