### PR TITLE
#2742 auto apply vvm status to batch

### DIFF
--- a/src/actions/TemperatureSyncActions.js
+++ b/src/actions/TemperatureSyncActions.js
@@ -244,7 +244,7 @@ const syncTemperatures = () => async (dispatch, getState) => {
   const { temperatureSync } = getState();
   const { isSyncing } = temperatureSync;
 
-  const sensors = UIDatabase.objects('Sensor').filtered('location != null');
+  const sensors = UIDatabase.objects('Sensor').filtered('location != null && isActive == true');
   const { length: numberOfSensors } = sensors;
 
   if (isSyncing) return null;

--- a/src/database/DataTypes/Sensor.js
+++ b/src/database/DataTypes/Sensor.js
@@ -62,6 +62,7 @@ Sensor.schema = {
     location: { type: 'Location', optional: true },
     batteryLevel: { type: 'double', default: 0 },
     sensorLogs: { type: 'linkingObjects', objectType: 'SensorLog', property: 'sensor' },
+    isActive: { type: 'bool', default: true },
   },
 };
 

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -802,10 +802,9 @@ const createStocktakeBatch = (database, stocktakeItem, itemBatch) => {
     batch,
     costPrice,
     sellPrice,
+    currentVvmStatus,
   } = itemBatch;
   const { isVaccine } = item;
-
-  const vaccineVialMonitorStatus = database.objects('VaccineVialMonitorStatus').sorted('level')[0];
 
   const stocktakeBatch = database.create('StocktakeBatch', {
     id: generateUUID(),
@@ -820,8 +819,8 @@ const createStocktakeBatch = (database, stocktakeItem, itemBatch) => {
     sellPrice,
     sortIndex: (stocktakeItem?.stocktake?.numberOfBatches || 0) + 1 || 1,
 
-    // If the underlying item is a vaccine, auto apply a VVM status
-    vaccineVialMonitorStatus: isVaccine ? vaccineVialMonitorStatus : null,
+    // If the underlying item is a vaccine, auto apply the current itembatches VVM status.
+    vaccineVialMonitorStatus: isVaccine ? currentVvmStatus : null,
   });
 
   stocktakeItem.addBatch(stocktakeBatch);
@@ -868,9 +867,17 @@ const createSupplierInvoice = (database, supplier, user) => {
  * @return  {TransactionBatch}
  */
 const createTransactionBatch = (database, transactionItem, itemBatch, isAddition = true) => {
-  const { item, batch, expiryDate, packSize, costPrice, sellPrice, donor } = itemBatch;
+  const {
+    item,
+    batch,
+    expiryDate,
+    packSize,
+    costPrice,
+    sellPrice,
+    donor,
+    currentVvmStatus,
+  } = itemBatch;
   const { transaction, note } = transactionItem || {};
-  const vaccineVialMonitorStatus = database.objects('VaccineVialMonitorStatus').sorted('level')[0];
   const { isVaccine } = item;
 
   const transactionBatch = database.create('TransactionBatch', {
@@ -890,8 +897,8 @@ const createTransactionBatch = (database, transactionItem, itemBatch, isAddition
     type: isAddition ? 'stock_in' : 'stock_out',
     sortIndex: (transactionItem?.transaction?.numberOfBatches || 0) + 1 || 1,
 
-    // If the underlying item is a vaccine, auto apply a VVM status.
-    vaccineVialMonitorStatus: isVaccine ? vaccineVialMonitorStatus : null,
+    // If the underlying item is a vaccine, auto apply the current itembatches VVM status.
+    vaccineVialMonitorStatus: isVaccine ? currentVvmStatus : null,
   });
 
   transactionItem.addBatch(transactionBatch);

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -284,7 +284,7 @@ export const toggleFridges = state => {
 };
 
 export const toggleSensors = state => {
-  const backingData = UIDatabase.objects('Sensor');
+  const backingData = UIDatabase.objects('Sensor').filtered('isActive == true');
   const data = backingData.slice();
 
   return {

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -266,7 +266,7 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
     },
     Location: { cannotBeBlank: [], canBeBlank: ['Description', 'code', 'type_ID'] },
     LocationType: { cannotBeBlank: [], canBeBlank: ['Description'] },
-    Sensor: { cannotBeBlank: ['macAddress', 'name'], canBeBlank: ['batteryLevel'] },
+    Sensor: { cannotBeBlank: ['macAddress', 'name'], canBeBlank: ['batteryLevel', 'is_active'] },
     TemperatureBreachConfiguration: {
       cannotBeBlank: [
         'minimum_temperature',
@@ -1032,6 +1032,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         location: database.getOrCreate('Location', record.locationID),
         batteryLevel: parseNumber(record.batteryLevel),
         name: record.name,
+        isActive: record.is_active,
       });
       break;
     }

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -369,6 +369,7 @@ const generateSyncData = (settings, recordType, record) => {
         batteryLevel: String(record.batteryLevel),
         storeID: settings.get(THIS_STORE_ID),
         locationID: record.location?.id,
+        isActive: record.isActive,
       };
     }
     case 'Location': {


### PR DESCRIPTION
Fixes #2742 

## Change summary

- Auto applies the lowest level VVM status to item batches when created.
- Auto applies the underlying item batches current vvm status to a `TransactionBatch` when created.
- Auto applies the underlying item batches current vvm status to a `StocktakeBatch` when created.

## Testing

N/A

### Related areas to think about

N/A
