### PR TITLE
#3375 passively downloading temperatures

### DIFF
--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -6,7 +6,7 @@
 import moment from 'moment';
 import { ToastAndroid } from 'react-native';
 import { PermissionSelectors } from '../selectors/permission';
-import { selectScannedSensors, selectIsSyncingTemps } from '../selectors/vaccine';
+import { selectScannedSensors, selectIsDownloadingLogs } from '../selectors/vaccine';
 import { PermissionActions } from './PermissionActions';
 import BleService from '../bluetooth/BleService';
 import TemperatureLogManager from '../bluetooth/TemperatureLogManager';
@@ -166,8 +166,8 @@ const scanForSensors = (dispatch, getState) => {
 const startDownloadAllLogs = () => async (dispatch, getState) => {
   // Ensure there isn't already a download in progress before starting a new one
   const state = getState();
-  const isDownloadingTemps = selectIsSyncingTemps(state);
-  if (isDownloadingTemps) return null;
+  const isDownloadingLogs = selectIsDownloadingLogs(state);
+  if (isDownloadingLogs) return null;
 
   await withPermissions(dispatch, getState, downloadAllLogs());
   return null;

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -45,12 +45,7 @@ const downloadLogsComplete = () => ({
   type: VACCINE_ACTIONS.DOWNLOAD_LOGS_COMPLETE,
 });
 
-const downloadAllLogs = () => async (dispatch, getState) => {
-  // Ensure there isn't already a download in progress before starting a new one
-  const state = getState();
-  const isDownloadingTemps = selectIsSyncingTemps(state);
-  if (isDownloadingTemps) return null;
-
+const downloadAllLogs = () => async dispatch => {
   dispatch(downloadLogsStart());
   // Ensure there are some sensors which have been assigned a location before syncing.
   const sensors = UIDatabase.objects('Sensor').filtered('location != null && isActive == true');
@@ -169,6 +164,11 @@ const scanForSensors = (dispatch, getState) => {
 };
 
 const startDownloadAllLogs = macAddress => async (dispatch, getState) => {
+  // Ensure there isn't already a download in progress before starting a new one
+  const state = getState();
+  const isDownloadingTemps = selectIsSyncingTemps(state);
+  if (isDownloadingTemps) return null;
+
   await withPermissions(dispatch, getState, downloadAllLogs(macAddress));
   return null;
 };

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -163,13 +163,13 @@ const scanForSensors = (dispatch, getState) => {
   BleService().scanForSensors(deviceCallback);
 };
 
-const startDownloadAllLogs = macAddress => async (dispatch, getState) => {
+const startDownloadAllLogs = () => async (dispatch, getState) => {
   // Ensure there isn't already a download in progress before starting a new one
   const state = getState();
   const isDownloadingTemps = selectIsSyncingTemps(state);
   if (isDownloadingTemps) return null;
 
-  await withPermissions(dispatch, getState, downloadAllLogs(macAddress));
+  await withPermissions(dispatch, getState, downloadAllLogs());
   return null;
 };
 

--- a/src/actions/VaccineActions.js
+++ b/src/actions/VaccineActions.js
@@ -6,7 +6,7 @@
 import moment from 'moment';
 import { ToastAndroid } from 'react-native';
 import { PermissionSelectors } from '../selectors/permission';
-import { selectScannedSensors } from '../selectors/vaccine';
+import { selectScannedSensors, selectIsSyncingTemps } from '../selectors/vaccine';
 import { PermissionActions } from './PermissionActions';
 import BleService from '../bluetooth/BleService';
 import TemperatureLogManager from '../bluetooth/TemperatureLogManager';
@@ -45,9 +45,13 @@ const downloadLogsComplete = () => ({
   type: VACCINE_ACTIONS.DOWNLOAD_LOGS_COMPLETE,
 });
 
-const downloadAllLogs = () => async dispatch => {
-  dispatch(downloadLogsStart());
+const downloadAllLogs = () => async (dispatch, getState) => {
+  // Ensure there isn't already a download in progress before starting a new one
+  const state = getState();
+  const isDownloadingTemps = selectIsSyncingTemps(state);
+  if (isDownloadingTemps) return null;
 
+  dispatch(downloadLogsStart());
   // Ensure there are some sensors which have been assigned a location before syncing.
   const sensors = UIDatabase.objects('Sensor').filtered('location != null && isActive == true');
 

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -53,6 +53,7 @@ import TemperatureLogManager from './bluetooth/TemperatureLogManager';
 import { DevBleManager } from './bluetooth/DevBleManager';
 import { VaccineDataAccess } from './bluetooth/VaccineDataAccess';
 import { UtilService } from './database/utilities/utilService';
+import { VaccineActions } from './actions/VaccineActions';
 
 const SYNC_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 const AUTHENTICATION_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
@@ -279,7 +280,7 @@ const mapDispatchToProps = dispatch => {
   const closeTemperatureSyncModal = () => dispatch(TemperatureSyncActions.closeModal());
   const onOpenSyncModal = () => dispatch(openSyncModal());
   const closeBreachModal = () => dispatch(BreachActions.close());
-  const syncTemperatures = () => dispatch(TemperatureSyncActions.syncTemperatures());
+  const syncTemperatures = () => dispatch(VaccineActions.startDownloadAllLogs());
   const requestBluetooth = newStatus => dispatch(PermissionActions.requestBluetooth(newStatus));
 
   return {

--- a/src/selectors/vaccine.js
+++ b/src/selectors/vaccine.js
@@ -8,6 +8,11 @@ export const selectScannedSensors = ({ vaccine }) => {
   return scannedSensorAddresses;
 };
 
+export const selectIsSyncingTemps = ({ vaccine }) => {
+  const { isSyncingTemps = false } = vaccine || {};
+  return isSyncingTemps;
+};
+
 export const selectIsScanning = ({ vaccine }) => {
   const { isScanning = false } = vaccine || {};
   return isScanning;

--- a/src/selectors/vaccine.js
+++ b/src/selectors/vaccine.js
@@ -8,9 +8,9 @@ export const selectScannedSensors = ({ vaccine }) => {
   return scannedSensorAddresses;
 };
 
-export const selectIsSyncingTemps = ({ vaccine }) => {
-  const { isSyncingTemps = false } = vaccine || {};
-  return isSyncingTemps;
+export const selectIsDownloadingLogs = ({ vaccine }) => {
+  const { isDownloadingLogs = false } = vaccine || {};
+  return isDownloadingLogs;
 };
 
 export const selectIsScanning = ({ vaccine }) => {


### PR DESCRIPTION
Fixes #3375

## Change summary

- Swap over the existing temperature sync scheduler to use the newly created temperature download action
- Got rid of macAddress param on `downloadAllLogs()` method as it wasn't needed
- Add check to not start download process if one is already in progress

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Added some `console.log` statements into the `downloadAllLogs()` function to check it was being called at the scheduled interval and set `SYNC_INTERVAL` to something short (in `mSupplyMobileApp`) for testing.

### Related areas to think about
- There is a UI component that looks like it was tied into the previous scheduler which also allows manual sync. Not sure about whether to keep it, get rid of it, or rework it. I think it's currently a little bit vague about what exactly is being synced, but probably a useful indicator to keep?
  <img width="117" alt="Screen Shot 2021-01-26 at 5 38 44 PM" src="https://user-images.githubusercontent.com/65875762/105801143-5efdfb80-5ffd-11eb-86b8-250b0dd4366e.png">
