### PR TITLE
#2509 add hide snapshot pref logic to stocktake batch modal

### DIFF
--- a/src/selectors/modules.js
+++ b/src/selectors/modules.js
@@ -28,7 +28,7 @@ export const selectUsingSupplierCreditCategories = ({ modules }) => {
   return usingSupplierCreditCategories;
 };
 
-export const selectHideSnapshotColumn = ({ modules }) => {
+export const selectUsingHideSnapshotColumn = ({ modules }) => {
   const { usingHideSnapshotColumn } = modules;
   return usingHideSnapshotColumn;
 };

--- a/src/selectors/pages.js
+++ b/src/selectors/pages.js
@@ -5,7 +5,7 @@
 
 import { createSelector } from 'reselect';
 
-import { selectHideSnapshotColumn } from './modules';
+import { selectUsingHideSnapshotColumn } from './modules';
 import { COLUMN_KEYS } from '../pages/dataTableUtilities/constants';
 
 /**
@@ -44,11 +44,11 @@ export const selectStocktakeEditor = createSelector([selectPages], pages => {
  * Selects stocktake editor columns.
  */
 export const selectStocktakeEditorColumns = createSelector(
-  [selectHideSnapshotColumn, selectStocktakeEditor],
-  (hideSnapshotColumn, stocktakeEditor) => {
+  [selectUsingHideSnapshotColumn, selectStocktakeEditor],
+  (usingHideSnapshotColumn, stocktakeEditor) => {
     const { columns } = stocktakeEditor;
     const stocktakeColumns = [...columns];
-    return hideSnapshotColumn
+    return usingHideSnapshotColumn
       ? stocktakeColumns.filter(({ key }) => key !== COLUMN_KEYS.SNAPSHOT_TOTAL_QUANTITY)
       : stocktakeColumns;
   }

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -12,6 +12,7 @@ import { connect, batch } from 'react-redux';
 import { MODAL_KEYS, getModalTitle } from '../../utilities';
 import { usePageReducer } from '../../hooks';
 import { getItemLayout } from '../../pages/dataTableUtilities';
+import { COLUMN_KEYS } from '../../pages/dataTableUtilities/constants';
 
 import { GenericChoiceList } from '../modalChildren/GenericChoiceList';
 import { PageInfo, DataTablePageView, PageButton } from '..';
@@ -24,7 +25,7 @@ import { ModalContainer } from './ModalContainer';
 import { buttonStrings } from '../../localization';
 import { ROUTES } from '../../navigation/constants';
 
-import { selectUsingPayments } from '../../selectors/modules';
+import { selectUsingPayments, selectHideSnapshotColumn } from '../../selectors/modules';
 import { AutocompleteSelector } from '../modalChildren';
 
 /**
@@ -41,15 +42,26 @@ import { AutocompleteSelector } from '../modalChildren';
  * holding the state of a given row. Each object has the shape :
  * { isSelected, isFocused, isDisabled },
  *
- * @prop {Object} stocktakeItem The realm transaction object for this invoice.
+ * @prop {Object} stocktakeItem The realm transsingHaction object for this invoice.
  * @prop {Object} page the current routeName for this modal.
  *
  */
-export const StocktakeBatchModalComponent = ({ stocktakeItem, page, dispatch: reduxDispatch }) => {
+export const StocktakeBatchModalComponent = ({
+  stocktakeItem,
+  usingPayments,
+  usingReasons,
+  hideSnapshotColumn,
+  dispatch: reduxDispatch,
+}) => {
   const initialState = {
-    page,
+    page: 'stocktakeBatchEditModal',
     pageObject: stocktakeItem,
   };
+
+  if (usingReasons) {
+    initialState.page += 'WithReasons';
+    if (usingPayments) initialState.page += 'AndPrices';
+  } else if (usingPayments) initialState.page += 'WithPrices';
 
   const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
 
@@ -63,10 +75,14 @@ export const StocktakeBatchModalComponent = ({ stocktakeItem, page, dispatch: re
     modalValue,
     keyExtractor,
     PageActions,
-    columns,
+    columns: pageColumns,
     getPageInfoColumns,
     suppliers,
   } = state;
+
+  const columns = hideSnapshotColumn
+    ? pageColumns.filter(({ key }) => key !== COLUMN_KEYS.SNAPSHOT_TOTAL_QUANTITY)
+    : pageColumns;
 
   const { stocktake = {} } = stocktakeItem;
   const { isFinalised = false } = stocktake;
@@ -212,23 +228,19 @@ export const StocktakeBatchModalComponent = ({ stocktakeItem, page, dispatch: re
 
 StocktakeBatchModalComponent.propTypes = {
   stocktakeItem: PropTypes.object.isRequired,
-  page: PropTypes.string.isRequired,
+  usingPayments: PropTypes.bool.isRequired,
+  usingReasons: PropTypes.bool.isRequired,
+  hideSnapshotColumn: PropTypes.bool.isRequired,
   dispatch: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => {
-  const usingPaymentsModule = selectUsingPayments(state);
+  const usingPayments = selectUsingPayments(state);
   const usingReasons =
     UIDatabase.objects('NegativeAdjustmentReason').length > 0 &&
     UIDatabase.objects('PositiveAdjustmentReason').length > 0;
-
-  if (usingReasons) {
-    if (usingPaymentsModule) return { page: 'stocktakeBatchEditModalWithReasonsAndPrices' };
-    return { page: 'stocktakeBatchEditModalWithReasons' };
-  }
-
-  if (usingPaymentsModule) return { page: 'stocktakeBatchEditModalWithPrices' };
-  return { page: 'stocktakeBatchEditModal' };
+  const hideSnapshotColumn = selectHideSnapshotColumn(state);
+  return { usingPayments, usingReasons, hideSnapshotColumn };
 };
 
 export const StocktakeBatchModal = connect(mapStateToProps)(StocktakeBatchModalComponent);

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -25,7 +25,7 @@ import { ModalContainer } from './ModalContainer';
 import { buttonStrings } from '../../localization';
 import { ROUTES } from '../../navigation/constants';
 
-import { selectUsingPayments, selectHideSnapshotColumn } from '../../selectors/modules';
+import { selectUsingPayments, selectUsingHideSnapshotColumn } from '../../selectors/modules';
 import { AutocompleteSelector } from '../modalChildren';
 
 /**
@@ -50,7 +50,7 @@ export const StocktakeBatchModalComponent = ({
   stocktakeItem,
   usingPayments,
   usingReasons,
-  hideSnapshotColumn,
+  usingHideSnapshotColumn,
   dispatch: reduxDispatch,
 }) => {
   const initialState = {
@@ -80,7 +80,7 @@ export const StocktakeBatchModalComponent = ({
     suppliers,
   } = state;
 
-  const columns = hideSnapshotColumn
+  const columns = usingHideSnapshotColumn
     ? pageColumns.filter(({ key }) => key !== COLUMN_KEYS.SNAPSHOT_TOTAL_QUANTITY)
     : pageColumns;
 
@@ -230,7 +230,7 @@ StocktakeBatchModalComponent.propTypes = {
   stocktakeItem: PropTypes.object.isRequired,
   usingPayments: PropTypes.bool.isRequired,
   usingReasons: PropTypes.bool.isRequired,
-  hideSnapshotColumn: PropTypes.bool.isRequired,
+  usingHideSnapshotColumn: PropTypes.bool.isRequired,
   dispatch: PropTypes.func.isRequired,
 };
 
@@ -239,8 +239,8 @@ const mapStateToProps = state => {
   const usingReasons =
     UIDatabase.objects('NegativeAdjustmentReason').length > 0 &&
     UIDatabase.objects('PositiveAdjustmentReason').length > 0;
-  const hideSnapshotColumn = selectHideSnapshotColumn(state);
-  return { usingPayments, usingReasons, hideSnapshotColumn };
+  const usingHideSnapshotColumn = selectUsingHideSnapshotColumn(state);
+  return { usingPayments, usingReasons, usingHideSnapshotColumn };
 };
 
 export const StocktakeBatchModal = connect(mapStateToProps)(StocktakeBatchModalComponent);


### PR DESCRIPTION
Fixes #2509.

Really should have made a new issue, but a bit of time pressure on `v5`.

## Change summary

- Follows up on #2524 by adding column hiding logic to stocktake batches.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When the `usesHideSnapshotColumn` store pref is `true`, the snapshot quantity column is hidden for stocktakes, **including stocktake batches**.

### Related areas to think about

Initial idea was to migrate this back to a user pref, but have bumped that to desktop `v11`.

For next steps, see desktop and mobile PRs: #2700 and https://github.com/sussol/msupply/pull/6023.
