### PR TITLE
Make ChevronRightIcon usage in DataTableRow consistent with other icons

### DIFF
--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -299,7 +299,7 @@ const DataTableRow = React.memo(
               const { hasBreached, isVaccine } = rowData ?? {};
 
               const icons = {
-                chevron_right: ChevronRightIcon,
+                chevron_right: () => <ChevronRightIcon />,
                 history: () => <HistoryIcon color={SUSSOL_ORANGE} />,
                 pencil: () => <PencilIcon color={SUSSOL_ORANGE} />,
                 breach: () => (hasBreached ? <HazardIcon color={SUSSOL_ORANGE} /> : null),


### PR DESCRIPTION
Fixes #3407?

## Change summary

We changed how we were exporting `ChevronRightIcon` presumably, causing any data table using it to cause a cryptic crash.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Can view current stock
- [ ] Can view dispensing

### Related areas to think about

