### PR TITLE
#3330 Add correct constant

### DIFF
--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -64,7 +64,7 @@ export const StocktakeBatchModalComponent = ({
       return { page: MODALS.STOCKTAKE_BATCH_EDIT_WITH_REASONS_AND_PRICES, pageObject };
     }
     if (usingReasons) return { page: MODALS.STOCKTAKE_BATCH_EDIT_WITH_REASONS, pageObject };
-    if (usingPayments) return { page: MODALS.STOCKTAKE_BATCH_EDIT_WITH_PAYMENTS, pageObject };
+    if (usingPayments) return { page: MODALS.STOCKTAKE_BATCH_EDIT_WITH_PRICES, pageObject };
     return { page: MODALS.STOCKTAKE_BATCH_EDIT, pageObject };
   }, [stocktakeItem, usingPayments, usingReasons]);
 


### PR DESCRIPTION
Fixes #3330 

## Change summary

![](https://media3.giphy.com/media/YSeRKAa0JJjTJxbD0R/200.gif?cid=5a38a5a2enkgq088kenc46xh1g3skg4vuqj3ood17ly758az&rid=200.gif)

## Testing

- [ ] Pushing the `>` to open the batch modal on stocktake page with prices preference enabled (And no others) does not crash the app.

### Related areas to think about

I don't think anyone is using payments and nothing else.