### PR TITLE
#3072 fix insurance family policy not enforced

### DIFF
--- a/src/reducers/FormReducer.js
+++ b/src/reducers/FormReducer.js
@@ -43,14 +43,16 @@ export const FormReducer = (state = initialState(), action) => {
 
       const updatePolicyNumberPerson = key === INSURANCE_POLICY_FIELDS.POLICY_NUMBER_PERSON;
       const updatePolicyNumberFamily = key === INSURANCE_POLICY_FIELDS.POLICY_NUMBER_FAMILY;
+      const updatePolicyNumber = updatePolicyNumberPerson || updatePolicyNumberFamily;
 
-      if (updatePolicyNumberPerson || updatePolicyNumberFamily) {
+      if (updatePolicyNumber) {
         const { policyNumberPerson: policyNumberPersonState } = formConfig;
+        const { policyNumberFamily: policyNumberFamilyState } = formConfig;
+
         const { value: policyNumberPersonValue } = updatePolicyNumberPerson
           ? { value }
           : policyNumberPersonState;
 
-        const { policyNumberFamily: policyNumberFamilyState } = formConfig;
         const { value: policyNumberFamilyValue } = updatePolicyNumberFamily
           ? { value }
           : policyNumberFamilyState;

--- a/src/reducers/FormReducer.js
+++ b/src/reducers/FormReducer.js
@@ -55,8 +55,13 @@ export const FormReducer = (state = initialState(), action) => {
           ? { value }
           : policyNumberFamilyState;
 
-        const policyNumberPersonLength = policyNumberPersonValue.length;
-        const policyNumberFamilyLength = policyNumberFamilyValue.length;
+        const isPolicyNumberPersonValid = policyNumberPersonState.validator(
+          policyNumberPersonValue
+        );
+
+        const isPolicyNumberFamilyValid = policyNumberFamilyState.validator(
+          policyNumberFamilyValue
+        );
 
         const isPolicyNumberUnique =
           UIDatabase.objects('InsurancePolicy').filtered(
@@ -65,23 +70,16 @@ export const FormReducer = (state = initialState(), action) => {
             policyNumberFamilyValue
           ).length === 0;
 
-        const isPolicyNumberPersonLengthValid = updatePolicyNumberPerson
-          ? policyNumberPersonLength > 0 && policyNumberPersonLength < 50
-          : true;
-        const isPolicyNumberFamilyLengthValid = updatePolicyNumberFamily
-          ? policyNumberFamilyLength >= 0 && policyNumberFamilyLength < 50
-          : true;
-
         const newPolicyNumberPersonState = {
           ...policyNumberPersonState,
           value: policyNumberPersonValue,
-          isValid: isPolicyNumberUnique && isPolicyNumberPersonLengthValid,
+          isValid: isPolicyNumberUnique && isPolicyNumberPersonValid,
         };
 
         const newPolicyNumberFamilyState = {
           ...policyNumberFamilyState,
           value: policyNumberFamilyValue,
-          isValid: isPolicyNumberUnique && isPolicyNumberFamilyLengthValid,
+          isValid: isPolicyNumberUnique && isPolicyNumberFamilyValid,
         };
 
         return {

--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -185,7 +185,7 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     type: FORM_INPUT_TYPES.TEXT,
     initialValue: '',
     key: 'policyNumberFamily',
-    validator: input => input.length >= 0 && input.length < 50,
+    validator: input => input.length > 0 && input.length < 50,
     isRequired: true,
     invalidMessage: formInputStrings.unique_policy,
     label: formInputStrings.family_policy_number,


### PR DESCRIPTION
Fixes #3072.

## Change summary

Enforces family policy number on creating new insurance policy.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Users are unable to create a new insurance policy without a family policy number.
- [ ] Users are able to  create a new insurance policy number without a personal policy number.

### Related areas to think about

As discussed with @joshxg, at some point may need to revisit the form config design, as the current implementation splits validation responsibility between the form reducer and the config + `FormTextInput` component (violation of the SRP principle). May want to look at how we can refactor to manage validation across multiple input fields (but not high priority).
