### PR TITLE
#2768 update stocktake manage page confirm modal conditionals

### DIFF
--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -46,10 +46,13 @@ export const StocktakeManage = ({
   route,
 }) => {
   const runWithLoadingIndicator = useLoadingIndicator();
+
   // On navigating to this screen, if a stocktake is passed through, update the selection with
   // the items already in the stocktake.
   useEffect(() => {
-    if (pageObject) dispatch(PageActions.selectItems(pageObject.itemsInStocktake, route));
+    const { itemsInStocktake = [] } = pageObject ?? {};
+    const stocktakeHasItems = !!itemsInStocktake.length;
+    if (stocktakeHasItems) dispatch(PageActions.selectItems(itemsInStocktake, route));
   }, []);
 
   const getCallback = (colKey, propName) => {
@@ -139,7 +142,7 @@ export const StocktakeManage = ({
       />
 
       <BottomTextEditor
-        isOpen
+        isOpen={hasSelection}
         buttonText={pageObject ? modalStrings.confirm : modalStrings.create}
         value={name}
         placeholder={modalStrings.give_your_stocktake_a_name}

--- a/src/pages/dataTableUtilities/reducer/rowReducers.js
+++ b/src/pages/dataTableUtilities/reducer/rowReducers.js
@@ -104,27 +104,28 @@ export const toggleSelectAll = state => {
 };
 
 /**
- * Sets the rowState of each of the array of items from the undering data
+ * Sets the rowState of each of the array of items from the underlying data
  * in the current store within dataState to true.
  */
 export const selectRows = (state, action) => {
-  const { dataState, keyExtractor } = state;
+  const { dataState, hasSelection, keyExtractor } = state;
   const { payload } = action;
   const { items } = payload;
 
   const newDataState = new Map(dataState);
 
-  items.forEach(item => {
+  const isSelectionUpdated = items.reduce((_, item) => {
     const rowKey = keyExtractor(item);
     newDataState.set(rowKey, { ...dataState.get(rowKey), isSelected: true });
-  });
+    return true;
+  }, false);
 
   return {
     ...state,
     dataState: newDataState,
     showAll: true,
     allSelected: false,
-    hasSelection: true,
+    hasSelection: isSelectionUpdated || hasSelection,
   };
 };
 


### PR DESCRIPTION
Fixes #2768.

May be the case that this fix is not needed, but made a fix while investigating the issue so may as well put it here :rofl:!

THIS IS ONLY FOR REFERENCE, DO NOT REVIEW (will remove this if issue is confirmed).

## Change summary

Stocktake bottom modal is hidden if no items selected.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] If no items selected, confirm modal is closed.
- [ ] If at least one item selected, confirm modal is open.

### Related areas to think about

N/A.