### PR TITLE
#2638 additional breach methods

### DIFF
--- a/src/actions/TemperatureSyncActions.js
+++ b/src/actions/TemperatureSyncActions.js
@@ -1,0 +1,259 @@
+/* eslint-disable no-await-in-loop */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+import { generateUUID } from 'react-native-database';
+
+import { UIDatabase } from '../database';
+import { Sensor } from '../database/DataTypes';
+import { createRecord } from '../database/utilities';
+import { MILLISECONDS } from '../utilities';
+import { chunk } from '../utilities/chunk';
+
+export const TEMPERATURE_SYNC_ACTIONS = {
+  OPEN_MODAL: 'TemperatureSync/openModal',
+  CLOSE_MODAL: 'TemperatureSync/closeModal',
+  ERROR_NO_SENSORS: 'TemperatureSync/errorNoSensors',
+
+  START_SYNC: 'TemperatureSync/startSync',
+  COMPLETE_SYNC: 'TemperatureSync/completeSync',
+
+  SCAN_START: 'TemperatureSync/scanStart',
+  SCAN_COMPLETE: 'TemperatureSync/scanComplete',
+  SCAN_ERROR: 'TemperatureSync/scanError',
+
+  DOWNLOAD_LOGS_START: 'TemperatureSync/downloadLogsStart',
+  DOWNLOAD_LOGS_COMPLETE: 'TemperatureSync/downloadLogsComplete',
+  DOWNLOAD_LOGS_ERROR: 'TemperatureSync/downloadLogsError',
+
+  START_RESETTING_ADVERTISEMENT_FREQUENCY: 'TemperatureSync/startResettingAdvertisementFrequency',
+  ERROR_RESETTING_ADVERTISEMENT_FREQUENCY: 'TemperatureSync/errorResettingAdvertisementFrequency',
+  COMPLETE_RESETTING_ADVERTISEMENT_FREQUENCY:
+    'TemperatureSync/completeResettingAdvertisementFrequency',
+  START_RESETTING_LOG_FREQUENCY: 'TemperatureSync/startResettingLogFrequency',
+  COMPLETE_RESETTING_LOG_FREQUENCY: 'TemperatureSync/completeResettingLogFrequency',
+  ERROR_RESETTING_LOG_FREQUENCY: 'TemperatureSync/errorResettingLogFrequency',
+
+  START_SAVING_TEMPERATURE_LOGS: 'TemperatureSync/startSavingTemperatureLogs',
+  COMPLETE_SAVING_TEMPERATURE_LOGS: 'TemperatureSync/completeSavingTemperatureLogs',
+
+  UPDATE_SENSOR_PROGRESS: 'TemperatureSync/updateSensorProgress',
+};
+
+const scanStart = () => ({ type: TEMPERATURE_SYNC_ACTIONS.SCAN_START });
+const scanComplete = () => ({ type: TEMPERATURE_SYNC_ACTIONS.SCAN_COMPLETE });
+const scanError = () => ({ type: TEMPERATURE_SYNC_ACTIONS.SCAN_ERROR });
+
+const updateSensors = sensorAdvertisements => dispatch => {
+  const isArray = Array.isArray(sensorAdvertisements);
+
+  if (!isArray) dispatch(scanError());
+  if (isArray && !sensorAdvertisements.length) dispatch(scanError());
+
+  if (isArray && sensorAdvertisements.length) {
+    sensorAdvertisements.forEach(({ macAddress, batteryLevel }) => {
+      UIDatabase.write(() => {
+        UIDatabase.update('Sensor', {
+          id: generateUUID(),
+          ...UIDatabase.get('Sensor', macAddress, 'macAddress'),
+          macAddress,
+          batteryLevel,
+        });
+      });
+    });
+  }
+};
+
+const scanForSensors = () => async dispatch => {
+  dispatch(scanStart());
+
+  const sensorResult = await Sensor.startScan();
+  const { success, data } = sensorResult;
+
+  dispatch(updateSensors(data));
+
+  if (success) dispatch(scanComplete());
+};
+
+const downloadLogsError = () => ({ type: TEMPERATURE_SYNC_ACTIONS.DOWNLOAD_LOGS_ERROR });
+const downloadLogsStart = () => ({ type: TEMPERATURE_SYNC_ACTIONS.DOWNLOAD_LOGS_START });
+const downloadLogsComplete = () => ({
+  type: TEMPERATURE_SYNC_ACTIONS.DOWNLOAD_LOGS_COMPLETE,
+});
+
+const downloadLogs = sensor => async dispatch => {
+  dispatch(downloadLogsStart());
+
+  const downloadedLogsResult = (await sensor?.downloadLogs()) ?? {};
+  const { success = false, data = [] } = downloadedLogsResult;
+
+  if (success && data?.[0]?.logs) {
+    const sensorLogs = data[0]?.logs;
+    const timeNow = new Date().getTime();
+
+    if (Array.isArray(sensorLogs)) {
+      UIDatabase.write(() =>
+        sensorLogs.forEach(({ temperature }, i) => {
+          const timestamp = timeNow - (i + 1) * MILLISECONDS.FIVE_MINUTES;
+          createRecord(UIDatabase, 'SensorLog', temperature, new Date(timestamp), sensor);
+        })
+      );
+    }
+
+    dispatch(downloadLogsComplete());
+  } else {
+    dispatch(downloadLogsError());
+  }
+
+  return new Promise(resolver => resolver(success));
+};
+
+const startResettingAdvertisementFrequency = () => ({
+  type: TEMPERATURE_SYNC_ACTIONS.START_RESETTING_ADVERTISEMENT_FREQUENCY,
+});
+const completeResettingAdvertisementFrequency = () => ({
+  type: TEMPERATURE_SYNC_ACTIONS.COMPLETE_RESETTING_ADVERTISEMENT_FREQUENCY,
+});
+const errorResettingAdvertisementFrequency = () => ({
+  type: TEMPERATURE_SYNC_ACTIONS.ERROR_RESETTING_ADVERTISEMENT_FREQUENCY,
+});
+
+const resetAdvertisementFrequency = sensor => async dispatch => {
+  dispatch(startResettingAdvertisementFrequency());
+
+  const resettingAdvertisementFrequencyResult = await sensor.resetAdvertisementFrequency();
+
+  const { success } = resettingAdvertisementFrequencyResult;
+
+  if (success) dispatch(completeResettingAdvertisementFrequency());
+  else dispatch(errorResettingAdvertisementFrequency());
+
+  return new Promise(resolver => resolver(success));
+};
+
+const startResettingLogFrequency = () => ({
+  type: TEMPERATURE_SYNC_ACTIONS.START_RESETTING_LOG_FREQUENCY,
+});
+const completeResettingLogFrequency = () => ({
+  type: TEMPERATURE_SYNC_ACTIONS.COMPLETE_RESETTING_LOG_FREQUENCY,
+});
+const errorResettingLogFrequency = () => ({
+  type: TEMPERATURE_SYNC_ACTIONS.ERROR_RESETTING_LOG_FREQUENCY,
+});
+
+const resetLogFrequency = sensor => async dispatch => {
+  dispatch(startResettingLogFrequency());
+
+  const resettingLogFrequencyResult = await sensor.resetLogFrequency();
+
+  const { success } = resettingLogFrequencyResult;
+
+  if (success) dispatch(completeResettingLogFrequency());
+  else dispatch(errorResettingLogFrequency());
+
+  return new Promise(resolver => resolver(success));
+};
+
+const startSavingTemperatureLogs = () => ({
+  type: TEMPERATURE_SYNC_ACTIONS.START_SAVING_TEMPERATURE_LOGS,
+});
+const completeSavingTemperatureLogs = () => ({
+  type: TEMPERATURE_SYNC_ACTIONS.COMPLETE_SAVING_TEMPERATURE_LOGS,
+});
+
+const createTemperatureLogs = sensor => dispatch => {
+  const { sensorLogs, location } = sensor;
+
+  // Only create TemperatureLogs for the greatest multiple of 6 SensorLogs,
+  // as each SensorLog is a 5 minute log, and each Temperature log a 30 minute log.
+  const iterateTo = sensorLogs.length - (sensorLogs.length % 6);
+  const sensorLogsToGroup = sensorLogs.sorted('timestamp').slice(0, iterateTo);
+  const groupedSensorLogs = chunk(sensorLogsToGroup, 6);
+
+  dispatch(startSavingTemperatureLogs(groupedSensorLogs.length));
+
+  UIDatabase.write(() => {
+    groupedSensorLogs.forEach(sensorLogGroup => {
+      const { isInBreach, mostRecentTemperatureBreach } = sensor;
+      const newLogTemperature = Math.min(...sensorLogGroup.map(({ temperature }) => temperature));
+      const newLogTimestamp = Math.min(...sensorLogGroup.map(({ timestamp }) => timestamp));
+
+      const newLog = createRecord(
+        UIDatabase,
+        'TemperatureLog',
+        newLogTemperature,
+        new Date(newLogTimestamp),
+        location
+      );
+
+      if (isInBreach) {
+        if (mostRecentTemperatureBreach?.willContinueBreach(newLog)) {
+          UIDatabase.update('TemperatureLog', { ...newLog, breach: mostRecentTemperatureBreach });
+        } else {
+          UIDatabase.update('TemperatureBreach', {
+            ...mostRecentTemperatureBreach,
+            endTimestamp: newLogTimestamp,
+          });
+        }
+      } else {
+        const breachConfigs = UIDatabase.objects('TemperatureBreachConfiguration');
+        breachConfigs.some(breachConfig => breachConfig.createBreach(UIDatabase, location, newLog));
+      }
+    });
+
+    UIDatabase.delete('SensorLog', sensorLogsToGroup);
+  });
+
+  dispatch(completeSavingTemperatureLogs());
+
+  return Promise.resolve();
+};
+
+const errorNoSensors = () => ({ type: TEMPERATURE_SYNC_ACTIONS.ERROR_NO_SENSORS });
+const startSync = () => ({ type: TEMPERATURE_SYNC_ACTIONS.START_SYNC });
+const completeSync = () => ({ type: TEMPERATURE_SYNC_ACTIONS.COMPLETE_SYNC });
+const updateSensorProgress = sensor => ({
+  type: TEMPERATURE_SYNC_ACTIONS.UPDATE_SENSOR_PROGRESS,
+  payload: { sensor },
+});
+
+const syncTemperatures = () => async (dispatch, getState) => {
+  const { temperatureSync } = getState();
+  const { isSyncing } = temperatureSync;
+
+  const sensors = UIDatabase.objects('Sensor').filtered('location != null');
+  const { length: numberOfSensors } = sensors;
+
+  if (isSyncing) return null;
+  if (!numberOfSensors) return dispatch(errorNoSensors());
+
+  dispatch(startSync());
+
+  for (let i = 0; i < numberOfSensors; i++) {
+    const sensor = sensors[i];
+
+    dispatch(updateSensorProgress(sensor));
+
+    const downloadedLogsResult = await dispatch(downloadLogs(sensor));
+    if (downloadedLogsResult) {
+      const resetLogFrequencyResult = await dispatch(resetLogFrequency(sensor));
+      if (resetLogFrequencyResult) {
+        const resetAdvertisementFrequencyResult = await dispatch(
+          resetAdvertisementFrequency(sensor)
+        );
+        if (resetAdvertisementFrequencyResult) {
+          dispatch(createTemperatureLogs(sensor));
+        }
+      }
+    }
+  }
+
+  return dispatch(completeSync());
+};
+
+export const TemperatureSyncActions = {
+  scanForSensors,
+  syncTemperatures,
+};

--- a/src/database/DataTypes/Sensor.js
+++ b/src/database/DataTypes/Sensor.js
@@ -34,6 +34,14 @@ export class Sensor extends Realm.Object {
   async downloadLogs() {
     return this.sendCommand('*logall');
   }
+
+  get isInBreach() {
+    return this.location?.isInBreach ?? false;
+  }
+
+  get mostRecentTemperatureBreach() {
+    return this.location?.mostRecentTemperatureBreach;
+  }
 }
 
 Sensor.schema = {
@@ -46,6 +54,7 @@ Sensor.schema = {
     location: { type: 'Location', optional: true },
     batteryLevel: { type: 'double', default: 0 },
     sensorLogs: { type: 'linkingObjects', objectType: 'SensorLog', property: 'sensor' },
+    location: { type: 'Location', optional: true },
   },
 };
 

--- a/src/database/DataTypes/TemperatureBreach.js
+++ b/src/database/DataTypes/TemperatureBreach.js
@@ -58,6 +58,13 @@ export class TemperatureBreach extends Realm.Object {
 
     return incomingStock.sum('numberOfPacks') ?? 0 - outgoingStock.sum('numberOfPacks') ?? 0;
   }
+
+  willContinueBreach(temperatureLog) {
+    const { minimumTemperature, maximumTemperature } = this.temperatureBreachConfiguration;
+    const { temperature } = temperatureLog;
+
+    return temperature >= minimumTemperature && temperature <= maximumTemperature;
+  }
 }
 
 TemperatureBreach.schema = {
@@ -69,6 +76,7 @@ TemperatureBreach.schema = {
     startTimestamp: { type: 'date', optional: true },
     endTimestamp: { type: 'date', optional: true },
     location: { type: 'Location', optional: true },
+    temperatureBreachConfiguration: { type: 'TemperatureBreachConfiguration', optional: false },
   },
 };
 

--- a/src/database/DataTypes/TemperatureBreachConfiguration.js
+++ b/src/database/DataTypes/TemperatureBreachConfiguration.js
@@ -4,8 +4,69 @@
  */
 
 import Realm from 'realm';
+import moment from 'moment';
+import { createRecord } from '../utilities';
 
-export class TemperatureBreachConfiguration extends Realm.Object {}
+export class TemperatureBreachConfiguration extends Realm.Object {
+  /**
+   * With the provided temperatureLog, determines if the passed location
+   * was in a breach at the time of the temperature log and if so, will
+   * create a temperature breach record. Also adds to each of the temperature
+   * logs which are currently part of that breach, the related breach
+   * record.
+   *
+   * A breach has a duration and minimum and maximum temperatures defined by this
+   * configuration - for example above 8 degrees for 2 hours. To determine if a
+   * location has currently been breached, look back from the temperature logs
+   * timestamp the duration of this configuration and determine if every temperature
+   * log since that time has been outside of the threshold.
+   *
+   * @param {Realm}          database App-wide database interface
+   * @param {Location}       location A Location record to create a breach for.
+   * @param {TemperatureLog} temperatureLog A potential log which may create a breach.
+   */
+  createBreach(database, location, temperatureLog) {
+    const { timestamp } = temperatureLog;
+    const { temperatureLogs } = location;
+
+    // The potential start time of the breach - looking back from the passed
+    // temperature log to the pre-configured minimum duration of a breach.
+    const startTime = moment(timestamp)
+      .subtract(this.duration, 'ms')
+      .toDate();
+
+    // Find all of the temperature logs since the possible start time of the
+    // breach.
+    const proximalLogs = temperatureLogs.filtered(
+      'timestamp >= $0 && timestamp <= $1',
+      startTime,
+      timestamp
+    );
+
+    // Ensure the duration of the temporally proximal temperature logs is
+    // greater than the duration required for a breach.
+    const mostRecentTimestamp = moment(proximalLogs.max('timestamp'));
+    const leastRecentTimestamp = moment(proximalLogs.min('timestamp'));
+    const isDurationLongEnough =
+      mostRecentTimestamp.diff(leastRecentTimestamp, 'ms') >= this.duration;
+
+    // If the duration of logs is sufficiently long enough, also ensure each temperature
+    // log exceeds the threshold required for a breach
+    const logInBreachRange = ({ temperature: logTemperature }) =>
+      logTemperature >= this.minimumTemperature && logTemperature <= this.maximumTemperature;
+
+    const willCreateBreach = isDurationLongEnough && proximalLogs.every(logInBreachRange);
+
+    // Create a breach if the duration of logs and temperatures define a breach and set
+    // each temperature log as part of the breach.
+    if (willCreateBreach) {
+      const breach = createRecord(database, 'TemperatureBreach', startTime, location, this);
+      proximalLogs.forEach(log => database.update('TemperatureLog', { ...log, breach }));
+    }
+
+    return willCreateBreach;
+  }
+}
 
 TemperatureBreachConfiguration.schema = {
   name: 'TemperatureBreachConfiguration',
@@ -17,6 +78,11 @@ TemperatureBreachConfiguration.schema = {
     duration: { type: 'double', optional: true },
     description: { type: 'string', optional: true },
     colour: { type: 'string', optional: true },
+    breaches: {
+      objectType: 'TemperatureBreach',
+      type: 'linkingObjects',
+      property: 'temperatureBreachConfiguration',
+    },
   },
 };
 

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -761,12 +761,11 @@ const createLocation = (database, description, code, locationType) => {
   return location;
 };
 
-const createSensor = (database, macAddress, batteryLevel, location) => {
+const createSensor = (database, macAddress, batteryLevel) => {
   const sensor = database.create('Sensor', {
     id: generateUUID(),
     macAddress,
     batteryLevel,
-    location,
   });
 
   return sensor;
@@ -819,11 +818,17 @@ const createTemperatureLog = (database, temperature, timestamp, location) => {
   return temperatureLog;
 };
 
-const createTemperatureBreach = (database, startTimestamp, location) => {
-  const temperatureLog = database.create('SensorLog', {
+const createTemperatureBreach = (
+  database,
+  startTimestamp,
+  location,
+  temperatureBreachConfiguration
+) => {
+  const temperatureLog = database.create('TemperatureBreach', {
     id: generateUUID(),
     startTimestamp,
     location,
+    temperatureBreachConfiguration,
   });
 
   return temperatureLog;

--- a/src/globalStyles/buttonStyles.js
+++ b/src/globalStyles/buttonStyles.js
@@ -27,6 +27,14 @@ export const buttonStyles = {
     margin: 5,
     borderColor: SUSSOL_ORANGE,
   },
+  manualSyncButton: {
+    width: 200,
+    backgroundColor: SUSSOL_ORANGE,
+    borderWidth: 0,
+    alignSelf: 'center',
+    padding: 15,
+    margin: 5,
+  },
   wideButton: {
     width: 285,
     marginLeft: 5,
@@ -48,6 +56,11 @@ export const buttonStyles = {
     fontFamily: APP_FONT_FAMILY,
     fontSize: 17,
     color: DARKER_GREY,
+  },
+  whiteButtonText: {
+    fontSize: 18,
+    color: WHITE,
+    fontFamily: APP_FONT_FAMILY,
   },
   menuButton: {
     alignItems: 'center',

--- a/src/localization/syncStrings.json
+++ b/src/localization/syncStrings.json
@@ -13,7 +13,16 @@
     "last_successful_sync": "Last successful sync",
     "initialising": "Initialising...",
     "pulling_changes": "Pulling changes from the server",
-    "pushing_changes": "Pushing changes to the server"
+    "pushing_changes": "Pushing changes to the server",
+    "scanning_for_sensors": "Scanning for temperature sensors",
+    "error_scanning_for_sensors": "Error scanning for temperature sensors",
+    "downloading_temperature_logs": "Downloading temperature logs",
+    "error_downloading_temperature_logs": "Error downloading temperature logs",
+    "resetting_sensor": "Resetting sensor",
+    "error_resetting_sensor": "Error resetting sensor",
+    "saving_temperature_logs": "Saving temperature logs",
+    "no_sensors": "No sensors to scan for",
+    "syncing_temperatures": "Syncing temperatures"
   },
   "fr": {
     "last_sync": "DERNIER SYNC",

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -38,6 +38,7 @@ import { FirstUsePage } from './pages';
 import { SupplierCredit } from './widgets/modalChildren/SupplierCredit';
 
 import globalStyles, { SUSSOL_ORANGE } from './globalStyles';
+import { TemperatureSyncActions } from './actions/TemperatureSyncActions';
 
 const SYNC_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 const AUTHENTICATION_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
@@ -66,6 +67,10 @@ class MSupplyMobileAppContainer extends React.Component {
         this.userAuthenticator.reauthenticate(this.onAuthentication);
       }
     }, AUTHENTICATION_INTERVAL);
+    this.scheduler.schedule(
+      () => props.dispatch(TemperatureSyncActions.syncTemperatures()),
+      SYNC_INTERVAL
+    );
     this.state = {
       isInitialised,
       isLoading: false,

--- a/src/reducers/TemperatureSyncReducer.js
+++ b/src/reducers/TemperatureSyncReducer.js
@@ -1,0 +1,151 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+import { TEMPERATURE_SYNC_ACTIONS } from '../actions/TemperatureSyncActions';
+import { REHYDRATE } from '../utilities';
+
+export const TEMPERATURE_SYNC_STATES = {
+  SCANNING: 'SCANNING',
+  SCAN_ERROR: 'SCAN_ERROR',
+  DOWNLOADING_LOGS: 'DOWNLOADING_LOGS',
+  DOWNLOADING_LOGS_ERROR: 'DOWNLOADING_LOGS_ERROR',
+  RESETTING_ADVERTISEMENT_FREQUENCY: 'RESETTING_ADVERTISEMENT_FREQUENCY',
+  RESETTING_LOG_FREQUENCY: 'RESETTING_LOG_FREQUENCY',
+  ERROR_RESETTING_ADVERTISEMENT_FREQUENCY: 'ERROR_RESETTING_ADVERTISEMENT_FREQUENCY',
+  ERROR_RESETTING_LOG_FREQUENCY: 'ERROR_RESETTING_LOG_FREQUENCY',
+  SAVING_LOGS: 'SAVING_LOGS',
+  NO_SENSORS: 'NO_SENSORS',
+  SYNCING: 'SYNCING',
+};
+
+const initialState = () => ({
+  progress: 0,
+  total: 0,
+  syncState: null,
+  isSyncing: false,
+  modalIsOpen: false,
+  lastTemperatureSync: null,
+  lastSyncError: null,
+  currentSensorName: null,
+});
+
+export const TemperatureSyncReducer = (state = initialState(), action) => {
+  const { type } = action;
+
+  switch (type) {
+    case REHYDRATE: {
+      const { payload: previousState } = action;
+      const { temperatureSync: previousTemperatureSyncState } = previousState;
+      const { lastTemperatureSync } = previousTemperatureSyncState;
+
+      return { ...initialState(), lastTemperatureSync };
+    }
+
+    case TEMPERATURE_SYNC_ACTIONS.UPDATE_SENSOR_PROGRESS: {
+      const { payload } = action;
+      const { sensor } = payload;
+      const { name: currentSensorName } = sensor;
+
+      return { ...state, currentSensorName };
+    }
+
+    case TEMPERATURE_SYNC_ACTIONS.OPEN_MODAL: {
+      return { ...state, modalIsOpen: true };
+    }
+    case TEMPERATURE_SYNC_ACTIONS.CLOSE_MODAL: {
+      return { ...state, modalIsOpen: false };
+    }
+
+    case TEMPERATURE_SYNC_ACTIONS.START_SCAN: {
+      return { ...state, syncState: TEMPERATURE_SYNC_STATES.SCANNING, isSyncing: true };
+    }
+    case TEMPERATURE_SYNC_ACTIONS.SCAN_COMPLETE: {
+      return { ...state, syncState: null, isSyncing: false };
+    }
+    case TEMPERATURE_SYNC_ACTIONS.SCAN_ERROR: {
+      return {
+        ...state,
+        syncState: '',
+        syncError: TEMPERATURE_SYNC_STATES.SCAN_ERROR,
+        isSyncing: false,
+      };
+    }
+    case TEMPERATURE_SYNC_ACTIONS.DOWNLOAD_LOGS_START: {
+      return { ...state, syncState: TEMPERATURE_SYNC_STATES.DOWNLOADING_LOGS, progress: 1 };
+    }
+    case TEMPERATURE_SYNC_ACTIONS.DOWNLOAD_LOGS_ERROR: {
+      return {
+        ...state,
+        syncState: '',
+        isSyncing: false,
+        syncError: TEMPERATURE_SYNC_STATES.DOWNLOADING_LOGS_ERROR,
+      };
+    }
+    case TEMPERATURE_SYNC_ACTIONS.DOWNLOAD_LOGS_COMPLETE: {
+      return { ...state, syncState: null };
+    }
+
+    case TEMPERATURE_SYNC_ACTIONS.START_RESETTING_LOG_FREQUENCY: {
+      return { ...state, syncState: TEMPERATURE_SYNC_STATES.RESETTING_LOG_FREQUENCY, progress: 2 };
+    }
+    case TEMPERATURE_SYNC_ACTIONS.COMPLETE_RESETTING_LOG_FREQUENCY: {
+      return { ...state, syncState: null };
+    }
+    case TEMPERATURE_SYNC_ACTIONS.ERROR_RESETTING_LOG_FREQUENCY: {
+      return {
+        ...state,
+        syncState: TEMPERATURE_SYNC_STATES.ERROR_RESETTING_LOG_FREQUENCY,
+        isSyncing: false,
+      };
+    }
+
+    case TEMPERATURE_SYNC_ACTIONS.START_RESETTING_ADVERTISEMENT_FREQUENCY: {
+      return {
+        ...state,
+        syncState: TEMPERATURE_SYNC_STATES.RESETTING_ADVERTISEMENT_FREQUENCY,
+        progress: 3,
+      };
+    }
+    case TEMPERATURE_SYNC_ACTIONS.COMPLETE_RESETTING_ADVERTISEMENT_FREQUENCY: {
+      return { ...state, syncState: null };
+    }
+    case TEMPERATURE_SYNC_ACTIONS.ERROR_RESETTING_ADVERTISEMENT_FREQUENCY: {
+      return { ...state, syncError: TEMPERATURE_SYNC_STATES.ERROR_RESETTING_LOG_FREQUENCY };
+    }
+
+    case TEMPERATURE_SYNC_ACTIONS.START_SAVING_TEMPERATURE_LOGS: {
+      return { ...state, syncState: TEMPERATURE_SYNC_STATES.SAVING_LOGS, progress: 4 };
+    }
+    case TEMPERATURE_SYNC_ACTIONS.COMPLETE_SAVING_TEMPERATURE_LOGS: {
+      return { ...state, syncState: null };
+    }
+
+    case TEMPERATURE_SYNC_ACTIONS.ERROR_NO_SENSORS: {
+      return {
+        ...state,
+        syncError: TEMPERATURE_SYNC_STATES.NO_SENSORS,
+        syncState: null,
+        isSyncing: false,
+      };
+    }
+
+    case TEMPERATURE_SYNC_ACTIONS.START_SYNC: {
+      return { ...state, syncState: TEMPERATURE_SYNC_STATES.SYNCING, isSyncing: true, total: 5 };
+    }
+    case TEMPERATURE_SYNC_ACTIONS.COMPLETE_SYNC: {
+      const { syncError, lastTemperatureSync } = state;
+      return {
+        ...state,
+        syncState: null,
+        isSyncing: false,
+        lastTemperatureSync: syncError ? lastTemperatureSync : new Date(),
+        progress: 5,
+        currentSensorName: null,
+      };
+    }
+    default:
+      return state;
+  }
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -21,6 +21,7 @@ import { UserReducer } from './UserReducer';
 import { WizardReducer } from './WizardReducer';
 
 import SyncReducer from './SyncReducer';
+import { TemperatureSyncReducer } from './TemperatureSyncReducer';
 
 export default combineReducers({
   dashboard: DashboardReducer,
@@ -36,6 +37,7 @@ export default combineReducers({
   prescription: PrescriptionReducer,
   supplierCredit: SupplierCreditReducer,
   sync: SyncReducer,
+  temperatureSync: TemperatureSyncReducer,
   user: UserReducer,
   wizard: WizardReducer,
 });

--- a/src/selectors/temperatureSync.js
+++ b/src/selectors/temperatureSync.js
@@ -1,0 +1,47 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+import moment from 'moment';
+
+import { TEMPERATURE_SYNC_STATES } from '../reducers/TemperatureSyncReducer';
+import { syncStrings } from '../localization';
+
+const STATE_TO_MESSAGE = {
+  [TEMPERATURE_SYNC_STATES.SCANNING]: syncStrings.scanning_for_sensors,
+  [TEMPERATURE_SYNC_STATES.SCAN_ERROR]: syncStrings.error_scanning_for_sensors,
+  [TEMPERATURE_SYNC_STATES.DOWNLOADING_LOGS]: syncStrings.downloading_temperature_logs,
+  [TEMPERATURE_SYNC_STATES.DOWNLOADING_LOGS_ERROR]: syncStrings.error_downloading_temperature_logs,
+  [TEMPERATURE_SYNC_STATES.RESETTING_ADVERTISEMENT_FREQUENCY]: syncStrings.resetting_sensor,
+  [TEMPERATURE_SYNC_STATES.RESETTING_LOG_FREQUENCY]: syncStrings.resetting_sensor,
+  [TEMPERATURE_SYNC_STATES.ERROR_RESETTING_ADVERTISEMENT_FREQUENCY]:
+    syncStrings.error_resetting_sensor,
+  [TEMPERATURE_SYNC_STATES.ERROR_RESETTING_LOG_FREQUENCY]: syncStrings.error_resetting_sensor,
+  [TEMPERATURE_SYNC_STATES.SAVING_LOGS]: syncStrings.saving_temperature_logs,
+  [TEMPERATURE_SYNC_STATES.NO_SENSORS]: syncStrings.no_sensors,
+  [TEMPERATURE_SYNC_STATES.SYNCING]: syncStrings.syncing_temperatures,
+};
+
+export const selectTemperatureSyncMessage = ({ temperatureSync }) => {
+  const { syncState, syncError } = temperatureSync;
+
+  return STATE_TO_MESSAGE[syncState ?? syncError] ?? syncStrings.sync_complete;
+};
+
+export const selectTemperatureSyncLastSyncString = ({ temperatureSync }) => {
+  const { lastTemperatureSync } = temperatureSync;
+
+  return `${moment(lastTemperatureSync).format('H:mm MMMM D, YYYY ')}`;
+};
+
+export const selectCurrentSensorNameString = ({ temperatureSync }) => {
+  const { currentSensorName } = temperatureSync;
+
+  return currentSensorName ? `Syncing sensor: ${currentSensorName}` : '';
+};
+
+export const selectTemperatureSyncIsComplete = ({ temperatureSync }) => {
+  const { total, progress } = temperatureSync;
+  return total === progress;
+};

--- a/src/utilities/chunk.js
+++ b/src/utilities/chunk.js
@@ -1,0 +1,18 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+export const chunk = (array, size) => {
+  if (!array || !size) return [];
+
+  let i = 0;
+  const tempArray = [];
+
+  while (i < array.length) {
+    tempArray.push(array.slice(i, i + size));
+    i += size;
+  }
+
+  return tempArray;
+};

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -1,0 +1,8 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+export const MILLISECONDS = {
+  FIVE_MINUTES: 1000 * 60 * 5,
+};

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -22,3 +22,4 @@ export { validateReport } from './validateReport';
 
 export { parsePositiveIntegerInterfaceInput } from './parsers';
 export { formatErrorItemNames, roundNumber } from './formatters';
+export { MILLISECONDS } from './constants';

--- a/src/widgets/modalChildren/TemperatureSync.js
+++ b/src/widgets/modalChildren/TemperatureSync.js
@@ -1,0 +1,101 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+import React from 'react';
+import { View, Text, StyleSheet, Dimensions } from 'react-native';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { PageButton, ProgressBar, FlexColumn } from '..';
+
+import { syncStrings } from '../../localization';
+import globalStyles, { WARM_GREY } from '../../globalStyles';
+
+import { TemperatureSyncActions } from '../../actions/TemperatureSyncActions';
+import {
+  selectTemperatureSyncMessage,
+  selectTemperatureSyncLastSyncString,
+  selectCurrentSensorNameString,
+  selectTemperatureSyncIsComplete,
+} from '../../selectors/temperatureSync';
+
+const TemperatureSyncComponent = ({
+  total,
+  progress,
+  lastTemperatureSync,
+  temperatureSyncMessage,
+  isSyncing,
+  currentSensor,
+  syncTemperatures,
+  isComplete,
+}) => (
+  <FlexColumn justifyContent="center" alignItems="center" flex={1}>
+    <View style={localStyles.row}>
+      <ProgressBar total={total} progress={progress} isComplete={isComplete} />
+    </View>
+
+    {currentSensor && <Text style={localStyles.progressDescription}>{currentSensor}</Text>}
+    <Text style={localStyles.progressDescription}> {temperatureSyncMessage} </Text>
+    <Text style={localStyles.lastSyncText}>{syncStrings.last_successful_sync}</Text>
+    <Text style={localStyles.lastSyncText}>{lastTemperatureSync}</Text>
+
+    <PageButton
+      style={globalStyles.manualSyncButton}
+      textStyle={globalStyles.whiteButtonText}
+      isDisabled={isSyncing}
+      disabledColor={WARM_GREY}
+      text={syncStrings.manual_sync}
+      onPress={syncTemperatures}
+    />
+  </FlexColumn>
+);
+
+const mapStateToProps = state => {
+  const temperatureSyncMessage = selectTemperatureSyncMessage(state);
+  const lastTemperatureSync = selectTemperatureSyncLastSyncString(state);
+  const currentSensor = selectCurrentSensorNameString(state);
+  const isComplete = selectTemperatureSyncIsComplete(state);
+
+  return { temperatureSyncMessage, lastTemperatureSync, currentSensor, isComplete };
+};
+
+const mapDispatchToProps = dispatch => ({
+  syncTemperatures: () => dispatch(TemperatureSyncActions.syncTemperatures()),
+});
+
+TemperatureSyncComponent.propTypes = {
+  total: PropTypes.number.isRequired,
+  progress: PropTypes.number.isRequired,
+  lastTemperatureSync: PropTypes.string.isRequired,
+  temperatureSyncMessage: PropTypes.string.isRequired,
+  isSyncing: PropTypes.bool.isRequired,
+  currentSensor: PropTypes.string.isRequired,
+  syncTemperatures: PropTypes.func.isRequired,
+  isComplete: PropTypes.bool.isRequired,
+};
+
+export const TemperatureSync = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TemperatureSyncComponent);
+
+const localStyles = StyleSheet.create({
+  progressDescription: {
+    fontSize: 18,
+    color: 'white',
+    textAlign: 'center',
+    marginBottom: 10,
+  },
+  row: {
+    width: Dimensions.get('window').width / 3,
+    paddingHorizontal: 50,
+    paddingVertical: 20,
+  },
+  lastSyncText: {
+    color: 'white',
+    fontSize: 14,
+    textAlign: 'center',
+    marginBottom: 5,
+  },
+});


### PR DESCRIPTION
Fixes #2638 

## Change summary

- Adds `TemperatureBreach.willContinueBreach` method : This will be used when creating a `TemperatureLog` - if the `Location` is currently in a breach, can simply call this with the created `TemperatureLog` to check if the breach should continue.
- Adds `TemperatureBreachConfiguration.createBreach` method : currently this will be used on a `TemperatureLog` where the current location is not in breach. Couple q's on opinions below!

## Testing
N/A

### Related areas to think about

The config `createBreach` method could be broken up into three methods:

```
`temperatureWithinBreachRange = (temperatureLog) => *checks if temperature within breach temperature range*`

`temperatureOfProximalLogsWithinBreachRange = (temperatureLog) => *checks if proximal logs duration and are all in the breach temperature range*

`createBreach = (temperatureLog) => *creates breach, sets all proximal logs*

```

However you would when creating a breach need to fetch the proximal logs twice, rather than once. Not sure which way is better. I have a feeling this second way is actually better but decided to PR and get any opinions and get it off my mind for a few hours so that I can come back and hate it. Oh well, it'll be basically the same logic/code !