### PR TITLE
#3015 fix insurance policy outgoing sync formatting

### DIFF
--- a/src/database/DataTypes/InsurancePolicy.js
+++ b/src/database/DataTypes/InsurancePolicy.js
@@ -2,7 +2,8 @@ import Realm from 'realm';
 
 export class InsurancePolicy extends Realm.Object {
   get policyNumber() {
-    return `${this.policyNumberPerson} ${this.policyNumberFamily}`;
+    if (!this.policyNumberPerson) return this.policyNumberFamily;
+    return `${this.policyNumberFamily}-${this.policyNumberPerson}`;
   }
 }
 

--- a/src/database/DataTypes/InsurancePolicy.js
+++ b/src/database/DataTypes/InsurancePolicy.js
@@ -13,7 +13,7 @@ InsurancePolicy.schema = {
   properties: {
     id: 'string',
     policyNumberFamily: 'string',
-    policyNumberPerson: 'string',
+    policyNumberPerson: { type: 'string', default: '' },
     type: 'string',
     discountRate: 'double',
     isActive: { type: 'bool', default: true },

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -190,7 +190,7 @@ export const schema = {
     User,
     Currency,
   ],
-  schemaVersion: 16,
+  schemaVersion: 17,
 };
 
 export default schema;

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -267,7 +267,7 @@ const generateSyncData = (settings, recordType, record) => {
         type: record.type,
         discountRate: String(record.discountRate),
         expiryDate: getDateString(record.expiryDate),
-        policyNumberFull: `${record.policyNumberFamily}-${record.policyNumberPerson}`,
+        policyNumberFull: record.policyNumber,
         enteredByID: record.enteredBy?.id,
       };
     }


### PR DESCRIPTION
Fixes #3015.

## Change summary

Fixes formatting of policy numbers synced from mobile to desktop.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Policies with personal numbers are correctly formatted after being synced from mobile to desktop  (`familyNumber-personalNumber`).
- [ ] Policies without personal numbers are correctly formatted after being synced from mobile to desktop  (`familyNumber`).

### Related areas to think about

N/A.