### PR TITLE
#3081 Sorting crash

### DIFF
--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -241,7 +241,7 @@ export const toggleStockOut = state => {
 
   const newToggleState = !showAll;
 
-  const newData = newToggleState ? backingData : backingData.filter(item => item.hasStock);
+  const newData = newToggleState ? backingData.slice() : backingData.filter(item => item.hasStock);
 
   return { ...state, data: newData, showAll: newToggleState, searchTerm: '' };
 };


### PR DESCRIPTION
Fixes #3081 

## Change summary
- Correctly makes `data` field an array after toggling stockouts

## Testing

- Exact steps to recreate the bug are:
    - Toggle to not show stock outs
    - Toggle to show them
    - sort a column

- [ ] when following the above steps, app doesn't crash and sorts by column correctly

### Related areas to think about

N/A
