### PR TITLE
#2943 fix patient not editable after home store is transferred

### DIFF
--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -17,6 +17,7 @@ import { ModalContainer } from '../widgets/modals/ModalContainer';
 
 import { recordKeyExtractor, getItemLayout } from './dataTableUtilities';
 import { createPrescription } from '../navigation/actions';
+import { useNavigationFocus, useSyncListener } from '../hooks';
 
 import { UIDatabase } from '../database';
 import { getFormInputConfig } from '../utilities/formInputConfigs';
@@ -51,6 +52,8 @@ const Dispensing = ({
   filter,
   sort,
   gotoPrescription,
+  navigation,
+  refreshData,
   switchDataset,
 
   // Dispensary lookup API callbacks
@@ -89,10 +92,15 @@ const Dispensing = ({
   selectedInsurancePolicy,
   canEditInsurancePolicy,
   isCreatingInsurancePolicy,
+  
   // Insurance callbacks
   cancelInsuranceEdit,
   saveInsurancePolicy,
 }) => {
+  // Custom hook to refresh data on this page when becoming the head of the stack again.
+  useNavigationFocus(navigation, refreshData);
+  useSyncListener(refreshData, 'Name');
+
   const getCellCallbacks = colKey => {
     switch (colKey) {
       case 'dispense':
@@ -334,6 +342,7 @@ const mapDispatchToProps = dispatch => ({
 
   filter: searchTerm => dispatch(DispensaryActions.filter(searchTerm)),
   sort: sortKey => dispatch(DispensaryActions.sort(sortKey)),
+  refreshData: () => dispatch(DispensaryActions.refresh()),
   switchDataset: () => dispatch(DispensaryActions.switchDataSet()),
 
   lookupRecord: () => dispatch(DispensaryActions.openLookupModal()),
@@ -374,6 +383,8 @@ Dispensing.propTypes = {
   sort: PropTypes.func.isRequired,
   searchTerm: PropTypes.string.isRequired,
   filter: PropTypes.func.isRequired,
+  navigation: PropTypes.object.isRequired,
+  refreshData: PropTypes.func.isRequired,
   switchDataset: PropTypes.func.isRequired,
   lookupRecord: PropTypes.func.isRequired,
   cancelLookupRecord: PropTypes.func.isRequired,

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -467,8 +467,6 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       const isPatient = record.type === 'patient';
       const thisStoresPatient = record.supplying_store_id === settings.get(THIS_STORE_ID);
 
-      if (isPatient && !thisStoresPatient) break;
-
       const {
         bill_address1: line1,
         bill_address2: line2,


### PR DESCRIPTION
Fixes #2943

## Change summary

- Removed statement `if (isPatient && !thisStoresPatient) break` that wasn't allowing the new incoming sync record proceed to change the Patient home store (aka supplyingStoreId).
- Added the hook to refresh the Dispensary page after an incoming sync record to change a `Name` (Patient) is processed.  

## Testing

### Important note: The Desktop version to use as your local Central server to test this PR needs to have this PR merged in: [msupply/#5082](https://github.com/sussol/msupply/pull/6236) Which should be part of the v4.12 release.

Steps to reproduce or otherwise test the changes of this PR:
- Patient created on Mobile:
  - [ ] On the mobile site, create a patient: Dispensary > New patient. Save. It is showing on the list with an `edit` icon. Sync with the Central server. 
  - [ ] On the Central server, open the patient window. The **home store** selected is the Mobile store and the patient can't be edited.
  - [ ] On the Central server, change the patient's **home store** to another one (Active on the central server). Close the window. Go to the mobile site and sync. Wait a few seconds after to refresh the page. The patient is now showing on the list with a `read` icon.
  - [ ] On the Central server, when you open this patient window, it is now editable. And the **home store** selected is the other store that is Active in the central server.
  - [ ] On the mobile site, when you click on the `read` icon on this patient line you can't edit it.
- Patient created on Central server:
  - [ ] On the Central server, create a patient while logged in a store that is Active on the central server. Select the Mobile store as visible to this patient.
  - [ ] On the mobile site, sync with the Central server. Then check that the patient is showing on the Dispensary list. The patient has a `read` icon showing. And when you click on the `read` icon on this patient line you can't edit it. 
  - [ ] On the Central server, change the patient's **home store** to the Mobile store. Close the window. Go to the mobile site and sync. Wait a few seconds after to refresh the page. The patient is now showing on the list with an `edit` icon.
  - [ ] On the Central server, when you open this patient window, it can't be edited (only the **home store** can be changed). And the **home store** selected is the mobile store.
  - [ ] On the mobile site, when you click on the `edit` icon on this patient line you can edit it.

### Related areas to think about

- Dispensary refreshing after receiving `Name` sync records. Which includes: Changes on visible Customers, Suppliers, Patients, Stores.
- Patient with different home store incoming syncing. Now that the break was removed.
