### PR TITLE
#2945 fix undefined patient name on back

### DIFF
--- a/src/selectors/prescription.js
+++ b/src/selectors/prescription.js
@@ -30,14 +30,16 @@ export const selectPrescriptionPrescriber = ({ prescription }) => {
 
 export const selectPrescriberName = ({ prescription }) => {
   const currentPrescriber = selectPrescriptionPrescriber({ prescription });
+  const { firstName = '', lastName = '' } = currentPrescriber ?? {};
 
-  return `${currentPrescriber?.firstName} ${currentPrescriber?.lastName}`.trim();
+  return `${firstName} ${lastName}`.trim();
 };
 
-export const selectPatientName = state => {
-  const currentPatient = selectPrescriptionPatient(state);
+export const selectPatientName = ({ prescription }) => {
+  const currentPatient = selectPrescriptionPatient({ prescription });
+  const { firstName = '', lastName = '' } = currentPatient ?? {};
 
-  return `${currentPatient?.firstName} ${currentPatient?.lastName}`.trim();
+  return `${firstName} ${lastName}`.trim();
 };
 
 export const selectItemSearchTerm = ({ prescription }) => {

--- a/src/selectors/prescription.js
+++ b/src/selectors/prescription.js
@@ -17,40 +17,34 @@ export const selectHasItemsAndQuantity = ({ prescription }) => {
 export const selectPrescriptionPatient = ({ prescription }) => {
   const { transaction } = prescription;
   const { otherParty } = transaction || {};
-
   return otherParty;
 };
 
 export const selectPrescriptionPrescriber = ({ prescription }) => {
   const { transaction } = prescription;
   const { prescriber } = transaction || {};
-
   return prescriber;
 };
 
 export const selectPrescriberName = ({ prescription }) => {
   const currentPrescriber = selectPrescriptionPrescriber({ prescription });
   const { firstName = '', lastName = '' } = currentPrescriber ?? {};
-
   return `${firstName} ${lastName}`.trim();
 };
 
 export const selectPatientName = ({ prescription }) => {
   const currentPatient = selectPrescriptionPatient({ prescription });
   const { firstName = '', lastName = '' } = currentPatient ?? {};
-
   return `${firstName} ${lastName}`.trim();
 };
 
 export const selectItemSearchTerm = ({ prescription }) => {
   const { itemSearchTerm } = prescription;
-
   return itemSearchTerm;
 };
 
 export const selectItems = ({ prescription }) => {
   const { items } = prescription;
-
   return items;
 };
 


### PR DESCRIPTION
Fixes #2945.

## Change summary

Fixes patient name from briefly displaying as `undefined` when navigating back to menu page.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When navigating back from the first page of a prescription, the patient name does not display as `undefined`.

### Related areas to think about

N/A.
