### PR TITLE
#3374 dont download before log delay

### DIFF
--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -75,38 +75,43 @@ const downloadLogsFromSensor = sensor => async dispatch => {
   dispatch(sensorDownloadStart(sensor));
 
   try {
-    const { macAddress, logInterval } = sensor;
+    const { macAddress, logInterval, logDelay } = sensor;
 
-    const downloadedLogsResult =
-      (await BleService().downloadLogsWithRetries(
-        macAddress,
-        VACCINE_CONSTANTS.MAX_BLUETOOTH_COMMAND_ATTEMPTS
-      )) ?? {};
+    const timeNow = moment();
 
-    if (downloadedLogsResult) {
-      const savedTemperatureLogs = UIDatabase.objects(VACCINE_ENTITIES.TEMPERATURE_LOG)
-        .filtered('sensor.macAddress == $0', macAddress)
-        .sorted('timestamp', true);
+    if (timeNow.isAfter(moment(logDelay))) {
+      const downloadedLogsResult =
+        (await BleService().downloadLogsWithRetries(
+          macAddress,
+          VACCINE_CONSTANTS.MAX_BLUETOOTH_COMMAND_ATTEMPTS
+        )) ?? {};
 
-      const [mostRecentLog] = savedTemperatureLogs;
-      const mostRecentLogTime = mostRecentLog ? mostRecentLog.timestamp : null;
-      const nextPossibleLogTime = mostRecentLogTime
-        ? moment(mostRecentLogTime).add(logInterval, 's')
-        : 0;
+      if (downloadedLogsResult) {
+        const savedTemperatureLogs = UIDatabase.objects(VACCINE_ENTITIES.TEMPERATURE_LOG)
+          .filtered('sensor.macAddress == $0', macAddress)
+          .sorted('timestamp', true);
 
-      const numberOfLogsToSave = await TemperatureLogManager().calculateNumberOfLogsToSave(
-        logInterval,
-        nextPossibleLogTime
-      );
+        const [mostRecentLog] = savedTemperatureLogs;
+        const mostRecentLogTime = mostRecentLog ? mostRecentLog.timestamp : null;
+        const nextPossibleLogTime = mostRecentLogTime
+          ? moment(mostRecentLogTime).add(logInterval, 's')
+          : 0;
 
-      const temperatureLogs = await TemperatureLogManager().createLogs(
-        downloadedLogsResult,
-        sensor,
-        numberOfLogsToSave,
-        mostRecentLogTime
-      );
+        const numberOfLogsToSave = await TemperatureLogManager().calculateNumberOfLogsToSave(
+          logInterval,
+          nextPossibleLogTime
+        );
 
-      await TemperatureLogManager().saveLogs(temperatureLogs);
+        const temperatureLogs = await TemperatureLogManager().createLogs(
+          downloadedLogsResult,
+          sensor,
+          numberOfLogsToSave,
+          mostRecentLogTime
+        );
+
+        await TemperatureLogManager().saveLogs(temperatureLogs);
+      }
+
       dispatch(sensorDownloadSuccess(sensor));
     }
   } catch (error) {

--- a/src/actions/Entities/SensorActions.js
+++ b/src/actions/Entities/SensorActions.js
@@ -37,7 +37,13 @@ const update = (id, field, value) => ({
 });
 
 const create = macAddress => async dispatch => {
-  const defaultSensor = { location: {}, logInterval: 300, macAddress, name: '' };
+  const defaultSensor = {
+    location: {},
+    logInterval: 300,
+    logDelay: new Date().getTime(),
+    macAddress,
+    name: '',
+  };
   const payload = await SensorManager().createSensor(defaultSensor);
   dispatch({ type: SENSOR_ACTIONS.CREATE, payload });
 };
@@ -93,7 +99,11 @@ const createNew = () => (dispatch, getState) => {
   let newSensor;
   UIDatabase.write(() => {
     newLocation = createRecord(UIDatabase, 'Location', location);
-    newSensor = createRecord(UIDatabase, 'Sensor', { ...sensor, location });
+    newSensor = createRecord(UIDatabase, 'Sensor', {
+      ...sensor,
+      location,
+      logDelay: new Date(sensor?.logDelay ?? 0),
+    });
     newConfigs = configs.map(config =>
       createRecord(UIDatabase, 'TemperatureBreachConfiguration', { ...config, location })
     );

--- a/src/database/DataTypes/Sensor.js
+++ b/src/database/DataTypes/Sensor.js
@@ -107,6 +107,8 @@ Sensor.schema = {
     breaches: { type: 'linkingObjects', objectType: 'TemperatureBreach', property: 'sensor' },
     isActive: { type: 'bool', default: true },
     logInterval: { type: 'int', default: 300 },
+    logDelay: { type: 'date', default: new Date(0) },
+    programmedDate: { type: 'date', default: new Date() },
   },
 };
 

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -1,5 +1,6 @@
 {
   "gb": {
+    "logging_delayed_until": "Logging delayed until",
     "hot_consecutive_breach": "Hot consecutive breach",
     "cold_consecutive_breach": "Cold consecutive breach",
     "cold_cumulative_breach": "Cold cumulative breach",

--- a/src/pages/NewSensor/NewSensorStepThree.js
+++ b/src/pages/NewSensor/NewSensorStepThree.js
@@ -39,7 +39,7 @@ export const NewSensorStepThreeComponent = ({
   connectToSensor,
   updateCode,
   updateLogInterval,
-  updateLoggingDelay,
+  updateLogDelay,
   exit,
   previousTab,
   macAddress,
@@ -73,8 +73,8 @@ export const NewSensorStepThreeComponent = ({
           label={vaccineStrings.start_logging}
           Icon={<CalendarIcon color={DARKER_GREY} />}
         >
-          <DateEditor onPress={updateLoggingDelay} date={loggingDelay} />
-          <TimeEditor onPress={updateLoggingDelay} time={loggingDelay} />
+          <DateEditor onPress={updateLogDelay} date={loggingDelay} />
+          <TimeEditor onPress={updateLogDelay} time={loggingDelay} />
         </EditorRow>
       </Paper>
 
@@ -107,8 +107,8 @@ export const NewSensorStepThreeComponent = ({
 const dispatchToProps = dispatch => {
   const updateName = value => dispatch(SensorActions.updateNewSensor(value, 'name'));
   const updateCode = value => dispatch(LocationActions.updateNew(value, 'code'));
-  const updateLoggingDelay = value =>
-    dispatch(SensorActions.updateNewSensor(value, 'loggingDelay'));
+  const updateLogDelay = value =>
+    dispatch(SensorActions.updateNewSensor(new Date(value).getTime(), 'logDelay'));
   const updateLogInterval = value => dispatch(SensorActions.updateNewSensor(value, 'logInterval'));
   const previousTab = () => dispatch(WizardActions.previousTab());
   const exit = () => dispatch(goBack());
@@ -129,7 +129,7 @@ const dispatchToProps = dispatch => {
     exit,
     updateName,
     updateCode,
-    updateLoggingDelay,
+    updateLogDelay,
     updateLogInterval,
   };
 };
@@ -144,10 +144,10 @@ const stateToProps = state => {
   const newSensor = selectNewSensor(state);
   const location = selectNewLocation(state);
 
-  const { logInterval, loggingDelay, name, macAddress } = newSensor ?? {};
+  const { logInterval, logDelay, name, macAddress } = newSensor ?? {};
   const { code } = location ?? {};
 
-  return { logInterval, loggingDelay, name, code, macAddress };
+  return { logInterval, logDelay: new Date(logDelay), name, code, macAddress };
 };
 
 NewSensorStepThreeComponent.defaultProps = {
@@ -166,7 +166,7 @@ NewSensorStepThreeComponent.propTypes = {
   macAddress: PropTypes.string,
   updateName: PropTypes.func.isRequired,
   updateCode: PropTypes.func.isRequired,
-  updateLoggingDelay: PropTypes.func.isRequired,
+  updateLogDelay: PropTypes.func.isRequired,
   updateLogInterval: PropTypes.func.isRequired,
   exit: PropTypes.func.isRequired,
   previousTab: PropTypes.func.isRequired,

--- a/src/reducers/Entities/SensorReducer.js
+++ b/src/reducers/Entities/SensorReducer.js
@@ -14,6 +14,7 @@ const getPlainSensor = sensor => ({
   breachConfigIDs: sensor?.breachConfigs?.map(({ id }) => id),
   isActive: sensor.isActive,
   logInterval: sensor.logInterval,
+  logDelay: new Date(sensor.logDelay).getTime(),
   currentTemperature: sensor?.currentTemperature ?? null,
   mostRecentBreachTime: sensor?.mostRecentBreachTime
     ? new Date(sensor?.mostRecentBreachTime).getTime()

--- a/src/selectors/Entities/sensor.js
+++ b/src/selectors/Entities/sensor.js
@@ -37,12 +37,3 @@ export const selectSensors = state => {
   const sensorsById = selectSensorsById(state);
   return Object.values(sensorsById);
 };
-
-export const selectSensorIsDelayed = (state, mac) => {
-  const sensor = selectSensorByMac(state, mac);
-  const { logDelay } = sensor;
-  const timeNow = new Date().getTime();
-  const isDelayed = logDelay > timeNow;
-
-  return isDelayed;
-};

--- a/src/selectors/Entities/sensor.js
+++ b/src/selectors/Entities/sensor.js
@@ -8,6 +8,12 @@ export const selectSensorsById = state => {
   return byId;
 };
 
+export const selectSensorByMac = (state, mac) => {
+  const sensorsById = selectSensorsById(state);
+  const foundSensor = Object.values(sensorsById).find(({ macAddress }) => macAddress === mac);
+  return foundSensor;
+};
+
 export const selectNewSensor = state => {
   const sensorState = selectSensorState(state);
   const { newId, byId } = sensorState;
@@ -30,4 +36,13 @@ export const selectNewSensorId = state => {
 export const selectSensors = state => {
   const sensorsById = selectSensorsById(state);
   return Object.values(sensorsById);
+};
+
+export const selectSensorIsDelayed = (state, mac) => {
+  const sensor = selectSensorByMac(state, mac);
+  const { logDelay } = sensor;
+  const timeNow = new Date().getTime();
+  const isDelayed = logDelay > timeNow;
+
+  return isDelayed;
 };

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -1075,6 +1075,8 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         batteryLevel: parseNumber(record.batteryLevel),
         name: record.name,
         isActive: parseBoolean(record.is_active),
+        logDelay: parseDate(record.log_delay_date, record.log_delay_time),
+        programmedDate: parseDate(record.programmed_date, record.programmed_time),
       });
       break;
     }

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -388,6 +388,10 @@ const generateSyncData = (settings, recordType, record) => {
         storeID: settings.get(THIS_STORE_ID),
         locationID: record.location?.id,
         is_active: String(record.isActive ?? true),
+        log_delay_time: getTimeString(record.logDelay),
+        log_delay_date: getDateString(record.logDelay),
+        programmed_time: getTimeString(record.programmedDate),
+        programmed_date: getDateString(record.programmedDate),
       };
     }
     case 'Location': {

--- a/src/widgets/LastSensorDownload.js
+++ b/src/widgets/LastSensorDownload.js
@@ -16,7 +16,7 @@ import {
   selectLastDownloadTime,
 } from '../selectors/Bluetooth/sensorDownload';
 import { vaccineStrings, generalStrings } from '../localization';
-import { selectSensorByMac, selectSensorIsDelayed } from '../selectors/Entities/sensor';
+import { selectSensorByMac } from '../selectors/Entities/sensor';
 
 const formatLastSyncDate = date => (date ? moment(date).fromNow() : generalStrings.not_available);
 const formatLogDelay = delay =>
@@ -26,10 +26,12 @@ export const LastSensorDownloadComponent = ({
   isDownloading,
   lastDownloadFailed,
   lastDownloadTime,
-  isDelayed,
   logDelay,
 }) => {
   useIntervalReRender(MILLISECONDS.TEN_SECONDS);
+
+  const timeNow = new Date().getTime();
+  const isDelayed = logDelay > timeNow;
 
   const wifiRef = useRef();
 
@@ -73,7 +75,6 @@ LastSensorDownloadComponent.propTypes = {
   isDownloading: PropTypes.bool.isRequired,
   lastDownloadFailed: PropTypes.bool.isRequired,
   lastDownloadTime: PropTypes.instanceOf(Date),
-  isDelayed: PropTypes.bool.isRequired,
   logDelay: PropTypes.number,
 };
 
@@ -92,12 +93,11 @@ const stateToProps = (state, props) => {
   const lastDownloadTime = selectLastDownloadTime(state, macAddress);
   const lastDownloadFailed = selectLastDownloadFailed(state, macAddress);
   const isDownloading = selectIsDownloading(state, macAddress);
-  const isDelayed = selectSensorIsDelayed(state, macAddress);
 
   const sensor = selectSensorByMac(state, macAddress);
   const { logDelay } = sensor;
 
-  return { lastDownloadTime, lastDownloadFailed, isDownloading, isDelayed, logDelay };
+  return { lastDownloadTime, lastDownloadFailed, isDownloading, logDelay };
 };
 
 export const LastSensorDownload = connect(stateToProps)(LastSensorDownloadComponent);


### PR DESCRIPTION
Fixes #3374 

## Change summary

- Adds logDelay to schema
- Adds programmedDate to schema - Offroad
- Adds setting the log delay 'better' in `SensorActions`/`SensorReducer`.
- prevents download logs for the sensor when the logging delay is greater than the time now.

## Testing

- [ ] Create a new sensor with a logging delay, logs aren't downloaded till after it
- [ ] Can see the logging delay in the UI

### Related areas to think about

- Not sure if this will display nicely on all screens
![image](https://user-images.githubusercontent.com/35858975/107307351-6c31e480-6aeb-11eb-8921-81f8f6af6739.png)
- Probably need to allow for users to change the logging delay after its been set... we are adding a remove button also, so maybe just make them remove it .. i dunno