### PR TITLE
#2294 Making Spinners great again

### DIFF
--- a/src/actions/FinaliseActions.js
+++ b/src/actions/FinaliseActions.js
@@ -2,7 +2,6 @@
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
  */
-import { batch } from 'react-redux';
 import { Client as BugsnagClient } from 'bugsnag-react-native';
 
 import { UIDatabase } from '../database';
@@ -40,10 +39,7 @@ const finalise = () => (dispatch, getState) => {
     bugsnagClient.notify(error);
   }
 
-  batch(() => {
-    dispatch(closeModal());
-    dispatch(refreshData(currentRoute));
-  });
+  dispatch(refreshData(currentRoute));
 };
 
 export const FinaliseActions = {

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -143,7 +143,8 @@ class MSupplyMobileAppContainer extends React.Component {
     await new Promise(resolve => {
       this.setState({ isLoading: true }, () => setTimeout(resolve, 1));
     });
-    functionToRun();
+
+    await functionToRun();
     this.setState({ isLoading: false });
   };
 
@@ -181,6 +182,7 @@ class MSupplyMobileAppContainer extends React.Component {
 
   renderLoadingIndicator = () => {
     const { isLoading } = this.state;
+
     return (
       <View style={globalStyles.loadingIndicatorContainer}>
         <Spinner isSpinning={isLoading} color={SUSSOL_ORANGE} />

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -21,6 +21,7 @@ import { BottomConfirmModal } from '../widgets/bottomModals';
 import { buttonStrings, modalStrings, generalStrings } from '../localization';
 import globalStyles from '../globalStyles';
 import { BreachActions } from '../actions/BreachActions';
+import { useLoadingIndicator } from '../hooks/useLoadingIndicator';
 
 /**
  * Renders a mSupply mobile page with customer invoice loaded for editing
@@ -75,6 +76,13 @@ export const CustomerInvoice = ({
     isFinalised,
   ]);
 
+  const runWithLoadingIndicator = useLoadingIndicator();
+
+  const onAddFromMasterLists = selected => {
+    onCloseModal();
+    runWithLoadingIndicator(() => onApplyMasterLists(selected, pageObject));
+  };
+
   const getCallback = (colKey, propName) => {
     switch (colKey) {
       case 'totalQuantity':
@@ -100,7 +108,7 @@ export const CustomerInvoice = ({
       case MODAL_KEYS.THEIR_REF_EDIT:
         return onEditTheirRef;
       case MODAL_KEYS.SELECT_MASTER_LISTS:
-        return onApplyMasterLists;
+        return onAddFromMasterLists;
       default:
         return null;
     }
@@ -200,9 +208,14 @@ export const CustomerInvoice = ({
 };
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-  const { transaction } = ownProps?.navigation?.route?.param || {};
+  const { transaction } = ownProps?.route?.params || {};
   const { otherParty } = transaction || {};
   const hasMasterLists = otherParty?.masterLists?.length > 0;
+
+  // console.log('-------------------------------------------');
+  // console.log('transaction', transaction);
+  // console.log('ownProps', ownProps);
+  // console.log('-------------------------------------------');
 
   const onViewBreaches = rowKey => dispatch(BreachActions.viewTransactionItemBreaches(rowKey));
 

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -212,11 +212,6 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   const { otherParty } = transaction || {};
   const hasMasterLists = otherParty?.masterLists?.length > 0;
 
-  // console.log('-------------------------------------------');
-  // console.log('transaction', transaction);
-  // console.log('ownProps', ownProps);
-  // console.log('-------------------------------------------');
-
   const onViewBreaches = rowKey => dispatch(BreachActions.viewTransactionItemBreaches(rowKey));
 
   const noMasterLists = () =>

--- a/src/pages/CustomerRequisitionsPage.js
+++ b/src/pages/CustomerRequisitionsPage.js
@@ -24,6 +24,7 @@ import { MODAL_KEYS } from '../utilities';
 import { DataTablePageModal } from '../widgets/modals';
 import { selectCurrentUser } from '../selectors/user';
 import { BottomConfirmModal } from '../widgets/bottomModals/index';
+import { useLoadingIndicator } from '../hooks/useLoadingIndicator';
 
 /**
  * Renders a mSupply mobile page with a list of Customer requisitions.
@@ -66,6 +67,7 @@ export const CustomerRequisitions = ({
   // Custom hook to refresh data on this page when becoming the head of the stack again.
   useNavigationFocus(navigation, refreshData);
   useSyncListener(refreshData, 'Requisition');
+  const runWithLoadingIndicator = useLoadingIndicator();
 
   const getCallback = useCallback((colKey, propName) => {
     switch (colKey) {
@@ -82,7 +84,9 @@ export const CustomerRequisitions = ({
       case MODAL_KEYS.PROGRAM_CUSTOMER_REQUISITION:
         return params => {
           onCloseModal();
-          dispatch(createCustomerRequisition({ ...params, currentUser }));
+          runWithLoadingIndicator(() =>
+            dispatch(createCustomerRequisition({ ...params, currentUser }))
+          );
         };
 
       default:

--- a/src/pages/StocktakesPage.js
+++ b/src/pages/StocktakesPage.js
@@ -31,6 +31,7 @@ import {
   gotoStocktakeEditPage,
 } from '../navigation/actions';
 import { selectCurrentUser } from '../selectors/user';
+import { useLoadingIndicator } from '../hooks/useLoadingIndicator';
 
 export const Stocktakes = ({
   currentUser,
@@ -61,6 +62,8 @@ export const Stocktakes = ({
   useSyncListener(refreshData, ['Stocktake']);
   useNavigationFocus(navigation, refreshData);
 
+  const runWithLoadingIndicator = useLoadingIndicator();
+
   const onRowPress = useCallback(stocktake => dispatch(gotoStocktakeEditPage(stocktake)), []);
 
   const getCallback = (colKey, propName) => {
@@ -77,8 +80,10 @@ export const Stocktakes = ({
     switch (modalKey) {
       case MODAL_KEYS.PROGRAM_STOCKTAKE:
         return ({ stocktakeName, program }) => {
-          dispatch(createStocktake({ program, stocktakeName, currentUser }));
           onCloseModal();
+          runWithLoadingIndicator(() =>
+            dispatch(createStocktake({ program, stocktakeName, currentUser }))
+          );
         };
       default:
         return null;

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -103,9 +103,15 @@ const SupplierRequisition = ({
   const runWithLoadingIndicator = useLoadingIndicator();
 
   const usingReasons = !!UIDatabase.objects('RequisitionReason').length;
-  const onAddMasterLists = React.useCallback(selected => onApplyMasterLists(selected, pageObject), [
-    pageObject,
-  ]);
+  const onAddMasterLists = React.useCallback(
+    selected => {
+      onCloseModal();
+      runWithLoadingIndicator(() => {
+        onApplyMasterLists(selected, pageObject);
+      });
+    },
+    [pageObject]
+  );
 
   const { isFinalised, comment, theirRef, program, daysToSupply } = pageObject;
 

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -25,6 +25,7 @@ import { selectCurrentUser } from '../selectors/user';
 
 import globalStyles from '../globalStyles';
 import { buttonStrings, modalStrings, generalStrings } from '../localization';
+import { useLoadingIndicator } from '../hooks/useLoadingIndicator';
 
 /**
  * Renders a mSupply mobile page with a list of supplier requisitions.
@@ -70,14 +71,22 @@ export const SupplierRequisitions = ({
 
   const onPressRow = useCallback(rowData => dispatch(gotoSupplierRequisition(rowData)), []);
 
-  const onCreateRequisition = otherStoreName => {
+  const runWithLoadingIndicator = useLoadingIndicator();
+
+  const onCreateRequisition = async otherStoreName => {
     onCloseModal();
-    dispatch(createSupplierRequisition({ otherStoreName, currentUser }));
+    await runWithLoadingIndicator(
+      async () => dispatch(createSupplierRequisition({ otherStoreName, currentUser })),
+      true
+    );
   };
 
-  const onCreateProgramRequisition = requisitionParameters => {
+  const onCreateProgramRequisition = async requisitionParameters => {
     onCloseModal();
-    dispatch(createSupplierRequisition({ ...requisitionParameters, currentUser }));
+    await runWithLoadingIndicator(
+      async () => dispatch(createSupplierRequisition({ ...requisitionParameters, currentUser })),
+      true
+    );
   };
 
   const getCallback = useCallback((colKey, propName) => {

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -138,7 +138,6 @@ export const addMasterListItems = (selected, objectType, route) => (dispatch, ge
   });
 
   dispatch(refreshData(route));
-  dispatch(closeModal(route));
 };
 
 /**

--- a/src/widgets/modals/FinaliseModal.js
+++ b/src/widgets/modals/FinaliseModal.js
@@ -35,10 +35,10 @@ export const FinaliseModalComponent = ({
 }) => {
   const runWithLoadingIndicator = useLoadingIndicator();
 
-  const finaliseWithLoadingIndicator = React.useCallback(
-    () => runWithLoadingIndicator(onFinalise),
-    []
-  );
+  const finaliseWithLoadingIndicator = React.useCallback(() => {
+    closeFinaliseModal();
+    runWithLoadingIndicator(onFinalise);
+  }, []);
 
   return (
     <ModalContainer isVisible={finaliseModalOpen}>
@@ -67,7 +67,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   const closeFinaliseModal = () => dispatch(FinaliseActions.closeModal());
-  const onFinalise = () => dispatch(FinaliseActions.finalise());
+  const onFinalise = async () => dispatch(FinaliseActions.finalise());
 
   return { onFinalise, closeFinaliseModal };
 };


### PR DESCRIPTION
Fixes #2294

## Change summary

- Makes Spinners work for supplierREquisition creating from program and adding from master lists
- Makes spinners work for adding items from master list for customer invoice page
- Makes spinners work for creating a stocktake
- Fixes a type bug in customer invoice `mapDispatchToProps`

## Testing

- [ ] When creating a `SupplierRequisition` from a program, a spinner is displayed.
- [ ] When adding items from a/many master lists to a supplierRequisition a spinner is displayed.
- [ ] When adding items from a/many master lists to a customerInvoice a spinner is displayed.
- [ ] When creating a `stocktake` from a program, a spinner is displayed.

### Related areas to think about

N/A
