### PR TITLE
#3127 Re-render fridges on navigation

### DIFF
--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -39,7 +39,7 @@ export const refreshIndicatorRow = route => ({
 export const editSensorLocation = (location, route) => (dispatch, getState) => {
   const { modalValue, keyExtractor } = selectPageState(getState());
 
-  UIDatabase.write(() => UIDatabase.update('Sensor', { ...modalValue, location }));
+  UIDatabase.write(() => UIDatabase.update('Sensor', { id: modalValue.id, location }));
 
   reduxBatch(() => {
     dispatch(refreshRow(keyExtractor(modalValue), route));

--- a/src/reducers/FridgeReducer.js
+++ b/src/reducers/FridgeReducer.js
@@ -59,9 +59,11 @@ export const FridgeReducer = (state = initialState(), action) => {
 
     case 'Navigation/BACK':
     case 'Navigation/NAVIGATE': {
-      const { routeName } = action;
+      const { routeName, payload } = action;
+      const { prevRouteName } = payload ?? {};
 
-      if (routeName === ROUTES.VACCINES) return initialState();
+      if (routeName === ROUTES.VACCINES || prevRouteName === ROUTES.VACCINES) return initialState();
+
       return state;
     }
 


### PR DESCRIPTION
Fixes #3128 

## Change summary

- Corrected case when navigating back

## Testing

- [ ] When navigating to fridges from vaccines admin page, the fridges in the vaccines page are refreshed

### Related areas to think about

N/A
