### PR TITLE
#2739 date pickers on charts

### DIFF
--- a/src/actions/FridgeActions.js
+++ b/src/actions/FridgeActions.js
@@ -5,10 +5,16 @@
 
 export const FRIDGE_ACTIONS = {
   SELECT: 'FridgeActions/select',
+  CHANGE_TO_DATE: 'FridgeActions/changeToDate',
+  CHANGE_FROM_DATE: 'FridgeActions/changeFromDate',
 };
 
 const select = fridge => ({ type: FRIDGE_ACTIONS.SELECT, payload: { fridge } });
+const changeToDate = date => ({ type: FRIDGE_ACTIONS.CHANGE_TO_DATE, payload: { date } });
+const changeFromDate = date => ({ type: FRIDGE_ACTIONS.CHANGE_FROM_DATE, payload: { date } });
 
 export const FridgeActions = {
   select,
+  changeToDate,
+  changeFromDate,
 };

--- a/src/hooks/useDatePicker.js
+++ b/src/hooks/useDatePicker.js
@@ -1,0 +1,42 @@
+/* eslint-disable import/prefer-default-export */
+import React from 'react';
+
+/**
+ * Hook to simplify the use of the native date picker component by unwrapping
+ * the callback event and firing the callback only when the date is changing,
+ * providing a value to conditionally render the native picker and a callback
+ * to set the render value.
+ *
+ * Pass an onChange callback which will be called when a new date is selected
+ * from the datepicker and not when cancelled or dismissed, with a JS date object
+ * rather than a nativeEvent.
+ *
+ * @param  {Func}  callback callback
+ * @return {Array} [
+ * datePickerIsOpen: boolean indicator whether the date picker is open.
+ * openDatePicker: Callback function to set the datePickerIsOpen to true.
+ * datePickerCallback: Wrapped callback, triggered on changing the date in the picker,
+ * returning a JS date object.
+ * ]
+ */
+export const useDatePicker = onChangeCallback => {
+  const [datePickerIsOpen, setDatePickerIsOpen] = React.useState(false);
+
+  const datePickerCallback = React.useCallback(
+    event => {
+      setDatePickerIsOpen(false);
+      const { type, nativeEvent } = event;
+      if (type === 'set' && onChangeCallback) {
+        const { timestamp } = nativeEvent;
+        onChangeCallback(new Date(timestamp));
+      }
+    },
+    [onChangeCallback]
+  );
+
+  const openDatePicker = React.useCallback(() => {
+    setDatePickerIsOpen(true);
+  }, []);
+
+  return [datePickerIsOpen, openDatePicker, datePickerCallback];
+};

--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -49,7 +49,8 @@
     "days": "days",
     "hours": "hours",
     "minutes": "minutes",
-    "no_location_types": "You don't have any location types. Contact your administrator."
+    "no_location_types": "You don't have any location types. Contact your administrator.",
+    "from": "from"
   },
   "fr": {
     "must_be_a_number_between": "Doit être un nombre entre",

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -8,7 +8,8 @@
     "no_fridges": "No Fridges",
     "temperature_breaches_for": "Temperature breaches for",
     "fridges": "Fridges",
-    "sensors": "Sensors"
+    "sensors": "Sensors",
+    "oops_no_temperatures": "Oops! There are no temperatures recorded during this time"
   },
   "fr": {},
   "gil": {},

--- a/src/reducers/FridgeReducer.js
+++ b/src/reducers/FridgeReducer.js
@@ -14,7 +14,7 @@ const initialState = () => {
     fridges,
     selectedFridge: fridges[0],
     fromDate: moment(new Date())
-      .subtract(150, 'd')
+      .subtract(30, 'd')
       .toDate(),
     toDate: new Date(),
   };

--- a/src/reducers/FridgeReducer.js
+++ b/src/reducers/FridgeReducer.js
@@ -35,13 +35,14 @@ export const FridgeReducer = (state = initialState(), action) => {
       const { payload } = action;
       const { date } = payload;
 
-      return { ...state, toDate: date };
+      return { ...state, fromDate: date };
     }
+
     case FRIDGE_ACTIONS.CHANGE_TO_DATE: {
       const { payload } = action;
       const { date } = payload;
 
-      return { ...state, fromDate: date };
+      return { ...state, toDate: date };
     }
 
     default:

--- a/src/reducers/FridgeReducer.js
+++ b/src/reducers/FridgeReducer.js
@@ -14,7 +14,7 @@ const initialState = () => {
     fridges,
     selectedFridge: fridges[0],
     fromDate: moment(new Date())
-      .subtract(30, 'd')
+      .subtract(150, 'd')
       .toDate(),
     toDate: new Date(),
   };
@@ -30,6 +30,20 @@ export const FridgeReducer = (state = initialState(), action) => {
 
       return { ...state, selectedFridge: fridge };
     }
+
+    case FRIDGE_ACTIONS.CHANGE_FROM_DATE: {
+      const { payload } = action;
+      const { date } = payload;
+
+      return { ...state, toDate: date };
+    }
+    case FRIDGE_ACTIONS.CHANGE_TO_DATE: {
+      const { payload } = action;
+      const { date } = payload;
+
+      return { ...state, fromDate: date };
+    }
+
     default:
       return state;
   }

--- a/src/selectors/fridge.js
+++ b/src/selectors/fridge.js
@@ -57,7 +57,7 @@ export const selectChunkedTemperatureLogs = createSelector(
   }
 );
 
-export const selectMinAndMaxLogs = createSelector(selectChunkedTemperatureLogs, logs =>
+export const selectMinAndMaxLogs = createSelector([selectChunkedTemperatureLogs], logs =>
   logs.reduce(
     (acc, logGroup) => {
       const temperatures = logGroup.map(({ temperature }) => temperature);
@@ -65,7 +65,6 @@ export const selectMinAndMaxLogs = createSelector(selectChunkedTemperatureLogs, 
 
       const maxTemperature = Math.max(...temperatures);
       const minTemperature = Math.min(...temperatures);
-
       const timestamp = Math.min(...timestamps);
 
       const { minLine, maxLine } = acc;
@@ -79,7 +78,7 @@ export const selectMinAndMaxLogs = createSelector(selectChunkedTemperatureLogs, 
   )
 );
 
-export const selectMinAndMaxDomains = createSelector(selectMinAndMaxLogs, minAndMaxLogs => {
+export const selectMinAndMaxDomains = createSelector([selectMinAndMaxLogs], minAndMaxLogs => {
   const { minLine, maxLine } = minAndMaxLogs;
 
   return {
@@ -88,8 +87,16 @@ export const selectMinAndMaxDomains = createSelector(selectMinAndMaxLogs, minAnd
   };
 });
 
-export const selectBreaches = createSelector([selectSelectedFridge], fridge => {
-  const { breaches } = fridge ?? {};
+export const selectBreaches = createSelector(
+  [selectTemperatureLogsFromDate, selectTemperatureLogsToDate, selectSelectedFridge],
+  (fromDate, toDate, fridge) => {
+    const { breaches } = fridge ?? {};
+    const breachesInDateRange = breaches.filtered(
+      'startTimestamp >= $0 && endTimestamp <= $1',
+      fromDate,
+      toDate
+    );
 
-  return breaches;
-});
+    return breachesInDateRange;
+  }
+);

--- a/src/selectors/fridge.js
+++ b/src/selectors/fridge.js
@@ -91,7 +91,7 @@ export const selectBreaches = createSelector(
   [selectTemperatureLogsFromDate, selectTemperatureLogsToDate, selectSelectedFridge],
   (fromDate, toDate, fridge) => {
     const { breaches } = fridge ?? {};
-    const breachesInDateRange = breaches.filtered(
+    const breachesInDateRange = breaches?.filtered(
       'startTimestamp >= $0 && endTimestamp <= $0',
       fromDate
     );

--- a/src/selectors/fridge.js
+++ b/src/selectors/fridge.js
@@ -92,9 +92,8 @@ export const selectBreaches = createSelector(
   (fromDate, toDate, fridge) => {
     const { breaches } = fridge ?? {};
     const breachesInDateRange = breaches.filtered(
-      'startTimestamp >= $0 && endTimestamp <= $1',
-      fromDate,
-      toDate
+      'startTimestamp >= $0 && endTimestamp <= $0',
+      fromDate
     );
 
     return breachesInDateRange;

--- a/src/widgets/DatePickerButton.js
+++ b/src/widgets/DatePickerButton.js
@@ -1,0 +1,44 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+import React from 'react';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import PropTypes from 'prop-types';
+
+import { CircleButton } from './CircleButton';
+import { CalendarIcon } from './icons';
+
+import { useDatePicker } from '../hooks/useDatePicker';
+
+export const DatePickerButton = ({ initialValue, onDateChanged, maximumDate, minimumDate }) => {
+  const [datePickerIsOpen, openDatePicker, datePickerCallback] = useDatePicker(onDateChanged);
+  return (
+    <>
+      <CircleButton IconComponent={CalendarIcon} onPress={openDatePicker} />
+      {datePickerIsOpen && (
+        <DateTimePicker
+          maximumDate={maximumDate}
+          minimumDate={minimumDate}
+          onChange={datePickerCallback}
+          mode="date"
+          display="spinner"
+          value={initialValue}
+        />
+      )}
+    </>
+  );
+};
+
+DatePickerButton.defaultProps = {
+  minimumDate: undefined,
+  maximumDate: undefined,
+};
+
+DatePickerButton.propTypes = {
+  initialValue: PropTypes.instanceOf(Date).isRequired,
+  onDateChanged: PropTypes.func.isRequired,
+  maximumDate: PropTypes.instanceOf(Date),
+  minimumDate: PropTypes.instanceOf(Date),
+};

--- a/src/widgets/DateRangeSelector.js
+++ b/src/widgets/DateRangeSelector.js
@@ -1,0 +1,76 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+import React from 'react';
+import { Text, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+
+import { DatePickerButton } from './DatePickerButton';
+import { FlexRow } from './FlexRow';
+import { FlexColumn } from './FlexColumn';
+
+import { textStyles, SUSSOL_ORANGE } from '../globalStyles';
+import { generalStrings } from '../localization/index';
+
+export const DateRangeSelector = ({
+  initialStartDate,
+  initialEndDate,
+  onChangeFromDate,
+  onChangeToDate,
+  labelTextStyle,
+  dateTextStyle,
+}) => {
+  const formattedStartDate = moment(initialStartDate).format('D/M/YYYY');
+  const formattedEndDate = moment(initialEndDate).format('D/M/YYYY');
+
+  return (
+    <FlexRow flex={1} alignItems="center">
+      <FlexRow alignItems="center">
+        <FlexColumn>
+          <Text style={labelTextStyle}>{generalStrings.from}</Text>
+          <Text style={dateTextStyle}>{formattedStartDate}</Text>
+        </FlexColumn>
+        <DatePickerButton
+          maximumDate={initialEndDate}
+          initialValue={initialStartDate}
+          onDateChanged={onChangeFromDate}
+        />
+      </FlexRow>
+
+      <FlexRow alignItems="center">
+        <Text style={dateTextStyle}> ___ </Text>
+        <FlexColumn>
+          <Text style={labelTextStyle}>{generalStrings.to}</Text>
+          <Text style={dateTextStyle}>{formattedEndDate}</Text>
+        </FlexColumn>
+        <DatePickerButton
+          minimumDate={initialStartDate}
+          initialValue={initialEndDate}
+          onDateChanged={onChangeToDate}
+        />
+      </FlexRow>
+    </FlexRow>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  dateText: { ...textStyles, marginHorizontal: 10 },
+  labelText: { ...textStyles, marginHorizontal: 10, fontWeight: 'bold', color: SUSSOL_ORANGE },
+});
+
+DateRangeSelector.defaultProps = {
+  labelTextStyle: localStyles.labelText,
+  dateTextStyle: localStyles.dateText,
+};
+
+DateRangeSelector.propTypes = {
+  initialStartDate: PropTypes.instanceOf(Date).isRequired,
+  initialEndDate: PropTypes.instanceOf(Date).isRequired,
+  onChangeFromDate: PropTypes.func.isRequired,
+  onChangeToDate: PropTypes.func.isRequired,
+  labelTextStyle: PropTypes.object,
+  dateTextStyle: PropTypes.object,
+};

--- a/src/widgets/FridgeDisplay.js
+++ b/src/widgets/FridgeDisplay.js
@@ -5,13 +5,13 @@
  */
 
 import React from 'react';
-import { View, StyleSheet, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import { VaccineChart } from './VaccineChart';
 import { FridgeDisplayInfo } from './FridgeDisplayInfo';
-import { WHITE, SUSSOL_ORANGE } from '../globalStyles';
+import { textStyles, WHITE, SUSSOL_ORANGE } from '../globalStyles';
 import { FlexView } from './FlexView';
 
 import { FridgeActions } from '../actions/FridgeActions';
@@ -39,12 +39,23 @@ export const FridgeDisplayComponent = ({
   const [render, setRender] = React.useState(false);
 
   React.useEffect(() => {
-    setTimeout(() => setRender(isActive), 1000);
+    setTimeout(() => setRender(isActive), 500);
   }, [isActive]);
+
+  const NoLogsComponent = React.useCallback(
+    () => (
+      <FlexView justifyContent="center" alignItems="center">
+        <Text style={{ ...textStyles }}>
+          Oops! There are no temperatures recorded during this time
+        </Text>
+      </FlexView>
+    ),
+    []
+  );
 
   const Chart = React.useCallback(
     () =>
-      render && minLine?.length ? (
+      render ? (
         <VaccineChart
           minLine={minLine}
           maxDomain={maxDomain}
@@ -73,7 +84,7 @@ export const FridgeDisplayComponent = ({
         onChangeToDate={onChangeToDate}
       />
 
-      {isActive ? <Chart /> : null}
+      {isActive ? (minLine.length && <Chart />) || <NoLogsComponent /> : null}
     </View>
   );
 };

--- a/src/widgets/FridgeDisplay.js
+++ b/src/widgets/FridgeDisplay.js
@@ -16,6 +16,7 @@ import { FlexView } from './FlexView';
 
 import { FridgeActions } from '../actions/FridgeActions';
 import { selectTemperatureLogsFromDate, selectTemperatureLogsToDate } from '../selectors/fridge';
+import { vaccineStrings } from '../localization';
 
 export const FridgeDisplayComponent = ({
   minLine,
@@ -45,9 +46,7 @@ export const FridgeDisplayComponent = ({
   const NoLogsComponent = React.useCallback(
     () => (
       <FlexView justifyContent="center" alignItems="center">
-        <Text style={{ ...textStyles }}>
-          Oops! There are no temperatures recorded during this time
-        </Text>
+        <Text style={{ ...textStyles }}>{vaccineStrings.oops_no_temperatures}</Text>
       </FlexView>
     ),
     []

--- a/src/widgets/FridgeDisplayInfo.js
+++ b/src/widgets/FridgeDisplayInfo.js
@@ -12,13 +12,22 @@ import { UIDatabase } from '../database';
 import { formatTemperatureExposure, formatTemperature } from '../utilities/formatters';
 
 import { FlexRow } from './FlexRow';
-import { ChevronDownIcon } from './icons';
+import { ChevronDownIcon, ChevronUpIcon } from './icons';
 import { SimpleLabel } from './SimpleLabel';
 
-import { WHITE, SUSSOL_ORANGE } from '../globalStyles';
+import { SUSSOL_ORANGE } from '../globalStyles';
 import { vaccineStrings } from '../localization';
+import { DateRangeSelector } from './DateRangeSelector';
 
-export const FridgeDisplayInfo = ({ fridge, isActive, onPress }) => {
+export const FridgeDisplayInfo = ({
+  fridge,
+  isActive,
+  onPress,
+  onChangeFromDate,
+  onChangeToDate,
+  fromDate,
+  toDate,
+}) => {
   const { description, currentTemperature, temperatureExposure, numberOfBreaches } = fridge;
 
   const Container = isActive ? View : TouchableOpacity;
@@ -26,10 +35,19 @@ export const FridgeDisplayInfo = ({ fridge, isActive, onPress }) => {
   const onSelectFridge = React.useCallback(() => onPress(fridge), []);
 
   return (
-    <Container onPress={onSelectFridge} style={localStyles.container}>
-      <FlexRow flex={1} justifyContent="space-between" alignItems="center">
+    <Container onPress={onSelectFridge}>
+      <FlexRow
+        flex={1}
+        justifyContent="space-between"
+        alignItems="center"
+        style={localStyles.container}
+      >
         <FlexRow flex={1} justifyContent="space-evenly">
-          <ChevronDownIcon color={isActive ? WHITE : SUSSOL_ORANGE} style={localStyles.icon} />
+          {isActive ? (
+            <ChevronUpIcon color={SUSSOL_ORANGE} style={localStyles.icon} />
+          ) : (
+            <ChevronDownIcon color={SUSSOL_ORANGE} style={localStyles.icon} />
+          )}
           <SimpleLabel
             label={description}
             size="large"
@@ -60,12 +78,24 @@ export const FridgeDisplayInfo = ({ fridge, isActive, onPress }) => {
           />
         </FlexRow>
       </FlexRow>
+
+      {isActive ? (
+        <FlexRow style={localStyles.datePickerRow}>
+          <DateRangeSelector
+            initialStartDate={fromDate}
+            initialEndDate={toDate}
+            onChangeToDate={onChangeFromDate}
+            onChangeFromDate={onChangeToDate}
+          />
+        </FlexRow>
+      ) : null}
     </Container>
   );
 };
 
 const localStyles = StyleSheet.create({
-  container: { height: 25, marginTop: 10, marginHorizontal: 10 },
+  container: { height: 30, marginTop: 20, marginHorizontal: 10 },
+  datePickerRow: { marginTop: 50, marginHorizontal: 10, height: 15 },
   icon: { marginRight: 10 },
 });
 
@@ -73,4 +103,8 @@ FridgeDisplayInfo.propTypes = {
   fridge: PropTypes.object.isRequired,
   isActive: PropTypes.bool.isRequired,
   onPress: PropTypes.func.isRequired,
+  onChangeFromDate: PropTypes.func.isRequired,
+  onChangeToDate: PropTypes.func.isRequired,
+  fromDate: PropTypes.instanceOf(Date).isRequired,
+  toDate: PropTypes.instanceOf(Date).isRequired,
 };

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -81,6 +81,16 @@ ChevronDownIcon.propTypes = {
   style: PropTypes.object,
 };
 
+export const ChevronUpIcon = React.memo(({ color, size, style }) => (
+  <FA5Icon name="chevron-up" color={color} size={size} style={style} />
+));
+ChevronUpIcon.defaultProps = { color: WHITE, size: 20, style: {} };
+ChevronUpIcon.propTypes = {
+  color: PropTypes.string,
+  size: PropTypes.number,
+  style: PropTypes.object,
+};
+
 export const PencilIcon = React.memo(({ color, size }) => (
   <FAIcon name="pencil" color={color} size={size} />
 ));


### PR DESCRIPTION
Fixes #2739 

## Change summary

- Adds date pickers to choose from a range of dates. Have tested with 10,000 logs and the performance is fine (7 months worth).
- Fixed the bug when the SVG has no data to render

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/35858975/83204759-ba42ca00-a1a0-11ea-9f66-c591adbea5b4.png">

<img width="1147" alt="image" src="https://user-images.githubusercontent.com/35858975/83204745-b151f880-a1a0-11ea-9dab-e688d5bca5c0.png">

## Testing

N/A

### Related areas to think about

I wonder if rather than having a list of fridges a drop down would be nicer:

![image](https://user-images.githubusercontent.com/35858975/83204679-849de100-a1a0-11ea-8f58-8d22b6590c27.png)

