### PR TITLE
#3242 Show max lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "6.0.0-rc10",
+  "version": "6.0.0-rc11",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/database/DataTypes/MasterList.js
+++ b/src/database/DataTypes/MasterList.js
@@ -91,9 +91,7 @@ export class MasterList extends Realm.Object {
 
     if (!(tags && tags.length && storeTags)) return null;
 
-    const foundStoreTag = Object.keys(storeTags).find(
-      storeTag => tags.indexOf(storeTag.toLowerCase()) >= 0
-    );
+    const foundStoreTag = Object.keys(storeTags).find(storeTag => tags.indexOf(storeTag) >= 0);
 
     return foundStoreTag && storeTags[foundStoreTag];
   }
@@ -119,6 +117,7 @@ export class MasterList extends Realm.Object {
    */
   getOrderType(orderTypeName, tags) {
     const orderTypes = this.getOrderTypes(tags);
+
     if (!orderTypes) return null;
 
     return orderTypes.find(orderType => orderType.name === orderTypeName);

--- a/src/utilities/byProgram.js
+++ b/src/utilities/byProgram.js
@@ -28,7 +28,7 @@ const getAllProgramsForCustomer = (customer, database) => {
   const customersTags = database
     .objects('NameTag')
     .filtered('subquery(nameTagJoins, $joins, $joins.name.id == $0).@count > 0', id)
-    .map(({ description }) => description.toLowerCase());
+    .map(({ description }) => description);
 
   return database
     .objects('MasterListNameJoin')
@@ -63,7 +63,7 @@ const getAllPrograms = (settings, database) => {
       'subquery(nameTagJoins, $joins, $joins.name.id == $0).@count > 0',
       settings.get(SETTINGS_KEYS.THIS_STORE_NAME_ID)
     )
-    .map(({ description }) => description.toLowerCase());
+    .map(({ description }) => description);
 
   return database
     .objects('MasterListNameJoin')

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -133,7 +133,7 @@ export const ByProgramModal = ({ settings, database, transactionType, onConfirm 
       'subquery(nameTagJoins, $joins, $joins.name.id == $0).@count > 0',
       customer?.id ?? settings.get(THIS_STORE_NAME_ID)
     )
-    .map(({ description }) => description.toLowerCase());
+    .map(({ description }) => description);
 
   // Helper methods for fetching modal data for user selection
   const getPrograms = () => {

--- a/src/widgets/modals/ByProgramModal.js
+++ b/src/widgets/modals/ByProgramModal.js
@@ -59,10 +59,13 @@ const modalProps = ({ dispatch, program, orderType, customer }) => ({
         maxMOS: itemMOS,
         thresholdMOS: itemThreshMOS,
         isEmergency,
+        name,
       } = item;
 
-      const thisStoresTags = UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_TAGS);
-      const maxLinesForOrder = program.getMaxLines?.(item.name, thisStoresTags);
+      const tags = customer
+        ? customer?.nameTags.join(',')
+        : UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_TAGS);
+      const maxLinesForOrder = program?.getMaxLines?.(name, tags);
 
       const mosText = `${maxMOS}: ${itemMOS}`;
       const thresholdText = `${threshMOS}: ${itemThreshMOS}`;
@@ -70,6 +73,7 @@ const modalProps = ({ dispatch, program, orderType, customer }) => ({
         maxLinesForOrder && maxLinesForOrder !== Infinity
           ? `${programStrings.max_items}: ${maxLinesForOrder}`
           : '';
+
       const emergencyText = `[${programStrings.emergency_order}]  ${maxItemsText}`;
       const maxOrdersText = isEmergency ? emergencyText : `${maxOPP}: ${maxOrders}`;
 


### PR DESCRIPTION
Fixes #3242 BRANCHED FROM #3239 

## Change summary

- [ ] Adds corrected order type logic for max lines for customers

## Testing

- [ ] When creating a customer requisition with a maximum number of lines, the max lines are displayed

### Related areas to think about

![image](https://user-images.githubusercontent.com/35858975/100164094-07b7ae00-2f1c-11eb-9142-e5e9ae223d97.png)

