### PR TITLE
#2805 fix months of stock toggle bar styles

### DIFF
--- a/src/globalStyles/toggleBarStyles.js
+++ b/src/globalStyles/toggleBarStyles.js
@@ -14,17 +14,13 @@ export const toggleBarStyles = {
   },
   toggleText: {
     fontFamily: APP_FONT_FAMILY,
-    fontSize: 12,
+    fontSize: 16,
     color: SUSSOL_ORANGE,
   },
   toggleTextSelected: {
     fontFamily: APP_FONT_FAMILY,
-    fontSize: 12,
+    fontSize: 16,
     color: 'white',
-  },
-  toggleOption: {},
-  toggleOptionSelected: {
-    backgroundColor: SUSSOL_ORANGE,
   },
 };
 

--- a/src/widgets/modalChildren/ToggleSelector.js
+++ b/src/widgets/modalChildren/ToggleSelector.js
@@ -31,8 +31,6 @@ export const ToggleSelector = props => {
       style={globalStyles.toggleBar}
       textOffStyle={globalStyles.toggleText}
       textOnStyle={globalStyles.toggleTextSelected}
-      toggleOffStyle={globalStyles.toggleOption}
-      toggleOnStyle={globalStyles.toggleOptionSelected}
       toggles={toggles}
     />
   );


### PR DESCRIPTION
Fixes #2805.

## Change summary

- Fixes months of stock overriding default toggle styles.
- Small increase in months of stock toggle font size.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Toggle bar for supplier requisition months of stock displays correctly.

### Related areas to think about

N/A.
