### PR TITLE
#2842 update date parsing to handle timezone offsets (v4)

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -38,7 +38,12 @@ export const parseNumber = numberString => {
  * @return  {Date}             The Date representing |ISODate| (and |ISOTime|).
  */
 export const parseDate = (ISODate, ISOTime) => {
-  if (!ISODate || ISODate.length < 1 || ISODate === '0000-00-00T00:00:00') {
+  if (
+    !ISODate ||
+    ISODate.length < 1 ||
+    ISODate === '0000-00-00T00:00:00' ||
+    ISODate === '0000-00-00T00:00:00Z'
+  ) {
     return null;
   }
   const date = new Date(ISODate);


### PR DESCRIPTION
Fixes #2842.

## Change summary

Adds support for GMT timezone offset to date parsing logic.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Initial sync with mSupply desktop `v10` is successful without errors.
- [ ] Initial sync with mSupply desktop `v11` is successful without errors.

### Related areas to think about

N/A.
