### PR TITLE
#2845 add mobile version header

### DIFF
--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -57,7 +57,10 @@ export class Synchroniser {
     this.settings = settings;
     this.syncQueue = new SyncQueue(this.database);
     this.dispatch = dispatch;
-    this.extraHeaders = { 'msupply-site-uuid': DeviceInfo.getUniqueId() };
+    this.extraHeaders = {
+      'msupply-site-uuid': DeviceInfo.getUniqueId(),
+      'mobile-version': '5.0.0',
+    };
     this.refreshSyncParams();
     if (this.isInitialised()) this.syncQueue.enable();
   }

--- a/src/sync/Synchroniser.js
+++ b/src/sync/Synchroniser.js
@@ -6,10 +6,7 @@
 /* eslint-disable no-await-in-loop */
 
 import DeviceInfo from 'react-native-device-info';
-
 import { Client as BugsnagClient } from 'bugsnag-react-native';
-
-import { syncStrings } from '../localization/index';
 
 import {
   incrementSyncProgress,
@@ -20,11 +17,14 @@ import {
   setSyncIsSyncing,
   setSyncCompletionTime,
 } from '../actions';
+import { syncStrings } from '../localization';
 import { integrateRecord } from './incomingSyncUtils';
 import { generateSyncJson } from './outgoingSyncUtils';
 import { SyncDatabase } from './SyncDatabase';
 import { SyncQueue } from './SyncQueue';
 import { SETTINGS_KEYS } from '../settings';
+
+import { version as mobileVersion } from '../../package.json';
 
 const bugsnagClient = new BugsnagClient();
 
@@ -59,8 +59,9 @@ export class Synchroniser {
     this.dispatch = dispatch;
     this.extraHeaders = {
       'msupply-site-uuid': DeviceInfo.getUniqueId(),
-      'mobile-version': '5.0.0',
+      'mobile-version': mobileVersion,
     };
+    console.log(this.extraHeaders);
     this.refreshSyncParams();
     if (this.isInitialised()) this.syncQueue.enable();
   }


### PR DESCRIPTION
Fixes #2845.

## Change summary

Hotfix for `v5.0.2`.

## Testing

### Setup

- Get version header desktop structure [here](https://github.com/sussol/msupply/pull/6230).

### Test cases 

- [ ] Initial sync with `v4.10` occurs without error.
- [ ] Initial sync with `v4.11` occurs without error.
- [ ] Initial sync with `#6230` occurs without error.
- [ ] On sync with `v4.10`, incoming dates are formatted as ISO **GMT** (see note below).
- [ ] On sync with `v4.11`, incoming dates are formatted as ISO **GMT** (see note below).
- [ ] On sync with `#6230`, incoming dates are formatted as ISO **GMT** (see note below).

Note: log `parseDate` inputs and check for the timezone offset, e.g. `"Z"` (not sure how this can be tested in production!)

### Related areas to think about

N/A.