### PR TITLE
#2918 update insurance policy number config

### DIFF
--- a/src/reducers/FormReducer.js
+++ b/src/reducers/FormReducer.js
@@ -69,7 +69,7 @@ export const FormReducer = (state = initialState(), action) => {
           ? policyNumberPersonLength > 0 && policyNumberPersonLength < 50
           : true;
         const isPolicyNumberFamilyLengthValid = updatePolicyNumberFamily
-          ? policyNumberFamilyLength > 0 && policyNumberFamilyLength < 50
+          ? policyNumberFamilyLength >= 0 && policyNumberFamilyLength < 50
           : true;
 
         const newPolicyNumberPersonState = {

--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -185,7 +185,7 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     type: FORM_INPUT_TYPES.TEXT,
     initialValue: '',
     key: 'policyNumberFamily',
-    validator: input => input.length > 0 && input.length < 50,
+    validator: input => input.length >= 0 && input.length < 50,
     isRequired: false,
     invalidMessage: formInputStrings.unique_policy,
     label: formInputStrings.family_policy_number,

--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -186,7 +186,7 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     initialValue: '',
     key: 'policyNumberFamily',
     validator: input => input.length > 0 && input.length < 50,
-    isRequired: true,
+    isRequired: false,
     invalidMessage: formInputStrings.unique_policy,
     label: formInputStrings.family_policy_number,
     isEditable: !seedObject,


### PR DESCRIPTION
Fixes #2918.

## Change summary

Update family policy number to be optional.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Can create an insurance policy with a blank family policy number.

### Related areas to think about

N/A.