### PR TITLE
#2749 update patient search by policy

### DIFF
--- a/src/localization/formInputStrings.json
+++ b/src/localization/formInputStrings.json
@@ -20,6 +20,7 @@
     "must_be": "Must be",
     "must_not_be_empty": "Must not be empty",
     "no": "No",
+    "policy_number": "Policy number",
     "personal_policy_number": "Personal policy number",
     "personal": "Personal",
     "phone": "Phone",

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -20,7 +20,6 @@ const RESOURCES = {
 const SEPARATORS = {
   QUERY_STRING: '?',
   QUERY_PARAMETERS: '&',
-  POLICY_NUMBER: '-',
 };
 
 export const createPatientRecord = patient => {
@@ -58,17 +57,13 @@ const getPatientQueryString = ({
   firstName = '',
   lastName = '',
   dateOfBirth = '',
-  policyNumberPerson = '',
-  policyNumberFamily = '',
+  policyNumber = '',
 } = {}) => {
-  const policyNumberSeparator =
-    policyNumberPerson && policyNumberFamily ? SEPARATORS.POLICY_NUMBER : '';
-  const policyNumberFull = policyNumberPerson + policyNumberSeparator + policyNumberFamily;
   const queryParams = [
     { first_name: firstName },
     { last_name: lastName },
     { dob: dateOfBirth },
-    { policy_number: policyNumberFull },
+    { policy_number: policyNumber },
   ];
   return getQueryString(queryParams);
 };

--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -51,13 +51,12 @@ const FORM_INPUT_KEYS = {
   REGISTRATION_CODE: 'registrationCode',
   SEARCH_REGISTRATION_CODE: 'searchRegistrationCode',
   POLICY_NUMBER_FAMILY: 'policyNumberFamily',
-  SEARCH_POLICY_NUMBER_FAMILY: 'searchPolicyNumberFamily',
   POLICY_NUMBER_PERSON: 'policyNumberPerson',
-  SEARCH_POLICY_NUMBER_PERSON: 'searchPolicyNumberPerson',
   POLICY_PROVIDER: 'insuranceProvider',
   POLICY_TYPE: 'policyType',
   IS_ACTIVE: 'isActive',
   DISCOUNT_RATE: 'discountRate',
+  SEARCH_POLICY_NUMBER: 'searchPolicyNumber',
 };
 
 const FORM_INPUT_CONFIGS = seedObject => ({
@@ -227,16 +226,6 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     label: formInputStrings.personal_policy_number,
     isEditable: !seedObject,
   },
-  [FORM_INPUT_KEYS.SEARCH_POLICY_NUMBER_PERSON]: {
-    type: FORM_INPUT_TYPES.TEXT,
-    initialValue: '',
-    key: 'policyNumberPerson',
-    validator: null,
-    isRequired: false,
-    invalidMessage: '',
-    label: formInputStrings.personal_policy_number,
-    isEditable: true,
-  },
   [FORM_INPUT_KEYS.POLICY_NUMBER_FAMILY]: {
     type: FORM_INPUT_TYPES.TEXT,
     initialValue: '',
@@ -246,16 +235,6 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     invalidMessage: formInputStrings.unique_policy,
     label: formInputStrings.family_policy_number,
     isEditable: !seedObject,
-  },
-  [FORM_INPUT_KEYS.SEARCH_POLICY_NUMBER_FAMILY]: {
-    type: FORM_INPUT_TYPES.TEXT,
-    initialValue: '',
-    key: 'policyNumberFamily',
-    validator: null,
-    isRequired: false,
-    invalidMessage: '',
-    label: formInputStrings.family_policy_number,
-    isEditable: true,
   },
   [FORM_INPUT_KEYS.POLICY_PROVIDER]: {
     type: FORM_INPUT_TYPES.DROPDOWN,
@@ -294,6 +273,17 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     label: formInputStrings.discount_rate,
     isEditable: true,
   },
+  },
+  [FORM_INPUT_KEYS.SEARCH_POLICY_NUMBER]: {
+    type: FORM_INPUT_TYPES.TEXT,
+    initialValue: '',
+    key: 'policyNumber',
+    validator: null,
+    isRequired: false,
+    invalidMessage: '',
+    label: formInputStrings.policy_number,
+    isEditable: true,
+  },
 });
 
 const FORM_CONFIGS = {
@@ -330,8 +320,7 @@ const FORM_CONFIGS = {
     FORM_INPUT_KEYS.SEARCH_FIRST_NAME,
     FORM_INPUT_KEYS.SEARCH_LAST_NAME,
     FORM_INPUT_KEYS.SEARCH_DATE_OF_BIRTH,
-    FORM_INPUT_KEYS.SEARCH_POLICY_NUMBER_PERSON,
-    FORM_INPUT_KEYS.SEARCH_POLICY_NUMBER_FAMILY,
+    FORM_INPUT_KEYS.SEARCH_POLICY_NUMBER,
   ],
   searchPrescriber: [
     FORM_INPUT_KEYS.SEARCH_FIRST_NAME,

--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -37,25 +37,25 @@ export const FORM_INPUT_TYPES = {
 
 const FORM_INPUT_KEYS = {
   FIRST_NAME: 'firstName',
-  SEARCH_FIRST_NAME: 'searchFirstName',
   LAST_NAME: 'lastName',
-  SEARCH_LAST_NAME: 'searchLastName',
   CODE: 'code',
   DATE_OF_BIRTH: 'dateOfBirth',
-  SEARCH_DATE_OF_BIRTH: 'searchDateOfBirth',
   EMAIL: 'emailAddress',
   PHONE: 'phoneNumber',
   COUNTRY: 'country',
   ADDRESS_ONE: 'addressOne',
   ADDRESS_TWO: 'addressTwo',
   REGISTRATION_CODE: 'registrationCode',
-  SEARCH_REGISTRATION_CODE: 'searchRegistrationCode',
   POLICY_NUMBER_FAMILY: 'policyNumberFamily',
   POLICY_NUMBER_PERSON: 'policyNumberPerson',
   POLICY_PROVIDER: 'insuranceProvider',
   POLICY_TYPE: 'policyType',
   IS_ACTIVE: 'isActive',
   DISCOUNT_RATE: 'discountRate',
+  SEARCH_FIRST_NAME: 'searchFirstName',
+  SEARCH_LAST_NAME: 'searchLastName',
+  SEARCH_DATE_OF_BIRTH: 'searchDateOfBirth',
+  SEARCH_REGISTRATION_CODE: 'searchRegistrationCode',
   SEARCH_POLICY_NUMBER: 'searchPolicyNumber',
 };
 
@@ -70,16 +70,7 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     invalidMessage: formInputStrings.must_not_be_empty,
     isEditable: true,
   },
-  [FORM_INPUT_KEYS.SEARCH_FIRST_NAME]: {
-    type: FORM_INPUT_TYPES.TEXT,
-    initialValue: '',
-    key: 'firstName',
-    validator: () => true,
-    isRequired: false,
-    label: formInputStrings.first_name,
-    invalidMessage: '',
-    isEditable: true,
-  },
+
   [FORM_INPUT_KEYS.LAST_NAME]: {
     type: FORM_INPUT_TYPES.TEXT,
     initialValue: '',
@@ -88,16 +79,6 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     isRequired: true,
     label: formInputStrings.last_name,
     invalidMessage: formInputStrings.must_not_be_empty,
-    isEditable: true,
-  },
-  [FORM_INPUT_KEYS.SEARCH_LAST_NAME]: {
-    type: FORM_INPUT_TYPES.TEXT,
-    initialValue: '',
-    key: 'lastName',
-    validator: () => true,
-    isRequired: false,
-    label: formInputStrings.last_name,
-    invalidMessage: '',
     isEditable: true,
   },
   [FORM_INPUT_KEYS.CODE]: {
@@ -117,22 +98,6 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     invalidMessage: formInputStrings.must_be_a_date,
     isRequired: true,
     validator: input => {
-      const inputDate = moment(input, 'DD/MM/YYYY', null, true);
-      const isValid = inputDate.isValid();
-      const isDateOfBirth = inputDate.isSameOrBefore(new Date());
-      return isValid && isDateOfBirth;
-    },
-    label: formInputStrings.date_of_birth,
-    isEditable: true,
-  },
-  [FORM_INPUT_KEYS.SEARCH_DATE_OF_BIRTH]: {
-    type: FORM_INPUT_TYPES.DATE,
-    initialValue: '',
-    key: 'dateOfBirth',
-    invalidMessage: formInputStrings.must_be_a_date,
-    isRequired: false,
-    validator: input => {
-      if (input === '') return true;
       const inputDate = moment(input, 'DD/MM/YYYY', null, true);
       const isValid = inputDate.isValid();
       const isDateOfBirth = inputDate.isSameOrBefore(new Date());
@@ -206,16 +171,6 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     invalidMessage: formInputStrings.must_be_between_0_and_50,
     isEditable: true,
   },
-  [FORM_INPUT_KEYS.SEARCH_REGISTRATION_CODE]: {
-    type: FORM_INPUT_TYPES.TEXT,
-    initialValue: '',
-    key: 'registrationCode',
-    validator: () => true,
-    isRequired: false,
-    label: formInputStrings.registration_code,
-    invalidMessage: '',
-    isEditable: true,
-  },
   [FORM_INPUT_KEYS.POLICY_NUMBER_PERSON]: {
     type: FORM_INPUT_TYPES.TEXT,
     initialValue: '',
@@ -273,6 +228,51 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     label: formInputStrings.discount_rate,
     isEditable: true,
   },
+  [FORM_INPUT_KEYS.SEARCH_FIRST_NAME]: {
+    type: FORM_INPUT_TYPES.TEXT,
+    initialValue: '',
+    key: 'firstName',
+    validator: () => true,
+    isRequired: false,
+    label: formInputStrings.first_name,
+    invalidMessage: '',
+    isEditable: true,
+  },
+  [FORM_INPUT_KEYS.SEARCH_LAST_NAME]: {
+    type: FORM_INPUT_TYPES.TEXT,
+    initialValue: '',
+    key: 'lastName',
+    validator: () => true,
+    isRequired: false,
+    label: formInputStrings.last_name,
+    invalidMessage: '',
+    isEditable: true,
+  },
+  [FORM_INPUT_KEYS.SEARCH_DATE_OF_BIRTH]: {
+    type: FORM_INPUT_TYPES.DATE,
+    initialValue: '',
+    key: 'dateOfBirth',
+    invalidMessage: formInputStrings.must_be_a_date,
+    isRequired: false,
+    validator: input => {
+      if (input === '') return true;
+      const inputDate = moment(input, 'DD/MM/YYYY', null, true);
+      const isValid = inputDate.isValid();
+      const isDateOfBirth = inputDate.isSameOrBefore(new Date());
+      return isValid && isDateOfBirth;
+    },
+    label: formInputStrings.date_of_birth,
+    isEditable: true,
+  },
+  [FORM_INPUT_KEYS.SEARCH_REGISTRATION_CODE]: {
+    type: FORM_INPUT_TYPES.TEXT,
+    initialValue: '',
+    key: 'registrationCode',
+    validator: () => true,
+    isRequired: false,
+    label: formInputStrings.registration_code,
+    invalidMessage: '',
+    isEditable: true,
   },
   [FORM_INPUT_KEYS.SEARCH_POLICY_NUMBER]: {
     type: FORM_INPUT_TYPES.TEXT,


### PR DESCRIPTION
Fixes #2749.

## Change summary

Simplifies patient lookup search by policy functionality (replaces person and family number with single policy field). 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

NOTE: does not include wildcard changes (#2776), so make sure to manually prepend/append `@` wildcard to match policy numbers "greedily".

- [ ] Looking up patients by policy number returns all patients with personal policy numbers containing the search string.
- [ ] Looking up patients by policy number returns all patients with family policy numbers containing the search string.
- [ ] Looking up patients by policy number returns all patients with full policy numbers containing the search string (e.g. `12-3` matches a patient with personal policy number `12` and family policy number `345`).

### Related areas to think about

N/A.