### PR TITLE
#3056 fix missing fields transaction incoming sync

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -721,6 +721,8 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         option: database.getOrCreate('Options', record.optionID),
         linkedTransaction,
         user1: record.user1,
+        insuranceDiscountAmount: parseFloat(record.insuranceDiscountAmount),
+        insuranceDiscountRate: parseFloat(record.insuranceDiscountRate),
         paymentType: database.getOrCreate('PaymentType', record.paymentTypeID),
         isCancellation: parseBoolean(record.is_cancellation),
       };

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -695,6 +695,9 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       const linkedRequisition = record.requisition_ID
         ? database.getOrCreate('Requisition', record.requisition_ID)
         : null;
+      const linkedTransaction = record.linked_transaction_id
+        ? database.getOrCreate('Transaction', record.linked_transaction_id)
+        : null;
       const category = database.getOrCreate('TransactionCategory', record.category_ID);
       internalRecord = {
         id: record.ID,
@@ -712,7 +715,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         otherParty,
         linkedRequisition,
         option: database.getOrCreate('Options', record.optionID),
-        subtotal: parseFloat(record.subtotal),
+        linkedTransaction,
         user1: record.user1,
         paymentType: database.getOrCreate('PaymentType', record.paymentTypeID),
         isCancellation: parseBoolean(record.is_cancellation),

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -695,6 +695,9 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       const linkedRequisition = record.requisition_ID
         ? database.getOrCreate('Requisition', record.requisition_ID)
         : null;
+      const insurancePolicy = record.nameInsuranceJoin?.id
+        ? database.getOrCreate('InsurancePolicy', record.nameInsuranceJoin.id)
+        : null;
       const linkedTransaction = record.linked_transaction_id
         ? database.getOrCreate('Transaction', record.linked_transaction_id)
         : null;
@@ -714,6 +717,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         enteredBy,
         otherParty,
         linkedRequisition,
+        insurancePolicy,
         option: database.getOrCreate('Options', record.optionID),
         linkedTransaction,
         user1: record.user1,

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -702,20 +702,21 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         ? database.getOrCreate('Transaction', record.linked_transaction_id)
         : null;
       const category = database.getOrCreate('TransactionCategory', record.category_ID);
+
       internalRecord = {
         id: record.ID,
         serialNumber: record.invoice_num,
+        otherParty,
         comment: record.comment,
         entryDate: parseDate(record.entry_date),
         type: TRANSACTION_TYPES.translate(record.type, EXTERNAL_TO_INTERNAL),
         status: STATUSES.translate(record.status, EXTERNAL_TO_INTERNAL),
         confirmDate: parseDate(record.confirm_date),
+        enteredBy,
         theirRef: record.their_ref,
+        category,
         mode: record.mode,
         prescriber: database.getOrCreate('Prescriber', record.prescriber_ID),
-        category,
-        enteredBy,
-        otherParty,
         linkedRequisition,
         subtotal: parseFloat(record.subtotal),
         outstanding: parseFloat(record.total),

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -717,6 +717,8 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         enteredBy,
         otherParty,
         linkedRequisition,
+        subtotal: parseFloat(record.subtotal),
+        outstanding: parseFloat(record.total),
         insurancePolicy,
         option: database.getOrCreate('Options', record.optionID),
         linkedTransaction,


### PR DESCRIPTION
Fixes #3056 

## Change summary

Adds missing `Transaction` fields to incoming sync:

- `insurancePolicy`
- `linkedTransaction`
- `subtotal`
- `outstanding`
- `insuranceDiscountAmount`
- `insuranceDiscountRate`

Note: the above fields were isolated by cross-referencing `incomingSyncUtils` with `outgoingSyncUtils` (excluding `Transaction` fields defined by getters). Idea is to ensure all fields which are synced out are also synced in, so that no transaction fields are overwritten or "blanked out".

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Transactions synced from desktop to mobile retain field `insurancePolicy`.
- [ ] Transactions synced from desktop to mobile retain field `linkedTransaction`.
- [ ] Transactions synced from desktop to mobile retain field `subtotal`
- [ ] Transactions synced from desktop to mobile retain field `total` (as `outstanding`).
- [ ] Transactions synced from desktop to mobile retain field `insuranceDiscountAmount`.
- [ ] Transactions synced from desktop to mobile retain field `insuranceDiscountRate`.

### Related areas to think about

N/A.

