### PR TITLE
update location name when saving

### DIFF
--- a/src/actions/Bluetooth/SensorUpdateActions.js
+++ b/src/actions/Bluetooth/SensorUpdateActions.js
@@ -92,7 +92,14 @@ const startSetLogInterval = ({ macAddress, interval = 300 }) => async (dispatch,
   return result;
 };
 
+const isValidMacAddress = macAddress => /^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$/.test(macAddress);
+
 const updateSensor = sensor => async dispatch => {
+  if (!isValidMacAddress(sensor.macAddress)) {
+    // prevent errors if the sensor is not able to be contacted
+    return;
+  }
+
   await dispatch(SensorUpdateActions.startSetLogInterval(sensor));
   await dispatch(SensorUpdateActions.startSensorDisableButton(sensor.macAddress));
 };

--- a/src/actions/Entities/SensorActions.js
+++ b/src/actions/Entities/SensorActions.js
@@ -67,6 +67,8 @@ const save = () => (dispatch, getState) => {
   let updatedLocation;
   let updatedSensor;
   const updatedConfigs = [];
+
+  location.description = sensor.name;
   UIDatabase.write(() => {
     updatedLocation = UIDatabase.update('Location', location);
     updatedSensor = UIDatabase.update('Sensor', sensor);
@@ -91,6 +93,8 @@ const createNew = () => (dispatch, getState) => {
   let newLocation;
   let newConfigs;
   let newSensor;
+
+  location.description = sensor.name;
   UIDatabase.write(() => {
     newLocation = createRecord(UIDatabase, 'Location', location);
     newSensor = createRecord(UIDatabase, 'Sensor', { ...sensor, location });


### PR DESCRIPTION
Fixes #3427 

## Change summary

Updating `location.description` from `sensor.name` when saving sensors
Bonus task - when saving a sensor, skip trying to disable the button and set the log interval if the sensor has an invalid mac address, otherwise you cannot test this change when using an actual tablet and the generated dummy data.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Save a sensor. Check realm explorer to validate that the description and name are the same

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
