### PR TITLE
#2802 fix supplier requisition apply master list parameters

### DIFF
--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -101,7 +101,7 @@ const SupplierRequisition = ({
   const runWithLoadingIndicator = useLoadingIndicator();
 
   const usingReasons = !!UIDatabase.objects('RequisitionReason').length;
-  const onAddMasterLists = React.useCallback(selected => onApplyMasterLists(pageObject, selected), [
+  const onAddMasterLists = React.useCallback(selected => onApplyMasterLists(selected, pageObject), [
     pageObject,
   ]);
 


### PR DESCRIPTION
Fixes #2802.

## Change summary

- `onApplyMasterLists` parameters correctly ordered.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Adding items from master list to supplier requisition does not crash app.

### Related areas to think about

N/A.