### PR TITLE
#2664 extract record creation logic

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -12,6 +12,40 @@ import { NUMBER_SEQUENCE_KEYS } from './constants';
 import { generalStrings } from '../../localization';
 import { SETTINGS_KEYS } from '../../settings';
 
+/**
+ * Return a database Address object with the given address details (reuse if one
+ * already exists).
+ *
+ * @param   {Realm}         database  The local database.
+ * @param   {string}        line1     Line 1 of the address (can be undefined).
+ * @param   {string}        line2     Line 2 of the address (can be undefined).
+ * @param   {string}        line3     Line 3 of the address (can be undefined).
+ * @param   {string}        line4     Line 4 of the address (can be undefined).
+ * @param   {string}        zipCode   Zip code of the address (can be undefined).
+ * @return  {Realm.object}            The Address object described by the params.
+ */
+export const getOrCreateAddress = (database, line1, line2, line3, line4, zipCode) => {
+  let results = database.objects('Address');
+  if (typeof line1 === 'string') {
+    results = results.filtered('line1 == $0', line1);
+  }
+  if (typeof line2 === 'string') {
+    results = results.filtered('line2 == $0', line2);
+  }
+  if (typeof line3 === 'string') {
+    results = results.filtered('line3 == $0', line3);
+  }
+  if (typeof line4 === 'string') {
+    results = results.filtered('line4 == $0', line4);
+  }
+  if (typeof zipCode === 'string') {
+    results = results.filtered('zipCode == $0', zipCode);
+  }
+  if (results.length > 0) return results[0];
+
+  return createRecord(database, 'Address', { line1, line2, line3, line4, zipCode });
+};
+
 // Get the next highest number in an existing number sequence.
 export const getNextNumber = (database, sequenceKey) => {
   const numberSequence = getNumberSequence(database, sequenceKey);

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -112,8 +112,6 @@ const createInsurancePolicy = (database, policyDetails) => {
     patient,
     insuranceProvider,
   });
-
-  database.save('InsurancePolicy', policy);
   return policy;
 };
 
@@ -171,8 +169,7 @@ const createPrescriber = (database, prescriberDetails) => {
     isVisible,
     isActive,
   });
-
-  database.save('Prescriber', prescriber);
+  return prescriber;
 };
 
 /**
@@ -255,8 +252,6 @@ const createPatient = (database, patientDetails) => {
     thisStoresPatient,
     isVisible,
   });
-
-  database.save('Name', patient);
   return patient;
 };
 

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -88,7 +88,7 @@ const createInsurancePolicy = (database, policyDetails) => {
     policyNumberPerson,
     type,
     discountRate,
-    isActive,
+    isActive: policyIsActive,
     expiryDate: policyExpiryDate,
     enteredBy,
     patient,
@@ -96,9 +96,13 @@ const createInsurancePolicy = (database, policyDetails) => {
   } = policyDetails;
 
   const id = policyId ?? generateUUID();
-  const expiryDate = policyExpiryDate ?? moment(new Date())
-    .add(insuranceProvider.validityDays, 'days')
-    .toDate();
+  const expiryDate =
+    policyExpiryDate ??
+    moment(new Date())
+      .add(insuranceProvider.validityDays, 'days')
+      .toDate();
+
+  const isActive = policyIsActive ?? true;
 
   const policy = database.update('InsurancePolicy', {
     id,
@@ -144,17 +148,18 @@ const createPrescriber = (database, prescriberDetails) => {
     mobileNumber,
     emailAddress,
     storeId: prescriberStoreId,
+    isActive: prescriberIsActive,
   } = prescriberDetails;
 
   const id = prescriberId ?? generateUUID();
-  const thisStoreId = database.getSetting(SETTINGS_KEYS.THIS_STORE_ID)
+  const thisStoreId = database.getSetting(SETTINGS_KEYS.THIS_STORE_ID);
   const supplyingStoreId = prescriberStoreId ?? thisStoreId;
   const fromThisStore = supplyingStoreId === thisStoreId;
 
   const address = getOrCreateAddress(database, address1, address2);
 
   const isVisible = true;
-  const isActive = true;
+  const isActive = prescriberIsActive ?? true;
 
   const prescriber = database.create('Prescriber', {
     id,
@@ -165,7 +170,7 @@ const createPrescriber = (database, prescriberDetails) => {
     phoneNumber,
     mobileNumber,
     emailAddress,
-    fromThisStore,  
+    fromThisStore,
     isVisible,
     isActive,
   });
@@ -180,14 +185,14 @@ const getPatientUniqueCode = database => {
   const patientSequenceNumber = getNextNumber(database, PATIENT_CODE);
   const thisStoreCode = database.getSetting(SETTINGS_KEYS.THIS_STORE_CODE);
   return `${thisStoreCode}${String(patientSequenceNumber)}`;
-}
+};
 
 /**
  * Creates a new patient record. Patient details passed can be in the shape:
  *  {
  *    id, name, firstName, lastName, code, dateOfBirth, phoneNumber, emailAddress,
  *    billAddress1, billAddress2, billAddress3, billAddress4, billPostalZipCode,
- *    country, supplyingStoreId, 
+ *    country, supplyingStoreId,
  *  }
  */
 const createPatient = (database, patientDetails) => {
@@ -200,10 +205,10 @@ const createPatient = (database, patientDetails) => {
     dateOfBirth: patientDateOfBirth,
     phoneNumber,
     emailAddress,
-    billAddress1, 
-    billAddress2, 
+    billAddress1,
+    billAddress2,
     billAddress3,
-    billAddress4, 
+    billAddress4,
     billPostalZipCode,
     country,
     supplyingStoreId: patientSupplyingStoreId,
@@ -229,11 +234,11 @@ const createPatient = (database, patientDetails) => {
     billPostalZipCode
   );
 
-  const thisStoreId = database.getSetting(SETTINGS_KEYS.THIS_STORE_ID)
+  const thisStoreId = database.getSetting(SETTINGS_KEYS.THIS_STORE_ID);
   const supplyingStoreId = patientSupplyingStoreId ?? thisStoreId;
   const thisStoresPatient = supplyingStoreId === thisStoreId;
   const isVisible = true;
-  
+
   const patient = database.update('Name', {
     id,
     name,

--- a/src/database/utilities/index.js
+++ b/src/database/utilities/index.js
@@ -3,7 +3,13 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-export { createRecord, getNextNumber, getNumberSequence, reuseNumber } from './createRecord';
+export {
+  createRecord,
+  getOrCreateAddress,
+  getNextNumber,
+  getNumberSequence,
+  reuseNumber,
+} from './createRecord';
 export { deleteRecord } from './deleteRecord';
 export { parseNumber, parseDate, parseBoolean, parseJsonString } from './parsers';
 export { getTotal, addBatchToParent, millisecondsToDays } from './utilities';

--- a/src/database/utilities/index.js
+++ b/src/database/utilities/index.js
@@ -5,6 +5,7 @@
 
 export { createRecord, getNextNumber, getNumberSequence, reuseNumber } from './createRecord';
 export { deleteRecord } from './deleteRecord';
+export { parseNumber, parseDate, parseBoolean, parseJsonString } from './parsers';
 export { getTotal, addBatchToParent, millisecondsToDays } from './utilities';
 export {
   MILLISECONDS_PER_MINUTE,

--- a/src/database/utilities/parsers.js
+++ b/src/database/utilities/parsers.js
@@ -1,0 +1,64 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+/**
+ * Returns the boolean string as a boolean (false if none passed)
+ * @param  {string} numberString The string to convert to a boolean
+ * @return {boolean}               The boolean representation of the string
+ */
+export const parseBoolean = booleanString => {
+  const trueStrings = ['true', 'True', 'TRUE'];
+  return trueStrings.includes(booleanString);
+};
+
+/**
+ * Return a Date object representing the given date, time.
+ *
+ * @param   {string}  ISODate  The date in ISO 8601 format.
+ * @param   {string}  ISOTime  The time in ISO 8601 format. Optional.
+ * @return  {Date}             The Date representing |ISODate| (and |ISOTime|).
+ */
+export const parseDate = (ISODate, ISOTime) => {
+  if (!ISODate || ISODate.length < 1 || ISODate === '0000-00-00T00:00:00') {
+    return null;
+  }
+  const date = new Date(ISODate);
+  if (ISOTime && ISOTime.length >= 6) {
+    const hours = ISOTime.substring(0, 2);
+    const minutes = ISOTime.substring(3, 5);
+    const seconds = ISOTime.substring(6, 8);
+    date.setHours(hours, minutes, seconds);
+  }
+  return date;
+};
+
+/**
+ * Returns the number string as a float, or null if none passed.
+ *
+ * @param   {string}  numberString  The string to convert to a number.
+ * @return  {float}                 The numeric representation of the string.
+ */
+export const parseNumber = numberString => {
+  if (!numberString) return null;
+  const result = parseFloat(numberString);
+  return Number.isNaN(result) ? null : result;
+};
+
+/**
+ * Returns jsonString prepared correctly for mobile realm database
+ * @param  {string} jsonString The string to parse
+ * @return {string}            The parsed string or |null|
+ */
+export const parseJsonString = jsonString => {
+  // 4D adds extra backslashes, remove them so JSON.parse doesn't break
+  let validatedString = jsonString && jsonString.replace(/\\/g, '');
+  const nullValues = ['null', 'undefined'];
+  // 'undefined' is stored as string on 4D, but as an optional field
+  // in our realm schemas we can prefer |null|
+  if (!validatedString || nullValues.includes(validatedString.toLowerCase())) {
+    validatedString = null;
+  }
+  return validatedString;
+};

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -12,72 +12,13 @@ import {
   TRANSACTION_TYPES,
 } from './syncTranslators';
 import { CHANGE_TYPES } from '../database';
-import { deleteRecord, createRecord } from '../database/utilities';
+import { deleteRecord, getOrCreateAddress, parseBoolean, parseDate, parseNumber, parseJsonString } from '../database/utilities';
 import { SETTINGS_KEYS } from '../settings';
 import { validateReport } from '../utilities';
 
 const { THIS_STORE_ID, THIS_STORE_TAGS, THIS_STORE_CODE, THIS_STORE_CUSTOM_DATA } = SETTINGS_KEYS;
 
 /**
- * Returns the number string as a float, or null if none passed.
- *
- * @param   {string}  numberString  The string to convert to a number.
- * @return  {float}                 The numeric representation of the string.
- */
-export const parseNumber = numberString => {
-  if (!numberString) return null;
-  const result = parseFloat(numberString);
-  return Number.isNaN(result) ? null : result;
-};
-
-/**
- * Return a Date object representing the given date, time.
- *
- * @param   {string}  ISODate  The date in ISO 8601 format.
- * @param   {string}  ISOTime  The time in ISO 8601 format. Optional.
- * @return  {Date}             The Date representing |ISODate| (and |ISOTime|).
- */
-export const parseDate = (ISODate, ISOTime) => {
-  if (!ISODate || ISODate.length < 1 || ISODate === '0000-00-00T00:00:00') {
-    return null;
-  }
-  const date = new Date(ISODate);
-  if (ISOTime && ISOTime.length >= 6) {
-    const hours = ISOTime.substring(0, 2);
-    const minutes = ISOTime.substring(3, 5);
-    const seconds = ISOTime.substring(6, 8);
-    date.setHours(hours, minutes, seconds);
-  }
-  return date;
-};
-
-/**
- * Returns the boolean string as a boolean (false if none passed)
- * @param  {string} numberString The string to convert to a boolean
- * @return {boolean}               The boolean representation of the string
- */
-export const parseBoolean = booleanString => {
-  const trueStrings = ['true', 'True', 'TRUE'];
-  return trueStrings.includes(booleanString);
-};
-
-/**
- * Returns jsonString prepared correctly for mobile realm database
- * @param  {string} jsonString The string to parse
- * @return {string}            The parsed string or |null|
- */
-export const parseJsonString = jsonString => {
-  // 4D adds extra backslashes, remove them so JSON.parse doesn't break
-  let validatedString = jsonString && jsonString.replace(/\\/g, '');
-  const nullValues = ['null', 'undefined'];
-  // 'undefined' is stored as string on 4D, but as an optional field
-  // in our realm schemas we can prefer |null|
-  if (!validatedString || nullValues.includes(validatedString.toLowerCase())) {
-    validatedString = null;
-  }
-  return validatedString;
-};
-
 /**
  * Return a database Address object with the given address details (reuse if one
  * already exists).

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -12,46 +12,18 @@ import {
   TRANSACTION_TYPES,
 } from './syncTranslators';
 import { CHANGE_TYPES } from '../database';
-import { deleteRecord, getOrCreateAddress, parseBoolean, parseDate, parseNumber, parseJsonString } from '../database/utilities';
+import {
+  deleteRecord,
+  getOrCreateAddress,
+  parseBoolean,
+  parseDate,
+  parseNumber,
+  parseJsonString,
+} from '../database/utilities';
 import { SETTINGS_KEYS } from '../settings';
 import { validateReport } from '../utilities';
 
 const { THIS_STORE_ID, THIS_STORE_TAGS, THIS_STORE_CODE, THIS_STORE_CUSTOM_DATA } = SETTINGS_KEYS;
-
-/**
-/**
- * Return a database Address object with the given address details (reuse if one
- * already exists).
- *
- * @param   {Realm}         database  The local database.
- * @param   {string}        line1     Line 1 of the address (can be undefined).
- * @param   {string}        line2     Line 2 of the address (can be undefined).
- * @param   {string}        line3     Line 3 of the address (can be undefined).
- * @param   {string}        line4     Line 4 of the address (can be undefined).
- * @param   {string}        zipCode   Zip code of the address (can be undefined).
- * @return  {Realm.object}            The Address object described by the params.
- */
-export const getOrCreateAddress = (database, line1, line2, line3, line4, zipCode) => {
-  let results = database.objects('Address');
-  if (typeof line1 === 'string') {
-    results = results.filtered('line1 == $0', line1);
-  }
-  if (typeof line2 === 'string') {
-    results = results.filtered('line2 == $0', line2);
-  }
-  if (typeof line3 === 'string') {
-    results = results.filtered('line3 == $0', line3);
-  }
-  if (typeof line4 === 'string') {
-    results = results.filtered('line4 == $0', line4);
-  }
-  if (typeof zipCode === 'string') {
-    results = results.filtered('zipCode == $0', zipCode);
-  }
-  if (results.length > 0) return results[0];
-
-  return createRecord(database, 'Address', { line1, line2, line3, line4, zipCode });
-};
 
 /**
  * Ensure the given record has the right data to create an internal record of the given

--- a/src/utilities/network/lookupApi.js
+++ b/src/utilities/network/lookupApi.js
@@ -25,7 +25,7 @@ const SEPARATORS = {
 
 export const createPatientRecord = patient => {
   UIDatabase.write(() => createRecord(UIDatabase, 'Patient', patient));
-  patient?.policies?.forEach(policy => createPolicyRecord(policy));
+  patient?.policies?.forEach(createPolicyRecord);
 };
 
 export const createPrescriberRecord = prescriber =>
@@ -36,14 +36,8 @@ export const createPolicyRecord = policy => {
   const enteredBy = UIDatabase.getOrCreate('User', enteredById);
   const patient = UIDatabase.getOrCreate('Name', nameId);
   const insuranceProvider = UIDatabase.getOrCreate('InsuranceProvider', insuranceProviderId);
-  UIDatabase.write(() =>
-    createRecord(UIDatabase, 'InsurancePolicy', {
-      ...policy,
-      enteredBy,
-      patient,
-      insuranceProvider,
-    })
-  );
+  const policyRecord = { ...policy, enteredBy, patient, insuranceProvider };
+  UIDatabase.write(() => createRecord(UIDatabase, 'InsurancePolicy', policyRecord));
 };
 
 const getQueryString = params =>

--- a/src/utilities/network/lookupApi.js
+++ b/src/utilities/network/lookupApi.js
@@ -3,6 +3,9 @@
  * Sustainable Solutions (NZ) Ltd. 2020
  */
 
+/* eslint-disable camelcase */
+/* eslint-disable no-unused-expressions */
+
 import { SETTINGS_KEYS } from '../../settings';
 import { UIDatabase } from '../../database';
 import { createRecord, parseBoolean, parseDate, parseNumber } from '../../database/utilities';
@@ -25,18 +28,22 @@ export const createPatientRecord = patient => {
   patient?.policies?.forEach(policy => createPolicyRecord(policy));
 };
 
-export const createPrescriberRecord = prescriber => UIDatabase.write(() => createRecord(UIDatabase, 'Prescriber', prescriber));
+export const createPrescriberRecord = prescriber =>
+  UIDatabase.write(() => createRecord(UIDatabase, 'Prescriber', prescriber));
 
 export const createPolicyRecord = policy => {
-  const {
-    nameId,
-    enteredById,
-    insuranceProviderId,
-  } = policy;
+  const { nameId, enteredById, insuranceProviderId } = policy;
   const enteredBy = UIDatabase.getOrCreate('User', enteredById);
   const patient = UIDatabase.getOrCreate('Name', nameId);
   const insuranceProvider = UIDatabase.getOrCreate('InsuranceProvider', insuranceProviderId);
-  UIDatabase.write(() => createRecord(UIDatabase, 'InsurancePolicy', { ...policy, enteredBy, patient, insuranceProvider }));
+  UIDatabase.write(() =>
+    createRecord(UIDatabase, 'InsurancePolicy', {
+      ...policy,
+      enteredBy,
+      patient,
+      insuranceProvider,
+    })
+  );
 };
 
 const getQueryString = params =>
@@ -90,29 +97,32 @@ const getPrescriberRequestUrl = params => {
   return baseUrl + endpoint + queryString;
 };
 
-const processInsuranceResponse = response => response.map(({
-    ID: id,
-    insuranceProviderID: insuranceProviderId,
-    nameID: nameId,
-    policyNumberFamily,
-    policyNumberPerson,
-    discountRate,
-    expiryDate,
-    isActive: isActive,
-    enteredByID: enteredById,
-    type,
-  }) => ({
-    id,
-    insuranceProviderId,
-    nameId,
-    policyNumberFamily,
-    policyNumberPerson,
-    discountRate: parseNumber(discountRate),
-    expiryDate: parseDate(expiryDate),
-    isActive: parseBoolean(isActive),
-    enteredById,
-    type,
-  }));
+const processInsuranceResponse = response =>
+  response.map(
+    ({
+      ID: id,
+      insuranceProviderID: insuranceProviderId,
+      nameID: nameId,
+      policyNumberFamily,
+      policyNumberPerson,
+      discountRate,
+      expiryDate,
+      isActive,
+      enteredByID: enteredById,
+      type,
+    }) => ({
+      id,
+      insuranceProviderId,
+      nameId,
+      policyNumberFamily,
+      policyNumberPerson,
+      discountRate: parseNumber(discountRate),
+      expiryDate: parseDate(expiryDate),
+      isActive: parseBoolean(isActive),
+      enteredById,
+      type,
+    })
+  );
 
 const processPatientResponse = response => {
   const patientData = response.map(
@@ -150,7 +160,6 @@ const processPatientResponse = response => {
       policies: processInsuranceResponse(nameInsuranceJoin),
     })
   );
-  console.log(patientData);
   return patientData;
 };
 
@@ -185,13 +194,11 @@ const processPrescriberResponse = response => {
 
 export const queryPatientApi = async params => {
   const requestUrl = getPatientRequestUrl(params);
-  console.log(requestUrl);
   try {
     const response = await fetch(requestUrl);
     const responseJson = await response.json();
     const { error } = responseJson;
     if (error) throw new Error(error);
-    console.log(responseJson);
     const patientData = processPatientResponse(responseJson);
     return patientData;
   } catch (error) {

--- a/src/utilities/network/lookupApi.js
+++ b/src/utilities/network/lookupApi.js
@@ -5,9 +5,9 @@
 
 import { SETTINGS_KEYS } from '../../settings';
 import { UIDatabase } from '../../database';
+import { createRecord, parseBoolean, parseDate, parseNumber } from '../../database/utilities';
 
 import { NAME_TYPES } from '../../sync/syncTranslators';
-import { getOrCreateAddress, parseBoolean, parseDate, parseNumber } from '../../sync/incomingSyncUtils';
 
 const { THIS_STORE_ID, SYNC_URL } = SETTINGS_KEYS;
 


### PR DESCRIPTION
Fixes #2664

## Change summary

Updated `createRecord` cases and reduced network API creators to being wrappers over these cases. Tricky to find an optional solution that handles all use cases, but think this is a pretty decent compromise which will look OK once methods moved into thunks rather than utility methods.

Initial thinking was to consolidate all creation logic (including incoming sync), but after spending a bit of time on this, realised its potentially a bit of a bigger job than thought and has quite a lot of surface area for regressions. Thinking is its probably going to be best to do this in parts rather than trying to refactor everything in one go. 

## Testing

N/A (tests in feature PR).

### Related areas to think about

N/A.