### PR TITLE
Add Circle component

### DIFF
--- a/src/globalStyles/colors.js
+++ b/src/globalStyles/colors.js
@@ -7,6 +7,7 @@ export const BACKGROUND_COLOR = '#f8fbfe';
 export const BLUE_WHITE = '#ecf3fc';
 export const DARK_GREY = '#4a4a4a';
 export const DARKER_GREY = '#333333';
+export const MISTY_CHARCOAL = 'rgba(51,51,51,0.2)';
 export const FINALISE_GREEN = '#219d1b';
 export const FINALISED_RED = '#f63b30';
 export const GREY = '#909192';

--- a/src/pages/NewSensorPage.js
+++ b/src/pages/NewSensorPage.js
@@ -1,1 +1,24 @@
-export const NewSensorPage = () => null;
+import React from 'react';
+import { View } from 'react-native';
+
+import { Wizard } from '../widgets';
+
+const TabOne = () => <View style={{ backgroundColor: 'red', flex: 1, width: 500, height: 500 }} />;
+const TabTwo = () => (
+  <View style={{ backgroundColor: 'green', flex: 1, width: 500, height: 500 }} />
+);
+const TabThree = () => (
+  <View style={{ backgroundColor: 'blue', flex: 1, width: 500, height: 500 }} />
+);
+
+const tabs = [
+  { component: TabOne, name: 'prescription', title: '' },
+  { component: TabTwo, name: 'prescription', title: '' },
+  { component: TabThree, name: 'prescription', title: '' },
+];
+
+export const NewSensorPage = () => (
+  <>
+    <Wizard tabs={tabs} useNewStepper />
+  </>
+);

--- a/src/widgets/Circle.js
+++ b/src/widgets/Circle.js
@@ -1,0 +1,46 @@
+/* eslint-disable react/forbid-prop-types */
+import React from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { TRANSPARENT } from '../globalStyles';
+
+export const Circle = ({ size, children, backgroundColor, borderColor, elevate, style }) => {
+  const adjustedStyle = {
+    width: size,
+    height: size,
+    borderRadius: size / 2,
+    backgroundColor,
+    borderColor: borderColor ?? TRANSPARENT,
+    elevation: elevate ? 5 : 0,
+  };
+
+  const internalStyle = [adjustedStyle, defaultStyle, style];
+
+  return <View style={internalStyle}>{children}</View>;
+};
+
+const defaultStyle = {
+  alignItems: 'center',
+  justifyContent: 'center',
+  overflow: 'hidden',
+  borderWidth: 1,
+};
+
+Circle.defaultProps = {
+  size: 30,
+  children: null,
+  backgroundColor: TRANSPARENT,
+  borderColor: TRANSPARENT,
+  elevate: false,
+  style: {},
+};
+
+Circle.propTypes = {
+  style: PropTypes.object,
+  size: PropTypes.number,
+  children: PropTypes.node,
+  backgroundColor: PropTypes.string,
+  borderColor: PropTypes.string,
+  elevate: PropTypes.number,
+};

--- a/src/widgets/Circle.js
+++ b/src/widgets/Circle.js
@@ -42,5 +42,5 @@ Circle.propTypes = {
   children: PropTypes.node,
   backgroundColor: PropTypes.string,
   borderColor: PropTypes.string,
-  elevate: PropTypes.number,
+  elevate: PropTypes.bool,
 };

--- a/src/widgets/CircleButton.js
+++ b/src/widgets/CircleButton.js
@@ -5,10 +5,11 @@
  */
 
 import React from 'react';
-import { TouchableOpacity, StyleSheet, View } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
 import PropTypes from 'prop-types';
 
 import { SUSSOL_ORANGE, LIGHT_GREY } from '../globalStyles/index';
+import { Circle } from './Circle';
 
 const SIZE_VALUES = {
   small: 15,
@@ -37,24 +38,15 @@ export const CircleButton = ({
   isDisabled,
   size,
 }) => {
-  const styles = React.useMemo(() => localStyles(size), [size]);
-
   const Container = isDisabled ? View : TouchableOpacity;
 
-  const containerStyle = [
-    styles.dimensions,
-    styles.containerStyle,
-    isDisabled && styles.disabledStyle,
-  ];
+  const backgroundColor = isDisabled ? LIGHT_GREY : SUSSOL_ORANGE;
 
   return (
-    <Container
-      onPressIn={onPressIn}
-      onPressOut={onPressOut}
-      onPress={onPress}
-      style={containerStyle}
-    >
-      <IconComponent size={ICON_SIZE_VALUES[size]} />
+    <Container onPressIn={onPressIn} onPressOut={onPressOut} onPress={onPress}>
+      <Circle size={SIZE_VALUES[size]} backgroundColor={backgroundColor} elevate>
+        <IconComponent size={ICON_SIZE_VALUES[size]} />
+      </Circle>
     </Container>
   );
 };
@@ -75,24 +67,3 @@ CircleButton.propTypes = {
   isDisabled: PropTypes.bool,
   size: PropTypes.string,
 };
-
-const localStyles = size =>
-  StyleSheet.create({
-    dimensions: {
-      width: SIZE_VALUES[size],
-      height: SIZE_VALUES[size],
-      borderRadius: SIZE_VALUES[size],
-    },
-    disabledStyle: {
-      backgroundColor: LIGHT_GREY,
-      borderColor: LIGHT_GREY,
-    },
-    containerStyle: {
-      elevation: 5,
-      borderColor: SUSSOL_ORANGE,
-      borderWidth: 1,
-      alignItems: 'center',
-      justifyContent: 'center',
-      backgroundColor: SUSSOL_ORANGE,
-    },
-  });

--- a/src/widgets/Stepper.js
+++ b/src/widgets/Stepper.js
@@ -4,11 +4,57 @@ import React from 'react';
 import { View, Text, Dimensions, TouchableOpacity, StyleSheet } from 'react-native';
 import { PropTypes } from 'prop-types';
 
-import { WHITE, SUSSOL_ORANGE, GREY, APP_FONT_FAMILY, SHADOW_BORDER } from '../globalStyles';
+import { ConfirmIcon } from './icons';
+import { Circle } from './Circle';
+
+import {
+  DARKER_GREY,
+  MISTY_CHARCOAL,
+  TRANSPARENT,
+  WHITE,
+  SUSSOL_ORANGE,
+  GREY,
+  APP_FONT_FAMILY,
+  SHADOW_BORDER,
+} from '../globalStyles';
+
+const getNewLocalStyles = (step, numberOfSteps, currentStep) => ({
+  stepContainer: {
+    borderRadius: 15,
+    width: 30,
+    height: 30,
+    borderWidth: 1,
+    borderColor: step === currentStep ? DARKER_GREY : 'rgba(51,51,51,0.2)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: currentStep === step ? DARKER_GREY : TRANSPARENT,
+    overflow: 'hidden',
+  },
+  stepNumber: {
+    color: 'rgba(51,51,51,0.2)',
+    fontSize: 14,
+    fontFamily: APP_FONT_FAMILY,
+  },
+  stepText: {
+    color: step > currentStep ? GREY : SUSSOL_ORANGE,
+    fontSize: 14,
+    fontFamily: APP_FONT_FAMILY,
+  },
+  stepSeparator: {
+    borderTopColor: 'rgba(51,51,51,0.2)',
+    borderTopWidth: 1,
+    flex: 1,
+  },
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: step === numberOfSteps - 1 ? 0 : 1,
+  },
+});
 
 const { height, width } = Dimensions.get('window');
 
-const getLocalStyles = (step, numberOfSteps, currentStep) => ({
+const getOldLocalStyles = (step, numberOfSteps, currentStep) => ({
   stepContainer: {
     borderRadius: height / 20,
     borderWidth: 2,
@@ -43,8 +89,8 @@ const getLocalStyles = (step, numberOfSteps, currentStep) => ({
   },
 });
 
-const StepperNumber = ({ step, numberOfSteps, currentStep, title, onPress }) => {
-  const { stepContainer, stepNumber, stepText, stepSeperator, container } = getLocalStyles(
+const OldStepperNumber = ({ step, numberOfSteps, currentStep, title, onPress }) => {
+  const { stepContainer, stepNumber, stepText, stepSeperator, container } = getOldLocalStyles(
     step,
     numberOfSteps,
     currentStep
@@ -70,7 +116,7 @@ const StepperNumber = ({ step, numberOfSteps, currentStep, title, onPress }) => 
   );
 };
 
-StepperNumber.propTypes = {
+OldStepperNumber.propTypes = {
   step: PropTypes.number.isRequired,
   numberOfSteps: PropTypes.number.isRequired,
   currentStep: PropTypes.number.isRequired,
@@ -78,10 +124,48 @@ StepperNumber.propTypes = {
   onPress: PropTypes.func.isRequired,
 };
 
-export const Stepper = ({ numberOfSteps, currentStep, titles, onPress }) => (
-  <View style={localStyles.container}>
+const NewStepperNumber = ({ step, numberOfSteps, currentStep, isActive, isLast, onPress }) => {
+  const { stepNumber, stepSeparator, container } = getNewLocalStyles(
+    step,
+    numberOfSteps,
+    currentStep
+  );
+
+  const completedStep = currentStep > step;
+  const Container = completedStep ? TouchableOpacity : View;
+  const backgroundColor = isActive || completedStep ? DARKER_GREY : TRANSPARENT;
+  const borderColor = isActive || completedStep ? DARKER_GREY : MISTY_CHARCOAL;
+
+  const wrappedOnPress = () => onPress(step);
+
+  return (
+    <Container onPress={wrappedOnPress} style={container}>
+      <Circle size={30} backgroundColor={backgroundColor} borderColor={borderColor}>
+        {isActive || completedStep ? (
+          <ConfirmIcon color={DARKER_GREY} size={35} style={{ backgroundColor: 'white' }} />
+        ) : (
+          <Text style={stepNumber}>{step + 1}</Text>
+        )}
+      </Circle>
+
+      {!isLast && <View style={stepSeparator} />}
+    </Container>
+  );
+};
+
+NewStepperNumber.propTypes = {
+  step: PropTypes.number.isRequired,
+  numberOfSteps: PropTypes.number.isRequired,
+  currentStep: PropTypes.number.isRequired,
+  isActive: PropTypes.bool.isRequired,
+  isLast: PropTypes.bool.isRequired,
+  onPress: PropTypes.func.isRequired,
+};
+
+export const OldStepper = ({ numberOfSteps, currentStep, titles, onPress }) => (
+  <View style={localStyles.oldContainer}>
     {Array.from({ length: numberOfSteps }).map((_, i) => (
-      <StepperNumber
+      <OldStepperNumber
         onPress={onPress}
         step={i}
         numberOfSteps={numberOfSteps}
@@ -93,17 +177,63 @@ export const Stepper = ({ numberOfSteps, currentStep, titles, onPress }) => (
   </View>
 );
 
+export const NewStepper = ({ numberOfSteps, currentStep, onPress }) => (
+  <View style={localStyles.container}>
+    <View style={localStyles.innerContainer}>
+      {Array.from({ length: numberOfSteps }).map((_, i) => (
+        <NewStepperNumber
+          key={`${i}`}
+          step={i}
+          onPress={() => onPress(i)}
+          numberOfSteps={numberOfSteps}
+          currentStep={currentStep}
+          isActive={currentStep === i}
+          isLast={i === numberOfSteps - 1}
+        />
+      ))}
+    </View>
+  </View>
+);
+
+export const Stepper = ({ useNewStepper, ...stepperProps }) =>
+  useNewStepper ? <NewStepper {...stepperProps} /> : <OldStepper {...stepperProps} />;
+
 const localStyles = StyleSheet.create({
-  container: {
+  oldContainer: {
     borderColor: SHADOW_BORDER,
     borderWidth: 1,
     flexDirection: 'row',
     paddingHorizontal: 10,
     paddingVertical: 10,
   },
+  container: { height: 50, alignItems: 'center' },
+  innerContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: 400,
+  },
 });
 
+NewStepper.propTypes = {
+  numberOfSteps: PropTypes.number.isRequired,
+  currentStep: PropTypes.number.isRequired,
+  onPress: PropTypes.func.isRequired,
+};
+
+OldStepper.propTypes = {
+  numberOfSteps: PropTypes.number.isRequired,
+  currentStep: PropTypes.number.isRequired,
+  titles: PropTypes.array.isRequired,
+  onPress: PropTypes.func.isRequired,
+};
+
+Stepper.defaultProps = {
+  useNewStepper: false,
+};
+
 Stepper.propTypes = {
+  useNewStepper: PropTypes.bool,
   numberOfSteps: PropTypes.number.isRequired,
   currentStep: PropTypes.number.isRequired,
   titles: PropTypes.array.isRequired,

--- a/src/widgets/Wizard.js
+++ b/src/widgets/Wizard.js
@@ -14,7 +14,6 @@ import { selectCurrentTab } from '../selectors/wizard';
 
 import { PAGE_CONTENT_PADDING_HORIZONTAL } from '../globalStyles/pageStyles';
 import { BACKGROUND_COLOR, BLUE_WHITE, SHADOW_BORDER } from '../globalStyles/colors';
-import PageButton from './PageButton';
 
 /**
  * Layout component for a Tracker and TabNavigator, displaying steps
@@ -37,7 +36,6 @@ const WizardComponent = ({ tabs, currentTab, switchTab, useNewStepper }) => {
       </View>
       <DataTablePageView>
         <TabNavigator tabs={tabs} currentTabIndex={currentTab} />
-        <PageButton onPress={() => switchTab(2)} />
       </DataTablePageView>
     </View>
   );

--- a/src/widgets/Wizard.js
+++ b/src/widgets/Wizard.js
@@ -14,19 +14,21 @@ import { selectCurrentTab } from '../selectors/wizard';
 
 import { PAGE_CONTENT_PADDING_HORIZONTAL } from '../globalStyles/pageStyles';
 import { BACKGROUND_COLOR, BLUE_WHITE, SHADOW_BORDER } from '../globalStyles/colors';
+import PageButton from './PageButton';
 
 /**
  * Layout component for a Tracker and TabNavigator, displaying steps
  * to completion for completion. See TabNavigator and StepsTracker
  * for individual component implementation.
  */
-const WizardComponent = ({ tabs, currentTab, switchTab }) => {
+const WizardComponent = ({ tabs, currentTab, switchTab, useNewStepper }) => {
   const titles = useMemo(() => tabs.map(tab => tab.title), [tabs]);
 
   return (
     <View style={localStyles.container}>
       <View style={localStyles.stepperContainer}>
         <Stepper
+          useNewStepper={useNewStepper}
           numberOfSteps={tabs.length}
           currentStep={currentTab}
           onPress={switchTab}
@@ -35,6 +37,7 @@ const WizardComponent = ({ tabs, currentTab, switchTab }) => {
       </View>
       <DataTablePageView>
         <TabNavigator tabs={tabs} currentTabIndex={currentTab} />
+        <PageButton onPress={() => switchTab(2)} />
       </DataTablePageView>
     </View>
   );
@@ -50,10 +53,15 @@ const localStyles = StyleSheet.create({
   },
 });
 
+WizardComponent.defaultProps = {
+  useNewStepper: false,
+};
+
 WizardComponent.propTypes = {
   tabs: PropTypes.array.isRequired,
   switchTab: PropTypes.func.isRequired,
   currentTab: PropTypes.number.isRequired,
+  useNewStepper: PropTypes.bool,
 };
 
 const mapStateToProps = state => {

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -72,9 +72,15 @@ ExpandIcon.propTypes = {
   style: PropTypes.object,
 };
 
-export const ConfirmIcon = React.memo(({ style }) => <FAIcon name="check-circle" style={style} />);
-ConfirmIcon.defaultProps = { style: { color: FINALISE_GREEN, fontSize: 40 } };
-ConfirmIcon.propTypes = { style: PropTypes.object };
+export const ConfirmIcon = React.memo(({ style, color, size }) => (
+  <FAIcon name="check-circle" style={style} color={color} size={size} />
+));
+ConfirmIcon.defaultProps = { color: FINALISE_GREEN, size: 40, style: {} };
+ConfirmIcon.propTypes = {
+  style: PropTypes.object,
+  color: PropTypes.string,
+  size: PropTypes.number,
+};
 
 export const LockIcon = React.memo(({ style }) => <FAIcon name="lock" size={28} style={style} />);
 LockIcon.defaultProps = { style: { color: FINALISED_RED } };

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -51,6 +51,7 @@ export { Rectangle } from './Rectangle';
 export { Paper } from './Paper';
 export { PaperSection } from './PaperSection';
 export { CardDetail } from './CardDetail';
+export { Circle } from './Circle';
 
 export * from './icons';
 export * from './images';


### PR DESCRIPTION
Fixes #3348 

## Change summary

- Added a `Circle` component - was sick of dealing - used it in `CircleButton`
- Added a bit of a cheap hack to the stepper to choose between this new variant and the old one. I am hoping to change the old one to the new one.. 
- Added this stepper as an option to the WIZARD which "just works" and you can click on past steps and call the callback `switchTab` to change tabs
- Think this is sufficient enough for a PR even though there's not much real content yet

## Testing

Internal

### Related areas to think about

![image](https://user-images.githubusercontent.com/35858975/105102906-7e37ed00-5b14-11eb-9984-a3507fb9c0cb.png)
