### PR TITLE
#3109 Add invalid sync queue migration code

### DIFF
--- a/src/dataMigration.js
+++ b/src/dataMigration.js
@@ -252,7 +252,7 @@ const dataMigrations = [
           const { recordType, recordId } = syncRecord;
           const record = database.get(recordType, recordId);
           return !record;
-        }, []);
+        });
         database.delete('SyncOut', invalidSyncRecords);
       });
     },

--- a/src/dataMigration.js
+++ b/src/dataMigration.js
@@ -239,6 +239,24 @@ const dataMigrations = [
       });
     },
   },
+
+  // 5.1.2 fixes a sync out queue bug which was preventing invalid sync out records being
+  // overwritten. On upgrade, the following migration code filters the sync queue for invalid
+  // sync out records and deletes any which are found.
+  {
+    version: '5.1.2',
+    migrate: database => {
+      database.write(() => {
+        const syncRecords = database.objects('SyncOut');
+        const invalidSyncRecords = syncRecords.filter(syncRecord => {
+          const { recordType, recordId } = syncRecord;
+          const record = database.get(recordType, recordId);
+          return !record;
+        }, []);
+        database.delete('SyncOut', invalidSyncRecords);
+      });
+    },
+  },
 ];
 
 export default dataMigrations;

--- a/src/dataMigration.js
+++ b/src/dataMigration.js
@@ -247,7 +247,7 @@ const dataMigrations = [
     version: '5.1.2',
     migrate: database => {
       database.write(() => {
-        const syncRecords = database.objects('SyncOut');
+        const syncRecords = database.objects('SyncOut').slice();
         const invalidSyncRecords = syncRecords.filter(syncRecord => {
           const { recordType, recordId } = syncRecord;
           if (!recordType || !recordId) return true;

--- a/src/dataMigration.js
+++ b/src/dataMigration.js
@@ -250,6 +250,7 @@ const dataMigrations = [
         const syncRecords = database.objects('SyncOut');
         const invalidSyncRecords = syncRecords.filter(syncRecord => {
           const { recordType, recordId } = syncRecord;
+          if (!recordType || !recordId) return true;
           const record = database.get(recordType, recordId);
           return !record;
         });


### PR DESCRIPTION
Fixes #3109.

## Change summary

Adds migration code to delete invalid sync out records.

Tested locally by injecting invalid sync out records before upgrading. 

@bijaySussol Would be good if you could test this in production. Subject to approval will do a `v5.1.2` build and notify you. To ensure migration code runs correctly, will have to do a proper `v5.1.2` release (no more rcs).

@joshxg Any comments re. above? This patch has got quite big already, so I don't think there's any issue with bumping any other bugs to another patch, i.e. `v5.1.3`?

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When upgrading to `v5.1.2`, all invalid sync out records are removed from sync queue (to test in production, export realm database or use realm explorer).

### Related areas to think about

N/A.
