### PR TITLE
#3351 bluetooth scan start/stop thunks

### DIFF
--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -45,12 +45,12 @@ const scanForSensors = () => async dispatch => {
   BleService().scanForSensors(deviceCallback);
 };
 
-// eslint-disable-next-line no-unused-vars
 const stopSensorScan = () => async dispatch => {
+  dispatch(scanStop());
   BleService().stopScan();
-  console.log('scan stopped');
 };
 
 export const TemperatureSyncActions = {
   startSensorScan,
+  stopSensorScan,
 };

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -5,7 +5,7 @@
 
 import { ToastAndroid } from 'react-native';
 import { PermissionSelectors } from '../selectors/permission';
-import selectScannedSensorAddresses from '../selectors/vaccine';
+import selectScannedSensors from '../selectors/vaccine';
 import { PermissionActions } from './PermissionActions';
 import BleService from '../bluetooth/BleService';
 import { syncStrings } from '../localization/index';
@@ -51,7 +51,7 @@ const scanForSensors = () => async (dispatch, getState) => {
     const { id: macAddress } = device;
 
     if (macAddress) {
-      const alreadyScanned = selectScannedSensorAddresses(getState());
+      const alreadyScanned = selectScannedSensors(getState());
       const alreadySaved = UIDatabase.get('Sensor', macAddress, 'macAddress');
 
       if (!alreadyScanned?.includes(macAddress) && !alreadySaved) {

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -51,10 +51,10 @@ const scanForSensors = () => async (dispatch, getState) => {
     const { id: macAddress } = device;
 
     if (macAddress) {
-      const alreadyFound = selectScannedSensorAddresses(getState());
+      const alreadyScanned = selectScannedSensorAddresses(getState());
       const alreadySaved = UIDatabase.get('Sensor', macAddress, 'macAddress');
 
-      if (!alreadyFound.includes(macAddress) && !alreadySaved) {
+      if (!alreadyScanned?.includes(macAddress) && !alreadySaved) {
         dispatch(sensorFound(macAddress));
       }
     }

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -48,14 +48,14 @@ const scanForSensors = () => async (dispatch, getState) => {
   dispatch(scanStart());
 
   const deviceCallback = device => {
-    const { id } = device;
+    const { id: macAddress } = device;
 
-    if (id) {
+    if (macAddress) {
       const alreadyFound = selectScannedSensorAddresses(getState());
-      const alreadySaved = UIDatabase.get('Sensor', id, 'macAddress');
+      const alreadySaved = UIDatabase.get('Sensor', macAddress, 'macAddress');
 
-      if (!alreadyFound.includes(id) && !alreadySaved) {
-        dispatch(sensorFound(id));
+      if (!alreadyFound.includes(macAddress) && !alreadySaved) {
+        dispatch(sensorFound(macAddress));
       }
     }
   };

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -29,12 +29,12 @@ const startSensorScan = () => async (dispatch, getState) => {
   if (!locationPermission) await dispatch(PermissionActions.requestLocation());
 
   if (!bluetoothEnabled) {
-    ToastAndroid.show(syncStrings.please_enable_bluetooth, ToastAndroid.LONG);
+    ToastAndroid.show(syncStrings.bluetooth_disabled, ToastAndroid.LONG);
     return null;
   }
 
   if (!locationPermission) {
-    ToastAndroid.show(syncStrings.grant_location_permission, ToastAndroid.LONG);
+    ToastAndroid.show(syncStrings.location_permission, ToastAndroid.LONG);
     return null;
   }
 

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -1,0 +1,56 @@
+/* eslint-disable no-await-in-loop */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2021
+ */
+
+import { PermissionSelectors } from '../selectors/permission';
+import { PermissionActions } from './PermissionActions';
+import BleService from '../bluetooth/BleService';
+
+export const VACCINE_ACTIONS = {
+  ERROR_BLUETOOTH_DISABLED: 'Vaccine/errorBluetoothDisabled',
+  ERROR_LOCATION_DISABLED: 'Vaccine/errorLocationDisabled',
+
+  SCAN_START: 'Vaccine/sensorScanStart',
+  SCAN_COMPLETE: 'Vaccine/sensorScanComplete',
+  SCAN_ERROR: 'Vaccine/sensorScanError',
+  SCAN_STOP: 'Vaccine/sensorScanStop',
+};
+
+const scanStart = () => ({ type: VACCINE_ACTIONS.SCAN_START });
+// eslint-disable-next-line no-unused-vars
+const scanStop = () => ({ type: VACCINE_ACTIONS.SCAN_STOP });
+
+const startSensorScan = () => async (dispatch, getState) => {
+  const bluetoothEnabled = PermissionSelectors.bluetooth(getState());
+  const locationPermission = PermissionSelectors.location(getState());
+  // Ensure the correct permissions before initiating a new sync process.
+  if (!bluetoothEnabled) await dispatch(PermissionActions.requestBluetooth());
+  if (!locationPermission) await dispatch(PermissionActions.requestLocation());
+
+  if (!(bluetoothEnabled && locationPermission)) return null;
+  await dispatch(scanForSensors());
+  // TODO
+  return null;
+};
+
+const scanForSensors = () => async dispatch => {
+  dispatch(scanStart());
+
+  const deviceCallback = device => {
+    console.log(device);
+  };
+
+  BleService().scanForSensors(deviceCallback);
+};
+
+// eslint-disable-next-line no-unused-vars
+const stopSensorScan = () => async dispatch => {
+  BleService().stopScan();
+  console.log('scan stopped');
+};
+
+export const TemperatureSyncActions = {
+  startSensorScan,
+};

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -5,7 +5,7 @@
 
 import { ToastAndroid } from 'react-native';
 import { PermissionSelectors } from '../selectors/permission';
-import selectScannedSensors from '../selectors/vaccine';
+import selectScannedSensorAddresses from '../selectors/vaccine';
 import { PermissionActions } from './PermissionActions';
 import BleService from '../bluetooth/BleService';
 import { syncStrings } from '../localization/index';
@@ -51,7 +51,7 @@ const scanForSensors = () => async (dispatch, getState) => {
     const { id } = device;
 
     if (id) {
-      const alreadyFound = selectScannedSensors(getState());
+      const alreadyFound = selectScannedSensorAddresses(getState());
       const alreadySaved = UIDatabase.get('Sensor', id, 'macAddress');
 
       if (!alreadyFound.includes(id) && !alreadySaved) {

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -12,11 +12,7 @@ import { syncStrings } from '../localization/index';
 import { UIDatabase } from '../database/index';
 
 export const VACCINE_ACTIONS = {
-  ERROR_BLUETOOTH_DISABLED: 'Vaccine/errorBluetoothDisabled',
-  ERROR_LOCATION_DISABLED: 'Vaccine/errorLocationDisabled',
-
   SCAN_START: 'Vaccine/sensorScanStart',
-  SCAN_ERROR: 'Vaccine/sensorScanError',
   SCAN_STOP: 'Vaccine/sensorScanStop',
   SENSOR_FOUND: 'Vaccine/sensorFound',
 };
@@ -53,6 +49,7 @@ const scanForSensors = () => async (dispatch, getState) => {
 
   const deviceCallback = device => {
     const { id } = device;
+    console.log(id);
 
     if (id) {
       const alreadyFound = selectScannedSensors(getState());

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2021
@@ -10,6 +9,7 @@ import selectScannedSensors from '../selectors/vaccine';
 import { PermissionActions } from './PermissionActions';
 import BleService from '../bluetooth/BleService';
 import { syncStrings } from '../localization/index';
+import { UIDatabase } from '../database/index';
 
 export const VACCINE_ACTIONS = {
   ERROR_BLUETOOTH_DISABLED: 'Vaccine/errorBluetoothDisabled',
@@ -52,11 +52,15 @@ const scanForSensors = () => async (dispatch, getState) => {
   dispatch(scanStart());
 
   const deviceCallback = device => {
-    const alreadyFound = selectScannedSensors(getState());
+    const { id } = device;
 
-    // TODO: Filter out already saved sensors?
-    if (!alreadyFound.includes(device?.id)) {
-      dispatch(sensorFound(device?.id));
+    if (id) {
+      const alreadyFound = selectScannedSensors(getState());
+      const alreadySaved = UIDatabase.get('Sensor', id, 'macAddress');
+
+      if (!alreadyFound.includes(id) && !alreadySaved) {
+        dispatch(sensorFound(id));
+      }
     }
   };
 

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -68,7 +68,7 @@ const stopSensorScan = () => async dispatch => {
   BleService().stopScan();
 };
 
-export const TemperatureSyncActions = {
+export const VaccineActions = {
   startSensorScan,
   stopSensorScan,
 };

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -49,7 +49,6 @@ const scanForSensors = () => async (dispatch, getState) => {
 
   const deviceCallback = device => {
     const { id } = device;
-    console.log(id);
 
     if (id) {
       const alreadyFound = selectScannedSensors(getState());

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -25,7 +25,7 @@ const startSensorScan = () => async (dispatch, getState) => {
   const bluetoothEnabled = PermissionSelectors.bluetooth(getState());
   const locationPermission = PermissionSelectors.location(getState());
   // Ensure the correct permissions before initiating a new sync process.
-  if (!bluetoothEnabled) dispatch(PermissionActions.requestBluetooth());
+  if (!bluetoothEnabled) await dispatch(PermissionActions.requestBluetooth());
   if (!locationPermission) await dispatch(PermissionActions.requestLocation());
 
   if (!bluetoothEnabled) {

--- a/src/reducers/VaccineReducer.js
+++ b/src/reducers/VaccineReducer.js
@@ -1,0 +1,10 @@
+const initialState = () => ({
+  total: 0,
+  isScanning: false,
+});
+
+// eslint-disable-next-line no-unused-vars
+export const VaccineReducer = (_state = initialState(), action) => {
+  // eslint-disable-next-line no-unused-vars
+  const { type } = action;
+};

--- a/src/reducers/VaccineReducer.js
+++ b/src/reducers/VaccineReducer.js
@@ -24,11 +24,11 @@ export const VaccineReducer = (state = initialState(), action) => {
     case VACCINE_ACTIONS.SENSOR_FOUND: {
       const { payload } = action;
       const { scannedSensors } = state;
-      const updatedSensorList = scannedSensors.push(payload);
+      scannedSensors.push(payload);
 
       return {
         ...state,
-        scannedSensors: updatedSensorList,
+        scannedSensors,
       };
     }
     default:

--- a/src/reducers/VaccineReducer.js
+++ b/src/reducers/VaccineReducer.js
@@ -23,8 +23,10 @@ export const VaccineReducer = (state = initialState(), action) => {
     }
     case VACCINE_ACTIONS.SENSOR_FOUND: {
       const { payload } = action;
+      const { macAddress } = payload;
+
       const { scannedSensors } = state;
-      scannedSensors.push(payload);
+      scannedSensors.push(macAddress);
 
       return {
         ...state,

--- a/src/reducers/VaccineReducer.js
+++ b/src/reducers/VaccineReducer.js
@@ -1,7 +1,7 @@
 import { VACCINE_ACTIONS } from '../actions/VaccineActions';
 
 const initialState = () => ({
-  scannedSensors: [],
+  scannedSensorAddresses: [],
   isScanning: false,
 });
 
@@ -25,12 +25,12 @@ export const VaccineReducer = (state = initialState(), action) => {
       const { payload } = action;
       const { macAddress } = payload;
 
-      const { scannedSensors } = state;
-      scannedSensors.push(macAddress);
+      const { scannedSensorAddresses } = state;
+      scannedSensorAddresses.push(macAddress);
 
       return {
         ...state,
-        scannedSensors,
+        scannedSensorAddresses,
       };
     }
     default:

--- a/src/reducers/VaccineReducer.js
+++ b/src/reducers/VaccineReducer.js
@@ -1,10 +1,27 @@
+import { VACCINE_ACTIONS } from '../actions/VaccineActions';
+
 const initialState = () => ({
-  total: 0,
+  sensors: [],
   isScanning: false,
 });
 
-// eslint-disable-next-line no-unused-vars
-export const VaccineReducer = (_state = initialState(), action) => {
-  // eslint-disable-next-line no-unused-vars
+export const VaccineReducer = (state = initialState(), action) => {
   const { type } = action;
+
+  switch (type) {
+    case VACCINE_ACTIONS.SCAN_START: {
+      return {
+        ...state,
+        isScanning: true,
+      };
+    }
+    case VACCINE_ACTIONS.SCAN_STOP: {
+      return {
+        ...state,
+        isaScanning: false,
+      };
+    }
+    default:
+      return state;
+  }
 };

--- a/src/reducers/VaccineReducer.js
+++ b/src/reducers/VaccineReducer.js
@@ -28,7 +28,7 @@ export const VaccineReducer = (state = initialState(), action) => {
 
       return {
         ...state,
-        updatedSensorList,
+        scannedSensors: updatedSensorList,
       };
     }
     default:

--- a/src/reducers/VaccineReducer.js
+++ b/src/reducers/VaccineReducer.js
@@ -1,7 +1,7 @@
 import { VACCINE_ACTIONS } from '../actions/VaccineActions';
 
 const initialState = () => ({
-  sensors: [],
+  scannedSensors: [],
   isScanning: false,
 });
 
@@ -18,7 +18,17 @@ export const VaccineReducer = (state = initialState(), action) => {
     case VACCINE_ACTIONS.SCAN_STOP: {
       return {
         ...state,
-        isaScanning: false,
+        isScanning: false,
+      };
+    }
+    case VACCINE_ACTIONS.SENSOR_FOUND: {
+      const { payload } = action;
+      const { scannedSensors } = state;
+      const updatedSensorList = scannedSensors.push(payload);
+
+      return {
+        ...state,
+        updatedSensorList,
       };
     }
     default:

--- a/src/reducers/VaccineReducer.js
+++ b/src/reducers/VaccineReducer.js
@@ -26,11 +26,10 @@ export const VaccineReducer = (state = initialState(), action) => {
       const { macAddress } = payload;
 
       const { scannedSensorAddresses } = state;
-      scannedSensorAddresses.push(macAddress);
 
       return {
         ...state,
-        scannedSensorAddresses,
+        scannedSensorAddresses: [...scannedSensorAddresses, macAddress],
       };
     }
     default:

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -25,6 +25,7 @@ import { FridgeReducer } from './FridgeReducer';
 import { BreachReducer } from './BreachReducer';
 import { RowDetailReducer } from './RowDetailReducer';
 import { PermissionReducer } from './PermissionReducer';
+import { VaccineReducer } from './VaccineReducer';
 
 import SyncReducer from './SyncReducer';
 
@@ -50,4 +51,5 @@ export default combineReducers({
   breach: BreachReducer,
   rowDetail: RowDetailReducer,
   permission: PermissionReducer,
+  vaccine: VaccineReducer,
 });

--- a/src/selectors/vaccine.js
+++ b/src/selectors/vaccine.js
@@ -3,7 +3,12 @@
  * Sustainable Solutions (NZ) Ltd. 2021
  */
 
-export const selectScannedSensorAddresses = ({ state }) => {
-  const { scannedSensorAddresses } = state;
+export const selectScannedSensors = ({ vaccine }) => {
+  const { scannedSensorAddresses = [] } = vaccine || {};
   return scannedSensorAddresses;
+};
+
+export const selectIsScanning = ({ vaccine }) => {
+  const { isScanning = false } = vaccine || {};
+  return isScanning;
 };

--- a/src/selectors/vaccine.js
+++ b/src/selectors/vaccine.js
@@ -1,0 +1,9 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2021
+ */
+
+export const selectScannedSensors = ({ state }) => {
+  const { scannedSensors } = state;
+  return scannedSensors;
+};

--- a/src/selectors/vaccine.js
+++ b/src/selectors/vaccine.js
@@ -3,7 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2021
  */
 
-export const selectScannedSensors = ({ state }) => {
-  const { scannedSensors } = state;
-  return scannedSensors;
+export const selectScannedSensorAddresses = ({ state }) => {
+  const { scannedSensorAddresses } = state;
+  return scannedSensorAddresses;
 };


### PR DESCRIPTION
Fixes #3351

## Change summary

- Have added actions to start/stop scanning and adds found sensors to the store (not sure if `stop` was needed but thinking if 'connect' is clicked on the UI or someone navigates away scanning should stop?)
- Used the toasts from `TemperatureSyncActions` when BT/Locations are not available, not sure if appropriate or not

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Internal only 

### Related areas to think about
N/A
