### PR TITLE
#2916 fix patient lookup insurance provider logic

### DIFF
--- a/src/actions/InsuranceActions.js
+++ b/src/actions/InsuranceActions.js
@@ -58,6 +58,7 @@ const update = policyDetails => (dispatch, getState) => {
     policyNumberFamily,
     discountRate: policyDiscountRate,
     insuranceProviderId: policyProviderId,
+    insuranceProvider: policyProvider,
     isActive: policyIsActive,
     expiryDate: policyExpiryDate,
     type: policyType,
@@ -68,9 +69,11 @@ const update = policyDetails => (dispatch, getState) => {
     policyNumberPerson: policyNumberPerson ?? currentNumberPerson,
     policyNumberFamily: policyNumberFamily ?? currentNumberFamily,
     discountRate: policyDiscountRate ?? currentDiscountRate,
-    insuranceProvider: policyProviderId
-      ? UIDatabase.getOrCreate('InsuranceProvider', policyProviderId)
-      : currentProvider,
+    insuranceProvider:
+      policyProvider ??
+      (policyProviderId
+        ? UIDatabase.getOrCreate('InsuranceProvider', policyProviderId)
+        : currentProvider),
     isActive: policyIsActive ?? currentIsActive,
     type: policyType ?? currentType,
     expiryDate: policyExpiryDate ?? currentExpiryDate,

--- a/src/actions/InsuranceActions.js
+++ b/src/actions/InsuranceActions.js
@@ -57,7 +57,7 @@ const update = policyDetails => (dispatch, getState) => {
     policyNumberPerson,
     policyNumberFamily,
     discountRate: policyDiscountRate,
-    insuranceProvider: policyProvider,
+    insuranceProviderId: policyProviderId,
     isActive: policyIsActive,
     expiryDate: policyExpiryDate,
     type: policyType,
@@ -68,7 +68,9 @@ const update = policyDetails => (dispatch, getState) => {
     policyNumberPerson: policyNumberPerson ?? currentNumberPerson,
     policyNumberFamily: policyNumberFamily ?? currentNumberFamily,
     discountRate: policyDiscountRate ?? currentDiscountRate,
-    insuranceProvider: policyProvider ?? currentProvider,
+    insuranceProvider: policyProviderId
+      ? UIDatabase.getOrCreate('InsuranceProvider', policyProviderId)
+      : currentProvider,
     isActive: policyIsActive ?? currentIsActive,
     type: policyType ?? currentType,
     expiryDate: policyExpiryDate ?? currentExpiryDate,


### PR DESCRIPTION
Fixes #2916.

## Change summary

Fixes insurance provider not being created for patients added via lookup API.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] No sync error occurs when adding a new patient with one or more insurance policies.
  - [ ] Above error does not occur if the policy provider already exists on mobile.
  - [ ] Above error does not occur if the policy provider does not exist on mobile.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
