### PR TITLE
#3034 update period date formatting

### DIFF
--- a/src/database/DataTypes/Period.js
+++ b/src/database/DataTypes/Period.js
@@ -4,6 +4,7 @@
  */
 
 import Realm from 'realm';
+import moment from 'moment';
 import { getIndicatorValuesByPeriod, getIndicatorsByValues } from '../utilities/getIndicatorData';
 
 /**
@@ -48,7 +49,9 @@ export class Period extends Realm.Object {
   }
 
   toString() {
-    return `${this.startDate.toLocaleDateString()} - ${this.endDate.toLocaleDateString()}`;
+    const startDate = moment(this.startDate).format('DD/MM/YY');
+    const endDate = moment(this.endDate).format('DD/MM/YY');
+    return `${startDate} - ${endDate}`;
   }
 }
 


### PR DESCRIPTION
Fixes #3034.

## Change summary

Update period date formatting for consistency with desktop.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Period start and end date is formatted as `DD/MM/YY` when creating a new program requisition.
- [ ] Period start and end date is formatted as `DD/MM/YY` when viewing a program requisition.


### Related areas to think about

N/A.