### PR TITLE
#2773 fix program column not sortable

### DIFF
--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -489,7 +489,7 @@ const COLUMNS = () => ({
     key: COLUMN_KEYS.PROGRAM,
     title: tableStrings.program,
     textAlign: 'left',
-    sortable: false,
+    sortable: true,
     editable: false,
   },
 

--- a/src/utilities/sortDataBy.js
+++ b/src/utilities/sortDataBy.js
@@ -37,6 +37,7 @@ const sortKeyToType = {
   reasonTitle: 'string',
   confirmDate: 'date',
   type: 'string',
+  programName: 'string',
 };
 
 /**


### PR DESCRIPTION
Fixes #2773.

## Change summary

Updates program columns to be sortable.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Stocktakes are sortable by program.
- [ ] Customer requisitions are sortable by program.
- [ ] Supplier requisitions are sortable by program.

### Related areas to think about

N/A.