### PR TITLE
#2720 add payment types to prescription receipts

### DIFF
--- a/src/utilities/modules/dispensary/pay.js
+++ b/src/utilities/modules/dispensary/pay.js
@@ -50,7 +50,8 @@ export const pay = (
   scriptTotal,
   subtotal,
   discountAmount,
-  discountRate
+  discountRate,
+  paymentType
 ) => {
   if (!patient.isPatient) throw new Error('Patient is not a patient');
   if (!script.isPrescription) throw new Error('Script is not a script');
@@ -74,7 +75,7 @@ export const pay = (
     currentUser,
     patient,
     cashAmount,
-    null,
+    paymentType,
     receiptDescription
   );
 

--- a/src/widgets/Tabs/PrescriptionConfirmation.js
+++ b/src/widgets/Tabs/PrescriptionConfirmation.js
@@ -40,9 +40,8 @@ import { PageButtonWithOnePress } from '../PageButtonWithOnePress';
 const { pageTopViewContainer } = globalStyles;
 const mapStateToProps = state => {
   const { payment, wizard, modules } = state;
-  const { transaction, paymentValid, paymentAmount } = payment;
+  const { transaction, paymentValid, paymentAmount, paymentType } = payment;
   const { isComplete } = wizard;
-
   const { usingPayments } = modules;
   const currentPatient = selectCurrentPatient(state);
   const currentUser = selectCurrentUser(state);
@@ -61,6 +60,7 @@ const mapStateToProps = state => {
     transaction,
     canConfirm,
     paymentAmount,
+    paymentType,
     currentUser,
     currentPatient,
     usingPayments,
@@ -84,6 +84,7 @@ const PrescriptionConfirmationComponent = ({
   currentUser,
   currentPatient,
   paymentAmount,
+  paymentType,
   canConfirm,
   usingPayments,
   onDelete,
@@ -101,7 +102,8 @@ const PrescriptionConfirmationComponent = ({
       total.value,
       subtotal.value,
       discountAmount.value,
-      discountRate
+      discountRate,
+      paymentType
     );
   }, [
     currentUser,
@@ -112,6 +114,7 @@ const PrescriptionConfirmationComponent = ({
     total.value,
     discountAmount.value,
     discountRate,
+    paymentType,
   ]);
 
   const confirmPrescription = React.useCallback(
@@ -171,6 +174,7 @@ PrescriptionConfirmationComponent.propTypes = {
   currentUser: PropTypes.object.isRequired,
   currentPatient: PropTypes.object.isRequired,
   paymentAmount: PropTypes.object.isRequired,
+  paymentType: PropTypes.object.isRequired,
   canConfirm: PropTypes.bool.isRequired,
   usingPayments: PropTypes.bool.isRequired,
   onDelete: PropTypes.func.isRequired,


### PR DESCRIPTION
Fixes #2720.

## Change summary

Cash register filters by payment types, so receipts created from prescriptions were not displaying.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Make a new prescription with a payment. The receipt for the payment can be viewed in the cash register (under the correct payment type). 

### Related areas to think about

Wondering if it would be worth adding an `"All"` option to the cash register dropdown for filtering by payment type? 