### PR TITLE
#2780 reset finalise modal item on go back navigation

### DIFF
--- a/src/actions/FinaliseActions.js
+++ b/src/actions/FinaliseActions.js
@@ -17,11 +17,13 @@ const bugsnagClient = new BugsnagClient();
 export const FINALISE_ACTIONS = {
   OPEN_MODAL: 'Finalise/openModal',
   CLOSE_MODAL: 'Finalise/closeModal',
+  RESET_FINALISE_ITEM: 'Finalise/resetFinaliseItem',
   SET_FINALISE_ITEM: 'Finalise/setFinaliseItem',
 };
 
 const openModal = () => ({ type: FINALISE_ACTIONS.OPEN_MODAL });
 const closeModal = () => ({ type: FINALISE_ACTIONS.CLOSE_MODAL });
+const resetFinaliseItem = () => ({ type: FINALISE_ACTIONS.RESET_FINALISE_ITEM });
 const setFinaliseItem = finaliseItem => ({
   type: FINALISE_ACTIONS.SET_FINALISE_ITEM,
   payload: { finaliseItem },
@@ -44,4 +46,10 @@ const finalise = () => (dispatch, getState) => {
   });
 };
 
-export const FinaliseActions = { openModal, closeModal, setFinaliseItem, finalise };
+export const FinaliseActions = {
+  openModal,
+  closeModal,
+  resetFinaliseItem,
+  setFinaliseItem,
+  finalise,
+};

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -34,6 +34,11 @@ import { PREFERENCE_KEYS } from '../database/utilities/constants';
  *
  */
 
+/**
+ * Action creator for handling back navigation.
+ *
+ * Triggers back navigation and cleans up current state.
+ */
 export const goBack = () => dispatch => {
   if (!RootNavigator.canGoBack()) BackHandler.exitApp();
   else {
@@ -44,16 +49,22 @@ export const goBack = () => dispatch => {
       const prevRouteName = RootNavigator.getPrevRouteName();
       const currRouteName = RootNavigator.getCurrentRouteName();
 
-      if (FINALISABLE_PAGES.includes(currRouteName)) dispatch(FinaliseActions.resetFinaliseItem());
-
-      batch(() => {
+      const navigateBack = () =>
         dispatch({
           ...NavigationActions.back(),
-          payload: {
-            prevRouteName,
-          },
+          payload: { prevRouteName },
         });
+
+      const cleanUp = () => {
         dispatch(PrescriptionActions.deletePrescription());
+        if (FINALISABLE_PAGES.includes(currRouteName)) {
+          dispatch(FinaliseActions.resetFinaliseItem());
+        }
+      };
+
+      batch(() => {
+        navigateBack();
+        cleanUp();
       });
     });
   }
@@ -189,14 +200,13 @@ export const gotoCustomerRequisitions = () =>
 /**
  * Pushes the Supplier Invoices route onto the main navigation stack.
  */
-export const gotoSupplierInvoices = () => {
+export const gotoSupplierInvoices = () =>
   NavigationActions.navigate({
     routeName: ROUTES.SUPPLIER_INVOICES,
     params: {
       title: navStrings.supplier_invoices,
     },
   });
-};
 
 /**
  * Pushes the Supplier Requisitions route onto the main navigation stack.
@@ -212,14 +222,13 @@ export const gotoSupplierRequisitions = () =>
 /**
  * Pushes the Stocktakes route onto the main navigation stack.
  */
-export const gotoStocktakes = () => {
+export const gotoStocktakes = () =>
   NavigationActions.navigate({
     routeName: ROUTES.STOCKTAKES,
     params: {
       title: navStrings.stocktakes,
     },
   });
-};
 
 /**
  * Pushes the Stock route onto the main navigation stack.

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -10,7 +10,7 @@ import { NavigationActions, StackActions } from '@react-navigation/core';
 import { UIDatabase } from '../database';
 import { createRecord } from '../database/utilities';
 import { navStrings } from '../localization';
-import { ROUTES } from './constants';
+import { ROUTES, FINALISABLE_PAGES } from './constants';
 import { RootNavigator } from './RootNavigator';
 import { PrescriptionActions } from '../actions/PrescriptionActions';
 import { FinaliseActions } from '../actions/FinaliseActions';
@@ -41,11 +41,16 @@ export const goBack = () => dispatch => {
       const prescriptions = UIDatabase.objects('Prescription').filtered('status != "finalised"');
       UIDatabase.delete('Transaction', prescriptions);
 
+      const prevRouteName = RootNavigator.getPrevRouteName();
+      const currRouteName = RootNavigator.getCurrentRouteName();
+
+      if (FINALISABLE_PAGES.includes(currRouteName)) dispatch(FinaliseActions.resetFinaliseItem());
+
       batch(() => {
         dispatch({
           ...NavigationActions.back(),
           payload: {
-            prevRouteName: RootNavigator.getPrevRouteName(),
+            prevRouteName,
           },
         });
         dispatch(PrescriptionActions.deletePrescription());
@@ -184,13 +189,14 @@ export const gotoCustomerRequisitions = () =>
 /**
  * Pushes the Supplier Invoices route onto the main navigation stack.
  */
-export const gotoSupplierInvoices = () =>
+export const gotoSupplierInvoices = () => {
   NavigationActions.navigate({
     routeName: ROUTES.SUPPLIER_INVOICES,
     params: {
       title: navStrings.supplier_invoices,
     },
   });
+};
 
 /**
  * Pushes the Supplier Requisitions route onto the main navigation stack.
@@ -206,13 +212,14 @@ export const gotoSupplierRequisitions = () =>
 /**
  * Pushes the Stocktakes route onto the main navigation stack.
  */
-export const gotoStocktakes = () =>
+export const gotoStocktakes = () => {
   NavigationActions.navigate({
     routeName: ROUTES.STOCKTAKES,
     params: {
       title: navStrings.stocktakes,
     },
   });
+};
 
 /**
  * Pushes the Stock route onto the main navigation stack.

--- a/src/reducers/FinaliseReducer.js
+++ b/src/reducers/FinaliseReducer.js
@@ -28,6 +28,10 @@ export const FinaliseReducer = (state = initialState(), action) => {
       return { ...state, finaliseModalOpen: false };
     }
 
+    case FINALISE_ACTIONS.RESET_FINALISE_ITEM: {
+      return { ...state, finaliseItem: null };
+    }
+
     case FINALISE_ACTIONS.SET_FINALISE_ITEM: {
       const { payload } = action;
       const { finaliseItem } = payload;


### PR DESCRIPTION
Fixes #2780.

## Change summary

- Adds `resetFinaliseItem` to `FinaliseActions`.
- Dispatches `resetFinaliseItem` on `goBack` from a finalisable page. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a new customer invoice and navigate back to customer invoices page. No error is thrown on deleting the new invoice.

### Related areas to think about

Not sure if piggybacking onto the `goBack` action is the right way to do this, but seems consistent with other navigation actions. Might need to add some checks to ensure the item is only reset when navigating to `CustomerInvoicesPage`, etc?