### PR TITLE
#2851 fix sync error on name merge

### DIFF
--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -360,6 +360,7 @@ export const generateSyncJson = (database, settings, syncOutRecord) => {
         content.syncSite = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_SITE_NAME);
         content.record = syncOutRecord;
       });
+      error.canDeleteSyncOut = true;
       throw error;
     }
     if (recordResults.length > 1) {


### PR DESCRIPTION
Fixes #2851.

## Change summary

Hotfix for sync throwing error on name merge.

## Testing

### Setup

- Create two names on desktop (customers or suppliers).
- Associate each name with a master list.
- Sync to mobile.
- Merge the two names.
- Sync to mobile (if needed press manual sync twice, ensure no records are waiting).

## Test cases

- [ ] Sync does not cause an error.

### Related areas to think about

N/A.
