### PR TITLE
#3085 fix transaction lines syncing before parent transaction

### DIFF
--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -540,12 +540,14 @@ export class Transaction extends Realm.Object {
 
     this.status = 'finalised';
 
-    database.save('Transaction', this);
-
     // Trigger update on linked transaction batches to ensure they are pushed to sync out queue.
     this.items.forEach(item =>
       item.batches.forEach(batch => database.save('TransactionBatch', batch))
     );
+
+    // Transaction should be saved last (i.e. with most recent timestamp) to ensure transaction is
+    // not synced before linked items.
+    database.save('Transaction', this);
   }
 }
 


### PR DESCRIPTION
Fixes #3085.

## Change summary

Updates transaction finalisation logic and sync queue sorting to ensure transaction lines are always synced before parent transaction (prevent transactions without lines).

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Cannot replicate bug described in #3085 (@anildahalsussol).

### Related areas to think about

@joshxg @anildahalsussol Hard to replicate without access to same data. Do we want to do a draft `v5.1.2` release for testing this?
