### PR TITLE
#2882 datepicker returning times

### DIFF
--- a/src/hooks/useDatePicker.js
+++ b/src/hooks/useDatePicker.js
@@ -28,7 +28,8 @@ export const useDatePicker = onChangeCallback => {
       const { type, nativeEvent } = event;
       if (type === 'set' && onChangeCallback) {
         const { timestamp } = nativeEvent;
-        onChangeCallback(new Date(timestamp));
+
+        onChangeCallback(timestamp);
       }
     },
     [onChangeCallback]

--- a/src/reducers/FridgeReducer.js
+++ b/src/reducers/FridgeReducer.js
@@ -35,14 +35,20 @@ export const FridgeReducer = (state = initialState(), action) => {
       const { payload } = action;
       const { date } = payload;
 
-      return { ...state, fromDate: date };
+      const fromDate = new Date(date);
+      fromDate.setUTCHours(0, 0, 0, 0);
+
+      return { ...state, fromDate };
     }
 
     case FRIDGE_ACTIONS.CHANGE_TO_DATE: {
       const { payload } = action;
       const { date } = payload;
 
-      return { ...state, toDate: date };
+      const toDate = new Date(date);
+      toDate.setUTCHours(23, 59, 59, 999);
+
+      return { ...state, toDate };
     }
 
     default:


### PR DESCRIPTION
Fixes #2882 

## Change summary
- My solution in the issue I think was flawed. Instead, changed it to make the custom hook just pass the timestamp, and made the alterations to the date where I needed it for this particular use case.
- the fromDate is from the start of the day, where as the toDate is the end of the day

## Testing

N/A

### Related areas to think about

Not 100% on dates, so if there's a better way more then happy to hear it!
