### PR TITLE
#2764 refresh menu page on navigation focus

### DIFF
--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -6,6 +6,7 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Text, View, ToastAndroid } from 'react-native';
+import { useIsFocused } from '@react-navigation/native';
 
 import { Button } from 'react-native-ui-components';
 import Icon from 'react-native-vector-icons/FontAwesome';
@@ -66,6 +67,8 @@ const Menu = ({
   const { image, originalContainer, moduleContainer, container, bottomIcon, moduleRow } = styles;
 
   const containerStyle = { ...container, ...(usingModules ? moduleContainer : originalContainer) };
+
+  const isFocused = useIsFocused();
 
   const MenuButton = useCallback(
     props => <Button style={menuButton} textStyle={buttonText} {...props} />,
@@ -193,6 +196,8 @@ const Menu = ({
     ),
     [usingModules]
   );
+
+  if (!isFocused) return null;
 
   return (
     <View style={{ ...appBackground }}>


### PR DESCRIPTION
Fixes #2764

## Change summary

- Adds `isFocused` hook to `MenuPage`, triggers rerender on focus.
- Returns `null` if not focused, smoother re-render on back navigation.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Badges refresh correctly on returning to menu page (see issue).

### Related areas to think about

N/A.