### PR TITLE
#2747 fix patient lookup incorrect date of birth

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -238,7 +238,7 @@ const createPatient = (database, patientDetails) => {
   const firstName = patientFirstName ?? '';
   const lastName = patientLastName ?? '';
   const name = patientName ?? `${patientLastName}, ${patientFirstName}`;
-  const dateOfBirth = patientDateOfBirth ?? new Date();
+  const dateOfBirth = patientDateOfBirth ?? null;
   const emailAddress = patientEmailAddress ?? '';
   const phoneNumber = patientPhoneNumber ?? '';
 

--- a/src/selectors/dispensary.js
+++ b/src/selectors/dispensary.js
@@ -67,7 +67,7 @@ export const selectFilteredData = createSelector(
     const [names, birthYearString] = searchTerm.split(/-d/).map(name => name.trim());
     const [lastName, firstName] = names.split(/,/).map(name => name.trim());
 
-    const birthYearDate = moment(birthYearString || new Date(1900, 0, 0), 'Y', null, true);
+    const birthYearDate = moment(birthYearString, 'Y', null, true);
     const filterByBirthDate = usingPatientsDataSet && birthYearDate.isValid();
 
     let filteredData = lastName ? data.filtered('lastName BEGINSWITH[c] $0', lastName) : data;


### PR DESCRIPTION
Fixes #2747.

## Change summary

Fixes date inconsistencies when adding patients via lookup.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When a patient with a `"N/A"` date of birth is added via lookup, the patient details are correct in the dispensary table.

### Related areas to think about

N/A.