### PR TITLE
#3304 TextWithIcon

### DIFF
--- a/src/widgets/Typography/TextWithIcon.js
+++ b/src/widgets/Typography/TextWithIcon.js
@@ -1,0 +1,67 @@
+/* eslint-disable react/forbid-prop-types */
+/* eslint-disable arrow-body-style */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Text } from 'react-native';
+
+import { FlexRow } from '../FlexRow';
+
+import { APP_FONT_FAMILY, DARKER_GREY } from '../../globalStyles';
+
+const SIZES = {
+  xs: 10,
+  s: 12,
+  ms: 13,
+  m: 14,
+  ml: 16,
+  l: 20,
+};
+
+const getInternalStyle = (size, left, color, textStyle) => {
+  const margin = left ? 'marginLeft' : 'marginRight';
+  const alignment = left ? 'left' : 'right';
+
+  const styleAdjustment = {
+    fontSize: SIZES[size],
+    [margin]: 5,
+    textAlign: alignment,
+    color,
+    ...textStyle,
+  };
+
+  return [defaultStyle, styleAdjustment];
+};
+
+export const TextWithIcon = ({ Icon, left, children, color, size, containerStyle, textStyle }) => {
+  const internalStyle = getInternalStyle(size, left, color, textStyle);
+
+  return (
+    <FlexRow alignItems="center" flex={0} {...containerStyle}>
+      {left ? Icon : null}
+      <Text style={internalStyle}>{children}</Text>
+      {!left ? Icon : null}
+    </FlexRow>
+  );
+};
+
+const defaultStyle = { fontFamily: APP_FONT_FAMILY };
+
+TextWithIcon.defaultProps = {
+  left: false,
+  color: DARKER_GREY,
+  size: 'xs',
+  spaceOverride: 0,
+  containerStyle: {},
+  textStyle: {},
+};
+
+TextWithIcon.propTypes = {
+  Icon: PropTypes.node.isRequired,
+  left: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  color: PropTypes.string,
+  size: PropTypes.string,
+  spaceOverride: PropTypes.number,
+  containerStyle: PropTypes.object,
+  textStyle: PropTypes.object,
+};

--- a/src/widgets/Typography/index.js
+++ b/src/widgets/Typography/index.js
@@ -1,0 +1,1 @@
+export { TextWithIcon } from './TextWithIcon';


### PR DESCRIPTION
Fixes #3304 

## Change summary

- Adds `TextWithIcon` component


## Testing

Internal

### Related areas to think about

Bit controversial implementation or actual neccessititity of the component. Things to keep in mind
- There's a lot of text+and icon coming up in the work
- I've done this a bunch and its pretty annoying to constantly right code for it
- Yes some better typography components would make for a better implementation, but it's a bit out of scope

![image](https://user-images.githubusercontent.com/35858975/104822869-960c3880-58aa-11eb-98a3-8074c09c80ae.png)
