### PR TITLE
#2509 add user pref for hiding stocktake snapshot quantity

### DIFF
--- a/src/authentication/UserAuthenticator.js
+++ b/src/authentication/UserAuthenticator.js
@@ -73,8 +73,12 @@ export class UserAuthenticator {
             id: userJson.UserID,
             username,
             passwordHash,
-            isAdmin: userJson.isAdmin || false,
           });
+          user.permissions = {
+            isAdmin: userJson.isAdmin ?? false,
+            showStocktakeCurrentQuantity: userJson.showStocktakeCurrentQuantity ?? true,
+          };
+          this.database.save(user);
         });
       }
     } catch (error) {

--- a/src/database/DataTypes/User.js
+++ b/src/database/DataTypes/User.js
@@ -1,0 +1,75 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import Realm from 'realm';
+
+/**
+ * A user.
+ *
+ * @property  {String}  id
+ * @property  {String}  username
+ * @property  {Date}    lastLogin
+ * @property  {String}  firstName
+ * @property  {String}  lastName
+ * @property  {String}  email
+ * @property  {String}  passwordHash
+ * @property  {String}  salt
+ * @property  {Object}  permissions
+ */
+export class User extends Realm.Object {
+  /* eslint-disable class-methods-use-this */
+  get defaultPermissions() {
+    return {
+      isAdmin: false,
+      showStocktakeCurrentQuantity: true,
+    };
+  }
+
+  get permissions() {
+    const permissions = JSON.parse(this._permissions);
+    return { ...this.defaultPermissions, ...permissions };
+  }
+
+  get isAdmin() {
+    return this.permissions.isAdmin;
+  }
+
+  get showStocktakeCurrentQuantity() {
+    return this.permissions.showStocktakeCurrentQuantity;
+  }
+
+  set permissions(permissions) {
+    this._permissions = JSON.stringify(permissions);
+  }
+
+  set isAdmin(isAdmin) {
+    this.permissions = { ...this.permissions, isAdmin };
+  }
+
+  set showStocktakeCurrentQuantity(showStocktakeCurrentQuantity) {
+    this.permissions = { ...this.permissions, showStocktakeCurrentQuantity };
+  }
+}
+
+User.schema = {
+  name: 'User',
+  primaryKey: 'id',
+  properties: {
+    id: 'string',
+    username: { type: 'string', default: 'placeholderUsername' },
+    lastLogin: { type: 'date', optional: true },
+    firstName: { type: 'string', optional: true },
+    lastName: { type: 'string', optional: true },
+    email: { type: 'string', optional: true },
+    passwordHash: {
+      type: 'string',
+      default: '4ada0b60df8fe299b8a412bbc8c97d0cb204b80e5693608ab2fb09ecde6d252d',
+    },
+    salt: { type: 'string', optional: true },
+    _permissions: { type: 'string', default: '{}' },
+  },
+};
+
+export default User;

--- a/src/database/DataTypes/index.js
+++ b/src/database/DataTypes/index.js
@@ -14,7 +14,6 @@ export class ItemDepartment extends Realm.Object {}
 export class Setting extends Realm.Object {}
 export class SyncOut extends Realm.Object {}
 export class TransactionCategory extends Realm.Object {}
-export class User extends Realm.Object {}
 
 export { Item } from './Item';
 export { InsurancePolicy } from './InsurancePolicy';
@@ -47,6 +46,7 @@ export { Transaction } from './Transaction';
 export { TransactionBatch } from './TransactionBatch';
 export { TransactionItem } from './TransactionItem';
 export { Unit } from './Unit';
+export { User } from './User';
 export { Prescriber } from './Prescriber';
 export { Abbreviation } from './Abbreviation';
 export { ItemDirection } from './ItemDirection';

--- a/src/selectors/user.js
+++ b/src/selectors/user.js
@@ -4,14 +4,26 @@
  */
 
 export const selectCurrentUser = ({ user }) => {
-  const { currentUser } = user;
+  const { currentUser = {} } = user;
   return currentUser;
+};
+
+export const selectCurrentUserPermissions = ({ user }) => {
+  const { currentUser } = user;
+  const { permissions = {} } = currentUser ?? {};
+  return permissions;
 };
 
 export const selectCurrentUserIsAdmin = ({ user }) => {
   const { currentUser } = user;
   const { isAdmin = false } = currentUser ?? {};
   return isAdmin;
+};
+
+export const selectHideStocktakeSnapshotQuantity = ({ user }) => {
+  const { currentUser } = user;
+  const { showStocktakeCurrentQuantity = true } = currentUser ?? {};
+  return !showStocktakeCurrentQuantity;
 };
 
 export const selectCurrentUserPasswordHash = ({ user }) => {


### PR DESCRIPTION
Fixes #2509.

A bit of a mess here, apologies!

- Adds hide stocktake snapshot user pref. 
- Adds hiding snapshot logic to batches.

Just for reference at this stage, another PR coming for adding the existing store preferences implementation to batches. At a latest stage, this will need to be merged with that and existing stocktake page logic.

WARNING: THIS PR IS NOT COMPATIBLE WITH THE LATEST MSUPPLY AND SHOULD NOT BE MERGED INTO DEVELOP AT THIS STAGE.

## Change summary

- Updated user schema.
- Migrated `isAdmin` user pref.
- Added `showStocktakeCurrentQuantity` user pref.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

TODO: TESTS TO BE ADDED AFTER DESKTOP CHANGES MERGED (AFTER NEXT RELEASE).

### Related areas to think about

N/A.
