### PR TITLE
#3179 Not disabled when finalised

### DIFF
--- a/src/widgets/PageInfo/PageInfoDetail.js
+++ b/src/widgets/PageInfo/PageInfoDetail.js
@@ -7,8 +7,15 @@ import { FlexRow } from '../FlexRow';
 
 import { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../../globalStyles';
 
-export const PageInfoDetail = ({ isDisabled, onPress, info, type, color, numberOfLines }) => {
-  const editable = onPress && !isDisabled;
+export const PageInfoDetail = ({
+  isEditingDisabled,
+  onPress,
+  info,
+  type,
+  color,
+  numberOfLines,
+}) => {
+  const editable = onPress && !isEditingDisabled;
   const border = editable && type === 'text' ? localStyles.bottomBorder : {};
   const iconLookups = { selectable: 'angle-down', text: 'pencil', date: 'calendar' };
   const iconName = iconLookups[type ?? 'text'];
@@ -43,7 +50,7 @@ export const localStyles = {
 };
 
 PageInfoDetail.defaultProps = {
-  isDisabled: false,
+  isEditingDisabled: false,
   info: '',
   type: '',
   onPress: null,
@@ -51,7 +58,7 @@ PageInfoDetail.defaultProps = {
 };
 
 PageInfoDetail.propTypes = {
-  isDisabled: PropTypes.bool,
+  isEditingDisabled: PropTypes.bool,
   onPress: PropTypes.func,
   info: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   type: PropTypes.string,

--- a/src/widgets/PageInfo/PageInfoRow.js
+++ b/src/widgets/PageInfo/PageInfoRow.js
@@ -6,7 +6,7 @@ import { PageInfoTitle } from './PageInfoTitle';
 import { PageInfoDetail } from './PageInfoDetail';
 
 export const PageInfoRow = ({
-  isDisabled,
+  isEditingDisabled,
   titleColor,
   infoColor,
   onPress,
@@ -19,7 +19,7 @@ export const PageInfoRow = ({
   <FlexRow style={{ marginTop: 5 }}>
     <PageInfoTitle
       numberOfLines={numberOfLines}
-      isDisabled={isDisabled}
+      isEditingDisabled={isEditingDisabled}
       color={titleColor}
       onPress={onPress}
       title={title}
@@ -27,7 +27,7 @@ export const PageInfoRow = ({
     />
     <PageInfoDetail
       numberOfLines={numberOfLines}
-      isDisabled={isDisabled}
+      isEditingDisabled={isEditingDisabled}
       color={infoColor}
       onPress={onPress}
       info={info}
@@ -40,13 +40,13 @@ PageInfoRow.defaultProps = {
   info: '',
   editableType: '',
   onPress: null,
-  isDisabled: false,
+  isEditingDisabled: false,
   numberOfLines: 1,
   titleTextAlign: 'left',
 };
 
 PageInfoRow.propTypes = {
-  isDisabled: PropTypes.bool,
+  isEditingDisabled: PropTypes.bool,
   titleColor: PropTypes.string.isRequired,
   infoColor: PropTypes.string.isRequired,
   onPress: PropTypes.func,

--- a/src/widgets/PageInfo/PageInfoTitle.js
+++ b/src/widgets/PageInfo/PageInfoTitle.js
@@ -5,9 +5,16 @@ import PropTypes from 'prop-types';
 import { SUSSOL_ORANGE, APP_FONT_FAMILY } from '../../globalStyles';
 import { FlexRow } from '../FlexRow';
 
-export const PageInfoTitle = ({ isDisabled, color, onPress, title, numberOfLines, textAlign }) => {
+export const PageInfoTitle = ({
+  isEditingDisabled,
+  color,
+  onPress,
+  title,
+  numberOfLines,
+  textAlign,
+}) => {
   const style = { ...localStyles.text, ...localStyles.titleText, color, textAlign };
-  const editable = onPress && !isDisabled;
+  const editable = onPress && !isEditingDisabled;
   const Container = editable ? TouchableOpacity : FlexRow;
 
   return (
@@ -31,13 +38,13 @@ const localStyles = {
 
 PageInfoTitle.defaultProps = {
   onPress: null,
-  isDisabled: false,
+  isEditingDisabled: false,
   numberOfLines: 1,
   textAlign: 'left',
 };
 
 PageInfoTitle.propTypes = {
-  isDisabled: PropTypes.bool,
+  isEditingDisabled: PropTypes.bool,
   onPress: PropTypes.func,
   color: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,


### PR DESCRIPTION
Fixes #3179 

## Change summary

- Just correct prop drill/pass. This was a mistake in a recent refactor in develop

## Testing

- [ ] In all finalisable pages, when finalised the `PageInfo` (Comment etc) are disabeld.

### Related areas to think about

N/A
