### PR TITLE
#2676 fix form control cancel callback

### DIFF
--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -230,7 +230,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   const onUpdateForm = (key, value) => dispatch(FormActions.updateForm(key, value));
   const onCancel = () => {
     dispatch(FormActions.resetForm());
-    ownProps.showCancelButton && ownProps.onCancel();
+    ownProps.onCancel();
   };
   return { initialiseForm, onUpdateForm, onCancel };
 };


### PR DESCRIPTION
Fixes #2676.

## Change summary

Fixes `formControl` `onCancel` callback.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Form component cancel button fires `onCancel` callback.

### Related areas to think about

N/A.
