### PR TITLE
Add check for maxlines

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "6.0.0-rc10",
+  "version": "6.0.0-rc11",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/database/DataTypes/MasterList.js
+++ b/src/database/DataTypes/MasterList.js
@@ -91,9 +91,7 @@ export class MasterList extends Realm.Object {
 
     if (!(tags && tags.length && storeTags)) return null;
 
-    const foundStoreTag = Object.keys(storeTags).find(
-      storeTag => tags.indexOf(storeTag.toLowerCase()) >= 0
-    );
+    const foundStoreTag = Object.keys(storeTags).find(storeTag => tags.indexOf(storeTag) >= 0);
 
     return foundStoreTag && storeTags[foundStoreTag];
   }
@@ -119,6 +117,7 @@ export class MasterList extends Realm.Object {
    */
   getOrderType(orderTypeName, tags) {
     const orderTypes = this.getOrderTypes(tags);
+
     if (!orderTypes) return null;
 
     return orderTypes.find(orderType => orderType.name === orderTypeName);

--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -104,6 +104,10 @@ export class Name extends Realm.Object {
     return this.thisStoresPatient;
   }
 
+  get nameTags() {
+    return this.nameTagJoins.map(({ nameTag }) => nameTag.description);
+  }
+
   /**
    * Add master list to name, if it has not already been added.
    *

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -147,6 +147,11 @@ export class Requisition extends Realm.Object {
     return this.items.reduce((acc, item) => acc + hasBeenCounted(item), 0);
   }
 
+  get numberOfSuppliedItems() {
+    const hasBeenCounted = requisitionItem => (requisitionItem.suppliedQuantity !== 0 ? 1 : 0);
+    return this.items.reduce((acc, item) => acc + hasBeenCounted(item), 0);
+  }
+
   /**
    * Get number of items associated with requisition.
    *
@@ -434,6 +439,14 @@ export class Requisition extends Realm.Object {
 
     if (!daysOutOfStockAreValid) {
       return { success: false, message: modalStrings.requisition_days_out_of_stock };
+    }
+
+    const customersTags = this.otherStoreName.nameTags.join(',');
+    const maxLinesForOrder = this.program?.getMaxLines?.(this.orderType, customersTags);
+
+    if (this.numberOfSuppliedItems > maxLinesForOrder) {
+      finaliseStatus.success = false;
+      finaliseStatus.message = `${modalStrings.emergency_orders_can_only_have} ${maxLinesForOrder} ${modalStrings.items_remove_some}`;
     }
 
     return finaliseStatus;

--- a/src/utilities/byProgram.js
+++ b/src/utilities/byProgram.js
@@ -28,7 +28,7 @@ const getAllProgramsForCustomer = (customer, database) => {
   const customersTags = database
     .objects('NameTag')
     .filtered('subquery(nameTagJoins, $joins, $joins.name.id == $0).@count > 0', id)
-    .map(({ description }) => description.toLowerCase());
+    .map(({ description }) => description);
 
   return database
     .objects('MasterListNameJoin')
@@ -63,7 +63,7 @@ const getAllPrograms = (settings, database) => {
       'subquery(nameTagJoins, $joins, $joins.name.id == $0).@count > 0',
       settings.get(SETTINGS_KEYS.THIS_STORE_NAME_ID)
     )
-    .map(({ description }) => description.toLowerCase());
+    .map(({ description }) => description);
 
   return database
     .objects('MasterListNameJoin')

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -59,10 +59,13 @@ const modalProps = ({ dispatch, program, orderType, customer }) => ({
         maxMOS: itemMOS,
         thresholdMOS: itemThreshMOS,
         isEmergency,
+        name,
       } = item;
 
-      const thisStoresTags = UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_TAGS);
-      const maxLinesForOrder = program.getMaxLines?.(item.name, thisStoresTags);
+      const tags = customer
+        ? customer?.nameTags.join(',')
+        : UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_TAGS);
+      const maxLinesForOrder = program?.getMaxLines?.(name, tags);
 
       const mosText = `${maxMOS}: ${itemMOS}`;
       const thresholdText = `${threshMOS}: ${itemThreshMOS}`;
@@ -70,6 +73,7 @@ const modalProps = ({ dispatch, program, orderType, customer }) => ({
         maxLinesForOrder && maxLinesForOrder !== Infinity
           ? `${programStrings.max_items}: ${maxLinesForOrder}`
           : '';
+
       const emergencyText = `[${programStrings.emergency_order}]  ${maxItemsText}`;
       const maxOrdersText = isEmergency ? emergencyText : `${maxOPP}: ${maxOrders}`;
 
@@ -129,7 +133,7 @@ export const ByProgramModal = ({ settings, database, transactionType, onConfirm 
       'subquery(nameTagJoins, $joins, $joins.name.id == $0).@count > 0',
       customer?.id ?? settings.get(THIS_STORE_NAME_ID)
     )
-    .map(({ description }) => description.toLowerCase());
+    .map(({ description }) => description);
 
   // Helper methods for fetching modal data for user selection
   const getPrograms = () => {


### PR DESCRIPTION
Fixes #3238

## Change summary

- Adds a check for max lines when finalizing

## Testing

- [ ] Trying to finalise a customer requisition with the number of lines > max lines for the order type selected.

### Related areas to think about

N/A