### PR TITLE
#2946 update outgoing sync date format

### DIFF
--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -26,9 +26,8 @@ const bugsnagClient = new BugsnagClient();
 
 const getDateString = date => {
   let returnDate = '0000-00-00';
-  if (date && typeof date === 'object') returnDate = date.toISOString().slice(0, 10);
-
-  return `${returnDate}T00:00:00`;
+  if (date && typeof date === 'object') returnDate = moment(date).toISOString();
+  return returnDate;
 };
 
 function getTimeString(date) {


### PR DESCRIPTION
Fixes #2946.

## Change summary

Updates outgoing date string format to ISO + UTC.

## Testing

### Setup

- [ ] Setup mobile and desktop devices on different timezones such that the current day of the week differs. 
- [ ] Create a new customer invoice on mobile, finalise and sync to desktop.

### Test cases

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When the invoice is viewed on desktop, the dates are correct (from desktops point of view). I.e. if the transaction was made a few minutes ago on mobile, the transaction `entry_date` should be only a few minutes ago in desktop time (not a day ahead/behind). 

### Related areas to think about

N/A.
