### PR TITLE
add defaults for new dates

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -1075,8 +1075,8 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         batteryLevel: parseNumber(record.batteryLevel),
         name: record.name,
         isActive: parseBoolean(record.is_active),
-        logDelay: parseDate(record.log_delay_date, record.log_delay_time),
-        programmedDate: parseDate(record.programmed_date, record.programmed_time),
+        logDelay: parseDate(record.log_delay_date, record.log_delay_time) ?? new Date(0),
+        programmedDate: parseDate(record.programmed_date, record.programmed_time) ?? new Date(),
       });
       break;
     }


### PR DESCRIPTION
Fixes #3480

## Change summary

Added a default for the two new dates when sync is incoming.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Clear app data and sync with an existing store

