### PR TITLE
#2779 fix stocktake batch icon

### DIFF
--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -6,6 +6,7 @@
 import { pageInfoStrings, programStrings, tableStrings } from '../../localization';
 import { MODAL_KEYS, formatDate } from '../../utilities';
 import { ROUTES } from '../../navigation/constants';
+import { MODALS } from '../../widgets/constants';
 import { PageActions } from './actions';
 
 /**
@@ -50,10 +51,10 @@ const PER_PAGE_INFO_COLUMNS = {
     ['entryDate', 'enteredBy'],
     ['customer', 'transactionComment', 'prescriber'],
   ],
-  stocktakeBatchEditModal: [['itemName']],
-  stocktakeBatchEditModalWithReasons: [['itemName']],
-  stocktakeBatchEditModalWithPrices: [['itemName']],
-  stocktakeBatchEditModalWithReasonsAndPrices: [['itemName']],
+  [MODALS.STOCKTAKE_BATCH_EDIT]: [['itemName']],
+  [MODALS.STOCKTAKE_BATCH_EDIT_WITH_REASONS]: [['itemName']],
+  [MODALS.STOCKTAKE_BATCH_EDIT_WITH_PRICES]: [['itemName']],
+  [MODALS.STOCKTAKE_BATCH_EDIT_WITH_REASONS_AND_PRICES]: [['itemName']],
   supplierCredit: [
     ['entryDate', 'confirmDate', 'transactionCategory'],
     ['enteredBy', 'otherParty'],

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -244,6 +244,8 @@ const DataTableRow = React.memo(
                 !rowData.isEditable;
               const iconComponent = isEditReadOnlyRecord ? icons.book : icons[icon];
 
+              const isDisabledIcon = isDisabled && columnKey !== COLUMN_KEYS.BATCH;
+
               return (
                 <TouchableCell
                   key={columnKey}
@@ -253,7 +255,7 @@ const DataTableRow = React.memo(
                   onPress={getCallback(columnKey)}
                   width={width}
                   isLastCell={isLastCell}
-                  isDisabled={isDisabled}
+                  isDisabled={isDisabledIcon}
                   containerStyle={iconCell}
                 />
               );

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -72,11 +72,6 @@ export const StocktakeBatchModalComponent = ({
     return { page: STOCKTAKE_BATCH_EDIT, pageObject };
   }, [stocktakeItem, usingPayments, usingReasons]);
 
-  if (usingReasons) {
-    initialState.page += 'WithReasons';
-    if (usingPayments) initialState.page += 'AndPrices';
-  } else if (usingPayments) initialState.page += 'WithPrices';
-
   const [state, dispatch, instantDebouncedDispatch] = usePageReducer(initialState);
 
   const {


### PR DESCRIPTION
Fixes #2779.

## Change summary

Not the most elegant fix, but gets the job done. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Can view stocktake batch details for finalised stocktakes.

### Related areas to think about

Might need to revist `DataTableRow` disabling logic (maybe I've added workarounds where should be using `dataState`?)
