### PR TITLE
#2825 fix error on updating indicator selection

### DIFF
--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -213,10 +213,9 @@ export const toggleIndicators = state => {
 export const selectIndicator = (state, action) => {
   const { payload } = action;
   const { indicatorCode } = payload;
-
   const { indicators } = state;
 
-  const [currentIndicator] = indicators.filtered('code == $0', indicatorCode);
+  const currentIndicator = indicators.find(indicator => indicator.code === indicatorCode);
   const indicatorColumns = currentIndicator?.columns;
   const indicatorRows = currentIndicator?.rows;
 


### PR DESCRIPTION
Fixes #2825.

## Change summary

Indicators reducer was calling a realm method on a plain JS array (throws an error on develop, but just silently fails on build).

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Customer requisition indicator dropdown correctly updates the data table.
- [ ] Supplier requisition indicator dropdown correctly updates the data table.

### Related areas to think about

N/A.