### PR TITLE
#5989 add patient gender to outgoing sync

### DIFF
--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -100,6 +100,7 @@ const generateSyncData = (settings, recordType, record) => {
         barcode: `*${record.code}*`,
         'charge code': record.code,
         currency_id: defaultCurrency?.id ?? '',
+        female: String(record.female),
       };
     }
     case 'NumberSequence': {


### PR DESCRIPTION
Fixes #2989

## Change summary

Adds `female` field to outgoing sync for `Name` records.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Desktop displays correct gender for patients created on mobile.

### Related areas to think about

Only concern is whether this could effect non-patient name records. I'm guessing the field is irrelevant for those records, so not really an issue either way?
