### PR TITLE
fix prescriber select crash (master)

### DIFF
--- a/src/actions/PrescriptionActions.js
+++ b/src/actions/PrescriptionActions.js
@@ -173,13 +173,13 @@ const editQuantity = (id, quantity) => (dispatch, getState) => {
 const assignPrescriber = prescriber => (dispatch, getState) => {
   const { prescription } = getState();
   const { transaction } = prescription;
-
-  UIDatabase.write(() =>
+  UIDatabase.write(() => {
     UIDatabase.update('Transaction', {
-      ...transaction,
+      // Previously used spread, but Realm.Objects don't like being spread it turns out. Issue#3323
+      id: transaction.id,
       prescriber,
-    })
-  );
+    });
+  });
 
   batch(() => {
     dispatch(PrescriberActions.setPrescriber(prescriber));


### PR DESCRIPTION
Fixes #3323?

## Change summary

This was originally #3362 but we figured it'd be better for master, in case this is an issue in particular setups in the wild. Maybe.

Realm doesn't like object spreading on `Realm.Objects`. https://github.com/realm/realm-js/issues/2640 and/or https://github.com/realm/realm-js/issues/2844

## Testing

- [ ] Go dispensing, select patient
- [ ] Selecting prescriber navigates to Item selection, doesn't crash.

