### PR TITLE
#2825 revert increase default toggle font size

### DIFF
--- a/src/globalStyles/toggleBarStyles.js
+++ b/src/globalStyles/toggleBarStyles.js
@@ -14,12 +14,12 @@ export const toggleBarStyles = {
   },
   toggleText: {
     fontFamily: APP_FONT_FAMILY,
-    fontSize: 16,
+    fontSize: 12,
     color: SUSSOL_ORANGE,
   },
   toggleTextSelected: {
     fontFamily: APP_FONT_FAMILY,
-    fontSize: 16,
+    fontSize: 12,
     color: 'white',
   },
 };

--- a/src/widgets/modalChildren/ToggleSelector.js
+++ b/src/widgets/modalChildren/ToggleSelector.js
@@ -29,8 +29,8 @@ export const ToggleSelector = props => {
   return (
     <ToggleBar
       style={globalStyles.toggleBar}
-      textOffStyle={globalStyles.toggleText}
-      textOnStyle={globalStyles.toggleTextSelected}
+      textOnStyle={{ ...globalStyles.toggleTextSelected, fontSize: 14 }}
+      textOffStyle={{ ...globalStyles.toggleText, fontSize: 14 }}
       toggles={toggles}
     />
   );


### PR DESCRIPTION
Fixes #2826.

## Change summary

Reverts font size changes to toggle bar styles (see #2807).

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When viewing a supplier requisition, the `"Show/Hide over stocked"` toggle button text is not too large.
- [ ] When updating a supplier requisition months of stock, `"1 2 ... 6"` toggle bar text is not too small.

### Related areas to think about

N/A.
