### PR TITLE
#2801 add missing parameter to post sync credit finalisation

### DIFF
--- a/src/sync/PostSyncProcessor.js
+++ b/src/sync/PostSyncProcessor.js
@@ -208,7 +208,7 @@ export class PostSyncProcessor {
     // Auto-finalise all incoming consumer credits.
     if (record.type === 'customer_credit' && !record.isFinalised) {
       funcs.push(() => {
-        record.finalise();
+        record.finalise(this.database);
       });
     }
 


### PR DESCRIPTION
Fixes #2801.

## Change summary

Added missing parameter to customer credit finalisation function... took me forever to trace this!

## Testing

### Setup

- To sync a customer credit to mobile, create a supplier credit for the mobile store on desktop. 
- Customer credits can be viewed in customer invoices (should be finalised, so will have to toggle to `"Past"`.

### Test cases

- [ ] Customer credits are synced to mobile without any errors.
- [ ] Customer credits synced to mobile are auto-finalised.
- [ ] Customer credits synced to mobile cannot be edited.

### Related areas to think about

N/A.