### PR TITLE
#3291 Correct disabling of a row

### DIFF
--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -257,6 +257,15 @@ export class Transaction extends Realm.Object {
   }
 
   /**
+   * Get if this transaction is linked to a transaction.
+   *
+   * @return  {boolean}
+   */
+  get isLinkedToTransaction() {
+    return !!this.linkedTransaction;
+  }
+
+  /**
    * Get if this transaction includes a given item.
    *
    * @param   {Item}  item

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -109,7 +109,7 @@ const DataTableRow = React.memo(
           // - the page is finalised.
           // - the row has been explicitly set as disabled.
           const rowIsDisabled = rowState?.isDisabled ?? false;
-          const isDisabled = isFinalised || rowIsDisabled;
+          const isDisabled = isFinalised || rowIsDisabled || rowData?.isFinalised;
 
           // Alignment of this particular column. Default to left hand ide.
           const cellAlignment = alignText || 'left';

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -105,11 +105,15 @@ const DataTableRow = React.memo(
           // Indicator if the right hand border should be removed from styles for this cell.
           const isLastCell = index === columns.length - 1;
 
+          const { isLinkedToTransaction, isFinalised: rowIsFinalised } = rowData;
           // This cell is disabled if:
           // - the page is finalised.
           // - the row has been explicitly set as disabled.
+          // - The row itself is finalised.
+          // - The row is linked to another transaction: i.e. an SI created on the primary.
           const rowIsDisabled = rowState?.isDisabled ?? false;
-          const isDisabled = isFinalised || rowIsDisabled || rowData?.isFinalised;
+          const isDisabled =
+            isFinalised || rowIsDisabled || rowIsFinalised || isLinkedToTransaction;
 
           // Alignment of this particular column. Default to left hand ide.
           const cellAlignment = alignText || 'left';

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -105,15 +105,19 @@ const DataTableRow = React.memo(
           // Indicator if the right hand border should be removed from styles for this cell.
           const isLastCell = index === columns.length - 1;
 
-          const { isLinkedToTransaction, isFinalised: rowIsFinalised } = rowData;
+          const { isLinkedToTransaction, isFinalised: rowIsFinalised, isRemoteOrder } = rowData;
           // This cell is disabled if:
           // - the page is finalised.
           // - the row has been explicitly set as disabled.
           // - The row itself is finalised.
-          // - The row is linked to another transaction: i.e. an SI created on the primary.
+          // - The row was created on the primary
           const rowIsDisabled = rowState?.isDisabled ?? false;
           const isDisabled =
-            isFinalised || rowIsDisabled || rowIsFinalised || isLinkedToTransaction;
+            isFinalised ||
+            rowIsDisabled ||
+            rowIsFinalised ||
+            isLinkedToTransaction ||
+            isRemoteOrder;
 
           // Alignment of this particular column. Default to left hand ide.
           const cellAlignment = alignText || 'left';


### PR DESCRIPTION
Fixes #3291

## Change summary

- Disables a row when its finalised
- Disables a row when its a remote order - I think??

## Testing

- [ ] Cannot delete remote reqs/transacts
- [ ] Cannot check finalised rows

### Related areas to think about

I synced an SI in - it had no linked req, but did have a linked transct - I think this is right?? 