### PR TITLE
#3051 auto finalise prescriptions

### DIFF
--- a/src/sync/PostSyncProcessor.js
+++ b/src/sync/PostSyncProcessor.js
@@ -212,6 +212,17 @@ export class PostSyncProcessor {
       });
     }
 
+    // Auto-finalise all incoming prescriptions
+    if (
+      record.type === 'customer_invoice' &&
+      record.otherParty?.type === 'patient' &&
+      !record.isFinalised
+    ) {
+      funcs.push(() => {
+        record.finalise(this.database);
+      });
+    }
+
     // If any changes, add database update for record.
     if (funcs.length > 0) {
       funcs.push(() => {


### PR DESCRIPTION
Fixes #3051 

## Change summary

- Adds auto-finalise of prescriptions on incoming sync

## Testing

- Create a prescription on desktop, don't finalise.
- Make the store a mobile store
- initialise the mobile store
- Sync with desktop
- Check on desktop: The prescription should be finalised 

- [ ] Prescriptions are finalised auto matically on incoming sync

### Related areas to think about

N/a