### PR TITLE
#3181 memoization issues by program modal

### DIFF
--- a/src/widgets/Step.js
+++ b/src/widgets/Step.js
@@ -74,10 +74,10 @@ export const Step = memo(props => {
   useEffect(() => {
     if (status !== 'CURRENT' || !getModalData) return;
     setModalData(getModalData());
-  }, [status, internalStatus, data]);
+  }, [status, internalStatus, data, getModalData]);
 
   const onSelection = () => {
-    onPress({ selection: modalData, key: stepKey });
+    onPress({ selection: getModalData(), key: stepKey });
   };
 
   /** Inner components */

--- a/src/widgets/Step.js
+++ b/src/widgets/Step.js
@@ -77,7 +77,7 @@ export const Step = memo(props => {
   }, [status, internalStatus, data, getModalData]);
 
   const onSelection = () => {
-    onPress({ selection: getModalData(), key: stepKey });
+    onPress({ selection: modalData, key: stepKey });
   };
 
   /** Inner components */

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/forbid-prop-types */
-import React, { useReducer, useEffect, useCallback, useMemo } from 'react';
+import React, { useReducer, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, View } from 'react-native';
 
@@ -102,7 +102,7 @@ export const ByProgramModal = ({ settings, database, transactionType, onConfirm 
   );
 
   const { steps, modalData, program, orderType, period, supplier, name, customer } = state;
-  const strings = useMemo(() => getLocalizedStrings({ transactionType }), [transactionType]);
+  const strings = getLocalizedStrings({ transactionType });
 
   const mounting = () => {
     dispatch(setStoreTags(settings.get(THIS_STORE_TAGS)));
@@ -114,7 +114,7 @@ export const ByProgramModal = ({ settings, database, transactionType, onConfirm 
   // Calculates the current state of a step, according to what data is currently
   // stored in state, where the current step the user should perform is CURRENT,
   // data which is stored is COMPLETE and steps which can't be done yet are INCOMPLETE.
-  const getStatusCallback = key =>
+  const getStatus = key =>
     steps.reduceRight((status, value, i) => {
       if (state[key]) return 'COMPLETE';
       const previousStepIsCurrent = state[value] && steps[i + 1] === key;
@@ -122,16 +122,6 @@ export const ByProgramModal = ({ settings, database, transactionType, onConfirm 
       if (previousStepIsCurrent || firstStepIsCurrent) return 'CURRENT';
       return status;
     }, 'INCOMPLETE');
-  const getStatus = useCallback(getStatusCallback, [
-    program,
-    orderType,
-    supplier,
-    name,
-    period,
-    steps,
-    customer,
-    state.isProgramBased,
-  ]);
 
   const tags = database
     .objects('NameTag')
@@ -216,76 +206,62 @@ export const ByProgramModal = ({ settings, database, transactionType, onConfirm 
   };
 
   const stepProps = {
-    program: useMemo(
-      () => ({
-        data: program,
-        getModalData: getPrograms,
-        onPress: onOpenModal,
-        status: getStatus('program'),
-        stepKey: 'program',
-        type: 'select',
-        field: 'name',
-      }),
-      [program, state.isProgramBased, supplier, customer]
-    ),
-    customer: useMemo(
-      () => ({
-        data: customer,
-        getModalData: getCustomers,
-        onPress: onOpenModal,
-        status: getStatus('customer'),
-        stepKey: 'customer',
-        type: 'select',
-        field: 'name',
-      }),
-      [program, supplier, state.isProgramBased, customer]
-    ),
-    supplier: useMemo(
-      () => ({
-        data: supplier,
-        getModalData: getSuppliers,
-        onPress: onOpenModal,
-        status: getStatus('supplier'),
-        stepKey: 'supplier',
-        type: 'select',
-        field: 'name',
-      }),
-      [program, supplier, state.isProgramBased]
-    ),
-    orderType: useMemo(
-      () => ({
-        data: orderType,
-        getModalData: getOrderTypes,
-        onPress: onOpenModal,
-        status: getStatus('orderType'),
-        stepKey: 'orderType',
-        type: 'select',
-        field: 'name',
-      }),
-      [supplier, orderType, program]
-    ),
-    period: useMemo(
-      () => ({
-        data: period,
-        getModalData: getPeriods,
-        onPress: onOpenModal,
-        status: getStatus('period'),
-        stepKey: 'period',
-        type: 'select',
-        field: 'name',
-      }),
-      [orderType, period, supplier, program]
-    ),
-    name: useMemo(
-      () => ({
-        data: name,
-        status: getStatus('name'),
-        onPress: onOpenModal,
-        stepKey: 'name',
-        type: 'input',
-      }),
-      [program, state.isProgramBased, name]
-    ),
+    program: {
+      data: program,
+      getModalData: getPrograms,
+      onPress: onOpenModal,
+      status: getStatus('program'),
+      stepKey: 'program',
+      type: 'select',
+      field: 'name',
+    },
+    customer: {
+      data: customer,
+      getModalData: getCustomers,
+      onPress: onOpenModal,
+      status: getStatus('customer'),
+      stepKey: 'customer',
+      type: 'select',
+      field: 'name',
+    },
+
+    supplier: {
+      data: supplier,
+      getModalData: getSuppliers,
+      onPress: onOpenModal,
+      status: getStatus('supplier'),
+      stepKey: 'supplier',
+      type: 'select',
+      field: 'name',
+    },
+
+    orderType: {
+      data: orderType,
+      getModalData: getOrderTypes,
+      onPress: onOpenModal,
+      status: getStatus('orderType'),
+      stepKey: 'orderType',
+      type: 'select',
+      field: 'name',
+    },
+
+    period: {
+      data: period,
+      getModalData: getPeriods,
+      onPress: onOpenModal,
+      status: getStatus('period'),
+      stepKey: 'period',
+      type: 'select',
+      field: 'name',
+    },
+
+    name: {
+      data: name,
+      status: getStatus('name'),
+      onPress: onOpenModal,
+      stepKey: 'name',
+      type: 'input',
+    },
   };
 
   /** Render */


### PR DESCRIPTION
Fixes #3181 #3180 #3171 

## Change summary

Removes some prematurely optimized caching which just made things harder while saving some 1ms queries.. 🤷 

## Testing

- [ ] Can back pedal program steps correctly
- [ ] Changing the order type correctly updates the period
- [ ] Changing the program correctly updates the order types correctly
- [ ] Changing the customer correctly updates the programs correctly

### Related areas to think about

You live you learn - what I've learned: Avoid `useMemo` and `useCallback` unless it's causing actual performance issues that you want to solve. Not just to avoid potential or perceived performance issues!

For this particular issue: Removing the `getModalData` callback and just putting the data in the object straight up would probs be a better solution (But requires more work and, well.. )