### PR TITLE
#3336 Paper component

### DIFF
--- a/src/widgets/Paper.js
+++ b/src/widgets/Paper.js
@@ -1,0 +1,44 @@
+/* eslint-disable react/forbid-prop-types */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View } from 'react-native';
+
+import { WHITE } from '../globalStyles';
+
+export const Paper = ({ width, height, style, children }) => {
+  // If width and height are passed hard fix them in the container style,
+  // let the axis which isn't passed flex. Plain width or height properties
+  // sometimes act as suggestions when the container is flexing so use
+  // max/min properties.
+  const internalContainerStyle = { ...style };
+  if (width) {
+    internalContainerStyle.maxWidth = width;
+    internalContainerStyle.minWidth = width;
+  }
+
+  if (height) {
+    internalContainerStyle.maxHeight = height;
+    internalContainerStyle.minHeight = height;
+  }
+  return <View style={internalContainerStyle}>{children}</View>;
+};
+
+Paper.defaultProps = {
+  width: 0,
+  height: 0,
+  style: {
+    backgroundColor: WHITE,
+    elevation: 2,
+    borderRadius: 4,
+    display: 'flex',
+    flex: 1,
+  },
+  children: null,
+};
+
+Paper.propTypes = {
+  width: PropTypes.number,
+  height: PropTypes.number,
+  style: PropTypes.object,
+  children: PropTypes.element,
+};

--- a/src/widgets/PaperSection.js
+++ b/src/widgets/PaperSection.js
@@ -1,0 +1,64 @@
+/* eslint-disable react/forbid-prop-types */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View, Text } from 'react-native';
+
+import { Paper } from './Paper';
+
+import { APP_FONT_FAMILY, DARKER_GREY, BACKGROUND_COLOR } from '../globalStyles';
+
+const defaultHeaderStyle = { fontFamily: APP_FONT_FAMILY, color: DARKER_GREY, fontSize: 13 };
+const getDefaultHeader = text => <Text style={defaultHeaderStyle}>{text}</Text>;
+
+export const PaperSection = ({
+  width,
+  height,
+  Header,
+  children,
+  headerText,
+  innerPadding,
+  headerContainerStyle,
+  contentContainerStyle,
+}) => {
+  const InternalHeader = headerText ? getDefaultHeader(headerText) : Header;
+
+  // Pad the content and header if passed, keeping them in sync.
+  const internalContentStyle = { ...contentContainerStyle, padding: innerPadding };
+  const internalHeaderContainerStyle = { ...headerContainerStyle, padding: innerPadding };
+
+  return (
+    <Paper width={width} height={height}>
+      <View style={internalHeaderContainerStyle}>{InternalHeader}</View>
+      <View style={internalContentStyle}>{children}</View>
+    </Paper>
+  );
+};
+
+PaperSection.defaultProps = {
+  width: 0,
+  height: 0,
+  innerPadding: 20,
+  children: null,
+  Header: null,
+  headerText: '',
+  headerContainerStyle: {
+    height: 40,
+    display: 'flex',
+    paddingHorizontal: 10,
+    justifyContent: 'center',
+    backgroundColor: BACKGROUND_COLOR,
+    padding: 10,
+  },
+  contentContainerStyle: {},
+};
+
+PaperSection.propTypes = {
+  Header: PropTypes.node,
+  innerPadding: PropTypes.number,
+  headerContainerStyle: PropTypes.object,
+  contentContainerStyle: PropTypes.object,
+  width: PropTypes.number,
+  height: PropTypes.number,
+  children: PropTypes.node,
+  headerText: PropTypes.string,
+};

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -46,6 +46,8 @@ export { Wizard } from './Wizard';
 export { FridgeDisplay } from './FridgeDisplay';
 export { FridgeDisplayInfo } from './FridgeDisplayInfo';
 export { KeyboardSpacing } from './KeyboardSpacing';
+export { Paper } from './Paper';
+export { PaperSection } from './PaperSection';
 
 export * from './icons';
 export * from './images';


### PR DESCRIPTION
Fixes #3336 

## Change summary

- Adds two components `Paper` and `PaperSection`.
- Two components because there are some areas with a header and some without.
- Thought abstracting the `Paper` away from the component with the dedicated header gave more flexibility.
- Unsure about `PaperSection` naming.

## Testing

Internal

### Related areas to think about

N/A