### PR TITLE
#2756 update post sync to ensure all incoming customer credits are finalised

### DIFF
--- a/src/sync/PostSyncProcessor.js
+++ b/src/sync/PostSyncProcessor.js
@@ -205,6 +205,12 @@ export class PostSyncProcessor {
       }
     }
 
+    if (record.type === 'customer_credit' && !record.isFinalised) {
+      funcs.push(() => {
+        record.finalise();
+      });
+    }
+
     // If any changes, add database update for record.
     if (funcs.length > 0) {
       funcs.push(() => {

--- a/src/sync/PostSyncProcessor.js
+++ b/src/sync/PostSyncProcessor.js
@@ -205,6 +205,7 @@ export class PostSyncProcessor {
       }
     }
 
+    // Auto-finalise all incoming consumer credits.
     if (record.type === 'customer_credit' && !record.isFinalised) {
       funcs.push(() => {
         record.finalise();


### PR DESCRIPTION
Fixes #2756.

## Change summary

Auto-finalises customer credit on incoming sync.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

### Setup 

- Create a supplier credit for mobile store.
- Manually sync mobile.
- Navigate to customer invoices and toggle to `"Past"`.

### Test cases

- [ ] The customer credit which corresponds to the supplier credit is displayed
- [ ] The customer credit is finalised and cannot be edited

### Related areas to think about

Not too sure about existing finalisation logic, so played it safe and just replicated the existing logic for manually finalising a customer credit.
