### PR TITLE
#2994 fix payment summary discount rate

### DIFF
--- a/src/actions/InsuranceActions.js
+++ b/src/actions/InsuranceActions.js
@@ -6,7 +6,6 @@ import { batch } from 'react-redux';
 
 import { UIDatabase } from '../database';
 import { selectCurrentPatient } from '../selectors/patient';
-import { PaymentActions } from './PaymentActions';
 import { selectCurrentUser } from '../selectors/user';
 import { createRecord } from '../database/utilities';
 
@@ -102,10 +101,7 @@ const select = insurancePolicy => (dispatch, getState) => {
     UIDatabase.update('Transaction', { ...transaction, insurancePolicy });
   });
 
-  batch(() => {
-    dispatch(PaymentActions.setPolicy(insurancePolicy));
-    dispatch(selectPolicy(insurancePolicy));
-  });
+  dispatch(selectPolicy(insurancePolicy));
 };
 
 export const InsuranceActions = {

--- a/src/actions/PaymentActions.js
+++ b/src/actions/PaymentActions.js
@@ -10,18 +10,14 @@ import { selectPrescriptionTotal } from '../selectors/payment';
 import { UIDatabase } from '../database';
 
 export const PAYMENT_ACTIONS = {
-  SET_POLICY: 'Payment/setPolicy',
   CHOOSE_PAYMENT_TYPE: 'Payment/choosePaymentType',
   UPDATE_PAYMENT: 'Payment/updatePayment',
   CREDIT_OVERFLOW: 'Payment/creditOverflow',
 };
 
 const updatePayment = amount => ({ type: PAYMENT_ACTIONS.UPDATE_PAYMENT, payload: { amount } });
+
 const creditOverflow = () => ({ type: PAYMENT_ACTIONS.CREDIT_OVERFLOW });
-const setPolicy = insurancePolicy => ({
-  type: PAYMENT_ACTIONS.SET_POLICY,
-  payload: { insurancePolicy },
-});
 
 const choosePaymentType = paymentType => (dispatch, getState) => {
   const { payment } = getState();
@@ -53,6 +49,5 @@ const validatePayment = amount => (dispatch, getState) => {
 
 export const PaymentActions = {
   validatePayment,
-  setPolicy,
   choosePaymentType,
 };

--- a/src/reducers/PaymentReducer.js
+++ b/src/reducers/PaymentReducer.js
@@ -15,7 +15,7 @@ const initialState = () => ({
   transaction: null,
   patient: null,
   paymentAmount: currency(0),
-  insurancePolicy: null,
+  discountRate: 0,
   paymentValid: true,
   paymentType: null,
 });
@@ -43,13 +43,6 @@ export const PaymentReducer = (state = initialState(), action) => {
       return { ...state, paymentAmount };
     }
 
-    case PAYMENT_ACTIONS.SET_POLICY: {
-      const { payload } = action;
-      const { insurancePolicy } = payload;
-
-      return { ...state, insurancePolicy };
-    }
-
     case PAYMENT_ACTIONS.CHOOSE_PAYMENT_TYPE: {
       const { payload } = action;
       const { paymentType } = payload;
@@ -72,11 +65,14 @@ export const PaymentReducer = (state = initialState(), action) => {
     case INSURANCE_ACTIONS.SELECT: {
       const { payload } = action;
       const { insurancePolicy } = payload;
+      const { discountRate } = insurancePolicy;
+      const paymentAmount = selectPrescriptionTotal({ payment: { ...state, discountRate } });
 
-      const newState = { payment: { ...state, insurancePolicy } };
-      const paymentAmount = selectPrescriptionTotal(newState);
-
-      return { ...state, insurancePolicy, paymentAmount };
+      return {
+        ...state,
+        discountRate,
+        paymentAmount,
+      };
     }
 
     default:

--- a/src/selectors/insurance.js
+++ b/src/selectors/insurance.js
@@ -14,8 +14,10 @@ export const selectInsurancePolicyDiscountRate = ({ insurancePolicy }) => {
   return discountRate;
 };
 
-export const selectInsuranceDiscountRate = ({ insurance }) =>
-  selectInsurancePolicyDiscountRate(insurance);
+export const selectInsuranceDiscountRate = ({ insurance }) => {
+  const { insurancePolicy } = insurance;
+  selectInsurancePolicyDiscountRate({ insurancePolicy });
+};
 
 export const selectCanEditInsurancePolicy = ({ insurance }) => {
   const { isCreatingInsurancePolicy, selectedInsurancePolicy } = insurance ?? {};

--- a/src/selectors/payment.js
+++ b/src/selectors/payment.js
@@ -5,7 +5,6 @@
 
 import currency from '../localization/currency';
 import { UIDatabase } from '../database';
-import { selectInsurancePolicyDiscountRate } from './insurance';
 
 export const selectPrescriptionSubTotal = ({ payment }) => {
   const { transaction } = payment;
@@ -15,8 +14,7 @@ export const selectPrescriptionSubTotal = ({ payment }) => {
 };
 
 export const selectDiscountRate = ({ payment }) => {
-  const { insurancePolicy } = payment;
-  const discountRate = selectInsurancePolicyDiscountRate({ insurancePolicy });
+  const { discountRate } = payment;
   return discountRate;
 };
 
@@ -25,7 +23,6 @@ export const selectDiscountAmount = ({ payment }) => {
   const insuranceDiscountRate = selectDiscountRate({ payment });
   const insuranceDiscountMultiplier = insuranceDiscountRate ? insuranceDiscountRate / 100 : 0;
   const discountAmount = currency(subtotal).multiply(insuranceDiscountMultiplier);
-
   return discountAmount;
 };
 

--- a/src/selectors/payment.js
+++ b/src/selectors/payment.js
@@ -14,11 +14,15 @@ export const selectPrescriptionSubTotal = ({ payment }) => {
   return total;
 };
 
-export const selectDiscountAmount = ({ payment }) => {
+export const selectDiscountRate = ({ payment }) => {
   const { insurancePolicy } = payment;
-  const subtotal = selectPrescriptionSubTotal({ payment });
+  const discountRate = selectInsurancePolicyDiscountRate({ insurancePolicy });
+  return discountRate;
+};
 
-  const insuranceDiscountRate = selectInsurancePolicyDiscountRate({ insurancePolicy });
+export const selectDiscountAmount = ({ payment }) => {
+  const subtotal = selectPrescriptionSubTotal({ payment });
+  const insuranceDiscountRate = selectDiscountRate({ payment });
   const insuranceDiscountMultiplier = insuranceDiscountRate ? insuranceDiscountRate / 100 : 0;
   const discountAmount = currency(subtotal).multiply(insuranceDiscountMultiplier);
 

--- a/src/widgets/PaymentSummary.js
+++ b/src/widgets/PaymentSummary.js
@@ -24,13 +24,14 @@ import {
   selectPrescriptionSubTotal,
   selectPrescriptionTotal,
   selectCreditBeingUsed,
+  selectDiscountRate,
   selectDiscountAmount,
   selectChangeRequired,
 } from '../selectors/payment';
 import { selectPatientInsurancePolicies, selectAvailableCredit } from '../selectors/patient';
 
 import { InsuranceActions } from '../actions/InsuranceActions';
-import { selectInsuranceDiscountRate, selectCanEditInsurancePolicy } from '../selectors/insurance';
+import { selectCanEditInsurancePolicy } from '../selectors/insurance';
 import { selectUsingPaymentTypes } from '../selectors/modules';
 
 import { dispensingStrings } from '../localization';
@@ -50,7 +51,7 @@ const paymentState = state => {
   const insurancePolicies = selectPatientInsurancePolicies(state);
   const isPolicyEditable = selectCanEditInsurancePolicy(state);
   const paymentTypes = UIDatabase.objects('PaymentType').sorted('description');
-  const discountRate = selectInsuranceDiscountRate(state);
+  const discountRate = selectDiscountRate(state);
   const discountAmount = selectDiscountAmount(state);
   const changeRequired = selectChangeRequired(state);
   const usingPaymentTypes = selectUsingPaymentTypes(state);

--- a/src/widgets/Slider.js
+++ b/src/widgets/Slider.js
@@ -47,6 +47,13 @@ export const Slider = React.forwardRef(
   ) => {
     if (!onEndEditing) throw new Error('Must provide onEndEditing prop!');
 
+    React.useEffect(() => {
+      if (value !== currentValue) {
+        setString(value);
+        setSlider(value);
+      }
+    }, [value]);
+
     // Current value of the component which is an always-valid Number.
     const [currentValue, setValue] = React.useState(value);
 


### PR DESCRIPTION
Fixes #2994.

## Change summary

Fixes a few errors with insurance rate, including a few redux changes to make payment and insurance logic a bit clearer. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When selecting an insurance policy in the payment window,  the insurance discount rate updates correctly.
- [ ] After creating a new insurance policy in the payment window,  the insurance discount rate updates correctly.
- [ ] Edit an insurance policy in the payment window (ensure the policy has a discount rate which differs from the default of `25`). Cancel without making any changes. Create a new insurance policy. The insurance slider is reset to the default value of `25` (not the value of the previously edited policy).
- [ ] Create an insurance policy in the payment window. Cancel without creating the policy. Edit an existing policy (ensure the policy has a discount rate which differs from the default of `25`). The insurance slider is set to the correct value (not the default value of `25`).

### Related areas to think about

Depending on turn-around, this will be the last PR for `v5.1.0` or a patch `v5.1.1` (planning to release `v5.1.0` this arvo). 
