### PR TITLE
#2821 fix supplier credit page info

### DIFF
--- a/src/navigation/constants.js
+++ b/src/navigation/constants.js
@@ -25,6 +25,7 @@ export const ROUTES = {
   CUSTOMER_INVOICE: 'customerInvoice',
   CUSTOMER_INVOICES: 'customerInvoices',
 
+  SUPPLIER_CREDIT: 'supplierCredit',
   SUPPLIER_INVOICE: 'supplierInvoice',
   SUPPLIER_INVOICE_WITH_PRICES: 'supplierInvoiceWithPrices',
   SUPPLIER_INVOICES: 'supplierInvoices',

--- a/src/navigation/utilities.js
+++ b/src/navigation/utilities.js
@@ -28,7 +28,8 @@ export const SCREEN_TITLES = {
     `${navStrings.requisition} ${serialNumber}`,
   [ROUTES.CUSTOMER_INVOICE]: ({ isCredit, serialNumber } = {}) =>
     `${isCredit ? navStrings.credit : navStrings.invoice} ${serialNumber}`,
-  [ROUTES.SUPPLIER_INVOICE]: ({ serialNumber } = {}) => `${navStrings.invoice} ${serialNumber}`,
+  [ROUTES.SUPPLIER_INVOICE]: ({ isCredit, serialNumber } = {}) =>
+    `${isCredit ? navStrings.credit : navStrings.invoice} ${serialNumber}`,
   [ROUTES.STOCKTAKE_EDITOR]: ({ serialNumber } = {}) => `${navStrings.stocktake} ${serialNumber}`,
   [ROUTES.STOCKTAKE_MANAGER]: () => navStrings.manage_stocktake,
   [ROUTES.PRESCRIPTION]: ({ serialNumber } = {}) => `${navStrings.prescription} ${serialNumber}`,

--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -55,7 +55,7 @@ const PER_PAGE_INFO_COLUMNS = {
   [MODALS.STOCKTAKE_BATCH_EDIT_WITH_REASONS]: [['itemName']],
   [MODALS.STOCKTAKE_BATCH_EDIT_WITH_PRICES]: [['itemName']],
   [MODALS.STOCKTAKE_BATCH_EDIT_WITH_REASONS_AND_PRICES]: [['itemName']],
-  supplierCredit: [
+  [ROUTES.SUPPLIER_CREDIT]: [
     ['entryDate', 'confirmDate', 'transactionCategory'],
     ['enteredBy', 'otherParty'],
   ],
@@ -71,7 +71,7 @@ const PAGE_INFO_ROWS = (pageObject, dispatch, route) => ({
     info: formatDate(pageObject.confirmDate),
   },
   transactionCategory: {
-    title: `${pageInfoStrings.entered_by}:`,
+    title: `${pageInfoStrings.category}:`,
     info: pageObject?.category?.name ?? '',
   },
   enteredBy: {


### PR DESCRIPTION
Fixes #2821.

## Change summary

Fixes supplier credit page title/page info.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Supplier credit page title is `"Credit X"`, where `X` is the invoice number.
- [ ] Supplier credit page info includes: `"Entry Date"`, `"Confirm Date"`, `"Category"`, `"Entered By"`, `"Supplier"`. 

### Related areas to think about

N/A.
