### PR TITLE
#3167 Add header, axis labels to bar chart in mobile dashboard

### DIFF
--- a/src/widgets/BarChart.js
+++ b/src/widgets/BarChart.js
@@ -20,10 +20,18 @@ import { APP_FONT_FAMILY, GREY, LIGHT_GREY, DARK_GREY, SUSSOL_ORANGE } from '../
  */
 
 export const BarChart = ({ data, width, height }) => {
-  const renderYAxis = () => <VictoryAxis dependentAxis style={victoryStyles.axisY} />;
+  const renderYAxis = () => (
+    <VictoryAxis label={data[0].axis_label.y} dependentAxis style={victoryStyles.axisY} />
+  );
   const renderXAxis = () => {
     const tickTruncate = label => (label.length > 11 ? `${label.slice(0, 11)}...` : label);
-    return <VictoryAxis tickFormat={tickTruncate} style={victoryStyles.axisX} />;
+    return (
+      <VictoryAxis
+        label={data[0].axis_label.x}
+        tickFormat={tickTruncate}
+        style={victoryStyles.axisX}
+      />
+    );
   };
 
   const { padTop, padBottom, padLeft, padRight, padDomain, style } = victoryStyles.barChart;
@@ -40,6 +48,7 @@ export const BarChart = ({ data, width, height }) => {
 
   return (
     <VictoryChart width={width} height={height} padding={padding} domainPadding={domainPadding}>
+      <VictoryLabel text={data[0].label} x={width / 2} y={30} textAnchor="middle" />
       {data.map(({ values }) => (
         <VictoryBar
           style={style}


### PR DESCRIPTION
Fixes #3167

## Change summary

- Code the headed and axis labels in with code
- We also want names to be shown more clearly so we replace names with codes but that bit is done in mSupply side.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Generate dashboard JSON for Expiring items in mSupply
- [ ] Enable dashboard for the mobile site
- [ ] Go to the dashboard panel and see the graph with header and labels, also with codes in place of names.


### Related areas to think about

Related to https://github.com/sussol/msupply/issues/6762, the changes there has to go in first.
