### PR TITLE
#2383 update expiry date input format to dd/mm/yyyy

### DIFF
--- a/src/hooks/useExpiryDateMask.js
+++ b/src/hooks/useExpiryDateMask.js
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 /**
  * Simple custom hook which manages the state of input for an
- * expiry date in the form mm/yy[yy] such that the entered date
+ * expiry date in the form dd/mm/yy[yy] such that the entered date
  * always stays valid.
  *
  * @param {String} initialState Initial state of the expiry date
@@ -12,49 +12,75 @@ export const useExpiryDateMask = initialState => {
   const [date, setDate] = useState(initialState);
 
   const regexpLookup = {
-    // if there is only one character - match only singular digit months, or zero.
+    // One character matches:
+    // - a singular day.
     1: /[0-9]/,
-    // Two characters match a singular month and forward slash, or singular month with
-    // a zero prefix, or a double digit month.
-    2: /((^[0][1-9]$)|(^1[012]$)|(^[1-9]\/$))/,
-    // Three characters match a valid month (always prefixed with a zero, if singular)
-    // with a forward slash.
-    3: /(^[[^0](?!0)]\/$)|(^[0][1-9]\/$)|(^1[012]\/$)/,
-    // Entering the year, allows any year
-    4: /(^([[^0](?!0)]\/)|([0][1-9]\/)|(1[012]\/))\d{1}$/,
-    5: /(^([[^0](?!0)]\/)|([0][1-9]\/)|(1[012]\/))\d{2}$/,
-    6: /(^([[^0](?!0)]\/)|([0][1-9]\/)|(1[012]\/))\d{3}$/,
-    7: /(^([[^0](?!0)]\/)|([0][1-9]\/)|(1[012]\/))\d{4}$/,
+    // Two characters match:
+    // - a singular day and forward slash.
+    // - a singular day with a zero prefix.
+    // - a double digit day.
+    2: /((^[1-9]\/)|(^[012][1-9])|(^[3][01]))$/,
+    // Three characters match:
+    // - a valid day, prepended with zero if singular, appended with a forward slash.
+    3: /((^[012][1-9])|(^[3][01]))\/$/,
+    // Four characters match:
+    // - a valid day and singular month.
+    4: /((^[012][1-9])|(^[3][01]))\/[0-9]$/,
+    // Five characters match:
+    // - a valid day and a singular month and forward slash.
+    // - a valid day and a singular month with a zero prefix.
+    // - a valid day and a double digit month.
+    5: /((^[012][1-9])|(^[3][01]))\/(([1-9]\/)|([0][1-9])|([1][012]))$/,
+    // Six characters match:
+    // - a valid day and valid month, appended with a forward slash.
+    6: /((^[012][1-9])|(^[3][01]))\/(([0][1-9])|([1][012]))\/$/,
+    // Seven characters match:
+    // - a valid day and valid month and a singular year.
+    7: /((^[012][1-9])|(^[3][01]))\/(([0][1-9])|([1][012]))\/\d{1}$/,
+    // Eight characters match:
+    // - a valid day and valid month and a two digit year.
+    8: /((^[012][1-9])|(^[3][01]))\/(([0][1-9])|([1][012]))\/\d{2}$/,
+    // Nine characters match:
+    // - a valid day and valid month and a three digit year.
+    9: /((^[012][1-9])|(^[3][01]))\/(([0][1-9])|([1][012]))\/\d{3}$/,
+    // Ten characters match:
+    // - a valid day and valid month and a three digit year.
+    10: /((^[012][1-9])|(^[3][01]))\/(([0][1-9])|([1][012]))\/\d{4}$/,
   };
 
   // Validates a new value being set as state. Either allows the new value, or rejects
   // it, setting the current value as state. Appends/prepends a 0 or / to values of
   // length two. Resets the state when backspacing into an inconsistent state. Only
-  // allows values in the form MM-Y[YYY]
+  // allows values in the form DD/MM/Y[YYY]
   const checkAndSetDate = value => {
     const { length: oldLength } = date;
     const { length: newLength } = value;
 
-    // Helpers - prepend/append / or 0 for values in M/ or MM state.
-    const adjustMonth = newValue => (newValue.endsWith('/') ? `0${newValue}` : `${newValue}/`);
+    // Helpers - prepend/append / or 0 for values in D/, DD, M/ or MM state.
+    const adjustDay = newValue => (newValue.endsWith('/') ? `0${newValue}` : `${newValue}/`);
+    const adjustMonth = newValue => {
+      const [day, month] = newValue.split('/');
+      return newValue.endsWith('/') ? `${day}/0${month}/` : `${day}/${month}/`;
+    };
     const testString = newValue => regexpLookup[newLength].test(newValue);
 
-    if (newLength > 7) return null;
+    if (newLength > 10) return null;
     if (newLength === 0) return setDate('');
     if (newLength < oldLength) return testString(value) ? setDate(value) : setDate('');
-    if (newLength === 2) return testString(value) ? setDate(adjustMonth(value)) : setDate(date);
+    if (newLength === 2) return testString(value) ? setDate(adjustDay(value)) : setDate(date);
+    if (newLength === 5) return testString(value) ? setDate(adjustMonth(value)) : setDate(date);
     return testString(value) ? setDate(value) : setDate(date);
   };
 
-  // Finalises an expiry date to be in the format MM/YYYY if the user has entered
-  // MM/Y MM/YY MM/YYY by placing a potentially incorrect year in the 20th century.
+  // Finalises an expiry date to be in the format DD/MM/YYYY.
   const finaliseDate = () => {
-    // If the expiry date isn't in at least the form MM/Y - reset.
-    if (date.length < 4) return setDate('');
+    // If the expiry date isn't in at least the form DD/MM/Y - reset.
+    if (date.length < 7) return setDate('');
 
-    const [month, year] = date.split('/');
+    const [day, month, year] = date.split('/');
     const prependedYear = `${'200'.substring(0, 4 - year.length)}${year}`;
-    return setDate(`${month}/${prependedYear}`);
+
+    return setDate(`${day}/${month}/${prependedYear}`);
   };
 
   return [date, checkAndSetDate, finaliseDate];

--- a/src/widgets/ExpiryDateInput.js
+++ b/src/widgets/ExpiryDateInput.js
@@ -6,15 +6,14 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { View, TextInput } from 'react-native';
+import moment from 'moment';
 
 import Cell from './DataTable/Cell';
 
 import { useExpiryDateMask } from '../hooks/useExpiryDateMask';
 
 import { dataTableStyles } from '../globalStyles/index';
-import { parseExpiryDate, formatExpiryDate } from '../utilities';
 
 import { getAdjustedStyle } from './DataTable/utilities';
 import RefContext from './DataTable/RefContext';
@@ -63,6 +62,21 @@ export const ExpiryDateInput = React.memo(
 
     const refIndex = getRefIndex(rowIndex, columnKey);
 
+    const parseExpiryDate = React.useCallback(expiryDate => {
+      const parsedExpiryDate = moment(expiryDate, 'DD/MM/YYYY');
+      return parsedExpiryDate.isValid() ? parsedExpiryDate : null;
+    }, []);
+
+    const convertExpiryDate = React.useCallback(expiryDate => {
+      const parsedExpiryDate = parseExpiryDate(expiryDate);
+      return parsedExpiryDate?.toDate();
+    }, []);
+
+    const formatExpiryDate = React.useCallback(expiryDate => {
+      const parsedExpiryDate = parseExpiryDate(expiryDate);
+      return parsedExpiryDate?.format('DD/MM/YYYY') ?? '';
+    }, []);
+
     // Customhook managing the editing of an expiry date to stay valid.
     const [expiryDate, setExpiryDate, finaliseExpiryDate] = useExpiryDateMask(
       formatExpiryDate(value)
@@ -73,7 +87,7 @@ export const ExpiryDateInput = React.memo(
     // to the underlying model are not committed until a valid date is entered.
     const finishEditingExpiryDate = () => {
       finaliseExpiryDate();
-      onEndEditing(parseExpiryDate(expiryDate), rowKey, columnKey);
+      onEndEditing(convertExpiryDate(expiryDate), rowKey, columnKey);
     };
 
     const onSubmit = () => {
@@ -143,7 +157,7 @@ ExpiryDateInput.defaultProps = {
   isLastCell: false,
   width: 0,
   debug: false,
-  placeholder: 'mm/yyyy',
+  placeholder: 'dd/mm/yyyy',
   placeholderColour: '#CDCDCD',
   underlineColor: '#CDCDCD',
 };


### PR DESCRIPTION
Fixes #2383.

## Change summary

Changes expiry date format from `MM/YYYY` to `DD/MM/YYYY`.

May need to put this behind a pref?

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Expiry dates are formatted `DD/MM/YYYY`.
- [ ] Expiry dates are "autocorrected" with slashes, zeros.

### Related areas to think about

N/A.