### PR TITLE
#2758 add loading indicator hook to customer requisition page

### DIFF
--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -33,6 +33,8 @@ import {
 } from '../selectors/indicators';
 import { getItemLayout, getPageDispatchers, PageActions } from './dataTableUtilities';
 
+import { useLoadingIndicator } from '../hooks/useLoadingIndicator';
+
 import globalStyles from '../globalStyles';
 import { buttonStrings, generalStrings, programStrings } from '../localization';
 
@@ -50,7 +52,6 @@ import { buttonStrings, generalStrings, programStrings } from '../localization';
  * { isSelected, isDisabled },
  */
 export const CustomerRequisition = ({
-  runWithLoadingIndicator,
   data,
   dispatch,
   dataState,
@@ -78,15 +79,17 @@ export const CustomerRequisition = ({
 }) => {
   const { isFinalised, comment } = pageObject;
 
-  const onSetSuppliedToRequested = () =>
-    runWithLoadingIndicator(() => dispatch(PageActions.setSuppliedToRequested(route)));
-  const onSetSuppliedToSuggested = () =>
-    runWithLoadingIndicator(() => dispatch(PageActions.setSuppliedToSuggested(route)));
-
   const pageInfoColumns = useCallback(getPageInfoColumns(pageObject, dispatch, route), [
     comment,
     isFinalised,
   ]);
+
+  const runWithLoadingIndicator = useLoadingIndicator();
+
+  const onSetSuppliedToRequested = () =>
+    runWithLoadingIndicator(() => dispatch(PageActions.setSuppliedToRequested(route)));
+  const onSetSuppliedToSuggested = () =>
+    runWithLoadingIndicator(() => dispatch(PageActions.setSuppliedToSuggested(route)));
 
   const getCallback = useCallback(colKey => {
     switch (colKey) {
@@ -344,7 +347,6 @@ CustomerRequisition.propTypes = {
   searchTerm: PropTypes.string.isRequired,
   columns: PropTypes.array.isRequired,
   keyExtractor: PropTypes.func.isRequired,
-  runWithLoadingIndicator: PropTypes.func.isRequired,
   dataState: PropTypes.object.isRequired,
   modalKey: PropTypes.string.isRequired,
   pageObject: PropTypes.object.isRequired,


### PR DESCRIPTION
Fixes #2758.

## Change summary

Fixes error caused by missing `useLoadingIndicator` hook.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] App does not crash on setting customer requisition supplied quantity to requested quantity.
- [ ] App does not crash on setting customer requisition supplied quantity to suggested quantity.

### Related areas to think about

N/A.
