### PR TITLE
#3103 fix sync queue update bug

### DIFF
--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -56,7 +56,6 @@ export const goBack = () => dispatch => {
 
       const cleanUp = () => {
         dispatch(PrescriptionActions.deletePrescription());
-        dispatch(FinaliseActions.resetFinaliseItem());
       };
 
       batch(() => {

--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -10,7 +10,7 @@ import { NavigationActions, StackActions } from '@react-navigation/core';
 import { UIDatabase } from '../database';
 import { createRecord } from '../database/utilities';
 import { navStrings } from '../localization';
-import { ROUTES, FINALISABLE_PAGES } from './constants';
+import { ROUTES } from './constants';
 import { RootNavigator } from './RootNavigator';
 import { PrescriptionActions } from '../actions/PrescriptionActions';
 import { FinaliseActions } from '../actions/FinaliseActions';
@@ -47,7 +47,6 @@ export const goBack = () => dispatch => {
       UIDatabase.delete('Transaction', prescriptions);
 
       const prevRouteName = RootNavigator.getPrevRouteName();
-      const currRouteName = RootNavigator.getCurrentRouteName();
 
       const navigateBack = () =>
         dispatch({
@@ -57,9 +56,7 @@ export const goBack = () => dispatch => {
 
       const cleanUp = () => {
         dispatch(PrescriptionActions.deletePrescription());
-        if (FINALISABLE_PAGES.includes(currRouteName)) {
-          dispatch(FinaliseActions.resetFinaliseItem());
-        }
+        dispatch(FinaliseActions.resetFinaliseItem());
       };
 
       batch(() => {

--- a/src/reducers/FinaliseReducer.js
+++ b/src/reducers/FinaliseReducer.js
@@ -39,7 +39,7 @@ export const FinaliseReducer = (state = initialState(), action) => {
       return { ...state, finaliseItem };
     }
 
-    case 'Navigaton/BACK': {
+    case 'Navigation/BACK': {
       return { ...state, finaliseItem: null };
     }
 

--- a/src/sync/SyncQueue.js
+++ b/src/sync/SyncQueue.js
@@ -105,7 +105,7 @@ export class SyncQueue {
           if (this.isValidSyncOutRecord(syncOutRecord)) {
             const existingSyncOutRecord = this.database.get('SyncOut', recordId, 'recordId');
             if (existingSyncOutRecord) {
-              this.database.save('SyncOut', { id: existingSyncOutRecord.id, ...syncOutRecord });
+              this.database.update('SyncOut', { id: existingSyncOutRecord.id, ...syncOutRecord });
             } else {
               this.database.create('SyncOut', { id: generateUUID(), ...syncOutRecord });
             }


### PR DESCRIPTION
Fixes #3103.

Branches off #3101.

## Change summary

Fixes incorrect updating of sync queue due to use of `database.save` instead of `database.update`.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Bug described in #3103 cannot be replicated (@bijaySussol).

### Related areas to think about

I think this is probably responsible for a lot of the missing record errors being thrown up by bugsnag, so hopefully we can close them all out after this and see if any pop up again!