### PR TITLE
#3298 development ble manager

### DIFF
--- a/src/bluetooth/BleService.js
+++ b/src/bluetooth/BleService.js
@@ -24,7 +24,7 @@ const base64FromString = string => Buffer.from(string, 'utf-8').toString('base64
  *
  *
  */
-export class BleService {
+class BleService {
   constructor(manager = new BleManager()) {
     this.manager = manager;
   }
@@ -366,3 +366,14 @@ export class BleService {
     );
   };
 }
+
+let BleServiceInstance;
+
+export const getBleServiceInstance = manager => {
+  if (!BleServiceInstance) {
+    BleServiceInstance = new BleService(manager);
+  }
+  return BleServiceInstance;
+};
+
+export default getBleServiceInstance;

--- a/src/bluetooth/DevBleManager.js
+++ b/src/bluetooth/DevBleManager.js
@@ -1,0 +1,114 @@
+const COMMAND_TO_RESULT_LOOKUP = {
+  // *logall
+  'KmxvZ2FsbA==': callback => {
+    callback(null, { value: 'ABEAEQARAAIBAAAAAAA6' });
+    callback(null, { value: 'ARcBFwEXARcBFwEXARcBFwEXARc=' });
+    callback(null, { value: 'ARcBFwEXARYBFgEWARguAAAAAAA=' });
+    callback(null, null);
+  },
+  // *blink
+  KmJsaW5r: callback => {
+    callback(null, { value: 'T2sA' });
+    callback(null, null);
+  },
+  // *info
+  'KmluZm8=': callback => {
+    callback(null, { value: 'U0VUVElOR1MAAAAAAAAAAAAAAAA=' });
+    callback(null, { value: 'TmFtZTogICBFNzIyOTZERQAAAAA=' });
+    callback(null, { value: 'VmVyIG5vOiAxMwAAAAAAAAAAAAA=' });
+    callback(null, { value: 'U3ViIHZlciBubzogMTUuMC4wAAA=' });
+    callback(null, { value: 'UmVsIGR0ZTogMjYgU2VwIDE5AAA=' });
+    callback(null, { value: 'VHhwIGx2bDogNAAAAAAAAAAAAAA=' });
+    callback(null, { value: 'QmF0dCBsdmw6IDEwMCUAAAAAAAA=' });
+    callback(null, { value: 'TWVtIDgzMyBkYXlzAAAAAAAAAAA=' });
+    callback(null, { value: 'QWR2IHdrZXVwOiBOL0EAAAAAAAA=' });
+    callback(null, { value: 'VW5pdHM6IEMAAAAAAAAAAAAAAAA=' });
+    callback(null, { value: 'TWVtOiAyMDAwMAAAAAAAAAAAAAA=' });
+    callback(null, { value: 'QWlyIG1vZGUgb2ZmAAAAAAAAAAA=' });
+    callback(null, { value: 'UnVuIGFwcHggMTZocnMAAAAAAAA=' });
+    callback(null, { value: 'RGF0ZSB5eW1tZGRoaG1tOgAAAAA=' });
+    callback(null, { value: 'LT4gMDA6MDA6MDA6MDA6MDAAAAA=' });
+    callback(null, { value: 'SWQ6IDI1NQAAAAAAAAAAAAAAAAA=' });
+    callback(null, { value: 'QnRuIG9uL29mZjogMQAAAAAAAAA=' });
+    callback(null, { value: 'VGVtcCBDYWwuIDAAAAAAAAAAAAA=' });
+    callback(null, { value: 'SHVtIENhbHgxMCAwJQAAAAAAAAA=' });
+    callback(null, null);
+  },
+  // *bd
+  KmJk: callback => {
+    callback(null, { value: 'T2sA' });
+    callback(null, null);
+  },
+  // *lint300
+  'KmxpbnQzMDA=': callback => {
+    callback(null, { value: 'SW50ZXJ2YWw6IDYwcwAAAAAAAAA=' });
+    callback(null, null);
+  },
+};
+export class DevBleManager {
+  constructor() {
+    this.connectedDevices = {};
+    this.isScanning = false;
+    this.scannerInterval = null;
+  }
+
+  async connectToDevice(macAddress) {
+    this.connectedDevices[macAddress] = { device: { id: macAddress } };
+    return { id: macAddress };
+  }
+
+  async isDeviceConnected(macAddress) {
+    return !!this.connectedDevices[macAddress];
+  }
+
+  async cancelDeviceConnection(macAddress) {
+    this.connectedDevices[macAddress] = null;
+  }
+
+  async discoverAllServicesAndCharacteristicsForDevice(macAddress) {
+    const connectedDevice = this.connectedDevices[macAddress];
+    if (connectedDevice) {
+      this.connectedDevices[macAddress].discoveredServices = true;
+    } else {
+      throw new Error("Trying to discover services of a device which isn't connected");
+    }
+  }
+
+  async stopDeviceScan() {
+    this.isScanning = false;
+    clearInterval(this.scannerInterval);
+  }
+
+  async startDeviceScan(_, __, callback) {
+    this.isScanning = true;
+
+    setInterval(
+      () =>
+        callback(_, {
+          id: 'AB:CD:EF:GH:IJ:KL',
+          manufacturerData: 'MwEBDAN0AFkBtwEMA3QAWQG3AMwCrAAAAAAA',
+        }),
+      1000
+    );
+  }
+
+  async writeCharacteristicWithoutResponseForDevice(macAddress, _, __, command) {
+    const connectedDevice = this.connectedDevices[macAddress];
+    const { callback } = this.connectedDevices[macAddress];
+    if (connectedDevice && callback) {
+      COMMAND_TO_RESULT_LOOKUP[command](callback);
+      this.connectedDevices[macAddress] = null;
+    } else {
+      throw new Error("Trying to write to a device which isn't connected or isn't being monitored");
+    }
+  }
+
+  async monitorCharacteristicForDevice(macAddress, _, __, callback) {
+    const connectedDevice = this.connectedDevices[macAddress];
+    if (connectedDevice) {
+      this.connectedDevices[macAddress].callback = callback;
+    } else {
+      throw new Error("Trying to write to a device which isn't connected");
+    }
+  }
+}

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -94,11 +94,7 @@ class MSupplyMobileAppContainer extends React.Component {
       BluetoothStatus.addListener(requestBluetooth);
       dispatch(PermissionActions.checkPermissions());
 
-      DeviceInfo.isEmulator().then(isEmulator => {
-        if (isEmulator) {
-          BleService(new DevBleManager());
-        }
-      });
+      this.initialiseBtService();
     }
 
     if (!__DEV__) {
@@ -118,6 +114,16 @@ class MSupplyMobileAppContainer extends React.Component {
     }
 
     this.scheduler.clearAll();
+  };
+
+  initialiseBtService = async () => {
+    const isEmulator = await DeviceInfo.isEmulator();
+    if (isEmulator) {
+      console.log('Emulator detected - Init Dev BleManager');
+      BleService(new DevBleManager());
+    } else {
+      BleService();
+    }
   };
 
   onAppStateChange = nextAppState => {

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -97,8 +97,6 @@ class MSupplyMobileAppContainer extends React.Component {
       DeviceInfo.isEmulator().then(isEmulator => {
         if (isEmulator) {
           BleService(new DevBleManager());
-        } else {
-          BleService();
         }
       });
     }

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import DeviceInfo from 'react-native-device-info';
 import { connect } from 'react-redux';
 import { BluetoothStatus } from 'react-native-bluetooth-status';
 import { AppState, View } from 'react-native';
@@ -47,6 +48,8 @@ import { BreachActions } from './actions/BreachActions';
 import { TemperatureSync } from './widgets/modalChildren/TemperatureSync';
 import { RowDetail } from './widgets/RowDetail';
 import { PermissionActions } from './actions/PermissionActions';
+import BleService from './bluetooth/BleService';
+import { DevBleManager } from './bluetooth/DevBleManager';
 
 const SYNC_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 const AUTHENTICATION_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
@@ -90,6 +93,14 @@ class MSupplyMobileAppContainer extends React.Component {
       this.scheduler.schedule(syncTemperatures, SYNC_INTERVAL);
       BluetoothStatus.addListener(requestBluetooth);
       dispatch(PermissionActions.checkPermissions());
+
+      DeviceInfo.isEmulator().then(isEmulator => {
+        if (isEmulator) {
+          BleService(new DevBleManager());
+        } else {
+          BleService();
+        }
+      });
     }
 
     if (!__DEV__) {


### PR DESCRIPTION
Fixes #3298 

## Change summary

- Added copy of https://github.com/openmsupply/msupply-cold-chain/blob/develop/src/common/services/Bluetooth/DevBleManager.js 
- Modified BleService into singleton (if causes problems later - investigate passing instance into thunk(?))
- Added [isEmulator()](https://github.com/react-native-device-info/react-native-device-info#isemulator) check and Initialise BleService Singleton in mSupplyMobileApp 
  - Done inside `usingVaccines` check, as it looks like we only request BT Permissions right now if this module is enabled

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Dev Testing    
Make `componentDidMount` async, and add some methods into it on both emulator and real device and compare/observe results. e.g
```
    await this.initialiseBtService();
    await BleService().blinkWithRetries('E7:6F:FC:15:13:F2', 3);
    await BleService().getInfoWithRetries('E7:6F:FC:15:13:F2', 3);
```
Main issue/fix is to verify no RSOD on emulator when using BleService

### Related areas to think about
Not sure... we don't really use the BleService anywhere yet
