### PR TITLE
#2991 add prescriber merge logic

### DIFF
--- a/src/database/utilities/deleteRecord.js
+++ b/src/database/utilities/deleteRecord.js
@@ -35,6 +35,7 @@ export const deleteRecord = (database, recordType, primaryKey, primaryKeyField =
     case 'NameStoreJoin':
     case 'NumberSequence':
     case 'NumberToReuse':
+    case 'Prescriber':
     case 'Requisition':
     case 'RequisitionItem':
     case 'Stocktake':


### PR DESCRIPTION
Fixes #2991.

## Change summary

Adds `Prescriber` merge logic. 

## Testing

### Setup

- Create two prescribers (`prescriber_a` and `prescriber_b`) on a non-local store.
- Make both prescribers visible on mobile store using lookup API.
- Create a prescription associated with `prescriber_b` on mobile.
- Merge `prescriber_b` into `prescriber_a`.

### Test cases

- [ ] In dispensary, `prescriber_b` no longer appears in prescriber list.
- [ ] In patient history, prescription associated with `prescriber_b` is now associated with `prescriber_a`. 

### Related areas to think about

N/A.
