### PR TITLE
#3395 object link sensors and breaches

### DIFF
--- a/src/bluetooth/BreachManager.js
+++ b/src/bluetooth/BreachManager.js
@@ -8,7 +8,6 @@ const createBreachRecord = (
   startTimestamp,
   endTimestamp
 ) => {
-  const { id: sensorId, location } = sensor;
   const {
     minimumTemperature: thresholdMinTemperature,
     maximumTemperature: thresholdMaxTemperature,
@@ -16,10 +15,11 @@ const createBreachRecord = (
     type,
   } = temperatureBreachConfiguration;
   const id = uuid;
+  const { location } = sensor;
 
   return {
     id,
-    sensorId,
+    sensor,
     thresholdMinTemperature,
     thresholdMaxTemperature,
     thresholdDuration,

--- a/src/database/DataTypes/Location.js
+++ b/src/database/DataTypes/Location.js
@@ -88,6 +88,11 @@ Location.schema = {
       objectType: 'LocationMovement',
       property: 'location',
     },
+    sensors: {
+      type: 'linkingObjects',
+      objectType: 'Sensor',
+      property: 'location',
+    },
     temperatureLogs: {
       type: 'linkingObjects',
       objectType: 'TemperatureLog',

--- a/src/database/DataTypes/Sensor.js
+++ b/src/database/DataTypes/Sensor.js
@@ -69,6 +69,7 @@ Sensor.schema = {
     location: { type: 'Location', optional: true },
     batteryLevel: { type: 'double', default: 0 },
     logs: { type: 'linkingObjects', objectType: 'TemperatureLog', property: 'sensor' },
+    breaches: { type: 'linkingObjects', objectType: 'TemperatureBreach', property: 'sensor' },
     isActive: { type: 'bool', default: true },
     logInterval: { type: 'int', default: 300 },
   },

--- a/src/database/DataTypes/TemperatureBreach.js
+++ b/src/database/DataTypes/TemperatureBreach.js
@@ -98,7 +98,7 @@ TemperatureBreach.schema = {
     thresholdDuration: { type: 'double' },
     acknowledged: { type: 'bool', default: false },
     type: { type: 'string' },
-    sensorId: { type: 'string' },
+    sensor: { type: 'Sensor' },
   },
 };
 

--- a/src/database/DataTypes/TemperatureBreachConfiguration.js
+++ b/src/database/DataTypes/TemperatureBreachConfiguration.js
@@ -26,7 +26,7 @@ export class TemperatureBreachConfiguration extends Realm.Object {
    * @param {TemperatureLog} temperatureLog A potential log which may create a breach.
    */
   createBreach(database, location, temperatureLog) {
-    const { timestamp } = temperatureLog;
+    const { timestamp, sensor } = temperatureLog;
     const { temperatureLogs } = location;
 
     // The potential start time of the breach - looking back from the passed
@@ -58,7 +58,7 @@ export class TemperatureBreachConfiguration extends Realm.Object {
     // Create a breach if the duration of logs and temperatures define a breach and set
     // each temperature log as part of the breach.
     if (willCreateBreach) {
-      const breach = createRecord(database, 'TemperatureBreach', startTime, location, this);
+      const breach = createRecord(database, 'TemperatureBreach', startTime, location, sensor, this);
       proximalLogs.forEach(log => database.update('TemperatureLog', { ...log, breach }));
     }
 

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -1122,11 +1122,13 @@ const createTemperatureBreach = (
   database,
   startTimestamp,
   location,
+  sensor,
   temperatureBreachConfiguration
 ) => {
   const temperatureLog = database.create('TemperatureBreach', {
     id: generateUUID(),
     startTimestamp,
+    sensor,
     location,
     temperatureBreachConfiguration,
   });

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -176,6 +176,7 @@ const Settings = ({
           duration: 60 * 20,
           description: 'Config 1, 8 to 999 consecutive for 20 minutes',
           type: 'HOT_CONSECUTIVE',
+          location,
         });
 
         UIDatabase.update('TemperatureBreachConfiguration', {
@@ -185,6 +186,7 @@ const Settings = ({
           duration: 60 * 20,
           description: 'Config 1, 0 to -999 consecutive for 20 minutes',
           type: 'COLD_CONSECUTIVE',
+          location,
         });
 
         UIDatabase.update('TemperatureBreachConfiguration', {
@@ -194,6 +196,7 @@ const Settings = ({
           duration: 60 * 60,
           description: 'Config 1, 8 to 999 cumulative for 1 hour',
           type: 'HOT_CUMULATIVE',
+          location,
         });
 
         UIDatabase.update('TemperatureBreachConfiguration', {
@@ -203,6 +206,7 @@ const Settings = ({
           duration: 60 * 60,
           description: 'Config 1, 0 to -999 cumulative',
           type: 'COLD_CUMULATIVE',
+          location,
         });
       });
 

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -998,6 +998,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       break;
     }
     case 'TemperatureBreach': {
+      const sensor = database.getOrCreate('Sensor', record.sensor_ID);
       database.update(recordType, {
         id: record.ID,
         startTimestamp: parseDate(record.start_date, record.start_time),
@@ -1008,6 +1009,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         thresholdMaxTemperature: parseNumber(record.threshold_max_temperature),
         thresholdMinTemperature: parseNumber(record.threshold_min_temperature),
         thresholdDuration: parseNumber(record.threshold_duration),
+        sensor,
       });
       break;
     }

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -329,7 +329,7 @@ const generateSyncData = (settings, recordType, record) => {
     case 'TemperatureBreach': {
       return {
         ID: record.id,
-        sensor_ID: record.sensorId,
+        sensor_ID: record.sensor?.id,
         start_time: getTimeString(record.startTimestamp),
         start_date: getDateString(record.startTimestamp),
         end_time: getTimeString(record.endTimestamp),


### PR DESCRIPTION
Fixes #3395 

## Change summary

- Link `location.sensors`
- Link `sensor.breaches` and `breach.sensor`
- update sync utils
- update `breachManager` to use realm more (it already does to some degree, but further losing keeping it DB agnostic 😕 we'll try and unwind it later I guess?)
- Also bonus update the vaccine test data generator to link locations and temp configs so that navigation to FridgeDetailPage works.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Can navigate to a fridge 
- [ ] In data locations have sensors
- [ ] sensors have breaches and breaches have a sensor
- [ ] Syncing works for location, breach and sensor

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
