### PR TITLE
#3247 General Stocktake Crash

### DIFF
--- a/src/navigation/actions.js
+++ b/src/navigation/actions.js
@@ -293,7 +293,10 @@ export const gotoStocktakeManagePage = (stocktakeName, stocktake) => dispatch =>
     },
   };
 
-  dispatch(navigationActionCreator(navigationParameters));
+  batch(() => {
+    dispatch(navigationActionCreator(navigationParameters));
+    dispatch(FinaliseActions.setFinaliseItem(null));
+  });
 };
 
 /**


### PR DESCRIPTION
Fixes #3247

## Change summary

- Batch calling dispatch updates the state correctly.

## Testing

- [ ] When creating a general stocktake from the by program modal, the app does not crash

### Related areas to think about

N/A