### PR TITLE
#3235 Add hiding of thresholdMOS for customer requisitions

### DIFF
--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -73,7 +73,7 @@ const modalProps = ({ dispatch, program, orderType, customer }) => ({
       const emergencyText = `[${programStrings.emergency_order}]  ${maxItemsText}`;
       const maxOrdersText = isEmergency ? emergencyText : `${maxOPP}: ${maxOrders}`;
 
-      return `${maxOrdersText} - ${mosText} - ${thresholdText}`;
+      return `${maxOrdersText}\n${mosText}\n${customer ? '' : thresholdText}`;
     },
   },
   period: {


### PR DESCRIPTION
Fixes #3235

## Change summary

- Hides thresholdMOS for customer requisitions

## Testing

- [ ] ThresholdMOS is not shown in order type modal for customer requisitions

### Related areas to think about

N/A
