### PR TITLE
#3225 Stop pruning remote customer requisitions

### DIFF
--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -387,7 +387,7 @@ export class Requisition extends Realm.Object {
   pruneRedundantItems(database) {
     const itemsToPrune = [];
     this.items.forEach(requisitionItem => {
-      if (requisitionItem.requiredQuantity === 0) {
+      if (!requisitionItem.requisition?.isRemoteOrder && requisitionItem.requiredQuantity === 0) {
         itemsToPrune.push(requisitionItem);
       }
     });


### PR DESCRIPTION
Fixes #3225 

## Change summary

- Just add to the boolean to stop pruning requisition items which are from a remote order.

## Testing

- [ ] Finalising a remote customer requisition does not prune any lines
- [ ] Finalising a non-remote customer requisition does prune any item where the required quantity is 0.

### Related areas to think about

N/A