### PR TITLE
#2713 add wildcard to lookup query parameters

### DIFF
--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -20,6 +20,7 @@ const RESOURCES = {
 const SEPARATORS = {
   QUERY_STRING: '?',
   QUERY_PARAMETERS: '&',
+  QUERY_WILDCARD: '@',
   POLICY_NUMBER: '-',
 };
 
@@ -40,7 +41,7 @@ const getQueryString = params =>
   params.reduce((queryString, param) => {
     const [[key, value]] = Object.entries(param);
     if (!value) return queryString;
-    const paramString = `${key}=${value}`;
+    const paramString = `${key}=${SEPARATORS.QUERY_WILDCARD}${value}${SEPARATORS.QUERY_WILDCARD}`;
     const paramSeparator = queryString.length > 0 ? SEPARATORS.PARAMETERS : SEPARATORS.QUERY_STRING;
     return queryString + paramSeparator + paramString;
   }, '');


### PR DESCRIPTION
Fixes #2713.

## Change summary

Wraps all query parameters in "wildcard" symbol (`"@"`). Trade-off of more records being returned, but easier to find matches and closer to existing desktop search functionality.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Each patient record returned by a lookup query satisfies the following property: for all input fields with a value, that record field either matches that value, **or contains it**. 
- [ ] All patient records not returned by a lookup query satisfy the following property: for at least one input field with a value, that record does not match that value **and does not contain it**.
- [ ] Each prescriber record returned by a lookup query satisfies the following property: for all input fields with a value, that record field either matches that value, **or contains it**. 
- [ ] All prescriber records not returned by a lookup query satisfy the following property: for at least one input field with a value, that record does not match that value **and does not contain it**.

### Related areas to think about

This PR only ensures that all records which should be matched are matched, another PR coming soon to ensure that no records are matched which shouldn't be matched :rofl:.
