### PR TITLE
#3306 CardDetail

### DIFF
--- a/src/widgets/CardDetail.js
+++ b/src/widgets/CardDetail.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/forbid-prop-types */
-/* eslint-disable arrow-body-style */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { View, Text } from 'react-native';
@@ -20,22 +20,20 @@ export const CardDetail = ({
   fullContentContainerStyle,
   contentContainerStyle,
   footerContainerStyle,
-}) => {
-  return (
-    <PaperSection
-      width={width}
-      height={height}
-      Header={<Text style={headerStyle}>{headerText}</Text>}
-      innerPadding={innerPadding}
-      headerContainerStyle={headerContainerStyle}
-    >
-      <View style={fullContentContainerStyle}>
-        <View style={contentContainerStyle}>{Content}</View>
-        <View style={footerContainerStyle}>{Footer}</View>
-      </View>
-    </PaperSection>
-  );
-};
+}) => (
+  <PaperSection
+    width={width}
+    height={height}
+    Header={<Text style={headerStyle}>{headerText}</Text>}
+    innerPadding={innerPadding}
+    headerContainerStyle={headerContainerStyle}
+  >
+    <View style={fullContentContainerStyle}>
+      <View style={contentContainerStyle}>{Content}</View>
+      <View style={footerContainerStyle}>{Footer}</View>
+    </View>
+  </PaperSection>
+);
 
 CardDetail.defaultProps = {
   fullContentContainerStyle: { alignItems: 'center', justifyContent: 'center', height: 120 },

--- a/src/widgets/CardDetail.js
+++ b/src/widgets/CardDetail.js
@@ -1,0 +1,70 @@
+/* eslint-disable react/forbid-prop-types */
+/* eslint-disable arrow-body-style */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View, Text } from 'react-native';
+
+import { PaperSection } from './PaperSection';
+
+import { APP_FONT_FAMILY, DARKER_GREY, BACKGROUND_COLOR } from '../globalStyles';
+
+export const CardDetail = ({
+  Content,
+  Footer,
+  headerText,
+  width,
+  height,
+  innerPadding,
+  headerStyle,
+  headerContainerStyle,
+  fullContentContainerStyle,
+  contentContainerStyle,
+  footerContainerStyle,
+}) => {
+  return (
+    <PaperSection
+      width={width}
+      height={height}
+      Header={<Text style={headerStyle}>{headerText}</Text>}
+      innerPadding={innerPadding}
+      headerContainerStyle={headerContainerStyle}
+    >
+      <View style={fullContentContainerStyle}>
+        <View style={contentContainerStyle}>{Content}</View>
+        <View style={footerContainerStyle}>{Footer}</View>
+      </View>
+    </PaperSection>
+  );
+};
+
+CardDetail.defaultProps = {
+  fullContentContainerStyle: { alignItems: 'center', justifyContent: 'center', height: 120 },
+  contentContainerStyle: { flex: 2, alignItems: 'center', justifyContent: 'center' },
+  footerContainerStyle: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  headerStyle: { fontFamily: APP_FONT_FAMILY, fontSize: 13, color: DARKER_GREY },
+  headerContainerStyle: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: BACKGROUND_COLOR,
+  },
+  width: 160,
+  height: 160,
+  innerPadding: 5,
+  Content: null,
+  Footer: null,
+  headerText: '',
+};
+
+CardDetail.propTypes = {
+  headerStyle: PropTypes.object,
+  headerContainerStyle: PropTypes.object,
+  fullContentContainerStyle: PropTypes.object,
+  contentContainerStyle: PropTypes.object,
+  footerContainerStyle: PropTypes.object,
+  innerPadding: PropTypes.number,
+  width: PropTypes.number,
+  height: PropTypes.number,
+  Content: PropTypes.node,
+  Footer: PropTypes.node,
+  headerText: PropTypes.string,
+};

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -48,6 +48,7 @@ export { FridgeDisplayInfo } from './FridgeDisplayInfo';
 export { KeyboardSpacing } from './KeyboardSpacing';
 export { Paper } from './Paper';
 export { PaperSection } from './PaperSection';
+export { CardDetail } from './CardDetail';
 
 export * from './icons';
 export * from './images';


### PR DESCRIPTION
Fixes #3306 

## BRANCHED FROM THE PR #3337

## Change summary

- Adds `CardDetail` component

<img width="984" alt="Screen Shot 2021-01-16 at 9 23 59 AM" src="https://user-images.githubusercontent.com/35858975/104776746-6c3a0f80-57df-11eb-85cb-346484f865a6.png">

## Testing

Internal

### Related areas to think about

Was going to make a `BreachCardDetail` abstraction over the top but couldn't think of a good implementation