### PR TITLE
#2997 fix outgoing record null data

### DIFF
--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -543,10 +543,9 @@ export class Transaction extends Realm.Object {
     database.save('Transaction', this);
 
     // Trigger update on linked transaction batches to ensure they are pushed to sync out queue.
-    this.items.forEach(item => {
-      database.save('TransactionItem', item);
-      item.batches.forEach(batch => database.save('TransactionBatch', batch));
-    });
+    this.items.forEach(item =>
+      item.batches.forEach(batch => database.save('TransactionBatch', batch))
+    );
   }
 }
 

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -539,7 +539,14 @@ export class Transaction extends Realm.Object {
     }
 
     this.status = 'finalised';
+
     database.save('Transaction', this);
+
+    // Trigger update on linked transaction batches to ensure they are pushed to sync out queue.
+    this.items.forEach(item => {
+      database.save('TransactionItem', item);
+      item.batches.forEach(batch => database.save('TransactionBatch', batch));
+    });
   }
 }
 

--- a/src/sync/SyncDatabase.js
+++ b/src/sync/SyncDatabase.js
@@ -25,6 +25,10 @@ export class SyncDatabase {
     return this.database.create(...args, 'sync');
   }
 
+  get(type, primaryKey, primaryKeyField = 'id') {
+    return this.database.get(type, primaryKey, primaryKeyField);
+  }
+
   getOrCreate(type, primaryKey, primaryKeyField = 'id') {
     return this.database.getOrCreate(type, primaryKey, primaryKeyField, 'sync');
   }

--- a/src/sync/SyncQueue.js
+++ b/src/sync/SyncQueue.js
@@ -55,6 +55,27 @@ export class SyncQueue {
     this.database.removeListener(this.databaseListenerId);
   }
 
+  isValidSyncOutRecord(syncOutRecord) {
+    if (!syncOutRecord.recordId) return false;
+    const [record] = this.database
+      .objects(syncOutRecord.recordType)
+      .filtered('id == $0', syncOutRecord.recordId);
+    if (!record) return false;
+
+    switch (syncOutRecord.recordType) {
+      // Only sync prescriptions which are finalised.
+      case 'Transaction':
+        return !(record.isPrescription && !record.isFinalised);
+      case 'TransactionBatch':
+        return !(record.transaction.isPrescription && !record.transaction.isFinalised);
+      // Only sync out prescribers from this store.
+      case 'Prescriber':
+        return record.fromThisStore;
+      default:
+        return true;
+    }
+  }
+
   /**
    * Respond to a database change event. Must be called from within a database
    * write transaction.
@@ -72,24 +93,27 @@ export class SyncQueue {
         case CREATE:
         case UPDATE:
         case DELETE: {
-          if (!record.id) return;
-          const existingSyncOutRecord = this.database
-            .objects('SyncOut')
-            .filtered('recordId == $0', record.id)[0];
-          if (!existingSyncOutRecord) {
-            this.database.create('SyncOut', {
-              id: generateUUID(),
-              changeTime: new Date().getTime(),
-              changeType,
-              recordType,
-              recordId: record.id,
-            });
-          } else {
-            existingSyncOutRecord.changeTime = new Date().getTime();
-            existingSyncOutRecord.changeType = changeType;
-            existingSyncOutRecord.recordType = recordType;
-            this.database.save('SyncOut', existingSyncOutRecord);
+          const { id: recordId } = record;
+
+          const syncOutRecord = {
+            changeTime: new Date().getTime(),
+            changeType,
+            recordType,
+            recordId,
+          };
+
+          if (this.isValidSyncOutRecord(syncOutRecord)) {
+            const [existingSyncOutRecord] = this.database
+              .objects('SyncOut')
+              .filtered('recordId == $0', syncOutRecord.recordId);
+            if (existingSyncOutRecord) {
+              this.database.save('SyncOut', { ...existingSyncOutRecord, ...syncOutRecord });
+            } else {
+              const id = generateUUID();
+              this.database.create('SyncOut', { id, ...syncOutRecord });
+            }
           }
+
           break;
         }
         default:

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -188,9 +188,6 @@ const generateSyncData = (settings, recordType, record) => {
       };
     }
     case 'Transaction': {
-      // Only sync prescriptions which are finalised.
-      if (record.isPrescription && !record.isFinalised) return null;
-
       const defaultCurrency = UIDatabase.objects('Currency').filtered(
         'isDefaultCurrency == $0',
         true
@@ -234,9 +231,6 @@ const generateSyncData = (settings, recordType, record) => {
     }
     case 'TransactionBatch': {
       const { transaction } = record;
-
-      // Only sync prescription lines if prescription is finalised.
-      if (transaction.isPrescription && !transaction.isFinalised) return null;
 
       return {
         ID: record.id,
@@ -288,9 +282,6 @@ const generateSyncData = (settings, recordType, record) => {
       };
     }
     case 'Prescriber': {
-      // Only sync out prescribers from this store.
-      if (!record.fromThisStore) return null;
-
       const initials = `${record.firstName?.[0] ?? ''}${record.lastName?.[0] ?? ''}`;
 
       return {


### PR DESCRIPTION
Fixes #2997.

## Change summary

Adds validation logic to database listener to prevent unintended records being added to sync out queue.

## Testing

### Setup

- Clear sync out queue on mobile.

### Test cases 

- [ ] Create a new prescription. While the wizard is open, open the sync modal. No new records have been added to the sync queue.
- [ ] Complete the prescription. Open the sync modal. The transaction and transaction batch records have now been added to the sync queue.
- [ ] Lookup a prescriber from another store. Open the sync modal. No new records have been added to the sync queue.
- [ ] Add a new prescriber. Open the sync modal. The prescriber record has been added to the sync queue.

### Related areas to think about

N/A.
