### PR TITLE
#2767 single transaction sensor logs

### DIFF
--- a/src/selectors/fridge.js
+++ b/src/selectors/fridge.js
@@ -91,7 +91,7 @@ export const selectBreaches = createSelector(
   [selectTemperatureLogsFromDate, selectTemperatureLogsToDate, selectSelectedFridge],
   (fromDate, toDate, fridge) => {
     const { breaches } = fridge ?? {};
-    const breachesInDateRange = breaches.filtered(
+    const breachesInDateRange = breaches?.filtered(
       'startTimestamp >= $0 && endTimestamp <= $0',
       fromDate
     );


### PR DESCRIPTION
Fixes #?

## Change summary

- extracts the saving of sensorlogs and only saves thema fter having reset a sensor. This is because if we don't reset the sensor, the logs aren't cleared so next time you read it you would have double the sensor logs.
- This is pretty tricky and there's no real solution to being able to do this atomically without having timestamps on the logs on the sensor, so going with this for now (for example, what if you reset the sensor and dont write the logs. So ok, switch around the reset/write - what if you write before resetting...).
- The other option is to try and wrap this all in a `write`, however that means if its running in the background you might have issues with starting multiple writes with normal user tasks

## Testing

N/A

### Related areas to think about

N/A
