### PR TITLE
factor out retrieving store name to not be in the render code

### DIFF
--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -129,6 +129,10 @@ export class LoginModal extends React.Component {
   render() {
     const { isAuthenticated, settings } = this.props;
     const { authStatus, username, password, appVersion, isLanguageModalOpen } = this.state;
+    const storeName = UIDatabase.objects('Name').filtered(
+      'id == $0',
+      settings.get(SETTINGS_KEYS.THIS_STORE_NAME_ID)
+    )[0]?.name;
 
     return (
       <ModalContainer
@@ -149,13 +153,7 @@ export class LoginModal extends React.Component {
               {authStrings.site}: {settings.get(SETTINGS_KEYS.SYNC_SITE_NAME)}
             </Text>
             <Text style={[globalStyles.authFormTextInputStyle, { flex: 0, marginVertical: 10 }]}>
-              {authStrings.store}:
-              {
-                UIDatabase.objects('Name').filtered(
-                  'id == $0',
-                  settings.get(SETTINGS_KEYS.THIS_STORE_NAME_ID)
-                )[0]?.name
-              }
+              {authStrings.store}: {storeName}
             </Text>
             <View style={globalStyles.horizontalContainer}>
               <TextInput


### PR DESCRIPTION
Fixes #3254

## Change summary

Linter rules didn't like it being a one liner, but also didn't like trailing spaces! So couldn't get a space in without rearranging, but this is a bit more readable anyway 🙂 

## Testing

- [ ] Look at the login modal. It has a space between `Store: ` and `my store name`
![image](https://user-images.githubusercontent.com/7684221/100305490-15e1f900-3006-11eb-83e8-5c10d3141544.png)

