### PR TITLE
#3008 fix insurance policy lookup is active field

### DIFF
--- a/src/database/utilities/parsers.js
+++ b/src/database/utilities/parsers.js
@@ -9,7 +9,7 @@
  * @param  {string}  numberString  The string to convert to a boolean
  * @return {boolean}               The boolean representation of the string
  */
-export const parseBoolean = booleanString => booleanString.toString().toLowerCase() === 'true';
+export const parseBoolean = booleanString => booleanString?.toString()?.toLowerCase() === 'true';
 
 /**
  * Return a Date object representing the given date, time.

--- a/src/database/utilities/parsers.js
+++ b/src/database/utilities/parsers.js
@@ -5,13 +5,11 @@
 
 /**
  * Returns the boolean string as a boolean (false if none passed)
- * @param  {string} numberString The string to convert to a boolean
+ *
+ * @param  {string}  numberString  The string to convert to a boolean
  * @return {boolean}               The boolean representation of the string
  */
-export const parseBoolean = booleanString => {
-  const trueStrings = ['true', 'True', 'TRUE'];
-  return trueStrings.includes(booleanString);
-};
+export const parseBoolean = booleanString => booleanString.toString().toLowerCase() === 'true';
 
 /**
  * Return a Date object representing the given date, time.

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -120,8 +120,8 @@ const processInsuranceResponse = response =>
     })
   );
 
-export const processPatientResponse = response => {
-  const patientData = response.map(
+export const processPatientResponse = response =>
+  response.map(
     ({
       ID: id,
       name,
@@ -156,11 +156,9 @@ export const processPatientResponse = response => {
       policies: processInsuranceResponse(nameInsuranceJoin),
     })
   );
-  return patientData;
-};
 
-export const processPrescriberResponse = response => {
-  const prescriberData = response.map(
+export const processPrescriberResponse = response =>
+  response.map(
     ({
       ID,
       first_name,
@@ -185,5 +183,3 @@ export const processPrescriberResponse = response => {
       storeId: store_ID,
     })
   );
-  return prescriberData;
-};


### PR DESCRIPTION
Fixes #3008.

## Change summary

Minor fix to boolean parse helper.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Active policies for patients looked up via lookup API are displayed as active.
- [ ] Inactive policies for patients looked up via lookup API are displayed as inactive.

### Related areas to think about

N/A.
