### PR TITLE
#3174 Add xlargescreens support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
   <uses-permission android:name="android.permission.BLUETOOTH_PRIVILEGED" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-  <supports-screens android:smallScreens="false" android:normalScreens="false" android:largeScreens="false" android:requiresSmallestWidthDp="720" />
+  <supports-screens android:smallScreens="false" android:normalScreens="false" android:largeScreens="false" android:xlargeScreens="true" android:requiresSmallestWidthDp="720" />
   <application android:name=".MainApplication" android:allowBackup="true" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/AppTheme">
     <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize" android:screenOrientation="landscape" android:launchMode="singleTop" android:windowSoftInputMode="adjustResize">
       <intent-filter>


### PR DESCRIPTION
Fixes #3174 

## Change summary

Changes `supports-screens` android manifest option.

https://developer.android.com/guide/topics/manifest/supports-screens-element#compat-mode

Seems `requiresSmallestWidthDp` only allows for googly play store to apply filter. But google play store does not filter by it. 🤷 

## Testing

- [ ] @bijaySussol  ;-)

### Related areas to think about

Stab in the dark.. no idea if it'll work!
