### PR TITLE
#3308-1 TextInputWithAffix component

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react-native-safe-area-context": "^0.7.3",
     "react-native-screens": "^2.2.0",
     "react-native-svg": "^11.0.1",
+    "react-native-text-input-mask": "^2.0.0",
     "react-native-ui-components": "^0.5.0",
     "react-native-vector-icons": "^7.1.0",
     "react-navigation": "^4.2.2",

--- a/src/widgets/TextInputs/TextInputWithAffix.js
+++ b/src/widgets/TextInputs/TextInputWithAffix.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { TextInput as RNTextInput, TextInputProps as RNTextInputProps } from 'react-native';
+import propTypes from 'prop-types';
+
+import { FlexRow } from '../FlexRow';
+
+export const TextInputWithAffix = React.forwardRef(
+  ({ TextInputImpl, SuffixComponent, PrefixComponent, flexRowProps, ...textInputProps }, ref) => (
+    <FlexRow {...flexRowProps}>
+      {PrefixComponent}
+      <TextInputImpl ref={ref} {...textInputProps} />
+      {SuffixComponent}
+    </FlexRow>
+  )
+);
+
+TextInputWithAffix.displayName = 'TextInputWithAffix';
+
+TextInputWithAffix.defaultProps = {
+  TextInputImpl: RNTextInput,
+  SuffixComponent: <></>,
+  PrefixComponent: <></>,
+  textInputProps: {},
+  flexRowProps: { flex: 0, alignItems: 'center' },
+};
+
+TextInputWithAffix.propTypes = {
+  TextInputImpl: propTypes.element,
+  SuffixComponent: propTypes.element,
+  PrefixComponent: propTypes.element,
+  textInputProps: propTypes.shape(RNTextInputProps),
+  flexRowProps: propTypes.shape({
+    alignItems: propTypes.string,
+    justifyContent: propTypes.string,
+    flex: propTypes.number,
+  }),
+};

--- a/src/widgets/TextInputs/index.js
+++ b/src/widgets/TextInputs/index.js
@@ -1,0 +1,1 @@
+export { TextInputWithAffix } from './TextInputWithAffix';

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -48,3 +48,4 @@ export { KeyboardSpacing } from './KeyboardSpacing';
 
 export * from './icons';
 export * from './images';
+export * from './TextInputs';

--- a/yarn.lock
+++ b/yarn.lock
@@ -8169,6 +8169,11 @@ react-native-tab-view@^2.15.2:
   resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-2.15.2.tgz#4bc7832d33a119306614efee667509672a7ee64e"
   integrity sha512-2hxLkBnZtEKFDyfvNO5EUywhy3f/EiLOBO8SWqKj4BMBTO0QwnybaPE5MVF00Fhz+VA4+h/iI40Dkrrtq70dGg==
 
+react-native-text-input-mask@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-text-input-mask/-/react-native-text-input-mask-2.0.0.tgz#9cb793e764355d9282d92ea5231d8030a7ca5692"
+  integrity sha512-kP8gURb1+6iR6CxfUx802f4ja9Jzer76hY1w0cjaCVsfbbzyykYIAANTnlxbmFFv/8pQl4NTm1CbQqkg0Cp/gA==
+
 react-native-ui-components@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/react-native-ui-components/-/react-native-ui-components-0.5.0.tgz#d76908f50f390691185c7ab33e944dc20f65e6d9"


### PR DESCRIPTION
Fixes #3308 **Wrong branch name- oops**

## Change summary

*Note* I named a prefix or a suffix 'affix'. I have no idea if that is correct english. I also don't know if what I am calling a prefix or suffix is a prefix or suffix. It's what I came up with 🤷 

- Adds `TextInputWithAffix` Component
- Essentially this is to fill the role of having an input with, for example: `10 C` or `10 Mins`
- Creating an input with the affix within the editable input area would be a lot more work than you'd think (Or, at least, from what I can figure out)

## Testing

N/A - internal code only white box testing

### Related areas to think about

N/A