### PR TITLE
#2995 Add populating of sentPackSize

### DIFF
--- a/src/database/DataTypes/TransactionBatch.js
+++ b/src/database/DataTypes/TransactionBatch.js
@@ -267,6 +267,7 @@ TransactionBatch.schema = {
     location: { type: 'Location', optional: true },
     doses: { type: 'double', default: 0 },
     vaccineVialMonitorStatus: { type: 'VaccineVialMonitorStatus', optional: true },
+    sentPackSize: { type: 'double', default: 0 },
   },
 };
 

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -1007,6 +1007,7 @@ const createTransactionBatch = (database, transactionItem, itemBatch, isAddition
     location,
     type: isAddition ? 'stock_in' : 'stock_out',
     sortIndex: (transactionItem?.transaction?.numberOfBatches || 0) + 1 || 1,
+    sentPackSize: packSize,
 
     // If the underlying item is a vaccine, auto apply the current itembatches VVM status.
     vaccineVialMonitorStatus: isVaccine ? currentVvmStatus : null,

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -883,6 +883,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
           'VaccineVialMonitorStatus',
           record.vaccine_vial_monitor_status_ID
         ),
+        sentPackSize: parseNumber(record.sent_pack_size ?? 0),
       };
       const transactionBatch = database.update(recordType, internalRecord);
       transaction.addBatchIfUnique(database, transactionBatch);

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -883,7 +883,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
           'VaccineVialMonitorStatus',
           record.vaccine_vial_monitor_status_ID
         ),
-        sentPackSize: parseNumber(record.sent_pack_size ?? 0),
+        sentPackSize: parseNumber(record.sent_pack_size) || packSize,
       };
       const transactionBatch = database.update(recordType, internalRecord);
       transaction.addBatchIfUnique(database, transactionBatch);

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -270,6 +270,7 @@ const generateSyncData = (settings, recordType, record) => {
         doses: String(record.doses),
         location_ID: record.location?.id,
         vaccine_vial_monitor_status_ID: record.vaccineVialMonitorStatus?.id,
+        sentPackSize: String(record.sentPackSize),
       };
     }
     case 'InsurancePolicy': {

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -270,7 +270,7 @@ const generateSyncData = (settings, recordType, record) => {
         doses: String(record.doses),
         location_ID: record.location?.id,
         vaccine_vial_monitor_status_ID: record.vaccineVialMonitorStatus?.id,
-        sentPackSize: String(record.sentPackSize),
+        sent_pack_size: String(record.sentPackSize),
       };
     }
     case 'InsurancePolicy': {


### PR DESCRIPTION
Fixes #2995

## Change summary

- Adds sent pack size to the schema

## Testing

- [ ] Create a CI for the mobile store with an item with the pack size > 1 (and doesnt have pack to one set to true) and see the sent pack size field populated to be equal to the pack size sent

### Related areas to think about

N/A
