### PR TITLE
#2494 sync only finalised prescriptions

### DIFF
--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -189,6 +189,9 @@ const generateSyncData = (settings, recordType, record) => {
       };
     }
     case 'Transaction': {
+      // Only sync prescriptions which are finalised.
+      if (record.isPrescription && !record.isFinalised) return null;
+
       const defaultCurrency = UIDatabase.objects('Currency').filtered(
         'isDefaultCurrency == $0',
         true
@@ -232,6 +235,10 @@ const generateSyncData = (settings, recordType, record) => {
     }
     case 'TransactionBatch': {
       const { transaction } = record;
+
+      // Only sync prescription lines if prescription is finalised.
+      if (transaction.isPrescription && !transaction.isFinalised) return null;
+
       return {
         ID: record.id,
         transaction_ID: record.transaction.id,


### PR DESCRIPTION
Fixes #2494.

## Change summary

Not 100% on this one, so feedback appreciated!

Updates outgiong sync logic for prescriptions:

- Only sync out prescription `Transaction` (`[transact]`) records if finalised.
- Only sync out prescription `TransactionBatch` (`[trans_line]`) records if prescription is finalised.

## Testing

From issue:

    With the usesPaymentModule and usesDispensaryModule turned on:

    1. Create a prescription on mobile
    2. Add items that have a cost, but don't make a payment for them
    3. Click ok.
    4. Sync to desktop
    5. Make a new prescription for the same patient
    6. Click history - the goods from the prescription in Step 1 will show
    7. Search for prescriptions on desktop - the confirmed invoice will show up initially

- [ ] Step 6 is not replicable.
- [ ] Step 7 is not replicable.

### Related areas to think about

N/A.
