### PR TITLE
#2800 fix ISO GMT date parsing

### DIFF
--- a/src/database/utilities/parsers.js
+++ b/src/database/utilities/parsers.js
@@ -21,7 +21,12 @@ export const parseBoolean = booleanString => {
  * @return  {Date}             The Date representing |ISODate| (and |ISOTime|).
  */
 export const parseDate = (ISODate, ISOTime) => {
-  if (!ISODate || ISODate.length < 1 || ISODate === '0000-00-00T00:00:00') {
+  if (
+    !ISODate ||
+    ISODate.length < 1 ||
+    ISODate === '0000-00-00T00:00:00' ||
+    ISODate === '0000-00-00T00:00:00Z'
+  ) {
     return null;
   }
   const date = new Date(ISODate);


### PR DESCRIPTION
Fixes #2800.

## Change summary

One last one before `rc3` :tada:!

Fix `Invalid date` error caused by `parseDate` missing case for default `ISO GMT` date.

## Testing

Caught by bugsnag, so no test case to replicate here! 

- [ ] Date of birth for patients looked up using patient API is `"N/A"` (**not** `Invalid date`) if no record has no date of birth (mSupply API stringifies this as `"0000-00-00T00:00:00Z"`). 

### Related areas to think about

N/A.