### PR TITLE
#3277 generate vaccine data, fix things

### DIFF
--- a/src/bluetooth/BreachManager.js
+++ b/src/bluetooth/BreachManager.js
@@ -81,10 +81,10 @@ export class BreachManager {
     return [!!configToCreateBreachFrom, configToCreateBreachFrom];
   };
 
-  addLogToBreach = (breach, log) => {
-    const { id: temperatureBreachId } = breach;
-    return { ...log, temperatureBreachId };
-  };
+  // Previously used object spread, but https://github.com/realm/realm-js/issues/2844
+  // Fortunately the `temperatureLog` array only needs the log.id and the breach.id
+  // it's being assigned
+  addLogToBreach = (breach, log) => ({ id: log.id, temperatureBreachId: breach.id });
 
   willContinueBreach = (breach, log) => {
     if (!breach) return false;

--- a/src/bluetooth/BreachManager.js
+++ b/src/bluetooth/BreachManager.js
@@ -84,7 +84,7 @@ export class BreachManager {
   // Previously used object spread, but https://github.com/realm/realm-js/issues/2844
   // Fortunately the `temperatureLog` array only needs the log.id and the breach.id
   // it's being assigned
-  addLogToBreach = (breach, log) => ({ id: log.id, temperatureBreachId: breach.id });
+  addLogToBreach = (breach, log) => ({ id: log.id, breach });
 
   willContinueBreach = (breach, log) => {
     if (!breach) return false;

--- a/src/bluetooth/BreachManager.js
+++ b/src/bluetooth/BreachManager.js
@@ -157,9 +157,7 @@ export class BreachManager {
   };
 
   updateBreaches = async (breaches, temperatureLogs) => {
-    // eslint-disable-next-line no-param-reassign
-
-    const updatedBreaches = this.db.upsertBreaches(breaches);
+    const updatedBreaches = await this.db.upsertBreaches(breaches);
     const updatedLogs = await this.db.upsertTemperatureLog(temperatureLogs);
 
     return [updatedBreaches, updatedLogs];

--- a/src/bluetooth/BreachManager.test.js
+++ b/src/bluetooth/BreachManager.test.js
@@ -145,12 +145,12 @@ describe('BreachManager: addLogToBreach', () => {
     const utils = { createUuid: () => '1' };
     const breachManager = new BreachManager(dbService, utils);
 
-    const log = { timestamp: 0, temperature: 10 };
+    const log = { id: 'a', timestamp: 0, temperature: 10 };
     const breach = { id: 'breach' };
 
     const resultLog = breachManager.addLogToBreach(breach, log);
 
-    expect(resultLog).toEqual({ timestamp: 0, temperature: 10, temperatureBreachId: 'breach' });
+    expect(resultLog).toEqual({ id: 'a', breach });
   });
 });
 
@@ -290,8 +290,8 @@ describe('BreachManager: createBreaches', () => {
     const dummyLocation = { id: 'ABC', description: 'DEF' };
     const sensor = { id: 'a', location: dummyLocation };
     const logs = [
-      { temperature: 10, timestamp: 0 },
-      { temperature: 10, timestamp: 1 },
+      { id: 'a', temperature: 10, timestamp: 0 },
+      { id: 'b', temperature: 10, timestamp: 1 },
     ];
     const configs = [{ id: 'a', duration: 1000, minimumTemperature: 8, maximumTemperature: 999 }];
     const utils = { createUuid: () => '1' };
@@ -312,8 +312,8 @@ describe('BreachManager: createBreaches', () => {
     ];
 
     const logsShouldBe = [
-      { temperature: 10, timestamp: 0, temperatureBreachId: '1' },
-      { temperature: 10, timestamp: 1, temperatureBreachId: '1' },
+      { id: 'a', breach: breachesShouldBe[0] },
+      { id: 'b', breach: breachesShouldBe[0] },
     ];
 
     await expect(breachManager.createBreaches(sensor, logs, configs)).toEqual([
@@ -325,11 +325,19 @@ describe('BreachManager: createBreaches', () => {
     const dummyLocation = { id: 'ABC', description: 'DEF' };
     const sensor = { id: 'a', location: dummyLocation };
     const logs = [
-      { temperature: 10, timestamp: 0 },
-      { temperature: 10, timestamp: 1 },
-      { temperature: 1, timestamp: 2 },
+      { id: 'a', temperature: 10, timestamp: 0 },
+      { id: 'b', temperature: 10, timestamp: 1 },
+      { id: 'c', temperature: 1, timestamp: 2 },
     ];
-    const configs = [{ id: 'a', duration: 1000, minimumTemperature: 8, maximumTemperature: 999 }];
+    const configs = [
+      {
+        id: 'a',
+        duration: 1000,
+        minimumTemperature: 8,
+        maximumTemperature: 999,
+        type: 'HOT_CONSECUTIVE',
+      },
+    ];
 
     const utils = { createUuid: () => '1' };
     const breachManager = new BreachManager({}, utils);
@@ -344,12 +352,13 @@ describe('BreachManager: createBreaches', () => {
         startTimestamp: 0,
         endTimestamp: 2,
         location: dummyLocation,
+        type: 'HOT_CONSECUTIVE',
       },
     ];
 
     const logsShouldBe = [
-      { temperature: 10, timestamp: 0, temperatureBreachId: '1' },
-      { temperature: 10, timestamp: 1, temperatureBreachId: '1' },
+      { id: 'a', breach: breachesShouldBe[0] },
+      { id: 'b', breach: breachesShouldBe[0] },
     ];
 
     await expect(breachManager.createBreaches(sensor, logs, configs)).toEqual([
@@ -361,13 +370,21 @@ describe('BreachManager: createBreaches', () => {
     const dummyLocation = { id: 'ABC', description: 'DEF' };
     const sensor = { id: 'a', location: dummyLocation };
     const logs = [
-      { temperature: 10, timestamp: 0 },
-      { temperature: 10, timestamp: 1 },
-      { temperature: 1, timestamp: 2 },
-      { temperature: 10, timestamp: 3 },
-      { temperature: 10, timestamp: 4 },
+      { id: 'a', temperature: 10, timestamp: 0 },
+      { id: 'b', temperature: 10, timestamp: 1 },
+      { id: 'c', temperature: 1, timestamp: 2 },
+      { id: 'd', temperature: 10, timestamp: 3 },
+      { id: 'e', temperature: 10, timestamp: 4 },
     ];
-    const configs = [{ id: 'a', duration: 1000, minimumTemperature: 8, maximumTemperature: 999 }];
+    const configs = [
+      {
+        id: 'a',
+        duration: 1000,
+        minimumTemperature: 8,
+        maximumTemperature: 999,
+        type: 'HOT_CONSECUTIVE',
+      },
+    ];
     const mockDbService = {};
     const utils = { createUuid: () => '1' };
     const breachManager = new BreachManager(mockDbService, utils);
@@ -382,6 +399,7 @@ describe('BreachManager: createBreaches', () => {
         thresholdDuration: 1000,
         endTimestamp: 2,
         location: dummyLocation,
+        type: 'HOT_CONSECUTIVE',
       },
       {
         id: '1',
@@ -392,14 +410,15 @@ describe('BreachManager: createBreaches', () => {
         thresholdDuration: 1000,
         endTimestamp: undefined,
         location: dummyLocation,
+        type: 'HOT_CONSECUTIVE',
       },
     ];
 
     const logsShouldBe = [
-      { temperature: 10, timestamp: 0, temperatureBreachId: '1' },
-      { temperature: 10, timestamp: 1, temperatureBreachId: '1' },
-      { temperature: 10, timestamp: 3, temperatureBreachId: '1' },
-      { temperature: 10, timestamp: 4, temperatureBreachId: '1' },
+      { id: 'a', breach: breachesShouldBe[0] },
+      { id: 'b', breach: breachesShouldBe[0] },
+      { id: 'd', breach: breachesShouldBe[1] },
+      { id: 'e', breach: breachesShouldBe[1] },
     ];
 
     await expect(breachManager.createBreaches(sensor, logs, configs)).toEqual([

--- a/src/bluetooth/VaccineDataAccess.js
+++ b/src/bluetooth/VaccineDataAccess.js
@@ -46,11 +46,15 @@ export class VaccineDataAccess {
 
   upsertBreaches = breaches =>
     this.db.write(() => {
-      this.db.update(VACCINE_ENTITIES.TEMPERATURE_BREACH, breaches);
+      breaches.forEach(breach => {
+        this.db.update(VACCINE_ENTITIES.TEMPERATURE_BREACH, breach);
+      });
     });
 
   upsertTemperatureLog = temperatureLogs =>
     this.db.write(() => {
-      this.db.update(VACCINE_ENTITIES.TEMPERATURE_LOG, temperatureLogs);
+      temperatureLogs.forEach(log => {
+        this.db.update(VACCINE_ENTITIES.TEMPERATURE_LOG, log);
+      });
     });
 }

--- a/src/database/DataTypes/Sensor.js
+++ b/src/database/DataTypes/Sensor.js
@@ -61,7 +61,7 @@ Sensor.schema = {
     name: { type: 'string', default: '' },
     location: { type: 'Location', optional: true },
     batteryLevel: { type: 'double', default: 0 },
-    sensorLogs: { type: 'linkingObjects', objectType: 'SensorLog', property: 'sensor' },
+    logs: { type: 'linkingObjects', objectType: 'TemperatureLog', property: 'sensor' },
     isActive: { type: 'bool', default: true },
     logInterval: { type: 'int', default: 300 },
   },

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -115,10 +115,7 @@ const createInsurancePolicy = (database, policyDetails) => {
 
   const id = policyId ?? generateUUID();
   const expiryDate =
-    policyExpiryDate ??
-    moment(new Date())
-      .add(insuranceProvider.validityDays, 'days')
-      .toDate();
+    policyExpiryDate ?? moment(new Date()).add(insuranceProvider.validityDays, 'days').toDate();
 
   const isActive = policyIsActive ?? true;
 

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -139,8 +139,8 @@ const Settings = ({
       UIDatabase.delete('Sensor', oldSensors);
       const oldLogs = UIDatabase.objects('TemperatureLog');
       UIDatabase.delete('TemperatureLog', oldLogs);
-      const olUIDatabasereaches = UIDatabase.objects('TemperatureBreach');
-      UIDatabase.delete('TemperatureBreach', olUIDatabasereaches);
+      const oldUIDatabaseBreaches = UIDatabase.objects('TemperatureBreach');
+      UIDatabase.delete('TemperatureBreach', oldUIDatabaseBreaches);
 
       // create locations
       createRecord(UIDatabase, 'Location', null, 'Fridge 1', 'f1');
@@ -253,7 +253,6 @@ const Settings = ({
         sensor.logs.sorted('timestamp'),
         configs
       );
-      console.log(JSON.stringify(logs));
       return breachManager.updateBreaches(breaches, logs);
     });
     Promise.all(promises).then(() => ToastAndroid.show('Data generated', ToastAndroid.SHORT));

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -26,6 +26,9 @@ import globalStyles from '../globalStyles';
 import { generalStrings, buttonStrings } from '../localization';
 import { selectCurrentUserPasswordHash } from '../selectors/user';
 import { PermissionActions } from '../actions/PermissionActions';
+import { createRecord } from '../database/utilities/index';
+import { BreachManager } from '../bluetooth/BreachManager';
+import { VaccineDataAccess } from '../bluetooth/VaccineDataAccess';
 
 const exportData = async () => {
   const syncSiteName = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_SITE_NAME);
@@ -126,6 +129,135 @@ const Settings = ({
     [syncURL]
   );
 
+  const createVaccineData = () => {
+    UIDatabase.write(() => {
+      const oldLocations = UIDatabase.objects('Location');
+      ToastAndroid.show(String(oldLocations.length), ToastAndroid.SHORT);
+      UIDatabase.delete('Location', oldLocations);
+      const oldConfigs = UIDatabase.objects('TemperatureBreachConfiguration');
+      UIDatabase.delete('TemperatureBreachConfiguration', oldConfigs);
+      const oldSensors = UIDatabase.objects('Sensor');
+      UIDatabase.delete('Sensor', oldSensors);
+      const oldLogs = UIDatabase.objects('TemperatureLog');
+      UIDatabase.delete('TemperatureLog', oldLogs);
+      const olUIDatabasereaches = UIDatabase.objects('TemperatureBreach');
+      UIDatabase.delete('TemperatureBreach', olUIDatabasereaches);
+
+      // create locations
+      createRecord(UIDatabase, 'Location', null, 'Fridge 1', 'f1');
+      createRecord(UIDatabase, 'Location', null, 'Fridge 2', 'f2');
+      createRecord(UIDatabase, 'Location', null, 'Fridge 3', 'f3');
+      createRecord(UIDatabase, 'Location', null, 'Fridge 4', 'f4');
+
+      // create sensors
+      createRecord(UIDatabase, 'Sensor', 'sensor 1', 10);
+      createRecord(UIDatabase, 'Sensor', 'sensor 2', 20);
+      createRecord(UIDatabase, 'Sensor', 'sensor 3', 30);
+      createRecord(UIDatabase, 'Sensor', 'sensor 4', 40);
+
+      // create some configs
+      UIDatabase.update('TemperatureBreachConfiguration', {
+        id: '1',
+        minimumTemperature: 20,
+        maximumTemperature: 999,
+        duration: 60 * 10,
+        description: 'Config 1, 20 to 999 consecutive',
+        type: 'HOT_CONSECUTIVE',
+      });
+
+      UIDatabase.update('TemperatureBreachConfiguration', {
+        id: '2',
+        minimumTemperature: -999,
+        maximumTemperature: 0,
+        duration: 60 * 10,
+        description: 'Config 1, 0 to -999 consecutive',
+        type: 'COLD_CONSECUTIVE',
+      });
+
+      UIDatabase.update('TemperatureBreachConfiguration', {
+        id: '3',
+        minimumTemperature: 20,
+        maximumTemperature: 999,
+        duration: 60 * 100,
+        description: 'Config 1, 20 to 999 cumulative',
+        type: 'COLD_CUMULATIVE',
+      });
+
+      UIDatabase.update('TemperatureBreachConfiguration', {
+        id: '4',
+        minimumTemperature: -999,
+        maximumTemperature: 0,
+        duration: 60 * 100,
+        description: 'Config 1, 0 to -999 cumulative',
+        type: 'COLD_CUMULATIVE',
+      });
+
+      // create some logs. Leaving one location with no logs for handling that situation
+      const locations = UIDatabase.objects('Location');
+      const sensors = UIDatabase.objects('Sensor');
+      const currentDate = new Date();
+      let count = 0;
+
+      for (let i = -250; i < 250; i++) {
+        const { logInterval } = sensors[0];
+        UIDatabase.create('TemperatureLog', {
+          id: `${i}a`,
+          temperature: Math.floor((Math.random() * 40 + 20) * 100) / 100,
+          logInterval,
+          timestamp: new Date(currentDate - logInterval * 1000 * count),
+          location: locations[0],
+          sensor: sensors[0],
+        });
+      }
+
+      count = 0;
+      for (let i = -100; i < 100; i++) {
+        count += 1;
+        const { logInterval } = sensors[1];
+        UIDatabase.create('TemperatureLog', {
+          id: `${i}b`,
+          temperature: Math.random() * 40 - 20 - i,
+          logInterval,
+          timestamp: new Date(currentDate - logInterval * 1000 * count),
+          location: locations[1],
+          sensor: sensors[1],
+        });
+      }
+
+      count = 0;
+      for (let i = -50; i < 50; i++) {
+        const { logInterval } = sensors[1];
+        UIDatabase.create('TemperatureLog', {
+          id: `${i}c`,
+          temperature: Math.random() * 40 - 10 + i,
+          logInterval,
+          timestamp: new Date(currentDate - logInterval * 1000 * count),
+          location: locations[2],
+          sensor: sensors[2],
+        });
+      }
+    });
+
+    // create breaches
+    const utils = {};
+    const sensors = UIDatabase.objects('Sensor');
+    utils.createUuid = () => String(Math.random());
+    const configs = UIDatabase.objects('TemperatureBreachConfiguration');
+    const vaccineDB = new VaccineDataAccess(UIDatabase);
+    const breachManager = new BreachManager(vaccineDB, utils);
+
+    sensors.forEach(async sensor => {
+      const [breaches, logs] = await breachManager.createBreaches(sensor, sensor.logs, configs);
+      breachManager.updateBreaches(breaches, logs);
+    });
+    // for (let i = -250; i < 250; i++) {
+    //   const timestamp = Date();
+    //   createRecord(UIDatabase, 'TemperatureLog', i * i, timestamp, locations[0]);
+    // }
+
+    ToastAndroid.show('Data generated', ToastAndroid.SHORT);
+  };
+
   return (
     <DataTablePageView>
       <TouchableOpacity style={topRow} onPress={onSave}>
@@ -141,6 +273,7 @@ const Settings = ({
           <MenuButton text={buttonStrings.realm_explorer} onPress={toRealmExplorer} />
           <MenuButton text={buttonStrings.export_data} onPress={requestStorageWritePermission} />
           <MenuButton text="New vaccine module" onPress={toNewVaccineModulePage} />
+          <MenuButton text="Generate vaccine data" onPress={createVaccineData} />
         </View>
       </View>
 


### PR DESCRIPTION
Doesn't really fix #3277, as that wanted more of a framework.

## Change summary

But as discussed in the issue linked above, for doing vaccines a button under settings to generate some data would do to get us going.

Makes some locations, some configs, some sensors, some logs, then generates breaches using `breachManager`...

I added a few fixes and am now a `breachManager` scientist.

I also made `Sensor.log` link to `TemperatureLog` rather than `SensorLog` (deprecated).

## Testing

- Go to settings
- Press the new button
- Realm explorer check for `TemperatureBreach` records

### Related areas to think about
