### PR TITLE
Release v6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/actions/PrescriptionActions.js
+++ b/src/actions/PrescriptionActions.js
@@ -173,13 +173,13 @@ const editQuantity = (id, quantity) => (dispatch, getState) => {
 const assignPrescriber = prescriber => (dispatch, getState) => {
   const { prescription } = getState();
   const { transaction } = prescription;
-
-  UIDatabase.write(() =>
+  UIDatabase.write(() => {
     UIDatabase.update('Transaction', {
-      ...transaction,
+      // Previously used spread, but Realm.Objects don't like being spread it turns out. Issue#3323
+      id: transaction.id,
       prescriber,
-    })
-  );
+    });
+  });
 
   batch(() => {
     dispatch(PrescriberActions.setPrescriber(prescriber));

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -130,7 +130,7 @@ export class Requisition extends Realm.Object {
    * @return  {number}
    */
   get monthsToSupply() {
-    return Math.ceil(this.daysToSupply / NUMBER_OF_DAYS_IN_A_MONTH);
+    return Math.floor(this.daysToSupply / NUMBER_OF_DAYS_IN_A_MONTH);
   }
 
   /**

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -257,6 +257,15 @@ export class Transaction extends Realm.Object {
   }
 
   /**
+   * Get if this transaction is linked to a transaction.
+   *
+   * @return  {boolean}
+   */
+  get isLinkedToTransaction() {
+    return !!this.linkedTransaction;
+  }
+
+  /**
    * Get if this transaction includes a given item.
    *
    * @param   {Item}  item

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -691,9 +691,7 @@ const createRequisition = (
   const { name: orderTypeName, maxMOS, thresholdMOS } = orderType || {};
   const regimenData =
     program && program.parsedProgramSettings ? program.parsedProgramSettings.regimenData : null;
-  const daysToSupply = Math.ceil(
-    ((monthsLeadTime || 0) + (maxMOS || 1)) * NUMBER_OF_DAYS_IN_A_MONTH
-  );
+  const daysToSupply = ((monthsLeadTime || 0) + (maxMOS || 1)) * NUMBER_OF_DAYS_IN_A_MONTH;
 
   const requisition = database.create('Requisition', {
     id: generateUUID(),

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -105,11 +105,19 @@ const DataTableRow = React.memo(
           // Indicator if the right hand border should be removed from styles for this cell.
           const isLastCell = index === columns.length - 1;
 
+          const { isLinkedToTransaction, isFinalised: rowIsFinalised, isRemoteOrder } = rowData;
           // This cell is disabled if:
           // - the page is finalised.
           // - the row has been explicitly set as disabled.
+          // - The row itself is finalised.
+          // - The row was created on the primary
           const rowIsDisabled = rowState?.isDisabled ?? false;
-          const isDisabled = isFinalised || rowIsDisabled;
+          const isDisabled =
+            isFinalised ||
+            rowIsDisabled ||
+            rowIsFinalised ||
+            isLinkedToTransaction ||
+            isRemoteOrder;
 
           // Alignment of this particular column. Default to left hand ide.
           const cellAlignment = alignText || 'left';

--- a/src/widgets/StepperInput.js
+++ b/src/widgets/StepperInput.js
@@ -97,6 +97,7 @@ export const StepperInput = React.memo(
           onPressOut={isDisabled ? null : onEndLongPress}
         />
         <TextInput
+          keyboardType="numeric"
           editable={!isDisabled}
           onChangeText={onManualEdit}
           value={String(currentValue.current)}

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -64,7 +64,7 @@ export const StocktakeBatchModalComponent = ({
       return { page: MODALS.STOCKTAKE_BATCH_EDIT_WITH_REASONS_AND_PRICES, pageObject };
     }
     if (usingReasons) return { page: MODALS.STOCKTAKE_BATCH_EDIT_WITH_REASONS, pageObject };
-    if (usingPayments) return { page: MODALS.STOCKTAKE_BATCH_EDIT_WITH_PAYMENTS, pageObject };
+    if (usingPayments) return { page: MODALS.STOCKTAKE_BATCH_EDIT_WITH_PRICES, pageObject };
     return { page: MODALS.STOCKTAKE_BATCH_EDIT, pageObject };
   }, [stocktakeItem, usingPayments, usingReasons]);
 


### PR DESCRIPTION
**See the release discussion here: https://github.com/openmsupply/mobile/issues/3263**

*Please note, this version requires an mSupply server v4.13 or greater*

## RELEASE VERSION

v6.0.1

### SUMMARY

This release has some minor bug fixes for v6.0.1.

### Bugs
- #3291 - Selecting finalised rows.
- #3292 - Incorrect rounding of days of supply in requisitions.
- #3345 - Incorrect keyboard when issuing quantities in a prescription.
- #3344 - App crashes when opening a stocktake batch modal when (only) payment customisation is enabled
- #3362 - App crashes when selecting a prescriber, sometimes.
