### PR TITLE
#2957 add formatting to date input on submit callback

### DIFF
--- a/src/widgets/FormInputs/FormDateInput.js
+++ b/src/widgets/FormInputs/FormDateInput.js
@@ -103,9 +103,13 @@ export const FormDateInput = React.forwardRef(
 
     const openDatePicker = () => setInputState(state => ({ ...state, datePickerOpen: true }));
 
-    const onSubmitEditing = React.useCallback(event => onSubmit?.(event.nativeEvent.text), [
-      onSubmit,
-    ]);
+    const onSubmitEditing = React.useCallback(
+      event => {
+        onSubmit?.(event.nativeEvent.text);
+        onUpdate?.(event.nativeEvent.text);
+      },
+      [onUpdate, onSubmit]
+    );
 
     return (
       <FlexRow flex={1}>


### PR DESCRIPTION
Fixes #2957.

## Change summary

Minor change, calls `onUpdate` callback after submitting date input. Ensures submitted values are formatted consistently and prevents error on submitting date without date picker.

## Testing

### Setup

- Create a new patient. Add a first and last name and date of birth. Press date of birth input field and press enter (triggers `onSubmit` callback).

### Test cases

- [ ] Patient saves without error.

### Related areas to think about

@joshxg knows this functionality best, so would be good to get some feedback just to check that this won't cause any unexpected side-effects?
