### PR TITLE
#2735 fix prescription undefined title

### DIFF
--- a/src/navigation/utilities.js
+++ b/src/navigation/utilities.js
@@ -31,7 +31,7 @@ export const SCREEN_TITLES = {
   [ROUTES.SUPPLIER_INVOICE]: ({ serialNumber } = {}) => `${navStrings.invoice} ${serialNumber}`,
   [ROUTES.STOCKTAKE_EDITOR]: ({ serialNumber } = {}) => `${navStrings.stocktake} ${serialNumber}`,
   [ROUTES.STOCKTAKE_MANAGER]: () => navStrings.manage_stocktake,
-  [ROUTES.PRESCRIPTION]: ({ serialNumber } = {}) => `${navStrings.invoice} ${serialNumber}`,
+  [ROUTES.PRESCRIPTION]: ({ serialNumber } = {}) => `${navStrings.prescription} ${serialNumber}`,
 };
 
 export const getRouteTitle = (pageObject, routeName) => {

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -466,6 +466,9 @@ const pageInitialisers = {
  * @param    {object}    A mapper from page names to initialisation functions.
  * @returns  {Function}  A lookup function for retrieving page initialisers.
  */
-const getPageInitialiser = pageToInitialiser => page => pageToInitialiser[page];
+const getPageInitialiser = pageToInitialiser => page => {
+  const initialPage = pageToInitialiser[page];
+  return initialPage ?? (pageObject => (pageObject ? { pageObject } : {}));
+};
 
 export default getPageInitialiser(pageInitialisers);

--- a/src/reducers/PagesReducer.js
+++ b/src/reducers/PagesReducer.js
@@ -28,7 +28,7 @@ export const PagesReducer = (state = {}, action) => {
       const { pageObject } = params;
 
       const pageInitialiser = getPageInitialiser(routeName);
-      const pageInitialState = pageInitialiser ? pageInitialiser(pageObject) : pageObject;
+      const pageInitialState = pageInitialiser(pageObject);
 
       return { ...state, [routeName]: pageInitialState, currentRoute: routeName };
     }

--- a/src/reducers/PagesReducer.js
+++ b/src/reducers/PagesReducer.js
@@ -8,6 +8,7 @@ import getPageInitialiser from '../pages/dataTableUtilities/getPageInitialiser';
 
 /**
  * Redux reducer controlling the `pages` field.
+ *
  * @param {Object} state  Redux state, `pages` field.
  * @param {Object} action An action object, following the FSA-standard for action objects
  */
@@ -27,7 +28,7 @@ export const PagesReducer = (state = {}, action) => {
       const { pageObject } = params;
 
       const pageInitialiser = getPageInitialiser(routeName);
-      const pageInitialState = pageInitialiser?.(pageObject);
+      const pageInitialState = pageInitialiser ? pageInitialiser(pageObject) : pageObject;
 
       return { ...state, [routeName]: pageInitialState, currentRoute: routeName };
     }

--- a/src/widgets/BackButton.js
+++ b/src/widgets/BackButton.js
@@ -23,8 +23,7 @@ const mapStateToProps = state => {
   const { pages = {} } = state;
   const { currentRoute = '' } = pages;
   const { [currentRoute]: currentPageState = {} } = pages;
-  const { pageObject } = currentPageState;
-
+  const { pageObject = currentPageState } = currentPageState;
   return { title: getRouteTitle(pageObject, currentRoute) };
 };
 

--- a/src/widgets/BackButton.js
+++ b/src/widgets/BackButton.js
@@ -23,7 +23,7 @@ const mapStateToProps = state => {
   const { pages = {} } = state;
   const { currentRoute = '' } = pages;
   const { [currentRoute]: currentPageState = {} } = pages;
-  const { pageObject = currentPageState } = currentPageState;
+  const { pageObject } = currentPageState;
   return { title: getRouteTitle(pageObject, currentRoute) };
 };
 


### PR DESCRIPTION
Fixes #2735.

## Change summary

Prescription page shape is shallower than, e.g. customer invoice, so `pageObject` was not being passed to `getTitle`

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Prescription title is `"Prescription X"`, where `X` is the serial number of the invoice.

### Related areas to think about

May be that better option is to update the prescription page shape to be consistent with the other pages? Would require adding to initialisers, which I felt might be a bit OTT. Open to suggestions!
