### PR TITLE
Add handling of hardware back press for modals

### DIFF
--- a/src/widgets/modals/ModalContainer.js
+++ b/src/widgets/modals/ModalContainer.js
@@ -82,6 +82,7 @@ export const ModalContainer = ({
         presentationStyle="fullScreen"
         animationType="slide"
         hardwareAccelerated={true}
+        onRequestClose={onClose}
       >
         <View style={internalContentContainer}>
           <TitleBar />


### PR DESCRIPTION
Fixes #646

## Change summary

- Handles hardware back press for modals

## Testing

- [ ] When you have some modal open, pressing the hardware back button closes the modal

### Related areas to think about

N/A
