### PR TITLE
#3464 display data on bar chart

### DIFF
--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -241,7 +241,7 @@ export class Item extends Realm.Object {
    * A vaccine item can have multiple doses per 'unit' or 'pack'. For example, you can have
    * a single vaccine which has two doses. Once a vaccine has been opened, the doses must be
    * given quickly. When recording outgoing stock, the doses and quantity (or number of packs)
-   * are recorded seperately. The amount of open vial wastage (that is, the amount of doses
+   * are recorded separately. The amount of open vial wastage (that is, the amount of doses
    * which are left in a vial and wasted) is the difference between the total number of 'packs'
    * that are outgoing, multiplied by the amount of doses in each pack and the total number of
    * doses actually given.

--- a/src/globalStyles/colors.js
+++ b/src/globalStyles/colors.js
@@ -23,3 +23,4 @@ export const WHITE = '#FFFFFF';
 export const COLD_BREACH_BLUE = '#70b4f0';
 export const DANGER_RED = '#FA6400';
 export const BLACK = '#000000';
+export const WEARY_TARMAC = '#858585';

--- a/src/pages/FridgeDetailPage.js
+++ b/src/pages/FridgeDetailPage.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-wrap-multilines */
 /* eslint-disable react/forbid-prop-types */
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Text, View, StyleSheet } from 'react-native';
@@ -15,10 +15,13 @@ import {
   Paper,
   SensorStatus,
 } from '../widgets';
-import { VaccineChart } from '../widgets/VaccineChart';
+import { VaccineBarChart } from '../widgets/VaccineBarChart';
+import { VaccineLineChart } from '../widgets/VaccineLineChart';
 import { NoBreachMan } from '../widgets/NoBreachMan';
 import { FridgeActions } from '../actions/FridgeActions';
 import { AfterInteractions } from '../widgets/AfterInteractions';
+import { IconButton } from '../widgets/IconButton';
+import { BarChartIcon, LineChartIcon } from '../widgets/icons';
 
 import {
   selectAverageTemperature,
@@ -46,6 +49,7 @@ import {
   BLUE_WHITE,
   COLD_BREACH_BLUE,
   DANGER_RED,
+  WARMER_GREY,
 } from '../globalStyles';
 import { vaccineStrings } from '../localization/index';
 import { FridgeHeader } from '../widgets/FridgeHeader';
@@ -88,102 +92,136 @@ export const FridgeDetailPageComponent = ({
   currentTemperature,
   sensor,
   breachBoundaries,
-}) => (
-  <DataTablePageView>
-    <AfterInteractions>
-      <View style={localStyles.container}>
-        <DateRangeSelector
-          containerStyle={localStyles.datePickerContainer}
-          initialStartDate={fromDate}
-          initialEndDate={toDate}
-          onChangeToDate={onChangeToDate}
-          onChangeFromDate={onChangeFromDate}
-          minimumDate={minimumDate}
-          maximumDate={maximumDate}
-        />
+}) => {
+  const [chartType, setChartType] = useState('bar');
+  const getIconButton = type => {
+    const iconStyle = { color: chartType === type ? WARMER_GREY : DARKER_GREY };
+    return (
+      <IconButton
+        onPress={() => setChartType(type)}
+        Icon={
+          type === 'line' ? <LineChartIcon style={iconStyle} /> : <BarChartIcon style={iconStyle} />
+        }
+        containerStyle={{ padding: 8 }}
+      />
+    );
+  };
 
-        <Paper
-          height={300}
-          contentContainerStyle={{ flex: 1, marginTop: 20 }}
-          Header={<FridgeHeader showCog sensor={sensor} />}
-        >
-          <AfterInteractions>
-            <FlexRow alignItems="center">
-              <VaccineChart
-                breaches={breaches}
-                minLine={minLine}
-                maxLine={maxLine}
-                minDomain={minDomain}
-                maxDomain={maxDomain}
-                breachBoundaries={breachBoundaries}
-              />
-              <SensorStatus
-                isInHotBreach={isInHotBreach}
-                isInColdBreach={isInColdBreach}
-                isLowBattery={isLowBattery}
-                currentTemp={currentTemperature}
-              />
+  return (
+    <DataTablePageView>
+      <AfterInteractions>
+        <View style={localStyles.container}>
+          <View style={localStyles.topRow}>
+            <DateRangeSelector
+              containerStyle={localStyles.datePickerContainer}
+              initialStartDate={fromDate}
+              initialEndDate={toDate}
+              onChangeToDate={onChangeToDate}
+              onChangeFromDate={onChangeFromDate}
+              minimumDate={minimumDate}
+              maximumDate={maximumDate}
+            />
+            <View style={localStyles.buttonContainer}>
+              {getIconButton('line')}
+              {getIconButton('bar')}
+            </View>
+          </View>
+
+          <Paper
+            height={300}
+            contentContainerStyle={{ flex: 1, marginTop: 20 }}
+            Header={<FridgeHeader showCog sensor={sensor} />}
+          >
+            <AfterInteractions>
+              <FlexRow alignItems="center">
+                {chartType === 'line' && (
+                  <VaccineLineChart
+                    breaches={breaches}
+                    minLine={minLine}
+                    maxLine={maxLine}
+                    minDomain={minDomain}
+                    maxDomain={maxDomain}
+                    breachBoundaries={breachBoundaries}
+                  />
+                )}
+                {chartType === 'bar' && (
+                  <VaccineBarChart
+                    breaches={breaches}
+                    minLine={minLine}
+                    maxLine={maxLine}
+                    minDomain={minDomain}
+                    maxDomain={maxDomain}
+                    breachBoundaries={breachBoundaries}
+                  />
+                )}
+                <SensorStatus
+                  isInHotBreach={isInHotBreach}
+                  isInColdBreach={isInColdBreach}
+                  isLowBattery={isLowBattery}
+                  currentTemp={currentTemperature}
+                />
+              </FlexRow>
+            </AfterInteractions>
+          </Paper>
+
+          <Animatable.View animation="fadeIn" duration={3000} useNativeDriver>
+            <FlexRow>
+              <BreachCard headerText={vaccineStrings.cumulative_breach}>
+                {coldCumulativeBreach ? (
+                  <>
+                    <Text style={localStyles.coldText}>{coldCumulativeBreach}</Text>
+                    <ColdBreachIcon color={COLD_BREACH_BLUE} />
+                  </>
+                ) : (
+                  <NoBreachMessage />
+                )}
+              </BreachCard>
+
+              <BreachCard headerText={vaccineStrings.consecutive_breach}>
+                {numberOfColdBreaches ? (
+                  <>
+                    <Text style={localStyles.coldText}>{numberOfColdBreaches}</Text>
+                    <ColdBreachIcon color={COLD_BREACH_BLUE} />
+                  </>
+                ) : (
+                  <NoBreachMessage />
+                )}
+              </BreachCard>
+
+              <BreachCard headerText={vaccineStrings.average_temperature}>
+                <Text style={[localStyles.hotText, { color: DARKER_GREY }]}>
+                  {averageTemperature}
+                </Text>
+              </BreachCard>
+
+              <BreachCard headerText={vaccineStrings.cumulative_breach}>
+                {hotCumulativeBreach ? (
+                  <>
+                    <Text style={localStyles.hotText}>{hotCumulativeBreach}</Text>
+                    <HotBreachIcon color={DANGER_RED} />
+                  </>
+                ) : (
+                  <NoBreachMessage />
+                )}
+              </BreachCard>
+
+              <BreachCard headerText={vaccineStrings.consecutive_breach}>
+                {numberOfHotBreaches ? (
+                  <>
+                    <Text style={localStyles.hotText}>{numberOfHotBreaches}</Text>
+                    <HotBreachIcon color={DANGER_RED} />
+                  </>
+                ) : (
+                  <NoBreachMessage />
+                )}
+              </BreachCard>
             </FlexRow>
-          </AfterInteractions>
-        </Paper>
-
-        <Animatable.View animation="fadeIn" duration={3000} useNativeDriver>
-          <FlexRow>
-            <BreachCard headerText={vaccineStrings.cumulative_breach}>
-              {coldCumulativeBreach ? (
-                <>
-                  <Text style={localStyles.coldText}>{coldCumulativeBreach}</Text>
-                  <ColdBreachIcon color={COLD_BREACH_BLUE} />
-                </>
-              ) : (
-                <NoBreachMessage />
-              )}
-            </BreachCard>
-
-            <BreachCard headerText={vaccineStrings.consecutive_breach}>
-              {numberOfColdBreaches ? (
-                <>
-                  <Text style={localStyles.coldText}>{numberOfColdBreaches}</Text>
-                  <ColdBreachIcon color={COLD_BREACH_BLUE} />
-                </>
-              ) : (
-                <NoBreachMessage />
-              )}
-            </BreachCard>
-
-            <BreachCard headerText={vaccineStrings.average_temperature}>
-              <Text style={[localStyles.hotText, { color: DARKER_GREY }]}>
-                {averageTemperature}
-              </Text>
-            </BreachCard>
-
-            <BreachCard headerText={vaccineStrings.cumulative_breach}>
-              {hotCumulativeBreach ? (
-                <>
-                  <Text style={localStyles.hotText}>{hotCumulativeBreach}</Text>
-                  <HotBreachIcon color={DANGER_RED} />
-                </>
-              ) : (
-                <NoBreachMessage />
-              )}
-            </BreachCard>
-
-            <BreachCard headerText={vaccineStrings.consecutive_breach}>
-              {numberOfHotBreaches ? (
-                <>
-                  <Text style={localStyles.hotText}>{numberOfHotBreaches}</Text>
-                  <HotBreachIcon color={DANGER_RED} />
-                </>
-              ) : (
-                <NoBreachMessage />
-              )}
-            </BreachCard>
-          </FlexRow>
-        </Animatable.View>
-      </View>
-    </AfterInteractions>
-  </DataTablePageView>
-);
+          </Animatable.View>
+        </View>
+      </AfterInteractions>
+    </DataTablePageView>
+  );
+};
 
 const stateToProps = (state, props) => {
   const { route } = props;
@@ -291,6 +329,12 @@ const localStyles = StyleSheet.create({
     color: DARKER_GREY,
     fontFamily: APP_FONT_FAMILY,
   },
+  buttonContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+  },
+  topRow: { flexDirection: 'row' },
 });
 
 export const FridgeDetailPage = connect(stateToProps, dispatchToProps)(FridgeDetailPageComponent);

--- a/src/pages/FridgeDetailPage.js
+++ b/src/pages/FridgeDetailPage.js
@@ -37,6 +37,7 @@ import {
   selectSelectFridgeCurrentTemperature,
   selectTemperatureLogsFromDate,
   selectTemperatureLogsToDate,
+  selectBreachBoundaries,
 } from '../selectors/fridge';
 
 import {
@@ -86,6 +87,7 @@ export const FridgeDetailPageComponent = ({
   isLowBattery,
   currentTemperature,
   sensor,
+  breachBoundaries,
 }) => (
   <DataTablePageView>
     <AfterInteractions>
@@ -113,6 +115,7 @@ export const FridgeDetailPageComponent = ({
                 maxLine={maxLine}
                 minDomain={minDomain}
                 maxDomain={maxDomain}
+                breachBoundaries={breachBoundaries}
               />
               <SensorStatus
                 isInHotBreach={isInHotBreach}
@@ -206,6 +209,7 @@ const stateToProps = (state, props) => {
   const isInColdBreach = selectSelectedFridgeIsInColdBreach(state);
   const isLowBattery = selectSelectedFridgeSensorIsLowBattery(state);
   const currentTemperature = selectSelectFridgeCurrentTemperature(state);
+  const breachBoundaries = selectBreachBoundaries(state);
 
   return {
     sensor,
@@ -229,6 +233,7 @@ const stateToProps = (state, props) => {
     isInColdBreach,
     isLowBattery,
     currentTemperature,
+    breachBoundaries,
   };
 };
 
@@ -237,7 +242,10 @@ const dispatchToProps = dispatch => ({
   onChangeFromDate: date => dispatch(FridgeActions.changeFromDate(date)),
 });
 
-FridgeDetailPageComponent.defaultProps = {};
+FridgeDetailPageComponent.defaultProps = {
+  hotCumulativeBreach: null,
+  coldCumulativeBreach: null,
+};
 
 FridgeDetailPageComponent.propTypes = {
   breaches: PropTypes.object.isRequired,
@@ -253,14 +261,15 @@ FridgeDetailPageComponent.propTypes = {
   maximumDate: PropTypes.instanceOf(Date).isRequired,
   numberOfHotBreaches: PropTypes.number.isRequired,
   numberOfColdBreaches: PropTypes.number.isRequired,
-  hotCumulativeBreach: PropTypes.string.isRequired,
-  coldCumulativeBreach: PropTypes.string.isRequired,
+  hotCumulativeBreach: PropTypes.string,
+  coldCumulativeBreach: PropTypes.string,
   averageTemperature: PropTypes.string.isRequired,
   isInHotBreach: PropTypes.bool.isRequired,
   isInColdBreach: PropTypes.bool.isRequired,
   isLowBattery: PropTypes.bool.isRequired,
   currentTemperature: PropTypes.number.isRequired,
   sensor: PropTypes.object.isRequired,
+  breachBoundaries: PropTypes.object.isRequired,
 };
 
 const localStyles = StyleSheet.create({

--- a/src/selectors/fridge.js
+++ b/src/selectors/fridge.js
@@ -223,21 +223,13 @@ export const selectColdCumulativeBreach = createSelector(
 );
 
 export const selectBreachBoundaries = createSelector([selectSelectedFridge], fridge => {
-  const {
-    coldCumulativeBreachConfig,
-    coldConsecutiveBreachConfig,
-    hotCumulativeBreachConfig,
-    hotConsecutiveBreachConfig,
-  } = fridge;
-
-  const { maximumTemperature: coldConsecutiveMaximumTemperature } = coldConsecutiveBreachConfig;
-  const { maximumTemperature: coldCumulativeMaximumTemperature } = coldCumulativeBreachConfig;
-  const { minimumTemperature: hotConsecutiveMinimumTemperature } = hotConsecutiveBreachConfig;
-  const { minimumTemperature: hotCumulativeMinimumTemperature } = hotCumulativeBreachConfig;
+  const { coldConsecutiveBreachConfig, hotConsecutiveBreachConfig } = fridge;
+  const { maximumTemperature } = coldConsecutiveBreachConfig;
+  const { minimumTemperature } = hotConsecutiveBreachConfig;
 
   return {
-    lower: Math.min(coldConsecutiveMaximumTemperature, coldCumulativeMaximumTemperature),
-    upper: Math.max(hotConsecutiveMinimumTemperature, hotCumulativeMinimumTemperature),
+    lower: minimumTemperature,
+    upper: maximumTemperature,
   };
 });
 

--- a/src/selectors/fridge.js
+++ b/src/selectors/fridge.js
@@ -222,6 +222,25 @@ export const selectColdCumulativeBreach = createSelector(
   }
 );
 
+export const selectBreachBoundaries = createSelector([selectSelectedFridge], fridge => {
+  const {
+    coldCumulativeBreachConfig,
+    coldConsecutiveBreachConfig,
+    hotCumulativeBreachConfig,
+    hotConsecutiveBreachConfig,
+  } = fridge;
+
+  const { maximumTemperature: coldConsecutiveMaximumTemperature } = coldConsecutiveBreachConfig;
+  const { maximumTemperature: coldCumulativeMaximumTemperature } = coldCumulativeBreachConfig;
+  const { minimumTemperature: hotConsecutiveMinimumTemperature } = hotConsecutiveBreachConfig;
+  const { minimumTemperature: hotCumulativeMinimumTemperature } = hotCumulativeBreachConfig;
+
+  return {
+    lower: Math.min(coldConsecutiveMaximumTemperature, coldCumulativeMaximumTemperature),
+    upper: Math.max(hotConsecutiveMinimumTemperature, hotCumulativeMinimumTemperature),
+  };
+});
+
 export const selectAverageTemperature = createSelector(
   [selectFridgeTemperatureLogsFromDate],
   logs => {

--- a/src/selectors/fridge.js
+++ b/src/selectors/fridge.js
@@ -228,8 +228,8 @@ export const selectBreachBoundaries = createSelector([selectSelectedFridge], fri
   const { minimumTemperature } = hotConsecutiveBreachConfig;
 
   return {
-    lower: minimumTemperature,
-    upper: maximumTemperature,
+    lower: maximumTemperature,
+    upper: minimumTemperature,
   };
 });
 

--- a/src/widgets/VaccineBarChart.js
+++ b/src/widgets/VaccineBarChart.js
@@ -1,13 +1,13 @@
 /* eslint-disable react/forbid-prop-types */
 /**
  * mSupply Mobile
- * Sustainable Solutions (NZ) Ltd. 2020
+ * Sustainable Solutions (NZ) Ltd. 2021
  */
 
 import React from 'react';
 import { Svg } from 'react-native-svg';
-import { VictoryAxis, VictoryChart, VictoryLine, VictoryScatter, VictoryBar } from 'victory-native';
 import moment from 'moment';
+import { VictoryAxis, VictoryChart, VictoryLine, VictoryBar } from 'victory-native';
 import PropTypes from 'prop-types';
 
 import { useLayoutDimensions } from '../hooks/useLayoutDimensions';
@@ -18,20 +18,16 @@ import {
   APP_FONT_FAMILY,
   GREY,
 } from '../globalStyles';
-import { HazardPoint } from './HazardPoint';
 import { FlexView } from './FlexView';
 import { CHART_CONSTANTS } from '../utilities/modules/vaccines';
 
-export const VaccineChart = ({
+export const VaccineBarChart = ({
   minLine,
   maxLine,
   minDomain,
   maxDomain,
-  x,
-  y,
   xTickFormat,
   yTickFormat,
-  breaches,
   onPressBreach,
   breachBoundaries,
 }) => {
@@ -121,6 +117,7 @@ export const VaccineChart = ({
             style={chartStyles.hotBars}
             barWidth={30}
             alignment="start"
+            onPress={onPressBreach}
           />
           <VictoryBar data={barData} style={chartStyles.midBars} barWidth={30} alignment="start" />
           <VictoryBar
@@ -131,31 +128,19 @@ export const VaccineChart = ({
             barWidth={30}
             alignment="start"
           />
-
-          <VictoryScatter
-            data={breaches.slice()}
-            y={y}
-            x={x}
-            dataComponent={<HazardPoint onPress={onPressBreach} />}
-          />
         </VictoryChart>
       </Svg>
     </FlexView>
   );
 };
 
-VaccineChart.defaultProps = {
-  x: 'timestamp',
-  y: 'temperature',
+VaccineBarChart.defaultProps = {
   xTickFormat: tick => moment(new Date(tick)).format('DD/MM'),
   yTickFormat: tick => `${tick}\u2103`,
   onPressBreach: null,
-  breaches: null,
 };
 
-VaccineChart.propTypes = {
-  x: PropTypes.string,
-  y: PropTypes.string,
+VaccineBarChart.propTypes = {
   minDomain: PropTypes.number.isRequired,
   maxDomain: PropTypes.number.isRequired,
   minLine: PropTypes.array.isRequired,
@@ -163,7 +148,6 @@ VaccineChart.propTypes = {
   xTickFormat: PropTypes.func,
   yTickFormat: PropTypes.func,
   onPressBreach: PropTypes.func,
-  breaches: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   breachBoundaries: PropTypes.object.isRequired,
 };
 

--- a/src/widgets/VaccineBarChart.js
+++ b/src/widgets/VaccineBarChart.js
@@ -17,6 +17,7 @@ import {
   SUSSOL_ORANGE,
   APP_FONT_FAMILY,
   GREY,
+  WARMER_GREY,
 } from '../globalStyles';
 import { FlexView } from './FlexView';
 import { CHART_CONSTANTS } from '../utilities/modules/vaccines';
@@ -99,13 +100,13 @@ export const VaccineBarChart = ({
           <VictoryAxis
             offsetX={CHART_CONSTANTS.AXIS_OFFSET}
             dependentAxis
-            style={chartStyles.axis}
+            style={chartStyles.axisY}
             tickFormat={yTickFormat}
           />
           <VictoryAxis
             offsetY={CHART_CONSTANTS.AXIS_OFFSET}
             tickFormat={xTickFormat}
-            style={chartStyles.axis}
+            style={chartStyles.axisX}
           />
 
           <VictoryLine data={upperBoundData} style={chartStyles.maxBoundaryLine} />
@@ -156,7 +157,13 @@ const chartStyles = {
   minBoundaryLine: { data: { stroke: COLD_BREACH_BLUE, opacity: 0.75 } },
   maxLine: { data: { stroke: SUSSOL_ORANGE } },
   minLine: { data: { stroke: COLD_BREACH_BLUE } },
-  axis: { fontSize: 15, fontFamily: APP_FONT_FAMILY, fill: GREY },
+  axisX: { fontSize: 15, fontFamily: APP_FONT_FAMILY, fill: GREY },
+  axisY: {
+    fontSize: 15,
+    fontFamily: APP_FONT_FAMILY,
+    fill: GREY,
+    grid: { stroke: WARMER_GREY, strokeWidth: 0.5 },
+  },
   coldBars: { data: { fill: COLD_BREACH_BLUE, opacity: 0.9 } },
   hotBars: { data: { fill: SUSSOL_ORANGE, opacity: 0.9 } },
   midBars: { data: { fill: WEARY_TARMAC, opacity: 0.9 } },

--- a/src/widgets/VaccineLineChart.js
+++ b/src/widgets/VaccineLineChart.js
@@ -1,0 +1,139 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2020
+ */
+
+import React from 'react';
+import { Svg } from 'react-native-svg';
+import { VictoryAxis, VictoryChart, VictoryLine, VictoryScatter } from 'victory-native';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+
+import { useLayoutDimensions } from '../hooks/useLayoutDimensions';
+import { WHITE, COLD_BREACH_BLUE, SUSSOL_ORANGE, APP_FONT_FAMILY, GREY } from '../globalStyles';
+import { HazardPoint } from './HazardPoint';
+import { FlexView } from './FlexView';
+import { CHART_CONSTANTS } from '../utilities/modules/vaccines';
+
+export const VaccineLineChart = ({
+  minLine,
+  maxLine,
+  minDomain,
+  maxDomain,
+  x,
+  y,
+  xTickFormat,
+  yTickFormat,
+  breaches,
+  onPressBreach,
+}) => {
+  const [width, height, setDimensions] = useLayoutDimensions();
+
+  const maxBoundary = React.useCallback(() => maxDomain, []);
+  const minBoundary = React.useCallback(() => minDomain, []);
+
+  const chartMinDomain = React.useMemo(() => ({ y: minDomain - CHART_CONSTANTS.DOMAIN_OFFSET }), [
+    minDomain,
+  ]);
+  const chartMaxDomain = React.useMemo(() => ({ y: maxDomain + CHART_CONSTANTS.DOMAIN_OFFSET }), [
+    maxDomain,
+  ]);
+
+  return (
+    <FlexView onLayout={setDimensions}>
+      <Svg>
+        <VictoryChart
+          width={width}
+          height={height}
+          minDomain={chartMinDomain}
+          maxDomain={chartMaxDomain}
+        >
+          <VictoryAxis
+            offsetX={CHART_CONSTANTS.AXIS_OFFSET}
+            dependentAxis
+            style={chartStyles.axis}
+            tickFormat={yTickFormat}
+          />
+          <VictoryAxis
+            offsetY={CHART_CONSTANTS.AXIS_OFFSET}
+            tickFormat={xTickFormat}
+            style={chartStyles.axis}
+          />
+
+          <VictoryLine
+            interpolation={CHART_CONSTANTS.INTERPOLATION}
+            data={minLine}
+            y={y}
+            x={x}
+            style={chartStyles.minLine}
+          />
+          <VictoryLine
+            interpolation={CHART_CONSTANTS.INTERPOLATION}
+            data={maxLine}
+            y={y}
+            x={x}
+            style={chartStyles.maxLine}
+          />
+          <VictoryLine data={maxLine} y={maxBoundary} x={x} style={chartStyles.maxBoundaryLine} />
+          <VictoryLine data={minLine} y={minBoundary} x={x} style={chartStyles.minBoundaryLine} />
+
+          <VictoryScatter data={maxLine} y={y} x={x} style={chartStyles.maxScatterPlot} />
+          <VictoryScatter data={minLine} y={y} x={x} style={chartStyles.minScatterPlot} />
+          <VictoryScatter
+            data={breaches.slice()}
+            y={y}
+            x={x}
+            dataComponent={<HazardPoint onPress={onPressBreach} />}
+          />
+        </VictoryChart>
+      </Svg>
+    </FlexView>
+  );
+};
+
+VaccineLineChart.defaultProps = {
+  x: 'timestamp',
+  y: 'temperature',
+  xTickFormat: tick => moment(new Date(tick)).format('DD/MM'),
+  yTickFormat: tick => `${tick}\u2103`,
+  onPressBreach: null,
+  breaches: null,
+};
+
+VaccineLineChart.propTypes = {
+  x: PropTypes.string,
+  y: PropTypes.string,
+  minDomain: PropTypes.number.isRequired,
+  maxDomain: PropTypes.number.isRequired,
+  minLine: PropTypes.array.isRequired,
+  maxLine: PropTypes.array.isRequired,
+  xTickFormat: PropTypes.func,
+  yTickFormat: PropTypes.func,
+  onPressBreach: PropTypes.func,
+  breaches: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+};
+
+const chartStyles = {
+  maxBoundaryLine: { data: { stroke: SUSSOL_ORANGE, opacity: 0.3 } },
+  minBoundaryLine: { data: { stroke: COLD_BREACH_BLUE, opacity: 0.3 } },
+  minScatterPlot: {
+    data: {
+      fill: WHITE,
+      stroke: COLD_BREACH_BLUE,
+      strokeWidth: CHART_CONSTANTS.STROKE_WIDTH,
+      size: CHART_CONSTANTS.STROKE_SIZE,
+    },
+  },
+  maxScatterPlot: {
+    data: {
+      fill: WHITE,
+      stroke: SUSSOL_ORANGE,
+      strokeWidth: CHART_CONSTANTS.STROKE_WIDTH,
+      size: CHART_CONSTANTS.STROKE_SIZE,
+    },
+  },
+  maxLine: { data: { stroke: SUSSOL_ORANGE } },
+  minLine: { data: { stroke: COLD_BREACH_BLUE } },
+  axis: { fontSize: 15, fontFamily: APP_FONT_FAMILY, fill: GREY },
+};

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -328,3 +328,23 @@ AlarmClockIcon.propTypes = {
   style: PropTypes.object,
   color: PropTypes.string,
 };
+
+export const BarChartIcon = ({ size, style, color }) => (
+  <FAIcon size={size} style={style} color={color} name="bar-chart" />
+);
+BarChartIcon.defaultProps = { size: 20, style: {}, color: DARKER_GREY };
+BarChartIcon.propTypes = {
+  size: PropTypes.number,
+  style: PropTypes.object,
+  color: PropTypes.string,
+};
+
+export const LineChartIcon = ({ size, style, color }) => (
+  <FAIcon size={size} style={style} color={color} name="line-chart" />
+);
+LineChartIcon.defaultProps = { size: 20, style: {}, color: DARKER_GREY };
+LineChartIcon.propTypes = {
+  size: PropTypes.number,
+  style: PropTypes.object,
+  color: PropTypes.string,
+};


### PR DESCRIPTION
Fixes #3464 

## Change summary

Have added three bars to display the hot-mid-cold colour bars.
To do so, I've added a selector to grab the upper and lower breach values - it was unclear what, from the mockup, should be used out of the consecutive and cumulative options. ideas?

This version replaces the current line chart - should we have both options available?

This is how it looks with the generated data:

<img width="1219" alt="Screen Shot 2021-02-05 at 1 13 31 PM" src="https://user-images.githubusercontent.com/9192912/106971875-a4b48400-67b4-11eb-807d-b56a86c9d582.png">


## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] View fridge detail
- [ ] adjust the breach thresholds and check the chart again

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
