### PR TITLE
#2681 update lookup response logic

### DIFF
--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -215,7 +215,7 @@ export const queryPatientApi = async params => {
     }
     switch (status) {
       case 400:
-        throw new Error(ERROR_CODES.INVALID_URL);
+        throw new Error(ERROR_CODES.CONNECTION_FAILURE);
       case 401:
         throw new Error(ERROR_CODES.INVALID_PASSWORD);
       default:
@@ -245,7 +245,7 @@ export const queryPrescriberApi = async params => {
     }
     switch (status) {
       case 400:
-        throw new Error(ERROR_CODES.INVALID_URL);
+        throw new Error(ERROR_CODES.CONNECTION_FAILURE);
       case 401:
         throw new Error(ERROR_CODES.INVALID_PASSWORD);
       default:

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -199,7 +199,7 @@ SearchListItemColumnComponent.propTypes = {
 
 const localStyles = StyleSheet.create({
   container: {
-    height: 720,
+    height: '95%',
     marginVertical: 20,
     flexDirection: 'row',
     justifyContent: 'space-between',


### PR DESCRIPTION
Fixes #2681.

## Change summary

Adds logic for handling:

- Connection errors.
- Timeout errors.
- Authentication errors.
- No matching records.

Basically just a spinner and a confirm modal. Not the nicest from a UI point of a view, but does the job!

Replicates a bit of sync, epic still has an issue for updating sync constants so I suggest using that to modularise some of the shared lookup/sync logic.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When a user searches for a patient on an offline server, a confirm modal displays the error: `"Unable to connect"`.
- [ ] When a user searches for a patient using invalid/expired credentials, a confirm modal displays the error: `"Invalid username or password"`.
- [ ] When a user searches for a patient but no response is received in 10 seconds, a confirm modal displays the error: `"Unable to connect"`.
- [ ] When a user searches for a non-existent patient, a confirm modal displays the error `"No matching records found"`.
- [ ] When a user searches for a prescriber on an offline server, a confirm modal displays the error: `"Unable to connect"`.
- [ ] When a user searches for a prescriber using invalid/expired credentials, a confirm modal displays the error: `"Invalid username or password"`.
- [ ] When a user searches for a prescriber but no response is received in 10 seconds, a confirm modal displays the error: `"Unable to connect"`.
- [ ] When a user searches for a non-existent prescriber, a confirm modal displays the error `"No matching records found"`.

### Related areas to think about

N/A.