### PR TITLE
update battery level when syncing

### DIFF
--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -282,7 +282,7 @@ const mapDispatchToProps = dispatch => {
   const closeTemperatureSyncModal = () => dispatch(TemperatureSyncActions.closeModal());
   const onOpenSyncModal = () => dispatch(openSyncModal());
   const closeBreachModal = () => dispatch(BreachActions.close());
-  const syncTemperatures = () => dispatch(VaccineActions.startDownloadAllLogs());
+  const syncTemperatures = () => dispatch(VaccineActions.startDownloadAll());
   const requestBluetooth = newStatus => dispatch(PermissionActions.requestBluetooth(newStatus));
 
   return {

--- a/src/reducers/VaccineReducer.js
+++ b/src/reducers/VaccineReducer.js
@@ -3,6 +3,7 @@ import { VACCINE_ACTIONS } from '../actions/VaccineActions';
 const initialState = () => ({
   isSyncingTemps: false,
   setLogIntervalFor: '',
+  error: null,
 });
 
 export const VaccineReducer = (state = initialState(), action) => {
@@ -10,15 +11,17 @@ export const VaccineReducer = (state = initialState(), action) => {
 
   switch (type) {
     case VACCINE_ACTIONS.DOWNLOAD_LOGS_START: {
-      return { ...state, isSyncingTemps: true };
+      return { ...state, isSyncingTemps: true, error: null };
     }
 
     case VACCINE_ACTIONS.DOWNLOAD_LOGS_ERROR: {
-      return { ...state, isSyncingTemps: false };
+      const { payload } = action;
+      const { error } = payload;
+      return { ...state, isSyncingTemps: false, error };
     }
 
     case VACCINE_ACTIONS.DOWNLOAD_LOGS_COMPLETE: {
-      return { ...state, isSyncingTemps: false };
+      return { ...state, isSyncingTemps: false, error: null };
     }
 
     case VACCINE_ACTIONS.SET_LOG_INTERVAL_START: {

--- a/src/selectors/vaccine.js
+++ b/src/selectors/vaccine.js
@@ -2,8 +2,22 @@
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2021
  */
+import { syncStrings } from '../localization';
 
-export const selectIsDownloadingLogs = ({ vaccine }) => {
-  const { isDownloadingLogs = false } = vaccine || {};
-  return isDownloadingLogs;
+export const selectTemperatureSyncMessage = ({ vaccine }) => {
+  const { isSyncingTemps = false, error } = vaccine;
+  if (isSyncingTemps) {
+    return syncStrings.downloading_temperature_logs;
+  }
+
+  if (error) {
+    return `${syncStrings.error_downloading_temperature_logs} ${error}`;
+  }
+
+  return syncStrings.sync_complete;
+};
+
+export const selectIsSyncingTemps = ({ vaccine }) => {
+  const { isSyncingTemps = false } = vaccine || {};
+  return isSyncingTemps;
 };

--- a/src/widgets/modalChildren/TemperatureSync.js
+++ b/src/widgets/modalChildren/TemperatureSync.js
@@ -12,16 +12,15 @@ import { PageButton, ProgressBar, FlexColumn } from '..';
 import { syncStrings } from '../../localization';
 import globalStyles, { WARM_GREY } from '../../globalStyles';
 
-import { TemperatureSyncActions } from '../../actions/TemperatureSyncActions';
+import { VaccineActions } from '../../actions/VaccineActions';
 import {
-  selectTemperatureSyncMessage,
   selectTemperatureSyncLastSyncString,
   selectCurrentSensorNameString,
   selectTemperatureSyncIsComplete,
   selectTemperatureSyncProgress,
-  selectIsSyncingTemperatures,
   selectErrorMessage,
 } from '../../selectors/temperatureSync';
+import { selectIsSyncingTemps, selectTemperatureSyncMessage } from '../../selectors/vaccine';
 
 const TemperatureSyncComponent = ({
   total,
@@ -62,7 +61,7 @@ const mapStateToProps = state => {
   const currentSensor = selectCurrentSensorNameString(state);
   const isComplete = selectTemperatureSyncIsComplete(state);
   const { progress, total } = selectTemperatureSyncProgress(state);
-  const isSyncing = selectIsSyncingTemperatures(state);
+  const isSyncing = selectIsSyncingTemps(state);
   const errorMessage = selectErrorMessage(state);
 
   return {
@@ -78,7 +77,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  syncTemperatures: () => dispatch(TemperatureSyncActions.manualTemperatureSync()),
+  syncTemperatures: () => dispatch(VaccineActions.startDownloadAll()),
 });
 
 TemperatureSyncComponent.defaultProps = {


### PR DESCRIPTION
Fixes #3378 

## Change summary

Downloads battery status for all configured and enabled sensors, at the same time as downloading logs.
Have renamed the download methods - and at the same time updated the 'isDownloading' flag and handled an error. The manual sensor sync has been updated to use the new method and correctly displays status. Will show an error (briefly in the case of the final sensor)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Add a sensor, wait for sync or sync manually. Check the battery status.
- [ ] Check again some time later..

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
