### PR TITLE
#3132 Customer Requisitions ByProgramModal *A3

### DIFF
--- a/src/database/DataTypes/Period.js
+++ b/src/database/DataTypes/Period.js
@@ -31,7 +31,7 @@ export class Period extends Realm.Object {
     return this.requisitions.length;
   }
 
-  requisitionsForOrderType(program, orderType) {
+  numberOfSupplierRequisitionsForOrderType(program, orderType) {
     return this.requisitions.filtered(
       'program.id = $0 && orderType = $1 && type == "request"',
       program.id,
@@ -39,7 +39,7 @@ export class Period extends Realm.Object {
     ).length;
   }
 
-  customerRequisitionsForOrderTypeAndName(program, orderType, name) {
+  numberOfCustomerRequisitionsForOrderType(program, orderType, name) {
     return this.requisitions.filtered(
       'program.id = $0 && orderType = $1 && otherStoreName = $2',
       program.id,

--- a/src/database/DataTypes/Period.js
+++ b/src/database/DataTypes/Period.js
@@ -39,6 +39,15 @@ export class Period extends Realm.Object {
     ).length;
   }
 
+  customerRequisitionsForOrderTypeAndName(program, orderType, name) {
+    return this.requisitions.filtered(
+      'program.id = $0 && orderType = $1 && otherStoreName = $2',
+      program.id,
+      orderType.name,
+      name
+    ).length;
+  }
+
   addRequisitionIfUnique(requisition) {
     if (this.requisitions.filtered('id == $0', requisition.id).length > 0) return;
     this.requisitions.push(requisition);

--- a/src/database/DataTypes/Period.js
+++ b/src/database/DataTypes/Period.js
@@ -33,7 +33,7 @@ export class Period extends Realm.Object {
 
   requisitionsForOrderType(program, orderType) {
     return this.requisitions.filtered(
-      'program.id = $0 && orderType = $1',
+      'program.id = $0 && orderType = $1 && type == "request"',
       program.id,
       orderType.name
     ).length;

--- a/src/database/DataTypes/PeriodSchedule.js
+++ b/src/database/DataTypes/PeriodSchedule.js
@@ -28,12 +28,15 @@ export class PeriodSchedule extends Realm.Object {
     const filterValidPeriods = period => {
       if (customer) {
         return (
-          period.customerRequisitionsForOrderTypeAndName(program, orderType, customer) <
+          period.numberOfCustomerRequisitionsForOrderType(program, orderType, customer) <
           orderType.maxOrdersPerPeriod
         );
       }
 
-      return period.requisitionsForOrderType(program, orderType) < orderType.maxOrdersPerPeriod;
+      return (
+        period.numberOfSupplierRequisitionsForOrderType(program, orderType) <
+        orderType.maxOrdersPerPeriod
+      );
     };
 
     return isEmergency ? this.periods.slice() : this.periods.filter(filterValidPeriods);

--- a/src/database/DataTypes/PeriodSchedule.js
+++ b/src/database/DataTypes/PeriodSchedule.js
@@ -20,12 +20,21 @@ export class PeriodSchedule extends Realm.Object {
    * If the ordertype is an emergency order type, return all periods.
    * @param {MasterList}  program    The related program
    * @param {object}      orderType  The maxOrdersPerPeriod of the orderType
+   * @param {Name}        customer   Optional customer param to filter by.
    */
-  getPeriodsForOrderType(program, orderType) {
+  getPeriodsForOrderType(program, orderType, customer) {
     const { isEmergency } = orderType || {};
 
-    const filterValidPeriods = period =>
-      period.requisitionsForOrderType(program, orderType) < orderType.maxOrdersPerPeriod;
+    const filterValidPeriods = period => {
+      if (customer) {
+        return (
+          period.customerRequisitionsForOrderTypeAndName(program, orderType, customer) <
+          orderType.maxOrdersPerPeriod
+        );
+      }
+
+      return period.requisitionsForOrderType(program, orderType) < orderType.maxOrdersPerPeriod;
+    };
 
     return isEmergency ? this.periods.slice() : this.periods.filter(filterValidPeriods);
   }

--- a/src/localization/programStrings.json
+++ b/src/localization/programStrings.json
@@ -2,10 +2,12 @@
   "gb": {
     "select_a_program": "Select a program",
     "select_a_supplier": "Select a supplier",
+    "select_a_customer": "Select a customer",
     "select_an_order_type": "Select an order type",
     "select_a_period": "Select a period",
     "no_programs": "No programs available",
     "no_suppliers": "No suppliers available",
+    "no_customers": "No customers available",
     "no_order_types": "No order types available",
     "no_periods": "No periods available",
     "program": "Program",
@@ -29,7 +31,8 @@
     "program_stocktake": "Program stocktake",
     "general_order": "General order",
     "emergency_order": "Emergency order",
-    "max_items": "Max. Items"
+    "max_items": "Max. Items",
+    "customer_is_store": "Warning: This customer is also a store"
   },
   "fr": {
     "select_a_program": "Sélectionnez un programme",

--- a/src/reducers/ByProgramReducer.js
+++ b/src/reducers/ByProgramReducer.js
@@ -23,6 +23,7 @@ export const initialState = ({ transactionType }) => ({
 const actions = {
   SELECT_PROGRAM: 'selectProgram',
   SELECT_SUPPLIER: 'selectSupplier',
+  SELECT_CUSTOMER: 'selectCustomer',
   SELECT_ORDER_TYPE: 'selectOrderType',
   SELECT_PERIOD: 'selectPeriod',
   SET_TOGGLE: 'setToggle',
@@ -37,6 +38,10 @@ const STEPS = {
   requisition: {
     program: ['supplier', 'program', 'orderType', 'period'],
     general: ['supplier'],
+  },
+  customerRequisition: {
+    program: ['customer', 'program', 'orderType', 'period'],
+    general: ['customer'],
   },
   stocktake: {
     program: ['program', 'name'],
@@ -67,6 +72,11 @@ export const selectProgram = value => ({
 
 export const selectSupplier = value => ({
   type: actions.SELECT_SUPPLIER,
+  value,
+});
+
+export const selectCustomer = value => ({
+  type: actions.SELECT_CUSTOMER,
   value,
 });
 
@@ -121,6 +131,17 @@ export const byProgramReducer = (state, action) => {
         isModalOpen: false,
         complete: false,
       };
+    case actions.SELECT_CUSTOMER:
+      return {
+        ...state,
+        customer: value,
+        program: null,
+        orderType: null,
+        period: null,
+        name: '',
+        isModalOpen: false,
+        complete: false,
+      };
     case actions.SELECT_SUPPLIER:
       return {
         ...state,
@@ -132,6 +153,7 @@ export const byProgramReducer = (state, action) => {
         isModalOpen: false,
         complete: false,
       };
+
     case actions.SELECT_ORDER_TYPE:
       return {
         ...state,

--- a/src/utilities/byProgram.js
+++ b/src/utilities/byProgram.js
@@ -11,6 +11,30 @@ import { SETTINGS_KEYS } from '../settings';
  */
 
 /**
+ * Finds all MasterList objects which are programs usable by a passed customer.
+ * A program: A master list which satisfies the following:
+ * -- Is visible to the customer.
+ * -- masterList.isProgram = true,
+ * -- has a store tag in programSettings, with a key which matches a name_tag for this customer.
+ * @param  {Object} Customer
+ * @param  {Realm}  database
+ * @return {array}  MasterLists which are programs usable by this customer.
+ */
+const getAllProgramsForCustomer = (customer, database) => {
+  const { id } = customer;
+  const customersTags = database
+    .objects('NameTag')
+    .filtered('subquery(nameTagJoins, $joins, $joins.name.id == $0).@count > 0', id)
+    .map(({ description }) => description.toLowerCase());
+
+  return database
+    .objects('MasterListNameJoin')
+    .filtered('name.id = $0 && masterList.isProgram = $1', id, true)
+    .filter(({ masterList }) => masterList.getStoreTagObject(customersTags))
+    .map(({ masterList }) => masterList);
+};
+
+/**
  * Finds all MasterList objects which are programs usable by this store.
  * A program: A master list which satisfies the following:
  * -- associated with this store,
@@ -47,14 +71,14 @@ const getAllPrograms = (settings, database) => {
  * @param  {Object}             orderType           an order Type object
  * @return {array}
  */
-const getAllPeriodsForProgram = (database, program, periodScheduleName, orderType) => {
+const getAllPeriodsForProgram = (database, program, periodScheduleName, orderType, customer) => {
   const periodScheduleNames = database
     .objects('PeriodSchedule')
     .filtered('name = $0', periodScheduleName);
 
   if (!periodScheduleNames.length) return [];
 
-  return periodScheduleNames[0].getPeriodsForOrderType(program, orderType);
+  return periodScheduleNames[0].getPeriodsForOrderType(program, orderType, customer);
 };
 
-export { getAllPrograms, getAllPeriodsForProgram };
+export { getAllPrograms, getAllPeriodsForProgram, getAllProgramsForCustomer };

--- a/src/utilities/getModalTitle.js
+++ b/src/utilities/getModalTitle.js
@@ -3,7 +3,13 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import { authStrings, modalStrings, buttonStrings } from '../localization';
+import {
+  navStrings,
+  programStrings,
+  authStrings,
+  modalStrings,
+  buttonStrings,
+} from '../localization';
 
 export const MODAL_KEYS = {
   CONFIRM_USER_PASSWORD: 'confirmUserPassword',
@@ -43,6 +49,10 @@ export const getModalTitle = modalKey => {
   switch (modalKey) {
     default:
       return '';
+    case MODAL_KEYS.PROGRAM_REQUISITION:
+      return `${navStrings.requisition} ${programStrings.details}`;
+    case MODAL_KEYS.PROGRAM_STOCKTAKE:
+      return `${navStrings.stocktake} ${programStrings.details}`;
     case MODAL_KEYS.CREATE_CASH_TRANSACTION:
       return modalStrings.create_cash_transaction;
     case MODAL_KEYS.SELECT_PRESCRIBER:

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -12,7 +12,7 @@ export { formatStatus } from './formatStatus';
 export { sortDataBy } from './sortDataBy';
 export { compareVersions, versionToInteger } from './compareVersions';
 export { createReducer, REHYDRATE } from './createReducer';
-export { getAllPeriodsForProgram, getAllPrograms } from './byProgram';
+export { getAllPeriodsForProgram, getAllPrograms, getAllProgramsForCustomer } from './byProgram';
 export { requestPermission } from './requestPermission';
 export { backupValidation } from './fileSystem';
 export { debounce } from './underscoreMethods';

--- a/src/widgets/Step.js
+++ b/src/widgets/Step.js
@@ -21,8 +21,10 @@ const getLocalisation = ({ stepKey }) => {
     supplier: programStrings.no_suppliers,
     orderType: programStrings.no_order_types,
     period: programStrings.no_periods,
+    customer: programStrings.no_customers,
   };
   const placeholders = {
+    customer: programStrings.select_a_customer,
     program: programStrings.select_a_program,
     supplier: programStrings.select_a_supplier,
     orderType: programStrings.select_an_order_type,
@@ -59,6 +61,7 @@ export const Step = memo(props => {
   const { data, field, type, stepKey, status, getModalData, onPress } = props;
   // Each stepKey used with this component has a placeholder/error string in getLocalisation.
   const { placeholder, errorString } = getLocalisation({ stepKey });
+
   // Calculate the errorState in this component after fetching modalData. If there is no
   // modalData and the status is CURRENT, the step is in an error state - display the
   // error string and a new icon.
@@ -152,7 +155,6 @@ const localStyles = StyleSheet.create({
   containerStyle: {
     flexDirection: 'row',
     width: '100%',
-    justifyContent: 'center',
     alignItems: 'center',
     minHeight: '10%',
   },

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -83,8 +83,8 @@ const modalProps = ({ dispatch, program, orderType, customer }) => ({
       const { maxOrdersPerPeriod, isEmergency } = orderType;
 
       const requisitionsInPeriod = !customer
-        ? item.requisitionsForOrderType(program, orderType)
-        : item.customerRequisitionsForOrderTypeAndName(program, orderType, customer);
+        ? item.numberOfSupplierRequisitionsForOrderType(program, orderType)
+        : item.numberOfCustomerRequisitionsForOrderType(program, orderType, customer);
       const requisitionsCount = `${requisitionsInPeriod}/${maxOrdersPerPeriod} ${requisitions}`;
 
       const periodText = isEmergency

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -10,13 +10,18 @@ import { ModalContainer } from './ModalContainer';
 import globalStyles, { DARK_GREY, WARM_GREY, SUSSOL_ORANGE } from '../../globalStyles';
 
 import { SETTINGS_KEYS } from '../../settings';
-import { getAllPrograms, getAllPeriodsForProgram } from '../../utilities';
+import {
+  getAllPrograms,
+  getAllPeriodsForProgram,
+  getAllProgramsForCustomer,
+} from '../../utilities';
 import { programStrings, navStrings } from '../../localization';
 import { UIDatabase } from '../../database';
 import {
   selectProgram,
   selectSupplier,
   selectOrderType,
+  selectCustomer,
   selectPeriod,
   setStoreTags,
   setSteps,
@@ -31,10 +36,14 @@ import { FlexColumn } from '../FlexColumn';
 
 const { THIS_STORE_TAGS, THIS_STORE_NAME_ID } = SETTINGS_KEYS;
 
-const modalProps = ({ dispatch, program, orderType }) => ({
+const modalProps = ({ dispatch, program, orderType, customer }) => ({
   program: {
     queryStringSecondary: 'name CONTAINS[c] $0',
     onSelect: value => dispatch(selectProgram(value)),
+  },
+  customer: {
+    secondaryFilterProperty: 'code',
+    onSelect: value => dispatch(selectCustomer(value)),
   },
   supplier: {
     secondaryFilterProperty: 'code',
@@ -73,7 +82,9 @@ const modalProps = ({ dispatch, program, orderType }) => ({
       const { requisitions } = getLocalizedStrings();
       const { maxOrdersPerPeriod, isEmergency } = orderType;
 
-      const requisitionsInPeriod = item.requisitionsForOrderType(program, orderType);
+      const requisitionsInPeriod = !customer
+        ? item.requisitionsForOrderType(program, orderType)
+        : item.customerRequisitionsForOrderTypeAndName(program, orderType, customer);
       const requisitionsCount = `${requisitionsInPeriod}/${maxOrdersPerPeriod} ${requisitions}`;
 
       const periodText = isEmergency
@@ -90,7 +101,7 @@ export const ByProgramModal = ({ settings, database, transactionType, onConfirm 
     initialState({ transactionType })
   );
 
-  const { steps, modalData, program, orderType, period, supplier, name } = state;
+  const { steps, modalData, program, orderType, period, supplier, name, customer } = state;
   const strings = useMemo(() => getLocalizedStrings({ transactionType }), [transactionType]);
 
   const mounting = () => {
@@ -118,6 +129,7 @@ export const ByProgramModal = ({ settings, database, transactionType, onConfirm 
     name,
     period,
     steps,
+    customer,
     state.isProgramBased,
   ]);
 
@@ -130,13 +142,19 @@ export const ByProgramModal = ({ settings, database, transactionType, onConfirm 
     .map(({ description }) => description.toLowerCase());
 
   // Helper methods for fetching modal data for user selection
-  const getPrograms = () => getAllPrograms(settings, database);
+  const getPrograms = () => {
+    if (transactionType === 'customerRequisition') {
+      return getAllProgramsForCustomer(customer, database);
+    }
+    return getAllPrograms(settings, database);
+  };
   const getSuppliers = () => database.objects('InternalSupplier');
+  const getCustomers = () => database.objects('Customer');
   const getOrderTypes = () => program && program.getStoreTagObject(tags).orderTypes;
   const getPeriods = () => {
     if (!(program && orderType)) return null;
     const { periodScheduleName } = program.getStoreTagObject(tags);
-    return getAllPeriodsForProgram(database, program, periodScheduleName, orderType);
+    return getAllPeriodsForProgram(database, program, periodScheduleName, orderType, customer);
   };
 
   /** Call backs */
@@ -184,7 +202,7 @@ export const ByProgramModal = ({ settings, database, transactionType, onConfirm 
         primaryFilterProperty="name"
         renderLeftText={item => `${item.name}`}
         options={modalData}
-        {...modalProps({ dispatch, program, orderType })[currentKey]}
+        {...modalProps({ dispatch, program, orderType, customer })[currentKey]}
       />
     );
     const Editor = () => (
@@ -208,7 +226,19 @@ export const ByProgramModal = ({ settings, database, transactionType, onConfirm 
         type: 'select',
         field: 'name',
       }),
-      [program, state.isProgramBased, supplier]
+      [program, state.isProgramBased, supplier, customer]
+    ),
+    customer: useMemo(
+      () => ({
+        data: customer,
+        getModalData: getCustomers,
+        onPress: onOpenModal,
+        status: getStatus('customer'),
+        stepKey: 'customer',
+        type: 'select',
+        field: 'name',
+      }),
+      [program, supplier, state.isProgramBased, customer]
     ),
     supplier: useMemo(
       () => ({
@@ -266,7 +296,7 @@ export const ByProgramModal = ({ settings, database, transactionType, onConfirm 
 
   return (
     <FlexColumn flex={1} alignItems="center">
-      <ProgramToggleBar />
+      {transactionType !== 'customerRequisition' ? <ProgramToggleBar /> : null}
       {steps.map(stepKey => (
         <Step key={stepKey} {...stepProps[stepKey]} />
       ))}


### PR DESCRIPTION
### Branched from: #3138 

Fixes #3132

## Change summary

**Implemented differently to the issue describes**

- Initially thought it would be far too complex to add customers over suppliers into `ByProgramModal`. Turned out to be quite quick and simple (If you were the one to write it originally. Sorry).
- This should *still* be refactored into: Customer requisition `ByProgramModal`, Supplier Requisition and Stocktake variants as the logic in *general* is convoluted and extremely hard to follow.
- Essentially, this allows for passing `transactionType="customerRequisition"` as a prop which will have the steps "Customer -> Program -> Order type -> period"`.
- Not hooked up - can create a branch for testing if needed, otherwise can be tested in the next 'hook it up' PR

## Testing

*Internal changes, shouldn't be tested*

### Related areas to think about

- At this point I am not sure how much more extensible we need to make the component - surely there's not going to be customer invoices by program ... ?!?! So although I hate this code and want to refactor it desperately, I think it's only worth it once the requirements are completed proper?
