### PR TITLE
#2752 fix hardware back button being double handled

### DIFF
--- a/src/navigation/utilities.js
+++ b/src/navigation/utilities.js
@@ -44,8 +44,14 @@ export const getRouteTitle = (pageObject, routeName) => {
 /**
  * Simple hardware backhandler which dispatches a goBack action on a
  * provided store.
+ *
+ * WARNING: if returns falsey value, event will be "double handled",
+ * which will result in the stack being popped twice.
  */
-export const backHandler = store => () => store.dispatch(goBack());
+export const backHandler = store => () => {
+  store.dispatch(goBack());
+  return true;
+};
 
 /**
  * Simple middleware which intercepts navigation actions and calls a function


### PR DESCRIPTION
Fixes #2752.

## Change summary

Adds truthy return to navigation `backHander` to prevent event being double handled.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Pressing the hardware back button navigates to previous page.

NOTE: when testing back handling, make sure to include cases where navigation stack has more than one page (e.g. navigate to customer invoices -> customer invoice).

### Related areas to think about

N/A.