### PR TITLE
#3082 Dont enforce personal policy numbers

### DIFF
--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -187,7 +187,7 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     type: FORM_INPUT_TYPES.TEXT,
     initialValue: '',
     key: 'policyNumberPerson',
-    validator: input => input.length > 0 && input.length < 50,
+    validator: input => input.length < 50,
     isRequired: false,
     invalidMessage: formInputStrings.unique_policy,
     label: formInputStrings.personal_policy_number,


### PR DESCRIPTION
Fixes #3082 

## Change summary

- removes the lowerbound character length check of personal policy numbers

## Testing

- [ ] Can create a an insurance policy without a personal policy number

### Related areas to think about

N/A
