### PR TITLE
#2658 add lookup list date null check logic

### DIFF
--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -31,7 +31,7 @@ import {
 } from '../../selectors/dispensary';
 
 const SearchListItemColumnComponent = ({ value, type }) => {
-  const valueText = type === 'date' ? value?.toDateString() ?? '' : value;
+  const valueText = type === 'date' ? value?.toDateString() ?? generalStrings.not_available : value;
   return (
     <View style={localStyles.columnContainer}>
       <Text style={localStyles.text}>{valueText}</Text>


### PR DESCRIPTION
Fixes #2658.

## Change summary

Add logic to handle invalid/default dates.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Patient search form list renders default date of birth (`00/00/000`) as `N/A`.

### Related areas to think about

N/A.