### PR TITLE
#3016 fix incorrect policy number formatting

### DIFF
--- a/src/database/DataTypes/InsurancePolicy.js
+++ b/src/database/DataTypes/InsurancePolicy.js
@@ -2,7 +2,8 @@ import Realm from 'realm';
 
 export class InsurancePolicy extends Realm.Object {
   get policyNumber() {
-    return `${this.policyNumberPerson} ${this.policyNumberFamily}`;
+    if (!this.policyNumberPerson) return this.policyNumberFamily;
+    return `${this.policyNumberFamily}-${this.policyNumberPerson}`;
   }
 }
 


### PR DESCRIPTION
Fixes #3016.

## Change summary

Fix incorrect formatting of personal and family policy numbers.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Policies with personal numbers are displayed as `familyNumber-personalNumber`.
- [ ] Policies without personal numbers are displayed as `familyNumber`.

### Related areas to think about

N/A.