### PR TITLE
Add debug/AndroidManifest.xml

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+    <application
+        android:usesCleartextTraffic="true"
+        tools:targetApi="28"
+        tools:ignore="GoogleAppIndexingWarning">
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+    </application>
+</manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,5 +19,4 @@
     <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     <meta-data android:name="com.bugsnag.android.API_KEY" android:value="16a680e189b1e5f03f28665870f1401f"/>
   </application>
-
 </manifest>


### PR DESCRIPTION
Fixes #3288?

## Change summary

We need handle android 9 API changes for dev builds:
https://reactnative.dev/docs/_integration-with-exisiting-apps-java#cleartext-traffic-api-level-28

I stole the solution from the official RN template project:
https://github.com/facebook/react-native/blob/master/template/android/app/src/debug/AndroidManifest.xml

## Testing

I think the bug may only occur if your emulator is on Android 9 or higher.

1. `yarn start`
2. The app is installed on your emulator and works.
