### PR TITLE
#3050 login screen should show store name

### DIFF
--- a/src/localization/authStrings.json
+++ b/src/localization/authStrings.json
@@ -6,6 +6,8 @@
     "repeat_password": "Please re-enter password",
     "user_name": "User Name",
     "email": "E-mail Address",
+    "site": "Site",
+    "store": "Store",
     "invalid_username_or_password": "Invalid username or password",
     "warning_sync_edit": "WARNING:\nThis will effect syncing for this store.\nMake sure you know what you doing!",
     "incompatible_server": "The mSupply Server you're trying to sync with is not compatible with your current version. Please contact your administrator."

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -152,7 +152,7 @@ export class LoginModal extends React.Component {
             </View>
             <View style={[globalStyles.verticalContainer, { flex: 1 }]}>
               <Text style={[globalStyles.authFormTextInputStyle]}>
-                {authStrings.store}:{' '}
+                {authStrings.store}:
                 {
                   UIDatabase.objects('Name').filtered(
                     'id == $0',

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -145,22 +145,18 @@ export class LoginModal extends React.Component {
               style={globalStyles.authFormLogo}
               source={require('../../images/logo_large.png')}
             />
-            <View style={[globalStyles.verticalContainer, { flex: 1 }]}>
-              <Text style={[globalStyles.authFormTextInputStyle]}>
-                {authStrings.site}: {settings.get(SETTINGS_KEYS.SYNC_SITE_NAME)}
-              </Text>
-            </View>
-            <View style={[globalStyles.verticalContainer, { flex: 1 }]}>
-              <Text style={[globalStyles.authFormTextInputStyle]}>
-                {authStrings.store}:
-                {
-                  UIDatabase.objects('Name').filtered(
-                    'id == $0',
-                    settings.get(SETTINGS_KEYS.THIS_STORE_NAME_ID)
-                  )[0]?.name
-                }
-              </Text>
-            </View>
+            <Text style={[globalStyles.authFormTextInputStyle, { flex: 0 }]}>
+              {authStrings.site}: {settings.get(SETTINGS_KEYS.SYNC_SITE_NAME)}
+            </Text>
+            <Text style={[globalStyles.authFormTextInputStyle, { flex: 0, marginVertical: 10 }]}>
+              {authStrings.store}:
+              {
+                UIDatabase.objects('Name').filtered(
+                  'id == $0',
+                  settings.get(SETTINGS_KEYS.THIS_STORE_NAME_ID)
+                )[0]?.name
+              }
+            </Text>
             <View style={globalStyles.horizontalContainer}>
               <TextInput
                 style={globalStyles.authFormTextInputStyle}

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -22,6 +22,7 @@ import { LANGUAGE_NAMES, LANGUAGE_CHOICE, authStrings, navStrings } from '../../
 import { getModalTitle, MODAL_KEYS } from '../../utilities';
 import { setCurrencyLocalisation } from '../../localization/currency';
 import { setDateLocale } from '../../localization/utilities';
+import { UIDatabase } from '../../database';
 
 export class LoginModal extends React.Component {
   constructor(props) {
@@ -144,9 +145,20 @@ export class LoginModal extends React.Component {
               style={globalStyles.authFormLogo}
               source={require('../../images/logo_large.png')}
             />
-            <View style={globalStyles.horizontalContainer}>
-              <Text style={[globalStyles.authFormTextInputStyle, localStyles.syncSiteName]}>
-                {settings.get(SETTINGS_KEYS.SYNC_SITE_NAME)}
+            <View style={[globalStyles.verticalContainer, { flex: 1 }]}>
+              <Text style={[globalStyles.authFormTextInputStyle]}>
+                {authStrings.site}: {settings.get(SETTINGS_KEYS.SYNC_SITE_NAME)}
+              </Text>
+            </View>
+            <View style={[globalStyles.verticalContainer, { flex: 1 }]}>
+              <Text style={[globalStyles.authFormTextInputStyle]}>
+                {authStrings.store}:{' '}
+                {
+                  UIDatabase.objects('Name').filtered(
+                    'id == $0',
+                    settings.get(SETTINGS_KEYS.THIS_STORE_NAME_ID)
+                  )[0].name
+                }
               </Text>
             </View>
             <View style={globalStyles.horizontalContainer}>
@@ -251,8 +263,5 @@ LoginModal.propTypes = {
 const localStyles = StyleSheet.create({
   bottomIcon: {
     color: GREY,
-  },
-  syncSiteName: {
-    textAlign: 'center',
   },
 });

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -157,7 +157,7 @@ export class LoginModal extends React.Component {
                   UIDatabase.objects('Name').filtered(
                     'id == $0',
                     settings.get(SETTINGS_KEYS.THIS_STORE_NAME_ID)
-                  )[0].name
+                  )[0]?.name
                 }
               </Text>
             </View>


### PR DESCRIPTION
Fixes #3050 

## Change summary

Explain and justify your changes
- Adds store name to the login screen under the site name and some labels to distinguish between the two
- Removed a now unused local style, unsure about styling but seems reasonably clear/usable(?)
- Don't know translations for these words so English only for now

## Testing

- [ ] Open login page, check that the site name and store name are correctly displayed

### Related areas to think about

- Unsure - maybe check the rest of the login page still looks acceptable and it still looks ok on different sized tablets?