### PR TITLE
#3354 update logging interval

### DIFF
--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -16,20 +16,20 @@ export const VACCINE_ACTIONS = {
   SCAN_START: 'Vaccine/sensorScanStart',
   SCAN_STOP: 'Vaccine/sensorScanStop',
   SENSOR_FOUND: 'Vaccine/sensorFound',
-  SET_LOG_FREQUENCY_ERROR: 'Vaccine/setLogFrequencyError',
-  SET_LOG_FREQUENCY_START: 'Vaccine/setLogFrequencyStart',
-  SET_LOG_FREQUENCY_SUCCESS: 'Vaccine/setLogFrequencySuccess',
+  SET_LOG_INTERVAL_ERROR: 'Vaccine/setLogIntervalError',
+  SET_LOG_INTERVAL_START: 'Vaccine/setLogIntervalStart',
+  SET_LOG_INTERVAL_SUCCESS: 'Vaccine/setLogIntervalSuccess',
 };
 
 const scanStart = () => ({ type: VACCINE_ACTIONS.SCAN_START });
 const scanStop = () => ({ type: VACCINE_ACTIONS.SCAN_STOP });
 const sensorFound = macAddress => ({ type: VACCINE_ACTIONS.SENSOR_FOUND, payload: { macAddress } });
-const setLogFrequencyStart = macAddress => ({
-  type: VACCINE_ACTIONS.SET_LOG_FREQUENCY_START,
+const setLogIntervalStart = macAddress => ({
+  type: VACCINE_ACTIONS.SET_LOG_INTERVAL_START,
   payload: { macAddress },
 });
-const setLogFrequencySuccess = () => ({ type: VACCINE_ACTIONS.SET_LOG_FREQUENCY_SUCCESS });
-const setLogFrequencyError = () => ({ type: VACCINE_ACTIONS.SET_LOG_FREQUENCY_ERROR });
+const setLogIntervalSuccess = () => ({ type: VACCINE_ACTIONS.SET_LOG_INTERVAL_SUCCESS });
+const setLogIntervalError = () => ({ type: VACCINE_ACTIONS.SET_LOG_INTERVAL_ERROR });
 
 /**
  * Helper wrapper which will check permissions for
@@ -84,15 +84,15 @@ const scanForSensors = (dispatch, state) => {
   BleService().scanForSensors(deviceCallback);
 };
 
-const setLogFrequency = (macAddress, frequency) => async dispatch => {
+const setLogInterval = (macAddress, interval) => async dispatch => {
   let ok = false;
-  let error = `Sensor response was not equal to 'Interval: ${frequency}s'`;
+  let error = `Sensor response was not equal to 'Interval: ${interval}s'`;
 
-  dispatch(setLogFrequencyStart(macAddress));
+  dispatch(setLogIntervalStart(macAddress));
 
   try {
-    const result = await BleService().updateLogIntervalWithRetries(macAddress, frequency, 3, error);
-    const regex = new RegExp(`Interval: ${frequency}s`); // TODO: update with sensor specific response as needed
+    const result = await BleService().updateLogIntervalWithRetries(macAddress, interval, 3, error);
+    const regex = new RegExp(`Interval: ${interval}s`); // TODO: update with sensor specific response as needed
     ok = regex.test(result);
   } catch (e) {
     error = e;
@@ -100,14 +100,14 @@ const setLogFrequency = (macAddress, frequency) => async dispatch => {
   }
 
   if (ok) {
-    dispatch(setLogFrequencySuccess());
+    dispatch(setLogIntervalSuccess());
     ToastAndroid.show(
-      vaccineStrings.formatString(vaccineStrings.log_frequency_set, frequency),
+      vaccineStrings.formatString(vaccineStrings.log_interval_set, interval),
       ToastAndroid.LONG
     );
   } else {
     ToastAndroid.show(vaccineStrings.E_COMMAND_FAILED, ToastAndroid.LONG);
-    dispatch(setLogFrequencyError(error));
+    dispatch(setLogIntervalError(error));
   }
 
   return ok;
@@ -128,14 +128,14 @@ const stopSensorScan = () => dispatch => {
   BleService().stopScan();
 };
 
-const startSetLogFrequency = ({ macAddress, frequency = 300 }) => async (dispatch, getState) => {
-  const success = await withPermissions(dispatch, getState, setLogFrequency(macAddress, frequency));
+const startSetLogInterval = ({ macAddress, interval = 300 }) => async (dispatch, getState) => {
+  const success = await withPermissions(dispatch, getState, setLogInterval(macAddress, interval));
   return success;
 };
 
 export const VaccineActions = {
   startSensorBlink,
   startSensorScan,
-  startSetLogFrequency,
+  startSetLogInterval,
   stopSensorScan,
 };

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -86,13 +86,13 @@ const scanForSensors = (dispatch, state) => {
 
 const setLogFrequency = (macAddress, frequency) => async dispatch => {
   let ok = false;
-  let error = '';
+  let error = `Sensor response was not equal to 'Interval: ${frequency}s'`;
 
   dispatch(setLogFrequencyStart(macAddress));
 
   try {
     const result = await BleService().updateLogIntervalWithRetries(macAddress, frequency, 3, error);
-    const regex = new RegExp(`Interval: ${frequency}s`);
+    const regex = new RegExp(`Interval: ${frequency}s`); // TODO: update with sensor specific response as needed
     ok = regex.test(result);
   } catch (e) {
     error = e;

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -128,7 +128,7 @@ const stopSensorScan = () => dispatch => {
   BleService().stopScan();
 };
 
-const startSetLogFrequency = ({ macAddress, frequency }) => async (dispatch, getState) => {
+const startSetLogFrequency = ({ macAddress, frequency = 300 }) => async (dispatch, getState) => {
   const success = await withPermissions(dispatch, getState, setLogFrequency(macAddress, frequency));
   return success;
 };

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -7,20 +7,30 @@ import { ToastAndroid } from 'react-native';
 import { PermissionSelectors } from '../selectors/permission';
 import { selectScannedSensors } from '../selectors/vaccine';
 import { PermissionActions } from './PermissionActions';
-import BleService from '../bluetooth/BleService';
+import BleService, { stringFromBase64 } from '../bluetooth/BleService';
+import { BLUETOOTH } from '../bluetooth/constants';
 import { syncStrings } from '../localization/index';
 import { UIDatabase } from '../database/index';
 
 export const VACCINE_ACTIONS = {
+  BLINK: 'Vaccine/blinkSensor',
   SCAN_START: 'Vaccine/sensorScanStart',
   SCAN_STOP: 'Vaccine/sensorScanStop',
   SENSOR_FOUND: 'Vaccine/sensorFound',
-  BLINK: 'Vaccine/blinkSensor',
+  SET_LOG_FREQUENCY_ERROR: 'Vaccine/setLogFrequencyError',
+  SET_LOG_FREQUENCY_START: 'Vaccine/setLogFrequencyStart',
+  SET_LOG_FREQUENCY_SUCCESS: 'Vaccine/setLogFrequencySuccess',
 };
 
 const scanStart = () => ({ type: VACCINE_ACTIONS.SCAN_START });
 const scanStop = () => ({ type: VACCINE_ACTIONS.SCAN_STOP });
 const sensorFound = macAddress => ({ type: VACCINE_ACTIONS.SENSOR_FOUND, payload: { macAddress } });
+const setLogFrequencyStart = macAddress => ({
+  type: VACCINE_ACTIONS.SET_LOG_FREQUENCY_START,
+  payload: { macAddress },
+});
+const setLogFrequencySuccess = () => ({ type: VACCINE_ACTIONS.SET_LOG_FREQUENCY_SUCCESS });
+const setLogFrequencyError = () => ({ type: VACCINE_ACTIONS.SET_LOG_FREQUENCY_ERROR });
 
 /**
  * Helper wrapper which will check permissions for
@@ -75,6 +85,20 @@ const scanForSensors = (dispatch, state) => {
   BleService().scanForSensors(deviceCallback);
 };
 
+const setLogFrequency = (macAddress, frequency) => async dispatch => {
+  let error;
+  dispatch(setLogFrequencyStart(macAddress));
+
+  const result = await BleService().updateLogIntervalWithRetries(macAddress, frequency, 3, error);
+  const regex = new RegExp(`${BLUETOOTH.COMMANDS.UPDATE_LOG_INTERVAL}${frequency}`);
+  const ok = regex.test(stringFromBase64(result));
+
+  if (ok) dispatch(setLogFrequencySuccess());
+  else dispatch(setLogFrequencyError(error));
+
+  return ok;
+};
+
 const startSensorBlink = macAddress => async (dispatch, getState) => {
   await withPermissions(dispatch, getState, blinkSensor(macAddress));
   return null;
@@ -90,8 +114,14 @@ const stopSensorScan = () => dispatch => {
   BleService().stopScan();
 };
 
+const startSetLogFrequency = async ({ macAddress, frequency }) => async (dispatch, getState) => {
+  const success = await withPermissions(dispatch, getState, setLogFrequency(macAddress, frequency));
+  return success;
+};
+
 export const VaccineActions = {
   startSensorBlink,
   startSensorScan,
+  startSetLogFrequency,
   stopSensorScan,
 };

--- a/src/bluetooth/BleService.js
+++ b/src/bluetooth/BleService.js
@@ -3,7 +3,7 @@ import { Buffer } from 'buffer';
 import { BLUETOOTH } from './constants';
 
 const bufferFromBase64 = base64 => Buffer.from(base64, 'base64');
-export const stringFromBase64 = base64 => bufferFromBase64(base64).toString('utf-8');
+const stringFromBase64 = base64 => bufferFromBase64(base64).toString('utf-8');
 const base64FromString = string => Buffer.from(string, 'utf-8').toString('base64');
 
 /**

--- a/src/bluetooth/BleService.js
+++ b/src/bluetooth/BleService.js
@@ -3,7 +3,7 @@ import { Buffer } from 'buffer';
 import { BLUETOOTH } from './constants';
 
 const bufferFromBase64 = base64 => Buffer.from(base64, 'base64');
-const stringFromBase64 = base64 => bufferFromBase64(base64).toString('utf-8');
+export const stringFromBase64 = base64 => bufferFromBase64(base64).toString('utf-8');
 const base64FromString = string => Buffer.from(string, 'utf-8').toString('base64');
 
 /**

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -26,7 +26,7 @@
     "E_BLUETOOTH_DISABLED": "Problem enabling the bluetooth adapter",
     "E_BLUETOOTH_ADAPTER": "Problem accessing the bluetooth adapter",
     "E_BLUETOOTH_DENIED": "Denied access to the bluetooth adapter",
-    "log_frequency_set": "Log frequency updated to {0}s"
+    "log_interval_set": "Log interval updated to {0}s"
   },
   "fr": {},
   "gil": {},

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -25,7 +25,8 @@
     "E_CANT_SCAN": "Problem when initiating a BLE scan",
     "E_BLUETOOTH_DISABLED": "Problem enabling the bluetooth adapter",
     "E_BLUETOOTH_ADAPTER": "Problem accessing the bluetooth adapter",
-    "E_BLUETOOTH_DENIED": "Denied access to the bluetooth adapter"
+    "E_BLUETOOTH_DENIED": "Denied access to the bluetooth adapter",
+    "log_frequency_set": "Log frequency updated to {0}s"
   },
   "fr": {},
   "gil": {},

--- a/src/reducers/VaccineReducer.js
+++ b/src/reducers/VaccineReducer.js
@@ -3,6 +3,7 @@ import { VACCINE_ACTIONS } from '../actions/VaccineActions';
 const initialState = () => ({
   isScanning: false,
   scannedSensorAddresses: [],
+  setLogFrequencyFor: '',
 });
 
 export const VaccineReducer = (state = initialState(), action) => {
@@ -32,6 +33,18 @@ export const VaccineReducer = (state = initialState(), action) => {
         ...state,
         scannedSensorAddresses: [...scannedSensorAddresses, macAddress],
       };
+    }
+
+    case VACCINE_ACTIONS.SET_LOG_FREQUENCY_START: {
+      const { payload } = action;
+      const { macAddress } = payload;
+
+      return { ...state, setLogFrequencyFor: macAddress };
+    }
+
+    case VACCINE_ACTIONS.SET_LOG_FREQUENCY_SUCCESS:
+    case VACCINE_ACTIONS.SET_LOG_FREQUENCY_ERROR: {
+      return { ...state, setLogFrequencyFor: '' };
     }
 
     default:

--- a/src/reducers/VaccineReducer.js
+++ b/src/reducers/VaccineReducer.js
@@ -3,7 +3,7 @@ import { VACCINE_ACTIONS } from '../actions/VaccineActions';
 const initialState = () => ({
   isScanning: false,
   scannedSensorAddresses: [],
-  setLogFrequencyFor: '',
+  setLogIntervalFor: '',
 });
 
 export const VaccineReducer = (state = initialState(), action) => {
@@ -35,16 +35,16 @@ export const VaccineReducer = (state = initialState(), action) => {
       };
     }
 
-    case VACCINE_ACTIONS.SET_LOG_FREQUENCY_START: {
+    case VACCINE_ACTIONS.SET_LOG_INTERVAL_START: {
       const { payload } = action;
       const { macAddress } = payload;
 
-      return { ...state, setLogFrequencyFor: macAddress };
+      return { ...state, setLogIntervalFor: macAddress };
     }
 
-    case VACCINE_ACTIONS.SET_LOG_FREQUENCY_SUCCESS:
-    case VACCINE_ACTIONS.SET_LOG_FREQUENCY_ERROR: {
-      return { ...state, setLogFrequencyFor: '' };
+    case VACCINE_ACTIONS.SET_LOG_INTERVAL_SUCCESS:
+    case VACCINE_ACTIONS.SET_LOG_INTERVAL_ERROR: {
+      return { ...state, setLogIntervalFor: '' };
     }
 
     default:


### PR DESCRIPTION
Fixes #3354 

Adds actions and reducers for setting the log frequency. I've added the option to call with only the mac address, which will reset the frequency to the default of 300. Don't know if that will be useful or not?

Also not sure if you want to continue with the term 'frequency' or use 'interval' which is what BlueMaestro are using

## Change summary

tested with a couple of sensors 
- E7:F6:88:07:03:DA which is working nicely and is now set to 200s
- FC:C0:EE:9D:80:A3 which is not playing ball and throws an error. Good for error testing 😉 


