### PR TITLE
Add autoFocus of first form input

### DIFF
--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -116,6 +116,7 @@ const FormControlComponent = ({
                 label={label}
                 invalidMessage={invalidMessage}
                 isDisabled={!isEditable || isDisabled}
+                autoFocus={index === 0}
               />
             );
           }
@@ -132,6 +133,7 @@ const FormControlComponent = ({
                 invalidMessage={invalidMessage}
                 onSubmit={nextFocus(index, key)}
                 isDisabled={isDisabled}
+                autoFocus={index === 0}
               />
             );
           }

--- a/src/widgets/FormInputs/FormDateInput.js
+++ b/src/widgets/FormInputs/FormDateInput.js
@@ -51,6 +51,7 @@ export const FormDateInput = React.forwardRef(
       underlineColorAndroid,
       onSubmit,
       isDisabled,
+      autoFocus,
     },
     ref
   ) => {
@@ -131,6 +132,7 @@ export const FormDateInput = React.forwardRef(
               onChangeText={onChangeTextCallback}
               onSubmitEditing={onSubmitEditing}
               editable={!isDisabled}
+              autoFocus={autoFocus}
             />
             <CircleButton
               IconComponent={CalendarIcon}
@@ -171,6 +173,7 @@ FormDateInput.defaultProps = {
   invalidMessage: '',
   onSubmit: null,
   isDisabled: false,
+  autoFocus: false,
 };
 
 FormDateInput.propTypes = {
@@ -186,4 +189,5 @@ FormDateInput.propTypes = {
   underlineColorAndroid: PropTypes.string,
   onSubmit: PropTypes.func,
   isDisabled: PropTypes.bool,
+  autoFocus: PropTypes.bool,
 };

--- a/src/widgets/FormInputs/FormTextInput.js
+++ b/src/widgets/FormInputs/FormTextInput.js
@@ -42,6 +42,7 @@ export const FormTextInput = React.forwardRef(
       textInputStyle,
       onSubmit,
       isDisabled,
+      autoFocus,
     },
     ref
   ) => {
@@ -101,6 +102,7 @@ export const FormTextInput = React.forwardRef(
               onChangeText={onChangeTextCallback}
               onSubmitEditing={onSubmitEditing}
               editable={!isDisabled}
+              autoFocus={autoFocus}
             />
             <FormInvalidMessage message={invalidMessage} isValid={isValid ?? true} />
           </View>
@@ -129,6 +131,7 @@ FormTextInput.defaultProps = {
   onValidate: null,
   onSubmit: null,
   isDisabled: false,
+  autoFocus: false,
 };
 
 FormTextInput.propTypes = {
@@ -146,4 +149,5 @@ FormTextInput.propTypes = {
   textInputStyle: PropTypes.object,
   onSubmit: PropTypes.func,
   isDisabled: PropTypes.bool,
+  autoFocus: PropTypes.bool,
 };


### PR DESCRIPTION
Fixes #2725 

## Change summary

- AutoFocus on the form input components which can be focused when they're the first input

## Testing

- [ ] Opening the lookup modal for a patient or prescriber automatically has the first form entry component focused

### Related areas to think about

N/A
