### PR TITLE
#3305 date range selector update

### DIFF
--- a/src/widgets/DatePickerButton.js
+++ b/src/widgets/DatePickerButton.js
@@ -11,12 +11,38 @@ import { CircleButton } from './CircleButton';
 import { CalendarIcon } from './icons';
 
 import { useDatePicker } from '../hooks/useDatePicker';
+import { IconButton } from './IconButton';
+import { DARK_GREY } from '../globalStyles/index';
 
-export const DatePickerButton = ({ initialValue, onDateChanged, maximumDate, minimumDate }) => {
+/**
+ * Shows an Icon that is pressable and opens a date picker. Handle result with
+ * callback "onDateChanged".
+ *
+ * @prop {Node} initialValue  Initial date value to display in picker
+ * @prop {Func} onDateChanged Callback to handle output of selected date.
+ *                            Should take one parameter, a timestamp.
+ * @prop {Func} maximumDate Maximum date selectable.
+ * @prop {Func} minimumDate Minimum date selectable.
+ * @prop {Boolean} isCircle Should the Icon have a Circle background rendered.
+ */
+
+export const DatePickerButton = ({
+  initialValue,
+  onDateChanged,
+  maximumDate,
+  minimumDate,
+  isCircle,
+}) => {
   const [datePickerIsOpen, openDatePicker, datePickerCallback] = useDatePicker(onDateChanged);
+  const button = isCircle ? (
+    <CircleButton IconComponent={CalendarIcon} onPress={openDatePicker} />
+  ) : (
+    <IconButton Icon={<CalendarIcon color={DARK_GREY} />} onPress={openDatePicker} />
+  );
+
   return (
     <>
-      <CircleButton IconComponent={CalendarIcon} onPress={openDatePicker} />
+      {button}
       {datePickerIsOpen && (
         <DateTimePicker
           maximumDate={maximumDate}
@@ -34,6 +60,7 @@ export const DatePickerButton = ({ initialValue, onDateChanged, maximumDate, min
 DatePickerButton.defaultProps = {
   minimumDate: undefined,
   maximumDate: undefined,
+  isCircle: true,
 };
 
 DatePickerButton.propTypes = {
@@ -41,4 +68,5 @@ DatePickerButton.propTypes = {
   onDateChanged: PropTypes.func.isRequired,
   maximumDate: PropTypes.instanceOf(Date),
   minimumDate: PropTypes.instanceOf(Date),
+  isCircle: PropTypes.bool,
 };

--- a/src/widgets/DateRangeSelector.js
+++ b/src/widgets/DateRangeSelector.js
@@ -4,69 +4,69 @@
  * Sustainable Solutions (NZ) Ltd. 2020
  */
 import React from 'react';
-import { Text, StyleSheet } from 'react-native';
+import { Text, StyleSheet, View } from 'react-native';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
 import { DatePickerButton } from './DatePickerButton';
 import { FlexRow } from './FlexRow';
-import { FlexColumn } from './FlexColumn';
 
-import { textStyles, SUSSOL_ORANGE } from '../globalStyles';
-import { generalStrings } from '../localization/index';
+import { textStyles, LIGHT_GREY } from '../globalStyles';
+import { useLayoutDimensions } from '../hooks/useLayoutDimensions';
 
 export const DateRangeSelector = ({
   initialStartDate,
   initialEndDate,
   onChangeFromDate,
   onChangeToDate,
-  labelTextStyle,
   dateTextStyle,
   maximumDate,
   minimumDate,
 }) => {
   const formattedStartDate = moment(initialStartDate).format('D/M/YYYY');
   const formattedEndDate = moment(initialEndDate).format('D/M/YYYY');
+  const [, height, setDimensions] = useLayoutDimensions();
 
   return (
-    <FlexRow flex={1} alignItems="center">
+    <View onLayout={setDimensions} style={[localStyles.container, { borderRadius: height }]}>
       <FlexRow alignItems="center">
-        <FlexColumn>
-          <Text style={labelTextStyle}>{generalStrings.from}</Text>
-          <Text style={dateTextStyle}>{formattedStartDate}</Text>
-        </FlexColumn>
         <DatePickerButton
           minimumDate={minimumDate}
           maximumDate={initialEndDate}
           initialValue={moment(initialStartDate).startOf('day').toDate()}
           onDateChanged={onChangeFromDate}
         />
+        <Text style={dateTextStyle}>{formattedStartDate}</Text>
       </FlexRow>
 
       <FlexRow alignItems="center">
-        <Text style={dateTextStyle}> ___ </Text>
-        <FlexColumn>
-          <Text style={labelTextStyle}>{generalStrings.to}</Text>
-          <Text style={dateTextStyle}>{formattedEndDate}</Text>
-        </FlexColumn>
+        <Text style={localStyles.dashText}>—</Text>
         <DatePickerButton
           maximumDate={maximumDate}
           minimumDate={initialStartDate}
           initialValue={moment(initialEndDate).endOf('day').toDate()}
           onDateChanged={onChangeToDate}
         />
+        <Text style={dateTextStyle}>{formattedEndDate}</Text>
       </FlexRow>
-    </FlexRow>
+    </View>
   );
 };
 
 const localStyles = StyleSheet.create({
-  dateText: { ...textStyles, marginHorizontal: 10 },
-  labelText: { ...textStyles, marginHorizontal: 10, fontWeight: 'bold', color: SUSSOL_ORANGE },
+  dateText: { ...textStyles },
+  dashText: { ...textStyles, paddingHorizontal: 5 },
+  container: {
+    flexDirection: 'row',
+    backgroundColor: LIGHT_GREY,
+    borderColor: 'red',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: 15,
+  },
 });
 
 DateRangeSelector.defaultProps = {
-  labelTextStyle: localStyles.labelText,
   dateTextStyle: localStyles.dateText,
   maximumDate: null,
   minimumDate: null,
@@ -77,7 +77,6 @@ DateRangeSelector.propTypes = {
   initialEndDate: PropTypes.instanceOf(Date).isRequired,
   onChangeFromDate: PropTypes.func.isRequired,
   onChangeToDate: PropTypes.func.isRequired,
-  labelTextStyle: PropTypes.object,
   dateTextStyle: PropTypes.object,
   maximumDate: PropTypes.instanceOf(Date),
   minimumDate: PropTypes.instanceOf(Date),

--- a/src/widgets/DateRangeSelector.js
+++ b/src/widgets/DateRangeSelector.js
@@ -11,7 +11,7 @@ import moment from 'moment';
 import { DatePickerButton } from './DatePickerButton';
 import { FlexRow } from './FlexRow';
 
-import { textStyles, LIGHT_GREY } from '../globalStyles';
+import { textStyles, LIGHT_GREY, WHITE } from '../globalStyles';
 import { useLayoutDimensions } from '../hooks/useLayoutDimensions';
 
 export const DateRangeSelector = ({
@@ -22,19 +22,24 @@ export const DateRangeSelector = ({
   dateTextStyle,
   maximumDate,
   minimumDate,
+  backgroundColor,
 }) => {
   const formattedStartDate = moment(initialStartDate).format('D/M/YYYY');
   const formattedEndDate = moment(initialEndDate).format('D/M/YYYY');
   const [, height, setDimensions] = useLayoutDimensions();
 
   return (
-    <View onLayout={setDimensions} style={[localStyles.container, { borderRadius: height }]}>
+    <View
+      onLayout={setDimensions}
+      style={[localStyles.container, { borderRadius: height, backgroundColor }]}
+    >
       <FlexRow alignItems="center">
         <DatePickerButton
           minimumDate={minimumDate}
           maximumDate={initialEndDate}
           initialValue={moment(initialStartDate).startOf('day').toDate()}
           onDateChanged={onChangeFromDate}
+          isCircle={false}
         />
         <Text style={dateTextStyle}>{formattedStartDate}</Text>
       </FlexRow>
@@ -46,6 +51,7 @@ export const DateRangeSelector = ({
           minimumDate={initialStartDate}
           initialValue={moment(initialEndDate).endOf('day').toDate()}
           onDateChanged={onChangeToDate}
+          isCircle={false}
         />
         <Text style={dateTextStyle}>{formattedEndDate}</Text>
       </FlexRow>
@@ -54,7 +60,7 @@ export const DateRangeSelector = ({
 };
 
 const localStyles = StyleSheet.create({
-  dateText: { ...textStyles },
+  dateText: { ...textStyles, paddingLeft: 5 },
   dashText: { ...textStyles, paddingHorizontal: 5 },
   container: {
     flexDirection: 'row',
@@ -70,6 +76,7 @@ DateRangeSelector.defaultProps = {
   dateTextStyle: localStyles.dateText,
   maximumDate: null,
   minimumDate: null,
+  backgroundColor: WHITE,
 };
 
 DateRangeSelector.propTypes = {
@@ -80,4 +87,5 @@ DateRangeSelector.propTypes = {
   dateTextStyle: PropTypes.object,
   maximumDate: PropTypes.instanceOf(Date),
   minimumDate: PropTypes.instanceOf(Date),
+  backgroundColor: PropTypes.string,
 };

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -146,7 +146,15 @@ export const MinusIcon = ({ size, color }) => (
 MinusIcon.defaultProps = { color: WHITE, size: 30 };
 MinusIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
 
-export const CalendarIcon = () => <FAIcon name="calendar" size={20} color={WHITE} />;
+export const CalendarIcon = ({ color, size, style }) => (
+  <FAIcon name="calendar" size={size} style={style} color={color} />
+);
+CalendarIcon.defaultProps = { color: WHITE, size: 20, style: {} };
+CalendarIcon.propTypes = {
+  color: PropTypes.string,
+  size: PropTypes.number,
+  style: PropTypes.object,
+};
 
 export const BackIcon = () => <FAIcon name="chevron-left" size={16} color="black" />;
 

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -17,6 +17,7 @@ import { Flag, IconButton } from '..';
 import { GenericChoiceList } from '../modalChildren/GenericChoiceList';
 import { ModalContainer } from './ModalContainer';
 import { LanguageIcon } from '../icons';
+import { DateRangeSelector } from '../DateRangeSelector';
 
 import { LANGUAGE_NAMES, LANGUAGE_CHOICE, authStrings, navStrings } from '../../localization';
 import { getModalTitle, MODAL_KEYS } from '../../utilities';
@@ -199,6 +200,7 @@ export class LoginModal extends React.Component {
                 }}
               />
             </View>
+            <DateRangeSelector />
             <View style={globalStyles.authFormButtonContainer}>
               <Button
                 style={[globalStyles.authFormButton, globalStyles.loginButton]}

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -17,7 +17,6 @@ import { Flag, IconButton } from '..';
 import { GenericChoiceList } from '../modalChildren/GenericChoiceList';
 import { ModalContainer } from './ModalContainer';
 import { LanguageIcon } from '../icons';
-import { DateRangeSelector } from '../DateRangeSelector';
 
 import { LANGUAGE_NAMES, LANGUAGE_CHOICE, authStrings, navStrings } from '../../localization';
 import { getModalTitle, MODAL_KEYS } from '../../utilities';
@@ -200,7 +199,6 @@ export class LoginModal extends React.Component {
                 }}
               />
             </View>
-            <DateRangeSelector />
             <View style={globalStyles.authFormButtonContainer}>
               <Button
                 style={[globalStyles.authFormButton, globalStyles.loginButton]}


### PR DESCRIPTION
Fixes #3305 

## Change summary

Adjusts `DateRangeSelector` to look as it does in the designs as specified in issue.

- New DateRangeSelector look: 
<img width="301" alt="Screen Shot 2021-01-18 at 12 47 30 PM" src="https://user-images.githubusercontent.com/7684221/104859641-a811d800-598b-11eb-97f0-b1eb6ebc3e8d.png">

- New DateRangeSelector has a background, default is white. Here it is with `backgroundColor="red"`: 
<img width="301" alt="Screen Shot 2021-01-18 at 12 47 11 PM" src="https://user-images.githubusercontent.com/7684221/104859644-a8aa6e80-598b-11eb-9c66-351f6d284f76.png">

- Old DatePickerButton work fine:
<img width="83" alt="Screen Shot 2021-01-18 at 12 47 53 PM" src="https://user-images.githubusercontent.com/7684221/104859637-a6481480-598b-11eb-9711-73e034a4a157.png">


## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Only use or range selector is in current vaccine module, but we're about to rewrite that. So test that works if you like (though styles in old design are being dumped so just functionally test)
- [ ] New/edit patient age input works fine

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
