### PR TITLE
#1680 Create a stocktake batch when creating a StocktakeItem

### DIFF
--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -93,9 +93,13 @@ export class Stocktake extends Realm.Object {
       const stocktakeItem = createRecord(database, 'StocktakeItem', this, item);
 
       // Add all item batches currently in stock to the stocktake item as stocktake batches.
-      item.batchesWithStock.forEach(itemBatch => {
-        createRecord(database, 'StocktakeBatch', stocktakeItem, itemBatch);
-      });
+      if (item.batchesWithStock.length > 0) {
+        item.batchesWithStock.forEach(itemBatch => {
+          createRecord(database, 'StocktakeBatch', stocktakeItem, itemBatch);
+        });
+      } else {
+        stocktakeItem.createNewBatch(database);
+      }
     });
   }
 


### PR DESCRIPTION
Fixes #1680

## Change summary

- Create a basic `StocktakeBatch` when creating a `StocktakeItem`

## Testing

- [ ] Creating a Stocktake and don't count anything. Sync it to desktop: On desktop, you should see some lines

### Related areas to think about

N/A
