### PR TITLE
#2755 fix lookup form buggy behaviour on no matching records

### DIFF
--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -52,7 +52,7 @@ export const useFetch = (url, options = {}, timeout = CONNECTION_TIMEOUT_PERIOD)
             const responseData = await response.json();
             const { error: responseError } = responseData;
             if (responseError) throw new Error(responseError);
-            if (!responseData.length) throw new Error(ERROR_CODES.RESPONSE_NO_RECORDS);
+            if (!responseData.length) throw new Error(ERROR_CODES.EMPTY_RESPONSE);
             if (isMounted.current) setData(responseData);
           } else {
             const connectionError = new Error(ERROR_CODES.CONNECTION_FAILURE);

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -102,9 +102,11 @@ export const SearchFormComponent = ({
 
   const onError = useCallback(responseError => {
     setError(responseError);
+    resetData();
     resetQueryUrl();
   }, []);
 
+  const resetData = useCallback(() => setData(''), []);
   const resetError = useCallback(() => setError(''), []);
   const resetQueryUrl = useCallback(() => setQueryUrl(''), []);
 


### PR DESCRIPTION
Fixes #2755.

## Change summary

- Fixes error code typo preventing error modal on no matching records.
- Fixes data not reset on error.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Searching for a non-existent patient displays the error modal (`"No matching records found"`)
- [ ] Searching for a non-existent prescriber displays the error modal (`"No matching records found"`)
- [ ] After searching for a non-existent patient, no records are displayed from previous queries.
- [ ] After searching for a non-existent prescriber, no records are displayed from previous queries.

### Related areas to think about

Just a quick fix, reminded me of a lot of stuff I don't like about how I've done the current form/hook... but forcing myself to not do any refactoring until after release :cry:.
