### PR TITLE
#2817 fix missing lookup query string separator

### DIFF
--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -42,7 +42,8 @@ const getQueryString = params =>
     const [[key, value]] = Object.entries(param);
     if (!value) return queryString;
     const paramString = `${key}=${SEPARATORS.QUERY_WILDCARD}${value}${SEPARATORS.QUERY_WILDCARD}`;
-    const paramSeparator = queryString.length > 0 ? SEPARATORS.PARAMETERS : SEPARATORS.QUERY_STRING;
+    const paramSeparator =
+      queryString.length > 0 ? SEPARATORS.QUERY_PARAMETERS : SEPARATORS.QUERY_STRING;
     return queryString + paramSeparator + paramString;
   }, '');
 


### PR DESCRIPTION
Fixes #2817.

## Change summary

Lookup queries for more than one field were returning no records due to typo in query string `"&"` constant.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ]  Lookup queries involving multiple fields work correctly (e.g. lookup patient with given first name and last name).

### Related areas to think about

N/A.
