### PR TITLE
#2717 fix confirm modal cancellation

### DIFF
--- a/src/actions/FormActions.js
+++ b/src/actions/FormActions.js
@@ -8,11 +8,19 @@ export const FORM_ACTIONS = {
   UPDATE: 'Form/Update',
   CANCEL: 'Form/Cancel',
   SHOW_CONFIRM_FORM: 'Form/ShowConfirmForm',
+  HIDE_CONFIRM_FORM: 'Form/HideConfirmForm',
 };
 
 const initialiseForm = config => ({ type: FORM_ACTIONS.INITIALISE, payload: { config } });
 const updateForm = (key, value) => ({ type: FORM_ACTIONS.UPDATE, payload: { key, value } });
 const resetForm = () => ({ type: FORM_ACTIONS.CANCEL });
 const showConfirmForm = () => ({ type: FORM_ACTIONS.SHOW_CONFIRM_FORM });
+const hideConfirmForm = () => ({ type: FORM_ACTIONS.HIDE_CONFIRM_FORM });
 
-export const FormActions = { initialiseForm, updateForm, resetForm, showConfirmForm };
+export const FormActions = {
+  initialiseForm,
+  updateForm,
+  resetForm,
+  showConfirmForm,
+  hideConfirmForm,
+};

--- a/src/reducers/FormReducer.js
+++ b/src/reducers/FormReducer.js
@@ -37,13 +37,6 @@ export const FormReducer = (state = initialState(), action) => {
       return initialState(config);
     }
 
-    case FORM_ACTIONS.SHOW_CONFIRM_FORM: {
-      return {
-        formConfig,
-        isConfirmFormOpen: true,
-      };
-    }
-
     case FORM_ACTIONS.UPDATE: {
       const { payload } = action;
       const { key, value } = payload;
@@ -119,6 +112,20 @@ export const FormReducer = (state = initialState(), action) => {
 
     case FORM_ACTIONS.CANCEL: {
       return initialState();
+    }
+
+    case FORM_ACTIONS.SHOW_CONFIRM_FORM: {
+      return {
+        formConfig,
+        isConfirmFormOpen: true,
+      };
+    }
+
+    case FORM_ACTIONS.HIDE_CONFIRM_FORM: {
+      return {
+        formConfig,
+        isConfirmFormOpen: false,
+      };
     }
 
     default:

--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -24,6 +24,8 @@ import {
   selectIsConfirmFormOpen,
 } from '../selectors/form';
 import { FormActions } from '../actions/FormActions';
+
+import { ModalContainer } from './modals';
 import { ConfirmForm } from './modalChildren';
 
 /**
@@ -223,30 +225,16 @@ const FormControlComponent = ({
   );
 
   return (
-    <>
-      <View
-        style={
-          isConfirmFormOpen
-            ? { ...localStyles.flexOne, ...localStyles.hidden }
-            : localStyles.flexOne
-        }
-      >
-        <ScrollView style={localStyles.whiteBackground}>
-          <View style={localStyles.flexRow}>
-            <View style={localStyles.flexOne} />
-            <View style={localStyles.flexTen}>{formInputs()}</View>
-            <View style={localStyles.flexOne} />
-          </View>
-        </ScrollView>
-        <Buttons />
-      </View>
-      <View
-        style={
-          isConfirmFormOpen
-            ? localStyles.flexOne
-            : { ...localStyles.flexOne, ...localStyles.hidden }
-        }
-      >
+    <View style={localStyles.flexOne}>
+      <ScrollView style={localStyles.whiteBackground}>
+        <View style={localStyles.flexRow}>
+          <View style={localStyles.flexOne} />
+          <View style={localStyles.flexTen}>{formInputs()}</View>
+          <View style={localStyles.flexOne} />
+        </View>
+      </ScrollView>
+      <Buttons />
+      <ModalContainer fullScreen isVisible={isConfirmFormOpen} noCancel>
         <ConfirmForm
           isOpen={isConfirmFormOpen}
           questionText={confirmText}
@@ -254,8 +242,8 @@ const FormControlComponent = ({
           onCancel={onCancelForm}
           confirmText={modalStrings.confirm}
         />
-      </View>
-    </>
+      </ModalContainer>
+    </View>
   );
 };
 
@@ -373,5 +361,4 @@ const localStyles = StyleSheet.create({
   flexRow: { flex: 1, flexDirection: 'row' },
   buttonsRow: { marginTop: 10, flexDirection: 'row-reverse' },
   whiteBackground: { backgroundColor: WHITE },
-  hidden: { display: 'none' },
 });

--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -56,25 +56,23 @@ const FormControlComponent = ({
   canSaveForm,
   saveButtonText,
   // Confirm form state
-  confirmOnSave,
   isConfirmFormOpen,
   confirmText,
   // Cancel button state
   showCancelButton,
   cancelButtonText,
   // Form callbacks
-  initialiseForm,
+  onInitialiseForm,
   onUpdateForm,
-  showConfirmForm,
   // Save button callbacks
-  onSave,
+  onSaveForm,
   // Cancel button callbacks
-  onCancel,
+  onCancelForm,
 }) => {
   const [refs, setRefs] = React.useState([]);
 
   React.useEffect(() => {
-    initialiseForm(inputConfig);
+    onInitialiseForm();
     setRefs({ length: inputConfig.length });
   }, []);
 
@@ -188,35 +186,30 @@ const FormControlComponent = ({
       }
     );
 
-  const onSaveCompletedForm = React.useCallback(
-    () => (!confirmOnSave || isConfirmFormOpen ? onSave(completedForm) : showConfirmForm()),
-    [confirmOnSave, onSave, showConfirmForm, completedForm]
-  );
-
   const SaveButton = React.useCallback(
     () => (
       <PageButton
-        onPress={onSaveCompletedForm}
+        onPress={onSaveForm}
         style={localStyles.saveButton}
         isDisabled={!canSaveForm || isDisabled}
         textStyle={localStyles.saveButtonTextStyle}
         text={saveButtonText}
       />
     ),
-    [isDisabled, showCancelButton, canSaveForm, saveButtonText, onSaveCompletedForm]
+    [isDisabled, showCancelButton, canSaveForm, saveButtonText, onSaveForm]
   );
 
   const CancelButton = React.useCallback(
     () =>
       showCancelButton ? (
         <PageButton
-          onPress={onCancel}
+          onPress={onCancelForm}
           style={localStyles.cancelButton}
           textStyle={localStyles.cancelButtonTextStyle}
           text={cancelButtonText}
         />
       ) : null,
-    [showCancelButton, cancelButtonText, onCancel]
+    [showCancelButton, cancelButtonText, onCancelForm]
   );
 
   const Buttons = React.useCallback(
@@ -229,46 +222,95 @@ const FormControlComponent = ({
     [SaveButton, CancelButton]
   );
 
-  const InputConfirm = (
-    <ConfirmForm
-      isOpen={isConfirmFormOpen}
-      questionText={confirmText}
-      onConfirm={onSaveCompletedForm}
-      confirmText={modalStrings.confirm}
-    />
+  return (
+    <>
+      <View
+        style={
+          isConfirmFormOpen
+            ? { ...localStyles.flexOne, ...localStyles.hidden }
+            : localStyles.flexOne
+        }
+      >
+        <ScrollView style={localStyles.whiteBackground}>
+          <View style={localStyles.flexRow}>
+            <View style={localStyles.flexOne} />
+            <View style={localStyles.flexTen}>{formInputs()}</View>
+            <View style={localStyles.flexOne} />
+          </View>
+        </ScrollView>
+        <Buttons />
+      </View>
+      <View
+        style={
+          isConfirmFormOpen
+            ? localStyles.flexOne
+            : { ...localStyles.flexOne, ...localStyles.hidden }
+        }
+      >
+        <ConfirmForm
+          isOpen={isConfirmFormOpen}
+          questionText={confirmText}
+          onConfirm={onSaveForm}
+          onCancel={onCancelForm}
+          confirmText={modalStrings.confirm}
+        />
+      </View>
+    </>
   );
-
-  const InputDetails = (
-    <View style={localStyles.flexOne}>
-      <ScrollView style={localStyles.whiteBackground}>
-        <View style={localStyles.flexRow}>
-          <View style={localStyles.flexOne} />
-          <View style={localStyles.flexTen}>{formInputs()}</View>
-          <View style={localStyles.flexOne} />
-        </View>
-      </ScrollView>
-      <Buttons />
-    </View>
-  );
-
-  return isConfirmFormOpen ? InputConfirm : InputDetails;
 };
 
-const mapDispatchToProps = (dispatch, ownProps) => {
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+  const { form, completedForm, saveButtonText, canSaveForm, isConfirmFormOpen } = stateProps;
+  const { initialiseForm, showConfirmForm, hideConfirmForm, updateForm, resetForm } = dispatchProps;
+  const {
+    inputConfig,
+    isDisabled,
+    confirmOnSave,
+    confirmText,
+    onSave,
+    showCancelButton,
+    cancelButtonText,
+    onCancel,
+  } = ownProps;
+  const onInitialiseForm = () => initialiseForm(inputConfig);
+  const onUpdateForm = (key, value) => !isDisabled && updateForm(key, value);
+  const onSaveForm = () =>
+    confirmOnSave && !isConfirmFormOpen ? showConfirmForm() : onSave(completedForm);
+  const onCancelForm = () =>
+    confirmOnSave && isConfirmFormOpen ? hideConfirmForm() : onCancel() && resetForm();
+  return {
+    form,
+    completedForm,
+    inputConfig,
+    isDisabled,
+    canSaveForm,
+    saveButtonText,
+    isConfirmFormOpen,
+    confirmText,
+    showCancelButton,
+    cancelButtonText,
+    onInitialiseForm,
+    onUpdateForm,
+    onSaveForm,
+    onCancelForm,
+  };
+};
+
+const mapDispatchToProps = dispatch => {
   const initialiseForm = config => dispatch(FormActions.initialiseForm(config));
   const showConfirmForm = () => dispatch(FormActions.showConfirmForm());
-  const onUpdateForm = (key, value) => dispatch(FormActions.updateForm(key, value));
-  const onCancel = () => ownProps.onCancel() && dispatch(FormActions.resetForm());
-  return { initialiseForm, showConfirmForm, onUpdateForm, onCancel };
+  const hideConfirmForm = () => dispatch(FormActions.hideConfirmForm());
+  const updateForm = (key, value) => dispatch(FormActions.updateForm(key, value));
+  const resetForm = () => dispatch(FormActions.resetForm());
+  return { initialiseForm, showConfirmForm, hideConfirmForm, updateForm, resetForm };
 };
 
-const mapStateToProps = (state, ownProps) => {
+const mapStateToProps = state => {
   const form = selectForm(state);
+  const completedForm = selectCompletedForm(state);
   const canSaveForm = selectCanSaveForm(state);
   const isConfirmFormOpen = selectIsConfirmFormOpen(state);
-  const completedForm = selectCompletedForm(state);
-  const { confirmOnSave } = ownProps;
-  return { form, canSaveForm, confirmOnSave, isConfirmFormOpen, completedForm };
+  return { form, canSaveForm, isConfirmFormOpen, completedForm };
 };
 
 FormControlComponent.defaultProps = {
@@ -276,7 +318,6 @@ FormControlComponent.defaultProps = {
   completedForm: {},
   isDisabled: false,
   saveButtonText: generalStrings.save,
-  confirmOnSave: false,
   confirmText: modalStrings.confirm,
   showCancelButton: true,
   cancelButtonText: modalStrings.cancel,
@@ -289,18 +330,21 @@ FormControlComponent.propTypes = {
   isDisabled: PropTypes.bool,
   canSaveForm: PropTypes.bool.isRequired,
   saveButtonText: PropTypes.string,
-  confirmOnSave: PropTypes.bool,
   isConfirmFormOpen: PropTypes.bool.isRequired,
   confirmText: PropTypes.string,
   showCancelButton: PropTypes.bool,
   cancelButtonText: PropTypes.string,
-  initialiseForm: PropTypes.func.isRequired,
+  onInitialiseForm: PropTypes.func.isRequired,
   onUpdateForm: PropTypes.func.isRequired,
-  onSave: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
+  onSaveForm: PropTypes.func.isRequired,
+  onCancelForm: PropTypes.func.isRequired,
 };
 
-export const FormControl = connect(mapStateToProps, mapDispatchToProps)(FormControlComponent);
+export const FormControl = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps
+)(FormControlComponent);
 
 const localStyles = StyleSheet.create({
   saveButton: {
@@ -329,4 +373,5 @@ const localStyles = StyleSheet.create({
   flexRow: { flex: 1, flexDirection: 'row' },
   buttonsRow: { marginTop: 10, flexDirection: 'row-reverse' },
   whiteBackground: { backgroundColor: WHITE },
+  hidden: { display: 'none' },
 });


### PR DESCRIPTION
Fixes #2717,

## Change summary

Fixes the insurance confirmation modal popup not cancelling.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When saving an insurance policy for a non-local patient, a confirmation modal is displayed.
- [ ] When the confirmation modal is cancelled, the modal is hidden and the insurance policy details are NOT reset.
- [ ] When the confirmation modal is confirmed, the modal and form are closed and the insurance policy saved and selected.

### Related areas to think about

N/A.
