### PR TITLE
Add remove rounding days to supply

### DIFF
--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -130,7 +130,7 @@ export class Requisition extends Realm.Object {
    * @return  {number}
    */
   get monthsToSupply() {
-    return Math.ceil(this.daysToSupply / NUMBER_OF_DAYS_IN_A_MONTH);
+    return Math.floor(this.daysToSupply / NUMBER_OF_DAYS_IN_A_MONTH);
   }
 
   /**

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -691,9 +691,7 @@ const createRequisition = (
   const { name: orderTypeName, maxMOS, thresholdMOS } = orderType || {};
   const regimenData =
     program && program.parsedProgramSettings ? program.parsedProgramSettings.regimenData : null;
-  const daysToSupply = Math.ceil(
-    ((monthsLeadTime || 0) + (maxMOS || 1)) * NUMBER_OF_DAYS_IN_A_MONTH
-  );
+  const daysToSupply = ((monthsLeadTime || 0) + (maxMOS || 1)) * NUMBER_OF_DAYS_IN_A_MONTH;
 
   const requisition = database.create('Requisition', {
     id: generateUUID(),


### PR DESCRIPTION
Fixes #3290

## Change summary

- I think this is mainly cause of the rounding of the days to supply when creating a requisition. The changing of floor and ceil is probably not needed, technically, cause it should be some multiple of 365/12, always?

## Testing

- [ ] When creating a plain supplier requisition, the max MOS is default to 1
- [ ] Suggested quantities are correct as per the issue

### Related areas to think about

Nice find.

Need unit tests.

Putting this into a patch so based on master