### PR TITLE
#3308-2 Add react-native-text-input-mask

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react-native-safe-area-context": "^0.7.3",
     "react-native-screens": "^2.2.0",
     "react-native-svg": "^11.0.1",
+    "react-native-text-input-mask": "^2.0.0",
     "react-native-ui-components": "^0.5.0",
     "react-native-vector-icons": "^7.1.0",
     "react-navigation": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8169,6 +8169,11 @@ react-native-tab-view@^2.15.2:
   resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-2.15.2.tgz#4bc7832d33a119306614efee667509672a7ee64e"
   integrity sha512-2hxLkBnZtEKFDyfvNO5EUywhy3f/EiLOBO8SWqKj4BMBTO0QwnybaPE5MVF00Fhz+VA4+h/iI40Dkrrtq70dGg==
 
+react-native-text-input-mask@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-text-input-mask/-/react-native-text-input-mask-2.0.0.tgz#9cb793e764355d9282d92ea5231d8030a7ca5692"
+  integrity sha512-kP8gURb1+6iR6CxfUx802f4ja9Jzer76hY1w0cjaCVsfbbzyykYIAANTnlxbmFFv/8pQl4NTm1CbQqkg0Cp/gA==
+
 react-native-ui-components@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/react-native-ui-components/-/react-native-ui-components-0.5.0.tgz#d76908f50f390691185c7ab33e944dc20f65e6d9"


### PR DESCRIPTION
Fixes #3308

## Change summary

- Adds the package `react-native-text-input-mask`
- I tried a bunch of packages out and this was the best. It stops at the native component level a lot of jank. For example, if you were to use a `TextInput` as a controlled component and passed it `value` prop - you can actually type in the `TextInput` and NOT update the `value` and it will enter into the component. This is hard to explain but the `TextInput` basically has it's own internal state and if it's not in sync it causes odd behaviour, like if I had a mask which only allowed two digits and that was enforced through JS `onChangeText` prop, then I could type an `a` and it would be rendered for .5second, and then reverted back. This package however does the masking at the native level and this jank didn't seem to happen. Get it?

## Testing

Internal

### Related areas to think about

Not creating the masks to use in the future yet. Will do as used.