### PR TITLE
#2822 update supplier invoice batch column

### DIFF
--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -499,7 +499,8 @@ const COLUMNS = () => ({
     type: COLUMN_TYPES.EDITABLE_STRING,
     key: COLUMN_KEYS.BATCH,
     title: tableStrings.batch_name,
-    alignText: 'center',
+    alignText: 'left',
+    sortable: true,
     editable: true,
   },
   [COLUMN_NAMES.EDITABLE_COMMENT]: {


### PR DESCRIPTION
Fixes #2822.

## Change summary

Minor tweak to `BATCH_NAME` column config.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Unfinalised supplier invoice items are sortable by batch name.
- [ ] Unfinalised supplier invoice batch names are left-aligned.

### Related areas to think about

N/A.