### PR TITLE
#3256 consistent monthly usage

### DIFF
--- a/src/pages/dataTableUtilities/getPageInfoColumns.js
+++ b/src/pages/dataTableUtilities/getPageInfoColumns.js
@@ -137,7 +137,7 @@ const PAGE_INFO_ROWS = (pageObject, dispatch, route) => ({
     editableType: 'date',
   },
   customerRequisitionProgramAMCFormula: {
-    title: `${Math.ceil(pageObject.monthlyUsage)}`,
+    title: `${Math.round(pageObject.monthlyUsage)}`,
     info: `= (${pageObject.outgoingStock?.toFixed(2)} x ${NUMBER_OF_DAYS_IN_A_MONTH?.toFixed(
       2
     )}) / (${pageObject.numberOfDaysInPeriod} - ${pageObject.daysOutOfStock})`,


### PR DESCRIPTION
Fixes #3256 

## Change summary

https://github.com/openmsupply/mobile/blob/6421878e4e68aff5f06c1d78b4fa2f44f4caf1d8/src/widgets/DataTable/DataTableRow.js#L257

Makes the monthly usage shown in the row detail popup consistent with the column, code above

## Testing

- [ ] In a customer requisition, the monthly usage in the column as well as the row detail are consistentally rounded 

### Related areas to think about

Should use a getter on `RequisitionItem`, probably
