### PR TITLE
#3218 Fixed sync bug preventing stocktake lines from syncing

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -147,7 +147,7 @@ export const sanityCheckIncomingRecord = (recordType, record) => {
         'optionID',
         'doses',
         'vaccine_vial_monitor_status_ID',
-        'location_ID',
+        'location_id',
       ],
     },
     Store: {
@@ -772,7 +772,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         sortIndex: parseNumber(record.line_number),
         option: database.getOrCreate('Options', record.optionID),
         doses: packSize ? parseNumber(record.doses) / packSize : 0,
-        location: database.getOrCreate('Location', record.location_ID),
+        location: database.getOrCreate('Location', record.location_id),
         vaccineVialMonitorStatus: database.getOrCreate(
           'VaccineVialMonitorStatus',
           record.vaccine_vial_monitor_status_ID


### PR DESCRIPTION
Fixes #3218

## Change summary

- Fixes a field name such that the sanity check passes again

## Testing

*Have a stocktake with some lines on a mobile store*
- [ ] Initialize a mobile store - the stocktakes synced have all of their lines

### Related areas to think about

This area is ironically (I think I use this word here) trying to prevent errors (the sanity check) but it's pretty error prone itself! Worth a refactor/look at, imo!