### PR TITLE
#2596 VacicneModuleAdmin page

### DIFF
--- a/src/database/DataTypes/Sensor.js
+++ b/src/database/DataTypes/Sensor.js
@@ -42,6 +42,10 @@ export class Sensor extends Realm.Object {
   get mostRecentTemperatureBreach() {
     return this.location?.mostRecentTemperatureBreach;
   }
+
+  get batteryLevelString() {
+    return `${this.batteryLevel}%`;
+  }
 }
 
 Sensor.schema = {
@@ -50,7 +54,7 @@ Sensor.schema = {
   properties: {
     id: 'string',
     macAddress: { type: 'string', optional: true },
-    name: { type: 'string', optional: true },
+    name: { type: 'string', default: '' },
     location: { type: 'Location', optional: true },
     batteryLevel: { type: 'double', default: 0 },
     sensorLogs: { type: 'linkingObjects', objectType: 'SensorLog', property: 'sensor' },

--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -1,5 +1,6 @@
 {
   "gb": {
+    "admin": "admin",
     "submit": "Submit",
     "submitting": "Submitting...",
     "submitted": "Submitted",
@@ -33,6 +34,7 @@
     "total_price": "total price",
     "name": "name",
     "or": "or",
+    "description": "description",
     "expiry_date": "Expiry date",
     "quantity": "Quantity",
     "to": "to",

--- a/src/localization/navStrings.json
+++ b/src/localization/navStrings.json
@@ -23,7 +23,8 @@
     "supplier_credit": "Supplier Credit",
     "supplier_invoices": "Supplier Invoices",
     "supplier_requisitions": "Supplier Requisitions",
-    "vaccines": "Vaccines"
+    "vaccines": "Vaccines",
+    "vaccine_admin": "Vaccines admin"
   },
   "fr": {
     "supplier_credit": "Crédit Fournisseur",

--- a/src/localization/tableStrings.json
+++ b/src/localization/tableStrings.json
@@ -1,5 +1,7 @@
 {
   "gb": {
+    "mac_address": "MAC ADDRESS",
+    "battery_level": "BATTERY_LEVEL",
     "actual_quantity": "ACTUAL\nQUANTITY",
     "available_stock": "AVAILABLE STOCK",
     "batch_expiry": "EXPIRY",

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -4,7 +4,9 @@
     "breaches": "Breaches",
     "total_stock": "Total stock",
     "no_fridges": "No Fridges",
-    "temperature_breaches_for": "Temperature breaches for"
+    "temperature_breaches_for": "Temperature breaches for",
+    "fridges": "Fridges",
+    "sensors": "Sensors"
   },
   "fr": {},
   "gil": {},

--- a/src/navigation/Navigator.js
+++ b/src/navigation/Navigator.js
@@ -29,6 +29,7 @@ import {
   DashboardPage,
   StockPage,
   VaccinePage,
+  VaccineAdminPage,
 } from '../pages';
 
 export const DEFAULT_SCREEN_OPTIONS = {
@@ -69,6 +70,7 @@ const ROUTE_NAME_TO_PAGE = {
   [ROUTES.SETTINGS]: SettingsPage,
   [ROUTES.DASHBOARD]: DashboardPage,
   [ROUTES.VACCINES]: VaccinePage,
+  [ROUTES.VACCINES_ADMIN]: VaccineAdminPage,
 };
 
 export const Pages = Object.values(ROUTES).reduce((acc, route) => {

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -81,6 +81,12 @@ export const createPrescription = patientID => (dispatch, getState) => {
   dispatch(gotoPrescription(newPrescription));
 };
 
+export const gotoVaccineAdminPage = () =>
+  NavigationActions.navigate({
+    routeName: ROUTES.VACCINES_ADMIN,
+    params: { title: navStrings.vaccine_admin },
+  });
+
 export const goToVaccines = () =>
   NavigationActions.navigate({
     routeName: ROUTES.VACCINES,

--- a/src/navigation/constants.js
+++ b/src/navigation/constants.js
@@ -46,6 +46,7 @@ export const ROUTES = {
   DASHBOARD: 'dashboard',
 
   VACCINES: 'vaccines',
+  VACCINES_ADMIN: 'vaccinesAdmin',
 };
 
 export const FINALISABLE_PAGES = [

--- a/src/pages/VaccineAdminPage.js
+++ b/src/pages/VaccineAdminPage.js
@@ -19,7 +19,7 @@ import { ROUTES } from '../navigation';
 import { generalStrings, vaccineStrings } from '../localization';
 import globalStyles from '../globalStyles';
 
-export const VaccineAdminPageComponent = ({
+const VaccineAdminPageComponent = ({
   data,
   sortKey,
   isAscending,

--- a/src/pages/VaccineAdminPage.js
+++ b/src/pages/VaccineAdminPage.js
@@ -1,0 +1,140 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { ToggleBar, DataTablePageView, SearchBar, PageButton } from '../widgets';
+import { DataTable, DataTableRow, DataTableHeaderRow } from '../widgets/DataTable';
+
+import { recordKeyExtractor, getItemLayout, getPageDispatchers } from './dataTableUtilities';
+
+import { ROUTES } from '../navigation';
+import { generalStrings, vaccineStrings } from '../localization';
+import globalStyles from '../globalStyles';
+
+export const VaccineAdminPageComponent = ({
+  data,
+  sortKey,
+  isAscending,
+  columns,
+  dataSet,
+  modalKey,
+  dataState,
+  searchTerm,
+  onFilterData,
+  onEditLocationCode,
+  onEditLocationDescription,
+  onSortColumn,
+  onToggleFridges,
+  onToggleSensors,
+}) => {
+  const getCallback = colKey => {
+    switch (colKey) {
+      case 'description':
+        return onEditLocationDescription;
+      case 'code':
+        return onEditLocationCode;
+      default:
+        return null;
+    }
+  };
+
+  const renderHeader = React.useCallback(
+    () => (
+      <DataTableHeaderRow
+        columns={columns}
+        onPress={onSortColumn}
+        isAscending={isAscending}
+        sortKey={sortKey}
+      />
+    ),
+    [sortKey, isAscending, columns]
+  );
+
+  const renderRow = React.useCallback(
+    listItem => {
+      const { item, index } = listItem;
+
+      const rowKey = recordKeyExtractor(item);
+      return (
+        <DataTableRow
+          rowData={data[index]}
+          rowState={dataState.get(rowKey)}
+          rowKey={rowKey}
+          columns={columns}
+          getCallback={getCallback}
+          rowIndex={index}
+        />
+      );
+    },
+    [data, dataState]
+  );
+
+  const toggles = React.useMemo(
+    () => [
+      { text: vaccineStrings.fridges, onPress: onToggleFridges, isOn: dataSet === 'fridges' },
+      { text: vaccineStrings.sensors, onPress: onToggleSensors, isOn: dataSet === 'sensors' },
+    ],
+    [dataSet]
+  );
+
+  return (
+    <DataTablePageView>
+      <View style={globalStyles.pageTopSectionContainer}>
+        <ToggleBar toggles={toggles} />
+        <SearchBar
+          onChangeText={onFilterData}
+          value={searchTerm}
+          placeholder={`${generalStrings.search_by} ${generalStrings.code} ${generalStrings.or} ${generalStrings.description}`}
+        />
+        <PageButton text="" />
+      </View>
+      <DataTable
+        data={data}
+        renderRow={renderRow}
+        renderHeader={renderHeader}
+        keyExtractor={recordKeyExtractor}
+        getItemLayout={getItemLayout}
+        columns={columns}
+      />
+    </DataTablePageView>
+  );
+};
+
+const mapStateToProps = state => {
+  const { pages } = state;
+  const { vaccinesAdmin } = pages;
+
+  return vaccinesAdmin;
+};
+
+const mapDispatchToProps = dispatch => getPageDispatchers(dispatch, null, ROUTES.VACCINES_ADMIN);
+
+VaccineAdminPageComponent.propTypes = {
+  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
+  sortKey: PropTypes.string.isRequired,
+  isAscending: PropTypes.bool.isRequired,
+  columns: PropTypes.array.isRequired,
+  dataSet: PropTypes.string.isRequired,
+  modalKey: PropTypes.string.isRequired,
+  dataState: PropTypes.object.isRequired,
+  searchTerm: PropTypes.string.isRequired,
+  onFilterData: PropTypes.func.isRequired,
+  onEditLocationCode: PropTypes.func.isRequired,
+  onEditLocationDescription: PropTypes.func.isRequired,
+  onSortColumn: PropTypes.func.isRequired,
+  onToggleFridges: PropTypes.func.isRequired,
+  onToggleSensors: PropTypes.func.isRequired,
+};
+
+export const VaccineAdminPage = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(VaccineAdminPageComponent);

--- a/src/pages/VaccineAdminPage.js
+++ b/src/pages/VaccineAdminPage.js
@@ -61,8 +61,8 @@ const VaccineAdminPageComponent = ({
   const renderRow = React.useCallback(
     listItem => {
       const { item, index } = listItem;
-
       const rowKey = recordKeyExtractor(item);
+
       return (
         <DataTableRow
           rowData={data[index]}
@@ -77,6 +77,11 @@ const VaccineAdminPageComponent = ({
     [data, dataState]
   );
 
+  const placeholderString =
+    dataSet === 'fridges'
+      ? `${generalStrings.search_by} ${generalStrings.code} ${generalStrings.or} ${generalStrings.description}`
+      : `${generalStrings.search_by} ${generalStrings.name}`;
+
   const toggles = React.useMemo(
     () => [
       { text: vaccineStrings.fridges, onPress: onToggleFridges, isOn: dataSet === 'fridges' },
@@ -89,11 +94,7 @@ const VaccineAdminPageComponent = ({
     <DataTablePageView>
       <View style={globalStyles.pageTopSectionContainer}>
         <ToggleBar toggles={toggles} />
-        <SearchBar
-          onChangeText={onFilterData}
-          value={searchTerm}
-          placeholder={`${generalStrings.search_by} ${generalStrings.code} ${generalStrings.or} ${generalStrings.description}`}
-        />
+        <SearchBar onChangeText={onFilterData} value={searchTerm} placeholder={placeholderString} />
         <PageButton text="" />
       </View>
       <DataTable

--- a/src/pages/VaccinePage.js
+++ b/src/pages/VaccinePage.js
@@ -60,7 +60,7 @@ export const VaccinePageComponent = ({
   return (
     <DataTablePageView>
       <FlexView flex={0} alignItems="flex-end" style={{ margin: 10 }}>
-        <PageButton text={generalStrings.admin} style={{}} onPress={onViewAdminPage} />
+        <PageButton text={generalStrings.admin} onPress={onViewAdminPage} />
       </FlexView>
 
       {fridges.length ? <FlatList data={fridges} renderItem={Fridge} /> : <BlankComponent />}

--- a/src/pages/VaccinePage.js
+++ b/src/pages/VaccinePage.js
@@ -9,14 +9,15 @@ import { connect } from 'react-redux';
 import { StyleSheet, Text, FlatList } from 'react-native';
 import PropTypes from 'prop-types';
 
-import { FridgeDisplay, FlexView } from '../widgets';
+import { PageButton, DataTablePageView, FridgeDisplay, FlexView } from '../widgets';
 
-import { selectMinAndMaxLogs, selectMinAndMaxDomains } from '../selectors/fridge';
+import { selectMinAndMaxLogs, selectMinAndMaxDomains, selectBreaches } from '../selectors/fridge';
 import { FridgeActions } from '../actions/FridgeActions';
 import { BreachActions } from '../actions/BreachActions';
+import { gotoVaccineAdminPage } from '../navigation/actions';
 
 import { APP_FONT_FAMILY } from '../globalStyles';
-import { vaccineStrings } from '../localization';
+import { vaccineStrings, generalStrings } from '../localization';
 
 export const VaccinePageComponent = ({
   selectedFridge,
@@ -28,6 +29,7 @@ export const VaccinePageComponent = ({
   fridges,
   onSelectFridge,
   onOpenBreachModal,
+  onViewAdminPage,
 }) => {
   const Fridge = React.useCallback(
     ({ item }) => (
@@ -55,13 +57,21 @@ export const VaccinePageComponent = ({
     []
   );
 
-  return fridges.length ? <FlatList data={fridges} renderItem={Fridge} /> : <BlankComponent />;
+  return (
+    <DataTablePageView>
+      <FlexView flex={0} alignItems="flex-end" style={{ margin: 10 }}>
+        <PageButton text={generalStrings.admin} style={{}} onPress={onViewAdminPage} />
+      </FlexView>
+
+      {fridges.length ? <FlatList data={fridges} renderItem={Fridge} /> : <BlankComponent />}
+    </DataTablePageView>
+  );
 };
 
 const mapStateToProps = state => {
   const { fridge } = state;
   const { fridges, selectedFridge } = fridge;
-  const { breaches } = selectedFridge;
+  const { breaches } = selectBreaches(state);
 
   const { minLine, maxLine } = selectMinAndMaxLogs(state);
   const { minDomain, maxDomain } = selectMinAndMaxDomains(state);
@@ -77,6 +87,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
+  onViewAdminPage: () => dispatch(gotoVaccineAdminPage()),
   onSelectFridge: fridge => dispatch(FridgeActions.select(fridge)),
   onOpenBreachModal: breachId => {
     dispatch(BreachActions.viewFridgeBreach(breachId));
@@ -97,6 +108,7 @@ VaccinePageComponent.propTypes = {
   fridges: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
   onSelectFridge: PropTypes.func.isRequired,
   onOpenBreachModal: PropTypes.func.isRequired,
+  onViewAdminPage: PropTypes.func.isRequired,
 };
 
 const localStyles = StyleSheet.create({

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -36,6 +36,30 @@ export const refreshIndicatorRow = route => ({
   payload: { route },
 });
 
+export const editLocationDescription = (newValue, rowKey, route) => (dispatch, getState) => {
+  const { data, keyExtractor } = selectPageState(getState());
+
+  const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
+
+  if (objectToEdit) {
+    UIDatabase.write(() =>
+      UIDatabase.update('Location', { ...objectToEdit, description: newValue })
+    );
+    dispatch(refreshRow(rowKey, route));
+  }
+};
+
+export const editLocationCode = (newValue, rowKey, route) => (dispatch, getState) => {
+  const { data, keyExtractor } = selectPageState(getState());
+
+  const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
+
+  if (objectToEdit) {
+    UIDatabase.write(() => UIDatabase.update('Location', { ...objectToEdit, code: newValue }));
+    dispatch(refreshRow(rowKey, route));
+  }
+};
+
 export const editBatchDoses = (newValue, rowKey, route) => (dispatch, getState) => {
   const { data, keyExtractor } = selectPageState(getState());
 
@@ -438,4 +462,6 @@ export const CellActionsLookup = {
   editTransactionBatchVvmStatus,
   editStocktakeBatchVvmStatus,
   editBatchDoses,
+  editLocationCode,
+  editLocationDescription,
 };

--- a/src/pages/dataTableUtilities/actions/constants.js
+++ b/src/pages/dataTableUtilities/actions/constants.js
@@ -11,6 +11,8 @@ export const ACTIONS = {
   REFRESH_CASH_REGISTER: 'refreshCashRegister',
   ADD_ITEM: 'addItem',
   ADD_RECORD: 'addRecord',
+  TOGGLE_FRIDGES: 'toggleFridges',
+  TOGGLE_SENSORS: 'toggleSensors',
   TOGGLE_INDICATORS: 'toggleIndicators',
   SELECT_INDICATOR: 'selectIndicator',
   HIDE_OVER_STOCKED: 'hideOverStocked',

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -301,6 +301,9 @@ export const filterDataWithOverStockToggle = (searchTerm, route) => ({
   payload: { searchTerm, route },
 });
 
+export const toggleSensors = route => ({ type: ACTIONS.TOGGLE_SENSORS, payload: { route } });
+export const toggleFridges = route => ({ type: ACTIONS.TOGGLE_FRIDGES, payload: { route } });
+
 export const TableActionsLookup = {
   sortData,
   filterData,
@@ -326,4 +329,6 @@ export const TableActionsLookup = {
   refreshDataWithFinalisedToggle,
   filterDataWithFinalisedToggle,
   filterDataWithOverStockToggle,
+  toggleSensors,
+  toggleFridges,
 };

--- a/src/pages/dataTableUtilities/constants.js
+++ b/src/pages/dataTableUtilities/constants.js
@@ -17,6 +17,8 @@ export const COLUMN_TYPES = {
 };
 
 export const COLUMN_KEYS = {
+  BATTERY_LEVEL: 'batteryLevelString',
+  MAC_ADDRESS: 'macAddress',
   AVAILABLE_QUANTITY: 'availableQuantity',
   DOSES: 'doses',
   BATCH: 'batch',
@@ -74,6 +76,9 @@ export const COLUMN_KEYS = {
 };
 
 export const COLUMN_NAMES = {
+  TOTAL_STOCK: 'totalStock',
+  BATTERY_LEVEL: 'batteryLevel',
+  MAC_ADDRESS: 'macAddress',
   AVAILABLE_QUANTITY: 'availableQuantity',
   BATCH_NAME: 'batch',
   BATCHES: 'batches',

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -41,11 +41,20 @@ const PAGE_COLUMN_WIDTHS = {
   [ROUTES.SUPPLIER_REQUISITIONS]: [1.5, 2, 1, 1, 1, 1],
   [ROUTES.PRESCRIPTION]: [2, 4, 2, 2, 1],
   [ROUTES.PRESCRIPTIONS]: [1.5, 2.5, 2, 1.5, 3, 1],
+  fridges: [1, 3],
+  sensors: [1, 3, 2, 2],
   [TABS.ITEM]: [1, 3, 1],
   [TABS.PRESCRIBER]: [3, 3, 1],
 };
 
 const PAGE_COLUMNS = {
+  sensors: [
+    COLUMN_NAMES.LOCATION,
+    COLUMN_NAMES.EDITABLE_NAME,
+    COLUMN_NAMES.BATTERY_LEVEL,
+    COLUMN_NAMES.MAC_ADDRESS,
+  ],
+  fridges: [COLUMN_NAMES.CODE, COLUMN_NAMES.DESCRIPTION],
   [ROUTES.SUPPLIER_INVOICE_WITH_VACCINES]: [
     COLUMN_NAMES.ITEM_CODE,
     COLUMN_NAMES.ITEM_NAME,
@@ -374,6 +383,30 @@ const COLUMNS = () => ({
 
   // STRING COLUMNS
 
+  [COLUMN_NAMES.MAC_ADDRESS]: {
+    type: COLUMN_TYPES.STRING,
+    key: COLUMN_KEYS.MAC_ADDRESS,
+    title: tableStrings.mac_address,
+    alignText: 'left',
+    sortable: true,
+    editable: false,
+  },
+  [COLUMN_NAMES.BATTERY_LEVEL]: {
+    type: COLUMN_TYPES.STRING,
+    key: COLUMN_KEYS.BATTERY_LEVEL,
+    title: tableStrings.battery_level,
+    alignText: 'center',
+    sortable: true,
+    editable: false,
+  },
+  [COLUMN_NAMES.DESCRIPTION]: {
+    type: COLUMN_TYPES.EDITABLE_STRING,
+    key: COLUMN_KEYS.DESCRIPTION,
+    title: tableStrings.description,
+    alignText: 'left',
+    sortable: true,
+    editable: false,
+  },
   [COLUMN_NAMES.TRANSACTION_TYPE]: {
     type: COLUMN_TYPES.STRING,
     key: COLUMN_KEYS.TYPE,

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -391,6 +391,7 @@ const COLUMNS = () => ({
     sortable: true,
     editable: false,
   },
+
   [COLUMN_NAMES.BATTERY_LEVEL]: {
     type: COLUMN_TYPES.STRING,
     key: COLUMN_KEYS.BATTERY_LEVEL,
@@ -399,14 +400,7 @@ const COLUMNS = () => ({
     sortable: true,
     editable: false,
   },
-  [COLUMN_NAMES.DESCRIPTION]: {
-    type: COLUMN_TYPES.EDITABLE_STRING,
-    key: COLUMN_KEYS.DESCRIPTION,
-    title: tableStrings.description,
-    alignText: 'left',
-    sortable: true,
-    editable: false,
-  },
+
   [COLUMN_NAMES.TRANSACTION_TYPE]: {
     type: COLUMN_TYPES.STRING,
     key: COLUMN_KEYS.TYPE,
@@ -550,6 +544,15 @@ const COLUMNS = () => ({
   },
 
   // EDITABLE STRING COLUMNS
+
+  [COLUMN_NAMES.DESCRIPTION]: {
+    type: COLUMN_TYPES.EDITABLE_STRING,
+    key: COLUMN_KEYS.DESCRIPTION,
+    title: tableStrings.description,
+    alignText: 'left',
+    sortable: true,
+    editable: false,
+  },
 
   [COLUMN_NAMES.EDITABLE_BATCH_NAME]: {
     type: COLUMN_TYPES.EDITABLE_STRING,

--- a/src/pages/dataTableUtilities/getPageDispatchers.js
+++ b/src/pages/dataTableUtilities/getPageDispatchers.js
@@ -34,6 +34,8 @@ export const getPageDispatchers = (dispatch, dataType, route) => {
       dispatch(BasePageActions.refreshData(route));
     },
     onToggleTransactionType: () => dispatch(BasePageActions.toggleTransactionType(route)),
+    onToggleFridges: () => dispatch(BasePageActions.toggleFridges(route)),
+    onToggleSensors: () => dispatch(BasePageActions.toggleSensors(route)),
     onSelectIndicator: indicatorCode =>
       dispatch(BasePageActions.selectIndicator(indicatorCode, route)),
     onShowOverStocked: () => dispatch(BasePageActions.showOverStocked(route)),
@@ -109,6 +111,10 @@ export const getPageDispatchers = (dispatch, dataType, route) => {
     onDeleteBatches: () => dispatch(BasePageActions.deleteSelectedBatches(dataType, route)),
 
     // Editable cell callbacks
+    onEditLocationCode: (newValue, rowKey) =>
+      dispatch(BasePageActions.editLocationCode(newValue, rowKey, route)),
+    onEditLocationDescription: (newValue, rowKey) =>
+      dispatch(BasePageActions.editLocationDescription(newValue, rowKey, route)),
     onEditTransactionBatchName: (newValue, rowKey) =>
       dispatch(BasePageActions.editTransactionBatchName(newValue, rowKey, route)),
     onEditBatchDoses: (newValue, rowKey) =>

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -14,6 +14,27 @@ import { COLUMN_KEYS } from './constants';
 import { ROUTES } from '../../navigation/constants';
 import { SETTINGS_KEYS } from '../../settings';
 
+export const vaccinesAdminInitialiser = () => {
+  const backingData = UIDatabase.objects('Fridge');
+  const data = backingData.slice();
+  const sortedData = sortDataBy(data, COLUMN_KEYS.CODE, false);
+
+  return {
+    backingData,
+    data: sortedData,
+    dataState: new Map(),
+    sortKey: COLUMN_KEYS.CODE,
+    isAscending: true,
+    keyExtractor: recordKeyExtractor,
+    searchTerm: '',
+    modalKey: '',
+    columns: getColumns('fridges'),
+    route: ROUTES.VACCINES_ADMIN,
+    dataSet: 'fridges',
+    filterDataKeys: ['description', 'code'],
+  };
+};
+
 export const cashRegisterInitialiser = () => {
   const backingData = UIDatabase.objects('CashTransaction');
   const filteredData = backingData.slice();
@@ -492,6 +513,7 @@ const pageInitialisers = {
   supplierRequisition: supplierRequisitionInitialiser,
   supplierRequisitions: supplierRequisitionsInitialiser,
   cashRegister: cashRegisterInitialiser,
+  vaccinesAdmin: vaccinesAdminInitialiser,
 };
 
 /**

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -5,7 +5,7 @@
 
 import { ROUTES } from '../../../navigation/constants';
 import { sortDataBy } from '../../../utilities';
-import { UIDatabase } from '../../../database/index';
+import { UIDatabase } from '../../../database';
 import getColumns from '../getColumns';
 
 /**

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -280,6 +280,7 @@ export const toggleFridges = state => {
     isAscending: false,
     searchTerm: '',
     columns: getColumns('fridges'),
+    filterDataKeys: ['description', 'code'],
   };
 };
 
@@ -296,6 +297,7 @@ export const toggleSensors = state => {
     isAscending: false,
     searchTerm: '',
     columns: getColumns('sensors'),
+    filterDataKeys: ['name'],
   };
 };
 

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -5,6 +5,8 @@
 
 import { ROUTES } from '../../../navigation/constants';
 import { sortDataBy } from '../../../utilities';
+import { UIDatabase } from '../../../database/index';
+import getColumns from '../getColumns';
 
 /**
  * Sorts the current set of data by the provided
@@ -265,6 +267,38 @@ export const addRecord = state => {
   };
 };
 
+export const toggleFridges = state => {
+  const backingData = UIDatabase.objects('Fridge');
+  const data = backingData.slice();
+
+  return {
+    ...state,
+    backingData,
+    data,
+    dataSet: 'fridges',
+    sortKey: '',
+    isAscending: false,
+    searchTerm: '',
+    columns: getColumns('fridges'),
+  };
+};
+
+export const toggleSensors = state => {
+  const backingData = UIDatabase.objects('Sensor');
+  const data = backingData.slice();
+
+  return {
+    ...state,
+    backingData,
+    data,
+    dataSet: 'sensors',
+    sortKey: '',
+    isAscending: false,
+    searchTerm: '',
+    columns: getColumns('sensors'),
+  };
+};
+
 export const TableReducerLookup = {
   toggleStockOut,
   toggleShowFinalised,
@@ -280,4 +314,6 @@ export const TableReducerLookup = {
   refreshDataWithFinalisedToggle,
   filterDataWithFinalisedToggle,
   filterDataWithOverStockToggle,
+  toggleFridges,
+  toggleSensors,
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,3 +24,4 @@ export { StocktakeManagePage } from './StocktakeManagePage';
 export { StocktakeEditPage } from './StocktakeEditPage';
 export { StockPage } from './StockPage';
 export { VaccinePage } from './VaccinePage';
+export { VaccineAdminPage } from './VaccineAdminPage';

--- a/src/selectors/fridge.js
+++ b/src/selectors/fridge.js
@@ -87,3 +87,9 @@ export const selectMinAndMaxDomains = createSelector(selectMinAndMaxLogs, minAnd
     maxDomain: Math.max(...maxLine.map(({ temperature }) => temperature)),
   };
 });
+
+export const selectBreaches = createSelector([selectSelectedFridge], fridge => {
+  const { breaches } = fridge;
+
+  return breaches;
+});

--- a/src/utilities/sortDataBy.js
+++ b/src/utilities/sortDataBy.js
@@ -4,10 +4,13 @@
  */
 
 const sortKeyToType = {
+  macAddress: 'string',
+  batteryLevelString: 'string',
   itemCode: 'string',
   itemName: 'string',
   batch: 'string',
   dateOfBirth: 'date',
+  description: 'string',
   doses: 'number',
   availableQuantity: 'number',
   totalQuantity: 'number',


### PR DESCRIPTION
Fixes #2596 

## Change summary

- Adds an admin page for vaccines to be able to edit locations and sensors, as well as scan for new sensors (next PR).
- This PR adds basic functionality (stopped to PR to have it be a bit smaller, so not fully complete).
- This is just adding a table with a toggle for sensors/locations, where the table will be editable.

![admin1](https://user-images.githubusercontent.com/35858975/79712477-0a677a80-831f-11ea-9d4d-39b48c4b4228.png)

![admin2](https://user-images.githubusercontent.com/35858975/79713837-17866880-8323-11ea-85da-1155c224cdbe.png)

## Testing

N/A

### Related areas to think about

- Next PR will include: editable sensors. 
- A button to create a `Location`. [Right of the search bar]
- A button to scan for new sensors. [Right of the search bar]
- Conditional logic to only allow admin access with admin preference on.
