### PR TITLE
allow filtering by code

### DIFF
--- a/src/selectors/prescription.js
+++ b/src/selectors/prescription.js
@@ -52,7 +52,10 @@ export const selectFilteredAndSortedItems = createSelector(
   [selectItemSearchTerm, selectItems],
   (itemSearchTerm, items) => {
     // Filter the items by the entered search term.
-    const filteredItems = items.filtered('name CONTAINS[c] $0', itemSearchTerm);
+    const filteredItems = items.filtered(
+      'name CONTAINS[c] $0 || code CONTAINS[c] $0',
+      itemSearchTerm
+    );
 
     // Keep the items sorted alphabetically.
     const sortedItems = filteredItems.sorted('name');


### PR DESCRIPTION
Fixes #3130 

## Change summary

Allow searching for an item by name or code

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Dispense - at the point of selecting an item try filtering by an item code

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
