### PR TITLE
#3303 icon button

### DIFF
--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -154,21 +154,11 @@ const Menu = ({
   const AdminRow = useCallback(
     () => (
       <View style={styles.bottomRow}>
-        <IconButton
-          IconComponent={PowerIcon}
-          size="large"
-          label={navStrings.log_out}
-          onPress={logout}
-        />
+        <IconButton Icon={<PowerIcon />} label={navStrings.log_out} onPress={logout} />
         {isInAdminMode && <MenuButton text="Realm Explorer" onPress={toRealmExplorer} />}
         {isInAdminMode && <MenuButton text="Export Data" onPress={exportData} />}
         {isAdmin && (
-          <IconButton
-            IconComponent={CogIcon}
-            size="large"
-            label={buttonStrings.settings}
-            onPress={toSettings}
-          />
+          <IconButton Icon={<CogIcon />} label={buttonStrings.settings} onPress={toSettings} />
         )}
       </View>
     ),

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -148,12 +148,18 @@ const Menu = ({
   const AdminRow = useCallback(
     () => (
       <View style={styles.bottomRow}>
-        <IconButton IconComponent={PowerIcon} rightText={navStrings.log_out} onPress={logout} />
+        <IconButton
+          IconComponent={PowerIcon}
+          size="xlarge"
+          rightText={navStrings.log_out}
+          onPress={logout}
+        />
         {isInAdminMode && <MenuButton text="Realm Explorer" onPress={toRealmExplorer} />}
         {isInAdminMode && <MenuButton text="Export Data" onPress={exportData} />}
         {isAdmin && (
           <IconButton
             IconComponent={CogIcon}
+            size="xlarge"
             rightText={buttonStrings.settings}
             onPress={toSettings}
           />

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -157,7 +157,7 @@ const Menu = ({
         <IconButton
           IconComponent={PowerIcon}
           size="large"
-          rightText={navStrings.log_out}
+          label={navStrings.log_out}
           onPress={logout}
         />
         {isInAdminMode && <MenuButton text="Realm Explorer" onPress={toRealmExplorer} />}
@@ -166,7 +166,7 @@ const Menu = ({
           <IconButton
             IconComponent={CogIcon}
             size="large"
-            rightText={buttonStrings.settings}
+            label={buttonStrings.settings}
             onPress={toSettings}
           />
         )}

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -156,7 +156,7 @@ const Menu = ({
       <View style={styles.bottomRow}>
         <IconButton
           IconComponent={PowerIcon}
-          size="xlarge"
+          size="large"
           rightText={navStrings.log_out}
           onPress={logout}
         />
@@ -165,7 +165,7 @@ const Menu = ({
         {isAdmin && (
           <IconButton
             IconComponent={CogIcon}
-            size="xlarge"
+            size="large"
             rightText={buttonStrings.settings}
             onPress={toSettings}
           />

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -89,12 +89,14 @@ const Menu = ({
     () => (
       <View style={containerStyle}>
         <CustomerImage style={image} />
-        <InfoBadge routeName={ROUTES.CUSTOMER_INVOICES}>
-          <MenuButton text={navStrings.customer_invoices} onPress={toCustomerInvoices} />
-        </InfoBadge>
-        <InfoBadge routeName={ROUTES.CUSTOMER_REQUISITIONS}>
-          <MenuButton text={navStrings.customer_requisitions} onPress={toCustomerRequisitions} />
-        </InfoBadge>
+        <View>
+          <InfoBadge routeName={ROUTES.CUSTOMER_INVOICES}>
+            <MenuButton text={navStrings.customer_invoices} onPress={toCustomerInvoices} />
+          </InfoBadge>
+          <InfoBadge routeName={ROUTES.CUSTOMER_REQUISITIONS}>
+            <MenuButton text={navStrings.customer_requisitions} onPress={toCustomerRequisitions} />
+          </InfoBadge>
+        </View>
       </View>
     ),
     [usingDashboard, usingDispensary, usingCashRegister, usingModules]
@@ -104,12 +106,14 @@ const Menu = ({
     () => (
       <View style={containerStyle}>
         <SupplierImage style={image} />
-        <InfoBadge routeName={ROUTES.SUPPLIER_INVOICES}>
-          <MenuButton text={navStrings.supplier_invoices} onPress={toSupplierInvoices} />
-        </InfoBadge>
-        <InfoBadge routeName={ROUTES.SUPPLIER_REQUISITIONS}>
-          <MenuButton text={navStrings.supplier_requisitions} onPress={toSupplierRequisitions} />
-        </InfoBadge>
+        <View>
+          <InfoBadge routeName={ROUTES.SUPPLIER_INVOICES}>
+            <MenuButton text={navStrings.supplier_invoices} onPress={toSupplierInvoices} />
+          </InfoBadge>
+          <InfoBadge routeName={ROUTES.SUPPLIER_REQUISITIONS}>
+            <MenuButton text={navStrings.supplier_requisitions} onPress={toSupplierRequisitions} />
+          </InfoBadge>
+        </View>
       </View>
     ),
     [usingDashboard, usingDispensary, usingCashRegister, usingModules]
@@ -119,10 +123,12 @@ const Menu = ({
     () => (
       <View style={containerStyle}>
         <StockImage style={image} />
-        <MenuButton text={navStrings.current_stock} onPress={toStock} />
-        <InfoBadge routeName={ROUTES.STOCKTAKES}>
-          <MenuButton text={navStrings.stocktake} onPress={toStocktakes} />
-        </InfoBadge>
+        <View>
+          <MenuButton text={navStrings.current_stock} onPress={toStock} />
+          <InfoBadge routeName={ROUTES.STOCKTAKES}>
+            <MenuButton text={navStrings.stocktake} onPress={toStocktakes} />
+          </InfoBadge>
+        </View>
       </View>
     ),
     [usingDashboard, usingDispensary, usingCashRegister, usingModules]

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -5,13 +5,20 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Text, View, ToastAndroid } from 'react-native';
+import { View, ToastAndroid } from 'react-native';
 import { useIsFocused } from '@react-navigation/native';
 
 import { Button } from 'react-native-ui-components';
-import Icon from 'react-native-vector-icons/FontAwesome';
-import { CustomerImage, SupplierImage, StockImage, ModulesImage, InfoBadge } from '../widgets';
+import {
+  CustomerImage,
+  IconButton,
+  SupplierImage,
+  StockImage,
+  ModulesImage,
+  InfoBadge,
+} from '../widgets';
 
+import { PowerIcon, CogIcon } from '../widgets/icons';
 import { ROUTES } from '../navigation/constants';
 import { buttonStrings, navStrings } from '../localization';
 
@@ -33,7 +40,7 @@ import {
   goToVaccines,
 } from '../navigation/actions';
 
-import globalStyles, { SHADOW_BORDER, GREY } from '../globalStyles';
+import globalStyles, { SHADOW_BORDER } from '../globalStyles';
 import { UserActions } from '../actions/index';
 import { selectCurrentUserIsAdmin } from '../selectors/user';
 
@@ -67,7 +74,7 @@ const Menu = ({
   isAdmin,
 }) => {
   const { menuButton, menuButtonText: buttonText, appBackground } = globalStyles;
-  const { image, originalContainer, moduleContainer, container, bottomIcon, moduleRow } = styles;
+  const { image, originalContainer, moduleContainer, container, moduleRow } = styles;
 
   const containerStyle = { ...container, ...(usingModules ? moduleContainer : originalContainer) };
 
@@ -147,27 +154,15 @@ const Menu = ({
   const AdminRow = useCallback(
     () => (
       <View style={styles.bottomRow}>
-        <View style={styles.bottomIconView}>
-          <Icon.Button
-            name="power-off"
-            iconStyle={bottomIcon}
-            backgroundColor="rgba(255,255,255,0)"
-            onPress={logout}
-          >
-            <Text>{navStrings.log_out}</Text>
-          </Icon.Button>
-        </View>
+        <IconButton IconComponent={PowerIcon} rightText={navStrings.log_out} onPress={logout} />
         {isInAdminMode && <MenuButton text="Realm Explorer" onPress={toRealmExplorer} />}
         {isInAdminMode && <MenuButton text="Export Data" onPress={exportData} />}
         {isAdmin && (
-          <Icon.Button
-            name="cog"
-            iconStyle={bottomIcon}
-            backgroundColor="rgba(255,255,255,0)"
+          <IconButton
+            IconComponent={CogIcon}
+            rightText={buttonStrings.settings}
             onPress={toSettings}
-          >
-            <Text>{buttonStrings.settings}</Text>
-          </Icon.Button>
+          />
         )}
       </View>
     ),
@@ -216,7 +211,6 @@ const styles = {
   originalTopRow: { flex: 19, flexDirection: 'row' },
   moduleRow: { flex: 1, flexDirection: 'row' },
   image: { height: 150, width: 150, marginBottom: 30 },
-  bottomIcon: { color: GREY },
   bottomRow: {
     flex: 1,
     flexDirection: 'row',

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -89,14 +89,12 @@ const Menu = ({
     () => (
       <View style={containerStyle}>
         <CustomerImage style={image} />
-        <View>
-          <InfoBadge routeName={ROUTES.CUSTOMER_INVOICES}>
-            <MenuButton text={navStrings.customer_invoices} onPress={toCustomerInvoices} />
-          </InfoBadge>
-          <InfoBadge routeName={ROUTES.CUSTOMER_REQUISITIONS}>
-            <MenuButton text={navStrings.customer_requisitions} onPress={toCustomerRequisitions} />
-          </InfoBadge>
-        </View>
+        <InfoBadge routeName={ROUTES.CUSTOMER_INVOICES}>
+          <MenuButton text={navStrings.customer_invoices} onPress={toCustomerInvoices} />
+        </InfoBadge>
+        <InfoBadge routeName={ROUTES.CUSTOMER_REQUISITIONS}>
+          <MenuButton text={navStrings.customer_requisitions} onPress={toCustomerRequisitions} />
+        </InfoBadge>
       </View>
     ),
     [usingDashboard, usingDispensary, usingCashRegister, usingModules]
@@ -106,14 +104,12 @@ const Menu = ({
     () => (
       <View style={containerStyle}>
         <SupplierImage style={image} />
-        <View>
-          <InfoBadge routeName={ROUTES.SUPPLIER_INVOICES}>
-            <MenuButton text={navStrings.supplier_invoices} onPress={toSupplierInvoices} />
-          </InfoBadge>
-          <InfoBadge routeName={ROUTES.SUPPLIER_REQUISITIONS}>
-            <MenuButton text={navStrings.supplier_requisitions} onPress={toSupplierRequisitions} />
-          </InfoBadge>
-        </View>
+        <InfoBadge routeName={ROUTES.SUPPLIER_INVOICES}>
+          <MenuButton text={navStrings.supplier_invoices} onPress={toSupplierInvoices} />
+        </InfoBadge>
+        <InfoBadge routeName={ROUTES.SUPPLIER_REQUISITIONS}>
+          <MenuButton text={navStrings.supplier_requisitions} onPress={toSupplierRequisitions} />
+        </InfoBadge>
       </View>
     ),
     [usingDashboard, usingDispensary, usingCashRegister, usingModules]
@@ -123,12 +119,10 @@ const Menu = ({
     () => (
       <View style={containerStyle}>
         <StockImage style={image} />
-        <View>
-          <MenuButton text={navStrings.current_stock} onPress={toStock} />
-          <InfoBadge routeName={ROUTES.STOCKTAKES}>
-            <MenuButton text={navStrings.stocktake} onPress={toStocktakes} />
-          </InfoBadge>
-        </View>
+        <MenuButton text={navStrings.current_stock} onPress={toStock} />
+        <InfoBadge routeName={ROUTES.STOCKTAKES}>
+          <MenuButton text={navStrings.stocktake} onPress={toStocktakes} />
+        </InfoBadge>
       </View>
     ),
     [usingDashboard, usingDispensary, usingCashRegister, usingModules]

--- a/src/widgets/CircleButton.js
+++ b/src/widgets/CircleButton.js
@@ -41,15 +41,18 @@ export const CircleButton = ({
 
   const Container = isDisabled ? View : TouchableOpacity;
 
-  const containerStyle = [styles.dimensions, styles.containerStyle];
-  const internalStyle = isDisabled ? [containerStyle, styles.disabledStyle] : containerStyle;
+  const containerStyle = [
+    styles.dimensions,
+    styles.containerStyle,
+    isDisabled && styles.disabledStyle,
+  ];
 
   return (
     <Container
       onPressIn={onPressIn}
       onPressOut={onPressOut}
       onPress={onPress}
-      style={internalStyle}
+      style={containerStyle}
     >
       <IconComponent size={ICON_SIZE_VALUES[size]} />
     </Container>

--- a/src/widgets/DateRangeSelector.js
+++ b/src/widgets/DateRangeSelector.js
@@ -38,9 +38,7 @@ export const DateRangeSelector = ({
         <DatePickerButton
           minimumDate={minimumDate}
           maximumDate={initialEndDate}
-          initialValue={moment(initialStartDate)
-            .startOf('day')
-            .toDate()}
+          initialValue={moment(initialStartDate).startOf('day').toDate()}
           onDateChanged={onChangeFromDate}
         />
       </FlexRow>
@@ -54,9 +52,7 @@ export const DateRangeSelector = ({
         <DatePickerButton
           maximumDate={maximumDate}
           minimumDate={initialStartDate}
-          initialValue={moment(initialEndDate)
-            .endOf('day')
-            .toDate()}
+          initialValue={moment(initialEndDate).endOf('day').toDate()}
           onDateChanged={onChangeToDate}
         />
       </FlexRow>

--- a/src/widgets/IconButton.js
+++ b/src/widgets/IconButton.js
@@ -18,17 +18,16 @@ const ICON_SIZES = {
 };
 
 /**
- * Simple component rendering a button with a circular border radius
- * with an icon centered.
+ * Simple component rendering a button with an icon, and option text label on the right side
  *
  * @prop {Node} IconComponent An icon component to render in the center of the circle.
  * @prop {Func} onPress OnPress callback.
  * @prop {Func} onPressIn onPressIn callback.
  * @prop {Func} onPressOut  onPressOut callback.
  * @prop {Boolean} isDisabled  When true, no action on press. Disabled styling too.
- * @prop {String} size  Use size preset. "small", "medium" or "large".
- * @prop {String} leftText  Button label text to left of icon.
- * @prop {String} rightText Button label text to right of icon
+ * @prop {String} color  Color for the icon component
+ * @prop {String} size  Use size preset. "small", "medium", "large" or xlarge.
+ * @prop {String} label Button label text to right of icon
  */
 export const IconButton = ({
   IconComponent,
@@ -36,9 +35,9 @@ export const IconButton = ({
   onPressIn,
   onPressOut,
   isDisabled,
+  color,
   size,
-  leftText,
-  rightText,
+  label,
 }) => {
   const labelStyle = [localStyles.label, globalStyles.authWindowButtonText];
   const Container = isDisabled ? View : TouchableHighlight;
@@ -51,9 +50,8 @@ export const IconButton = ({
       onPress={onPress}
       style={localStyles.buttonContainer}
     >
-      {leftText && <Text style={labelStyle}>{leftText}</Text>}
-      <IconComponent color={GREY} size={iconSize} />
-      {rightText && <Text style={labelStyle}>{rightText}</Text>}
+      <IconComponent color={color} size={iconSize} />
+      {label && <Text style={labelStyle}>{label}</Text>}
     </Container>
   );
 };
@@ -63,9 +61,9 @@ IconButton.defaultProps = {
   onPressIn: null,
   onPressOut: null,
   isDisabled: false,
+  color: GREY,
   size: 'large',
-  leftText: null,
-  rightText: null,
+  label: null,
 };
 
 IconButton.propTypes = {
@@ -74,9 +72,9 @@ IconButton.propTypes = {
   onPressIn: PropTypes.func,
   onPressOut: PropTypes.func,
   isDisabled: PropTypes.bool,
+  color: PropTypes.string,
   size: PropTypes.string,
-  leftText: PropTypes.string,
-  rightText: PropTypes.string,
+  label: PropTypes.string,
 };
 
 const localStyles = StyleSheet.create({

--- a/src/widgets/IconButton.js
+++ b/src/widgets/IconButton.js
@@ -24,6 +24,7 @@ const ICON_SIZES = {
  * @prop {Func} onPress OnPress callback.
  * @prop {Func} onPressIn onPressIn callback.
  * @prop {Func} onPressOut  onPressOut callback.
+ * @prop {Boolean} containerStyle  When true, no action on press. Disabled styling too.
  * @prop {Boolean} isDisabled  When true, no action on press. Disabled styling too.
  * @prop {String} color  Color for the icon component
  * @prop {String} size  Use size preset. "small", "medium", "large" or xlarge.
@@ -34,12 +35,14 @@ export const IconButton = ({
   onPress,
   onPressIn,
   onPressOut,
+  containerStyle,
   isDisabled,
   color,
   size,
   label,
 }) => {
   const labelStyle = [localStyles.label, globalStyles.authWindowButtonText];
+  const buttonContainerStyle = [localStyles.buttonContainer, containerStyle];
   const Container = isDisabled ? View : TouchableHighlight;
   const iconSize = ICON_SIZES[size];
 
@@ -48,7 +51,7 @@ export const IconButton = ({
       onPressIn={onPressIn}
       onPressOut={onPressOut}
       onPress={onPress}
-      style={localStyles.buttonContainer}
+      style={buttonContainerStyle}
     >
       <IconComponent color={color} size={iconSize} />
       {label && <Text style={labelStyle}>{label}</Text>}
@@ -60,6 +63,7 @@ IconButton.defaultProps = {
   onPress: null,
   onPressIn: null,
   onPressOut: null,
+  containerStyle: null,
   isDisabled: false,
   color: GREY,
   size: 'large',
@@ -71,6 +75,7 @@ IconButton.propTypes = {
   onPress: PropTypes.func,
   onPressIn: PropTypes.func,
   onPressOut: PropTypes.func,
+  containerStyle: PropTypes.any,
   isDisabled: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.string,

--- a/src/widgets/IconButton.js
+++ b/src/widgets/IconButton.js
@@ -8,19 +8,12 @@ import React from 'react';
 import { TouchableOpacity as TouchableHighlight, StyleSheet, View, Text } from 'react-native';
 import PropTypes from 'prop-types';
 
-import globalStyles, { GREY } from '../globalStyles/index';
-
-const ICON_SIZES = {
-  small: 10,
-  medium: 15,
-  large: 20,
-  xlarge: 30,
-};
+import globalStyles from '../globalStyles/index';
 
 /**
  * Simple component rendering a button with an icon, and option text label on the right side
  *
- * @prop {Node} IconComponent An icon component to render in the center of the circle.
+ * @prop {Node} Icon An icon component (JSX literal).
  * @prop {Func} onPress OnPress callback.
  * @prop {Func} onPressIn onPressIn callback.
  * @prop {Func} onPressOut  onPressOut callback.
@@ -31,20 +24,17 @@ const ICON_SIZES = {
  * @prop {String} label Button label text to right of icon
  */
 export const IconButton = ({
-  IconComponent,
+  Icon,
   onPress,
   onPressIn,
   onPressOut,
   containerStyle,
   isDisabled,
-  color,
-  size,
   label,
 }) => {
   const labelStyle = [localStyles.label, globalStyles.authWindowButtonText];
   const buttonContainerStyle = [localStyles.buttonContainer, containerStyle];
   const Container = isDisabled ? View : TouchableHighlight;
-  const iconSize = ICON_SIZES[size];
 
   return (
     <Container
@@ -53,7 +43,7 @@ export const IconButton = ({
       onPress={onPress}
       style={buttonContainerStyle}
     >
-      <IconComponent color={color} size={iconSize} />
+      {Icon}
       {label && <Text style={labelStyle}>{label}</Text>}
     </Container>
   );
@@ -65,20 +55,16 @@ IconButton.defaultProps = {
   onPressOut: null,
   containerStyle: null,
   isDisabled: false,
-  color: GREY,
-  size: 'large',
   label: null,
 };
 
 IconButton.propTypes = {
-  IconComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func]).isRequired,
+  Icon: PropTypes.node.isRequired,
   onPress: PropTypes.func,
   onPressIn: PropTypes.func,
   onPressOut: PropTypes.func,
   containerStyle: PropTypes.object,
   isDisabled: PropTypes.bool,
-  color: PropTypes.string,
-  size: PropTypes.string,
   label: PropTypes.string,
 };
 

--- a/src/widgets/IconButton.js
+++ b/src/widgets/IconButton.js
@@ -24,7 +24,7 @@ const ICON_SIZES = {
  * @prop {Func} onPress OnPress callback.
  * @prop {Func} onPressIn onPressIn callback.
  * @prop {Func} onPressOut  onPressOut callback.
- * @prop {Boolean} containerStyle  When true, no action on press. Disabled styling too.
+ * @prop {Boolean} containerStyle  override default styles.
  * @prop {Boolean} isDisabled  When true, no action on press. Disabled styling too.
  * @prop {String} color  Color for the icon component
  * @prop {String} size  Use size preset. "small", "medium", "large" or xlarge.

--- a/src/widgets/IconButton.js
+++ b/src/widgets/IconButton.js
@@ -1,0 +1,123 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import { TouchableOpacity, StyleSheet, View, Text } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { SUSSOL_ORANGE, LIGHT_GREY } from '../globalStyles/index';
+
+const SIZE_VALUES = {
+  small: 15,
+  medium: 22,
+  large: 30,
+};
+
+const ICON_SIZE_VALUES = {
+  small: 10,
+  medium: 15,
+  large: 20,
+};
+
+/**
+ * Simple component rendering a button with a circular border radius
+ * with an icon centered.
+ *
+ * @prop {Node} IconComponent An icon component to render in the center of the circle.
+ * @prop {Func} onPress OnPress callback.
+ * @prop {Func} onPressIn onPressIn callback.
+ * @prop {Func} onPressOut  onPressOut callback.
+ * @prop {Boolean} isDisabled  When true, no action on press. Disabled styling too.
+ * @prop {String} size  Use size preset. "small", "medium" or "large".
+ * @prop {String} leftText  Button label text to left of icon.
+ * @prop {String} rightText Button label text to right of icon
+ */
+export const IconButton = ({
+  IconComponent,
+  textStyle,
+  onPress,
+  onPressIn,
+  onPressOut,
+  isDisabled,
+  size,
+  leftText,
+  rightText,
+}) => {
+  const styles = React.useMemo(() => localStyles(size), [size]);
+  const labelStyle = [styles.label, textStyle];
+  const Container = isDisabled ? View : TouchableOpacity;
+  const iconContainerStyle = [
+    styles.dimensions,
+    styles.container,
+    isDisabled && styles.iconDisabledStyle,
+  ];
+
+  return (
+    <Container
+      onPressIn={onPressIn}
+      onPressOut={onPressOut}
+      onPress={onPress}
+      style={styles.buttonContainer}
+    >
+      {leftText && <Text style={labelStyle}>{leftText}</Text>}
+      <View style={iconContainerStyle}>
+        <IconComponent size={ICON_SIZE_VALUES[size]} />
+      </View>
+      {rightText && <Text style={labelStyle}>{rightText}</Text>}
+    </Container>
+  );
+};
+
+IconButton.defaultProps = {
+  onPress: null,
+  onPressIn: null,
+  onPressOut: null,
+  isDisabled: false,
+  size: 'large',
+  leftText: null,
+  rightText: null,
+  textStyle: null,
+};
+
+IconButton.propTypes = {
+  IconComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func]).isRequired,
+  textStyle: PropTypes.any,
+  onPress: PropTypes.func,
+  onPressIn: PropTypes.func,
+  onPressOut: PropTypes.func,
+  isDisabled: PropTypes.bool,
+  size: PropTypes.string,
+  leftText: PropTypes.string,
+  rightText: PropTypes.string,
+};
+
+const localStyles = size =>
+  StyleSheet.create({
+    label: {
+      paddingHorizontal: 5,
+    },
+    dimensions: {
+      width: SIZE_VALUES[size],
+      height: SIZE_VALUES[size],
+      borderRadius: SIZE_VALUES[size],
+    },
+    iconDisabledStyle: {
+      backgroundColor: LIGHT_GREY,
+      borderColor: LIGHT_GREY,
+    },
+    buttonContainer: {
+      flex: 1,
+      flexDirection: 'row',
+      borderColor: 'red',
+      borderWidth: 1,
+      alignItems: 'center',
+    },
+    container: {
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: SUSSOL_ORANGE,
+    },
+  });

--- a/src/widgets/IconButton.js
+++ b/src/widgets/IconButton.js
@@ -8,7 +8,7 @@ import React from 'react';
 import { TouchableOpacity as TouchableHighlight, StyleSheet, View, Text } from 'react-native';
 import PropTypes from 'prop-types';
 
-import globalStyles, { SUSSOL_ORANGE, LIGHT_GREY, GREY } from '../globalStyles/index';
+import globalStyles, { GREY } from '../globalStyles/index';
 
 const ICON_SIZES = {
   small: 10,
@@ -83,14 +83,8 @@ const localStyles = StyleSheet.create({
   label: {
     paddingHorizontal: 5,
   },
-  iconDisabledStyle: {
-    backgroundColor: LIGHT_GREY,
-  },
   buttonContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-  },
-  iconCircle: {
-    backgroundColor: SUSSOL_ORANGE,
   },
 });

--- a/src/widgets/IconButton.js
+++ b/src/widgets/IconButton.js
@@ -75,7 +75,7 @@ IconButton.propTypes = {
   onPress: PropTypes.func,
   onPressIn: PropTypes.func,
   onPressOut: PropTypes.func,
-  containerStyle: PropTypes.any,
+  containerStyle: PropTypes.object,
   isDisabled: PropTypes.bool,
   color: PropTypes.string,
   size: PropTypes.string,

--- a/src/widgets/IconButton.js
+++ b/src/widgets/IconButton.js
@@ -5,18 +5,12 @@
  */
 
 import React from 'react';
-import { TouchableOpacity, StyleSheet, View, Text } from 'react-native';
+import { TouchableOpacity as TouchableHighlight, StyleSheet, View, Text } from 'react-native';
 import PropTypes from 'prop-types';
 
-import { SUSSOL_ORANGE, LIGHT_GREY } from '../globalStyles/index';
+import globalStyles, { SUSSOL_ORANGE, LIGHT_GREY, GREY } from '../globalStyles/index';
 
-const SIZE_VALUES = {
-  small: 15,
-  medium: 22,
-  large: 30,
-};
-
-const ICON_SIZE_VALUES = {
+const ICON_SIZES = {
   small: 10,
   medium: 15,
   large: 20,
@@ -37,7 +31,6 @@ const ICON_SIZE_VALUES = {
  */
 export const IconButton = ({
   IconComponent,
-  textStyle,
   onPress,
   onPressIn,
   onPressOut,
@@ -46,26 +39,19 @@ export const IconButton = ({
   leftText,
   rightText,
 }) => {
-  const styles = React.useMemo(() => localStyles(size), [size]);
-  const labelStyle = [styles.label, textStyle];
-  const Container = isDisabled ? View : TouchableOpacity;
-  const iconContainerStyle = [
-    styles.dimensions,
-    styles.container,
-    isDisabled && styles.iconDisabledStyle,
-  ];
+  const labelStyle = [localStyles.label, globalStyles.authWindowButtonText];
+  const Container = isDisabled ? View : TouchableHighlight;
+  const iconSize = ICON_SIZES[size];
 
   return (
     <Container
       onPressIn={onPressIn}
       onPressOut={onPressOut}
       onPress={onPress}
-      style={styles.buttonContainer}
+      style={localStyles.buttonContainer}
     >
       {leftText && <Text style={labelStyle}>{leftText}</Text>}
-      <View style={iconContainerStyle}>
-        <IconComponent size={ICON_SIZE_VALUES[size]} />
-      </View>
+      <IconComponent color={GREY} size={iconSize} />
       {rightText && <Text style={labelStyle}>{rightText}</Text>}
     </Container>
   );
@@ -79,12 +65,10 @@ IconButton.defaultProps = {
   size: 'large',
   leftText: null,
   rightText: null,
-  textStyle: null,
 };
 
 IconButton.propTypes = {
   IconComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func]).isRequired,
-  textStyle: PropTypes.any,
   onPress: PropTypes.func,
   onPressIn: PropTypes.func,
   onPressOut: PropTypes.func,
@@ -94,30 +78,18 @@ IconButton.propTypes = {
   rightText: PropTypes.string,
 };
 
-const localStyles = size =>
-  StyleSheet.create({
-    label: {
-      paddingHorizontal: 5,
-    },
-    dimensions: {
-      width: SIZE_VALUES[size],
-      height: SIZE_VALUES[size],
-      borderRadius: SIZE_VALUES[size],
-    },
-    iconDisabledStyle: {
-      backgroundColor: LIGHT_GREY,
-      borderColor: LIGHT_GREY,
-    },
-    buttonContainer: {
-      flex: 1,
-      flexDirection: 'row',
-      borderColor: 'red',
-      borderWidth: 1,
-      alignItems: 'center',
-    },
-    container: {
-      alignItems: 'center',
-      justifyContent: 'center',
-      backgroundColor: SUSSOL_ORANGE,
-    },
-  });
+const localStyles = StyleSheet.create({
+  label: {
+    paddingHorizontal: 5,
+  },
+  iconDisabledStyle: {
+    backgroundColor: LIGHT_GREY,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  iconCircle: {
+    backgroundColor: SUSSOL_ORANGE,
+  },
+});

--- a/src/widgets/IconButton.js
+++ b/src/widgets/IconButton.js
@@ -14,6 +14,7 @@ const ICON_SIZES = {
   small: 10,
   medium: 15,
   large: 20,
+  xlarge: 30,
 };
 
 /**

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -57,6 +57,10 @@ export const CloseIcon = ({ size, color }) => <IonIcon name="md-close" size={siz
 CloseIcon.defaultProps = { color: WHITE, size: 36 };
 CloseIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
 
+export const CogIcon = ({ size, color }) => <FAIcon name="cog" size={size} color={color} />;
+CogIcon.defaultProps = { color: WHITE, size: 36 };
+CogIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
+
 export const ExpandIcon = React.memo(({ style, color, size }) => (
   <FAIcon name="external-link" style={style} size={size} color={color} />
 ));
@@ -95,6 +99,12 @@ ChevronUpIcon.propTypes = {
   size: PropTypes.number,
   style: PropTypes.object,
 };
+
+export const PowerIcon = React.memo(({ color, size }) => (
+  <FAIcon name="power-off" color={color} size={size} />
+));
+PowerIcon.defaultProps = { color: WHITE, size: 20 };
+PowerIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
 
 export const PencilIcon = React.memo(({ color, size }) => (
   <FAIcon name="pencil" color={color} size={size} />

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -58,7 +58,7 @@ CloseIcon.defaultProps = { color: WHITE, size: 36 };
 CloseIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
 
 export const CogIcon = ({ size, color }) => <FAIcon name="cog" size={size} color={color} />;
-CogIcon.defaultProps = { color: GREY, size: 30 };
+CogIcon.defaultProps = { color: GREY, size: 20 };
 CogIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
 
 export const ExpandIcon = React.memo(({ style, color, size }) => (
@@ -109,7 +109,7 @@ ChevronUpIcon.propTypes = {
 export const PowerIcon = React.memo(({ color, size }) => (
   <FAIcon name="power-off" color={color} size={size} />
 ));
-PowerIcon.defaultProps = { color: GREY, size: 30 };
+PowerIcon.defaultProps = { color: GREY, size: 20 };
 PowerIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
 
 export const PencilIcon = React.memo(({ color, size }) => (

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -58,7 +58,7 @@ CloseIcon.defaultProps = { color: WHITE, size: 36 };
 CloseIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
 
 export const CogIcon = ({ size, color }) => <FAIcon name="cog" size={size} color={color} />;
-CogIcon.defaultProps = { color: WHITE, size: 36 };
+CogIcon.defaultProps = { color: GREY, size: 30 };
 CogIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
 
 export const ExpandIcon = React.memo(({ style, color, size }) => (
@@ -79,6 +79,12 @@ ConfirmIcon.propTypes = { style: PropTypes.object };
 export const LockIcon = React.memo(({ style }) => <FAIcon name="lock" size={28} style={style} />);
 LockIcon.defaultProps = { style: { color: FINALISED_RED } };
 LockIcon.propTypes = { style: PropTypes.object };
+
+export const LanguageIcon = ({ size, color }) => (
+  <FAIcon name="language" size={size} color={color} />
+);
+LanguageIcon.defaultProps = { color: GREY, size: 30 };
+LanguageIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
 
 export const ChevronDownIcon = React.memo(({ color, size, style }) => (
   <FA5Icon name="chevron-down" color={color} size={size} style={style} />
@@ -103,7 +109,7 @@ ChevronUpIcon.propTypes = {
 export const PowerIcon = React.memo(({ color, size }) => (
   <FAIcon name="power-off" color={color} size={size} />
 ));
-PowerIcon.defaultProps = { color: WHITE, size: 20 };
+PowerIcon.defaultProps = { color: GREY, size: 30 };
 PowerIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
 
 export const PencilIcon = React.memo(({ color, size }) => (

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -43,10 +43,6 @@ export const DisabledCheckedIcon = () => (
 );
 export const DisabledUncheckedIcon = () => <MaterialCommunityIcon name="cancel" size={15} />;
 
-export const OpenModalIcon = () => (
-  <FAIcon name="angle-double-up" size={20} color={SUSSOL_ORANGE} />
-);
-
 export const MagnifyingGlassIcon = React.memo(({ size, color }) => (
   <EvilIcon name="search" size={size} color={color} />
 ));

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -18,6 +18,7 @@ export { FormTextInput } from './FormInputs/FormTextInput';
 export { HeaderRight } from './HeaderRight';
 export { HazardPoint } from './HazardPoint';
 export { IconCell } from './IconCell';
+export { IconButton } from './IconButton';
 export { InfoBadge } from './InfoBadge';
 export { LineChart } from './LineChart';
 export { OnePressButton } from './OnePressButton';

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -214,6 +214,7 @@ export class LoginModal extends React.Component {
         <View style={globalStyles.bottomContainer}>
           <IconButton
             IconComponent={LanguageIcon}
+            size="xlarge"
             rightText={navStrings.language}
             onPress={() => {
               this.setState({ isLanguageModalOpen: true });

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -213,8 +213,7 @@ export class LoginModal extends React.Component {
         </View>
         <View style={globalStyles.bottomContainer}>
           <IconButton
-            IconComponent={LanguageIcon}
-            size="xlarge"
+            Icon={<LanguageIcon />}
             label={navStrings.language}
             onPress={() => {
               this.setState({ isLanguageModalOpen: true });

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -215,7 +215,7 @@ export class LoginModal extends React.Component {
           <IconButton
             IconComponent={LanguageIcon}
             size="xlarge"
-            rightText={navStrings.language}
+            label={navStrings.language}
             onPress={() => {
               this.setState({ isLanguageModalOpen: true });
             }}

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -7,16 +7,16 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Image, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Image, Text, TextInput, View } from 'react-native';
 import { Button } from 'react-native-ui-components';
-import Icon from 'react-native-vector-icons/FontAwesome';
 
 import { SETTINGS_KEYS, getAppVersion } from '../../settings';
 
-import globalStyles, { WHITE, SUSSOL_ORANGE, GREY, WARM_GREY } from '../../globalStyles';
-import { Flag } from '..';
+import globalStyles, { WHITE, SUSSOL_ORANGE, WARM_GREY } from '../../globalStyles';
+import { Flag, IconButton } from '..';
 import { GenericChoiceList } from '../modalChildren/GenericChoiceList';
 import { ModalContainer } from './ModalContainer';
+import { LanguageIcon } from '../icons';
 
 import { LANGUAGE_NAMES, LANGUAGE_CHOICE, authStrings, navStrings } from '../../localization';
 import { getModalTitle, MODAL_KEYS } from '../../utilities';
@@ -212,19 +212,13 @@ export class LoginModal extends React.Component {
           </View>
         </View>
         <View style={globalStyles.bottomContainer}>
-          <Icon.Button
-            name="language"
-            size={25}
-            underlayColor="#888888"
-            iconStyle={localStyles.bottomIcon}
-            borderRadius={4}
-            backgroundColor="rgba(255,255,255,0)"
+          <IconButton
+            IconComponent={LanguageIcon}
+            rightText={navStrings.language}
             onPress={() => {
               this.setState({ isLanguageModalOpen: true });
             }}
-          >
-            <Text style={globalStyles.authWindowButtonText}>{navStrings.language}</Text>
-          </Icon.Button>
+          />
           <Text style={globalStyles.authWindowButtonText}>v{appVersion}</Text>
         </View>
         <ModalContainer
@@ -253,9 +247,3 @@ LoginModal.propTypes = {
   onAuthentication: PropTypes.func.isRequired,
   settings: PropTypes.object.isRequired,
 };
-
-const localStyles = StyleSheet.create({
-  bottomIcon: {
-    color: GREY,
-  },
-});


### PR DESCRIPTION
Fixes #3303.
Fixes #3304 too.
I'm not super happy with it but want it on the table regardless. While not used as a model, actual implementation is similar to idea of [Icon.Button](https://github.com/oblador/react-native-vector-icons/blob/master/lib/icon-button.js)

## Change summary

- Added `IconButton` component. Ended up making it work for text on left and/or right; On the off chance we use it for sync status, which has left text.
- Some size constants baked in.
- Refactored some existing `Icon.Button` usage to use `IconButton`
- End result made some lacking fonts be adjusted to the app font:
![image](https://user-images.githubusercontent.com/7684221/104539248-fff5c980-5681-11eb-8582-5f9aee163ef5.png)
![image](https://user-images.githubusercontent.com/7684221/104539231-f53b3480-5681-11eb-886d-50058b2b468c.png)


## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Language button looks nice and works
- [ ] Logout button looks nice and works
- [ ] Settings button looks nice and works

### Related areas to think about

- Perhaps rethink how we structure `Text` styles... `globalStyles.authWindowButtonText` contextually isn't accurate but is what I'm using.
- Could think about making `IconButton` replace `CircleButton` too. Or `CircleButton` could use `IconButton` in render
- Could use prop pass through for text style
