### PR TITLE
#2666 fix null last sync

### DIFF
--- a/src/widgets/SyncState.js
+++ b/src/widgets/SyncState.js
@@ -33,7 +33,7 @@ export const SyncStateComponent = ({
   onOpenSyncModal,
 }) => {
   const syncMessage = isSyncing ? syncStrings.sync_in_progress : syncStrings.sync_enabled;
-  const formattedDate = formatDate(lastSyncTime, 'dots');
+  const formattedDate = formatDate(new Date(lastSyncTime), 'dots');
   const errorText = `${syncStrings.sync_error}. ${syncStrings.last_sync} ${formattedDate}`;
   const hasError = !!errorMessage?.length;
 


### PR DESCRIPTION
Fixes #2666.

## Change summary

Fixes last sync date displaying as `null`.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Manually sync before stopping the server. Attempt to sync and close the modal. The last sync date displays correctly in the top-right of page.

### Related areas to think about

N/A.
