### PR TITLE
Revert sync queue ordering by record type

### DIFF
--- a/src/sync/SyncQueue.js
+++ b/src/sync/SyncQueue.js
@@ -137,26 +137,8 @@ export class SyncQueue {
    */
   next(numberOfRecords) {
     const numberToReturn = numberOfRecords || 1;
-    const allRecords = this.database.objects('SyncOut').slice();
-    const sortedRecords = allRecords.sort((recordA, recordB) => {
-      const isParentOf = (parent, child) => {
-        if (parent.recordType === 'Transaction') {
-          return child.recordType === 'TransactionBatch' || child.recordType === 'TransactionItem';
-        }
-        if (parent.recordType === 'Requisition') {
-          return child.recordType === 'RequisitionItem';
-        }
-        return false;
-      };
-
-      // Ensure parent records are synced before children.
-      if (isParentOf(recordA, recordB)) return 1;
-      if (isParentOf(recordB, recordA)) return -1;
-
-      return recordA.changeTime - recordB.changeTime;
-    });
-    const nextRecords = sortedRecords.slice(0, numberToReturn);
-    return nextRecords;
+    const allRecords = this.database.objects('SyncOut').sorted('changeTime');
+    return allRecords.slice(0, numberToReturn);
   }
 
   /**


### PR DESCRIPTION
Fixes #3107.

## Change summary

Reverts sync queue ordering by record type.

## Testing

NOTE: these tests should be done against the `v5.1.2` build. @bijaySussol @anildahalsussol will notify you when build is ready.

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Cannot replicate issue described in #3084.
- [ ] Cannot replicate issue described in #3085.

### Related areas to think about

N/A.
