### PR TITLE
#3449 new sensor UI tweaks

### DIFF
--- a/src/pages/NewSensor/NewSensorStepThree.js
+++ b/src/pages/NewSensor/NewSensorStepThree.js
@@ -49,7 +49,7 @@ export const NewSensorStepThreeComponent = ({
 
   return (
     <TabContainer>
-      <Paper headerText={vaccineStrings.new_sensor_step_three_title}>
+      <Paper height={200} headerText={vaccineStrings.new_sensor_step_three_title}>
         <EditorRow
           containerStyle={localStyles.paperContentRow}
           label={vaccineStrings.sensor_name}

--- a/src/pages/NewSensor/NewSensorStepTwo.js
+++ b/src/pages/NewSensor/NewSensorStepTwo.js
@@ -36,7 +36,7 @@ export const NewSensorStepTwoComponent = ({
   coldCumulativeThreshold,
 }) => (
   <TabContainer>
-    <Paper headerText={vaccineStrings.new_sensor_step_two_title}>
+    <Paper height={420} headerText={vaccineStrings.new_sensor_step_two_title}>
       <AfterInteractions placeholder={null}>
         <BreachConfigRow
           threshold={hotConsecutiveThreshold}

--- a/src/widgets/TextEditor.js
+++ b/src/widgets/TextEditor.js
@@ -17,7 +17,7 @@ export const TextEditor = ({
   ...textInputProps
 }) => {
   const isSmall = size === 'small';
-  const sizeAdjustment = { width: isSmall ? 190 : 500 };
+  const sizeAdjustment = { width: isSmall ? 190 : 350 };
   const internalTextInput = [textInputStyle, sizeAdjustment];
   return (
     <FlexRow flex={0} alignItems="center" style={{ ...containerStyle }}>


### PR DESCRIPTION
Fixes #3449 ?

## Change summary

- Sets heights of paper to be similar across them. Preempts height based on children, so should solve the issue for stepTwo
- TextEditor width reverted so to not overlap with label on small screens.

## Testing

- [ ] Go through new sensor steps. Looks aight.

### Related areas to think about

![image](https://user-images.githubusercontent.com/7684221/106813082-685e2680-66d5-11eb-80ef-6b942ce30181.png)

![image](https://user-images.githubusercontent.com/7684221/106813101-70b66180-66d5-11eb-9cbf-3a707752960b.png)

![image](https://user-images.githubusercontent.com/7684221/106813171-82980480-66d5-11eb-807b-1e058e033944.png)

