### PR TITLE
#2721 fix new patient form defaulting to not editable

### DIFF
--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -50,6 +50,6 @@ export const selectPatientModalOpen = ({ patient }) => {
 
 export const selectCanEditPatient = ({ patient }) => {
   const { currentPatient } = patient;
-  const { isEditable = false } = currentPatient ?? {};
+  const { isEditable = true } = currentPatient ?? {};
   return isEditable;
 };


### PR DESCRIPTION
Fixes #2721.

## Change summary

Patient `isEditable` was incorrectly defaulting to `false`, locking the form for making a new patient.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When creating a new patient, all fields are editable.

### Related areas to think about

N/A.
