### PR TITLE
#3431 Remove DataTablePageView from capturing gestures to enable scrolling

### DIFF
--- a/src/pages/VaccinePage.js
+++ b/src/pages/VaccinePage.js
@@ -139,7 +139,10 @@ FridgeDisplay.propTypes = {
 };
 
 export const VaccinePageComponent = ({ fridges, toNewSensorPage, ...dispatchers }) => (
-  <DataTablePageView style={{ paddingHorizontal: 20, paddingVertical: 30 }}>
+  <DataTablePageView
+    captureUncaughtGestures={false}
+    style={{ paddingHorizontal: 20, paddingVertical: 30 }}
+  >
     <FlexRow style={{ justifyContent: 'flex-end', marginBottom: 10 }}>
       <PageButton text={buttonStrings.add_sensor} onPress={toNewSensorPage} />
     </FlexRow>

--- a/src/widgets/DataTablePageView.js
+++ b/src/widgets/DataTablePageView.js
@@ -16,8 +16,11 @@ const dismiss = () => Keyboard.dismiss();
 /**
  * Simple template container for a standard data table page.
  * Handles placement of content and wraps the page with a
- * Touchable, dismissing the keyboard when an event propogates
+ * Touchable, dismissing the keyboard when an event propagates
  * to this level.
+ *
+ * WARNING: If this component captures events they are not propagated further.
+ *          Be careful with components which scroll.
  */
 export const DataTablePageView = React.memo(({ children, captureUncaughtGestures, style }) => {
   // Use a Fragment over TouchableWithoutFeedback so no gesture events are caught.


### PR DESCRIPTION
Fixes #3431 

## Change summary

- `DataTablePageView` captures the gesture event and handles it, the flat list doesn't get a chance to handle it.

## Testing

- [ ] Have heaps of fridges, you can scroll

### Related areas to think about

N/A