### PR TITLE
#3099 Fix deleted stocktake in finalise state

### DIFF
--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -56,7 +56,6 @@ export const goBack = () => dispatch => {
 
       const cleanUp = () => {
         dispatch(PrescriptionActions.deletePrescription());
-        dispatch(FinaliseActions.resetFinaliseItem());
       };
 
       batch(() => {

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -10,7 +10,7 @@ import { NavigationActions, StackActions } from '@react-navigation/core';
 import { UIDatabase } from '../database';
 import { createRecord } from '../database/utilities';
 import { navStrings } from '../localization';
-import { ROUTES, FINALISABLE_PAGES } from './constants';
+import { ROUTES } from './constants';
 import { RootNavigator } from './RootNavigator';
 import { PrescriptionActions } from '../actions/PrescriptionActions';
 import { FinaliseActions } from '../actions/FinaliseActions';
@@ -47,7 +47,6 @@ export const goBack = () => dispatch => {
       UIDatabase.delete('Transaction', prescriptions);
 
       const prevRouteName = RootNavigator.getPrevRouteName();
-      const currRouteName = RootNavigator.getCurrentRouteName();
 
       const navigateBack = () =>
         dispatch({
@@ -57,9 +56,7 @@ export const goBack = () => dispatch => {
 
       const cleanUp = () => {
         dispatch(PrescriptionActions.deletePrescription());
-        if (FINALISABLE_PAGES.includes(currRouteName)) {
-          dispatch(FinaliseActions.resetFinaliseItem());
-        }
+        dispatch(FinaliseActions.resetFinaliseItem());
       };
 
       batch(() => {

--- a/src/reducers/FinaliseReducer.js
+++ b/src/reducers/FinaliseReducer.js
@@ -39,7 +39,7 @@ export const FinaliseReducer = (state = initialState(), action) => {
       return { ...state, finaliseItem };
     }
 
-    case 'Navigaton/BACK': {
+    case 'Navigation/BACK': {
       return { ...state, finaliseItem: null };
     }
 


### PR DESCRIPTION
Fixes #3099.

After a lot of dead ends (most caused by logging!), it looks like this is the culprit (@bijaySussol could you confirm?).

## Change summary

- Update back navigation to always reset finalise item.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Navigating back from `StocktakeManagePage` to `StocktakesPage` and deleting the previously viewed stocktake does not cause an error.

### Related areas to think about

From looking at the logic, it looks like it's safe to `resetFinaliseItem()` on all back navigation... but if I'm missing something, may need to revert back to a conditional (with an added edge case to handle this error)?
