### PR TITLE
#3273 Remove/Replace functionality

### DIFF
--- a/src/actions/Bluetooth/SensorScanActions.js
+++ b/src/actions/Bluetooth/SensorScanActions.js
@@ -25,7 +25,7 @@ const isNewlyFoundSensor = (macAddress, alreadyScannedMacAddresses) => {
   const isActive = alreadySaved?.isActive;
   const isAlreadySavedAndActive = alreadySaved && isActive;
 
-  // A newly found sensor are sensors which are not active in the database, and not found already
+  // Newly found sensor are sensors which are not active in the database, and not found already
   return !alreadyFound && !isAlreadySavedAndActive;
 };
 

--- a/src/actions/Bluetooth/SensorScanActions.js
+++ b/src/actions/Bluetooth/SensorScanActions.js
@@ -20,11 +20,8 @@ const scanStop = () => ({ type: SCAN_ACTIONS.SCAN_STOP });
 const sensorFound = macAddress => ({ type: SCAN_ACTIONS.SENSOR_FOUND, payload: { macAddress } });
 
 const isNewlyFoundSensor = (macAddress, alreadyScannedMacAddresses) => {
-  // The sensors has already been picked up in the current scan.
   const alreadyFound = alreadyScannedMacAddresses?.includes(macAddress);
-  // The sensor is already in the database
   const alreadySaved = UIDatabase.get('Sensor', macAddress, 'macAddress');
-  // The sensor is an active sensor in the database
   const isActive = alreadySaved?.isActive;
   const isAlreadySavedAndActive = alreadySaved && isActive;
 

--- a/src/actions/Entities/SensorActions.js
+++ b/src/actions/Entities/SensorActions.js
@@ -20,6 +20,7 @@ import { TemperatureBreachConfigActions } from './TemperatureBreachConfigActions
 export const SENSOR_ACTIONS = {
   CREATE: 'SENSOR/create',
   UPDATE: 'SENSOR/update',
+  REMOVE: 'SENSOR/remove',
   RESET: 'SENSOR/reset',
   SAVE_NEW: 'SENSOR/saveNew',
   SAVE_EDITING: 'SENSOR/saveEditing',
@@ -111,6 +112,24 @@ const replace = macAddress => ({
   payload: { macAddress, id: generateUUID() },
 });
 
+const remove = id => ({
+  type: SENSOR_ACTIONS.REMOVE,
+  payload: { id },
+});
+
+const removeSensor = sensorId => dispatch => {
+  const sensor = UIDatabase.get('Sensor', sensorId);
+
+  UIDatabase.write(() => {
+    UIDatabase.update('Sensor', {
+      id: sensor.id,
+      isActive: false,
+    });
+  });
+
+  dispatch(remove());
+};
+
 const createNew = () => (dispatch, getState) => {
   const fullState = getState();
   const location = selectNewLocation(fullState);
@@ -152,4 +171,5 @@ export const SensorActions = {
   save,
   saveEditing,
   replace,
+  removeSensor,
 };

--- a/src/hooks/useConditionalAnimationRef.js
+++ b/src/hooks/useConditionalAnimationRef.js
@@ -3,7 +3,7 @@ import { useRef, useEffect } from 'react';
 // Most animations are considered 'interactions' - if there is no break
 // in the interaction, then InteractionManager.runAfterInteractions() is
 // never fired.
-const DURATION_OFFSET = 50;
+const DURATION_OFFSET = 100;
 
 /**
  * Hook used to return a ref which should be applied to an animatable view created by

--- a/src/hooks/useConditionalAnimationRef.js
+++ b/src/hooks/useConditionalAnimationRef.js
@@ -1,9 +1,5 @@
 import { useRef, useEffect } from 'react';
-
-// Most animations are considered 'interactions' - if there is no break
-// in the interaction, then InteractionManager.runAfterInteractions() is
-// never fired.
-const DURATION_OFFSET = 100;
+import { MILLISECONDS } from '../utilities';
 
 /**
  * Hook used to return a ref which should be applied to an animatable view created by
@@ -13,19 +9,18 @@ const DURATION_OFFSET = 100;
  * @param {string} animation the animation type see: react-native-animatable.
  * @param {number} duration the number of milliseconds per animation.
  */
-export const useConditionalAnimationRef = (condition, animation = 'flash', duration = 1000) => {
+export const useConditionalAnimationRef = (
+  condition,
+  animation = 'flash',
+  duration = MILLISECONDS.ONE_SECOND
+) => {
   const ref = useRef();
-  const interval = useRef();
 
   const start = () => {
-    interval.current = setInterval(
-      () => ref?.current[animation](duration),
-      duration + DURATION_OFFSET
-    );
+    ref?.current[animation](duration);
   };
 
   const stop = () => {
-    clearInterval(interval.current);
     ref?.current?.stopAnimation();
   };
 

--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -1,5 +1,8 @@
 {
   "gb": {
+    "remove": "Remove",
+    "replace": "Replace",
+    "select": "Select",
     "no": "No",
     "yes": "Yes",
     "ongoing": "ongoing",

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -1,5 +1,6 @@
 {
   "gb": {
+    "are_you_sure_delete_sensor": "Are you sure you want to delete this sensor?",
     "add_at_least_one_item_before_finalising": "You need to add at least one item before finalising",
     "and": "and",
     "cancel": "Cancel",

--- a/src/localization/navStrings.json
+++ b/src/localization/navStrings.json
@@ -1,5 +1,6 @@
 {
   "gb": {
+    "go_back": "Go back",
     "new_sensor": "New Sensor",
     "edit_sensor": "Edit Sensor",
     "cash_register": "Cash Register",

--- a/src/pages/NewSensor/ScanRow.js
+++ b/src/pages/NewSensor/ScanRow.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { ActivityIndicator } from 'react-native';
 import { connect } from 'react-redux';
-import { useNavigation } from '@react-navigation/native';
 import PropTypes from 'prop-types';
 import * as Animatable from 'react-native-animatable';
 
@@ -11,8 +10,6 @@ import { TextWithIcon } from '../../widgets/Typography';
 import { vaccineStrings } from '../../localization';
 import { WithFixedDimensions } from '../../widgets/WithFixedDimensions';
 import { Spacer } from '../../widgets/Spacer';
-
-import { SensorActions, WizardActions } from '../../actions';
 import { SensorBlinkActions } from '../../actions/Bluetooth/SensorBlinkActions';
 import { selectSendingBlinkTo } from '../../selectors/Bluetooth/sensorBlink';
 
@@ -41,48 +38,44 @@ RectangleButton.propTypes = {
   isSpinning: PropTypes.bool.isRequired,
 };
 
-export const ScanRowComponent = ({ macAddress, blink, isBlinking, isDisabled, selectSensor }) => {
-  const navigation = useNavigation();
-  return (
-    <Animatable.View animation="fadeIn" duration={1000} useNativeDriver>
-      <WithFixedDimensions height={60}>
-        <FlexRow flex={0} alignItems="center" justifyContent="flex-end">
-          <RectangleButton
-            isSpinning={isBlinking}
-            isDisabled={isDisabled}
-            onPress={() => blink(macAddress)}
-          />
-          <Spacer space={20} />
-          <TextWithIcon left size="ms" Icon={<WifiIcon />}>
-            {macAddress}
-          </TextWithIcon>
+export const ScanRowComponent = ({
+  macAddress,
+  blink,
+  isBlinking,
+  isDisabled,
+  selectSensor,
+  text,
+}) => (
+  <Animatable.View animation="fadeIn" duration={1000} useNativeDriver>
+    <WithFixedDimensions height={60}>
+      <FlexRow flex={0} alignItems="center" justifyContent="flex-end">
+        <RectangleButton
+          isSpinning={isBlinking}
+          isDisabled={isDisabled}
+          onPress={() => blink(macAddress)}
+        />
+        <Spacer space={20} />
+        <TextWithIcon left size="ms" Icon={<WifiIcon />}>
+          {macAddress}
+        </TextWithIcon>
 
-          <IconButton
-            onPress={() => {
-              // Navigating to the next tab whose name is '1'
-              navigation.navigate('1');
-              selectSensor(macAddress);
-            }}
-            right
-            labelStyle={localStyles.connectText}
-            label={vaccineStrings.connect}
-            size="ms"
-            Icon={<ChevronRightIcon color={DARKER_GREY} />}
-          />
-        </FlexRow>
-      </WithFixedDimensions>
-    </Animatable.View>
-  );
-};
+        <IconButton
+          onPress={() => selectSensor(macAddress)}
+          right
+          labelStyle={localStyles.connectText}
+          label={text}
+          size="ms"
+          Icon={<ChevronRightIcon color={DARKER_GREY} />}
+        />
+      </FlexRow>
+    </WithFixedDimensions>
+  </Animatable.View>
+);
 
 const dispatchToProps = dispatch => {
   const blink = macAddress => dispatch(SensorBlinkActions.startSensorBlink(macAddress));
-  const selectSensor = macAddress => {
-    dispatch(SensorActions.createFromScanner(macAddress));
-    dispatch(WizardActions.nextTab());
-  };
 
-  return { blink, selectSensor };
+  return { blink };
 };
 
 const stateToProps = (state, ownProps) => {
@@ -111,10 +104,15 @@ const localStyles = {
   },
 };
 
+ScanRowComponent.defaultProps = {
+  text: vaccineStrings.connect,
+};
+
 ScanRowComponent.propTypes = {
   selectSensor: PropTypes.func.isRequired,
   isBlinking: PropTypes.bool.isRequired,
   isDisabled: PropTypes.bool.isRequired,
   macAddress: PropTypes.string.isRequired,
   blink: PropTypes.func.isRequired,
+  text: PropTypes.string,
 };

--- a/src/pages/SensorEditPage.js
+++ b/src/pages/SensorEditPage.js
@@ -2,7 +2,7 @@
 /* eslint-disable react/forbid-prop-types */
 /* eslint-disable react/jsx-wrap-multilines */
 import React from 'react';
-import { StyleSheet, ToastAndroid } from 'react-native';
+import { StyleSheet, ToastAndroid, View } from 'react-native';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -38,6 +38,9 @@ import { selectEditingLocation } from '../selectors/Entities/location';
 import { goBack } from '../navigation/actions';
 import { SensorHeader } from '../widgets/SensorHeader/SensorHeader';
 import { MILLISECONDS } from '../utilities/index';
+import { useToggle } from '../hooks/index';
+import { PaperModalContainer } from '../widgets/PaperModal/PaperModalContainer';
+import { SensorPicker } from '../widgets/SensorPicker';
 
 export const SensorEditPageComponent = ({
   logInterval,
@@ -59,90 +62,114 @@ export const SensorEditPageComponent = ({
   coldConsecutiveThreshold,
   hotCumulativeThreshold,
   sensor,
+  replaceSensor,
 }) => {
   const withLoadingIndicator = useLoadingIndicator();
+  const [open, toggleOpen] = useToggle();
+
   return (
-    <DataTablePageView style={{ paddingHorizontal: 20, paddingVertical: 30 }}>
-      <AfterInteractions>
-        <Paper Header={<SensorHeader sensor={sensor} />}>
-          <EditorRow
-            label={vaccineStrings.sensor_name}
-            Icon={<InfoIcon color={DARKER_GREY} />}
-            containerStyle={localStyles.paperContentRow}
-          >
-            <TextEditor size="large" value={name} onChangeText={updateName} />
-            <TextEditor label={vaccineStrings.sensor_code} value={code} onChangeText={updateCode} />
-          </EditorRow>
-        </Paper>
-
-        <Paper>
-          <BreachConfigRow
-            threshold={hotConsecutiveThreshold}
-            containerStyle={localStyles.paperContentRow}
-            type="HOT_CONSECUTIVE"
-            {...hotConsecutiveConfig}
-            updateDuration={(_, value) => updateDuration(hotConsecutiveConfig.id, value)}
-            updateTemperature={(type, value) =>
-              updateTemperature(type, hotConsecutiveConfig.id, value)
-            }
-          />
-          <BreachConfigRow
-            threshold={coldConsecutiveThreshold}
-            containerStyle={localStyles.paperContentRow}
-            type="COLD_CONSECUTIVE"
-            {...coldConsecutiveConfig}
-            updateDuration={(_, value) => updateDuration(coldConsecutiveConfig.id, value)}
-            updateTemperature={(type, value) =>
-              updateTemperature(type, coldConsecutiveConfig.id, value)
-            }
-          />
-          <BreachConfigRow
-            threshold={hotCumulativeThreshold}
-            containerStyle={localStyles.paperContentRow}
-            type="HOT_CUMULATIVE"
-            {...hotCumulativeConfig}
-            updateDuration={(_, value) => updateDuration(hotCumulativeConfig.id, value)}
-            updateTemperature={(type, value) =>
-              updateTemperature(type, hotCumulativeConfig.id, value)
-            }
-          />
-          <BreachConfigRow
-            threshold={coldCumulativeThreshold}
-            containerStyle={localStyles.paperContentRow}
-            type="COLD_CUMULATIVE"
-            {...coldCumulativeConfig}
-            updateDuration={(_, value) => updateDuration(coldCumulativeConfig.id, value)}
-            updateTemperature={(type, value) =>
-              updateTemperature(type, coldCumulativeConfig.id, value)
-            }
-          />
-        </Paper>
-
-        <Paper>
-          <FlexRow justifyContent="flex-end">
-            <DurationEditor
+    <>
+      <DataTablePageView style={{ paddingHorizontal: 20, paddingVertical: 30 }}>
+        <AfterInteractions>
+          <Paper Header={<SensorHeader sensor={sensor} />}>
+            <EditorRow
+              label={vaccineStrings.sensor_name}
+              Icon={<InfoIcon color={DARKER_GREY} />}
               containerStyle={localStyles.paperContentRow}
-              value={logInterval}
-              onChange={updateLogInterval}
-              label={vaccineStrings.logging_interval}
+            >
+              <TextEditor size="large" value={name} onChangeText={updateName} />
+              <TextEditor
+                label={vaccineStrings.sensor_code}
+                value={code}
+                onChangeText={updateCode}
+              />
+            </EditorRow>
+          </Paper>
+
+          <Paper>
+            <BreachConfigRow
+              threshold={hotConsecutiveThreshold}
+              containerStyle={localStyles.paperContentRow}
+              type="HOT_CONSECUTIVE"
+              {...hotConsecutiveConfig}
+              updateDuration={(_, value) => updateDuration(hotConsecutiveConfig.id, value)}
+              updateTemperature={(type, value) =>
+                updateTemperature(type, hotConsecutiveConfig.id, value)
+              }
+            />
+            <BreachConfigRow
+              threshold={coldConsecutiveThreshold}
+              containerStyle={localStyles.paperContentRow}
+              type="COLD_CONSECUTIVE"
+              {...coldConsecutiveConfig}
+              updateDuration={(_, value) => updateDuration(coldConsecutiveConfig.id, value)}
+              updateTemperature={(type, value) =>
+                updateTemperature(type, coldConsecutiveConfig.id, value)
+              }
+            />
+            <BreachConfigRow
+              threshold={hotCumulativeThreshold}
+              containerStyle={localStyles.paperContentRow}
+              type="HOT_CUMULATIVE"
+              {...hotCumulativeConfig}
+              updateDuration={(_, value) => updateDuration(hotCumulativeConfig.id, value)}
+              updateTemperature={(type, value) =>
+                updateTemperature(type, hotCumulativeConfig.id, value)
+              }
+            />
+            <BreachConfigRow
+              threshold={coldCumulativeThreshold}
+              containerStyle={localStyles.paperContentRow}
+              type="COLD_CUMULATIVE"
+              {...coldCumulativeConfig}
+              updateDuration={(_, value) => updateDuration(coldCumulativeConfig.id, value)}
+              updateTemperature={(type, value) =>
+                updateTemperature(type, coldCumulativeConfig.id, value)
+              }
+            />
+          </Paper>
+
+          <Paper>
+            <FlexRow justifyContent="flex-end" alignItems="center">
+              <PageButton text={generalStrings.remove} onPress={toggleOpen} />
+              <View style={{ marginLeft: 10, marginRight: 'auto' }}>
+                <PageButton text={generalStrings.replace} onPress={toggleOpen} />
+              </View>
+              <DurationEditor
+                containerStyle={localStyles.paperContentRow}
+                value={logInterval}
+                onChange={updateLogInterval}
+                label={vaccineStrings.logging_interval}
+              />
+            </FlexRow>
+          </Paper>
+
+          <FlexRow flex={1} alignItems="flex-end">
+            <TextWithIcon left Icon={<HazardIcon color={LIGHT_GREY} />} size="ms">
+              {vaccineStrings.bluetooth_changes_can_take_time}
+            </TextWithIcon>
+
+            <PageButton
+              onPress={() => withLoadingIndicator(() => saveSensor({ macAddress, logInterval }))}
+              text={generalStrings.save}
+              textStyle={localStyles.pageButtonText}
+              style={{ backgroundColor: SUSSOL_ORANGE }}
             />
           </FlexRow>
-        </Paper>
-
-        <FlexRow flex={1} alignItems="flex-end">
-          <TextWithIcon left Icon={<HazardIcon color={LIGHT_GREY} />} size="ms">
-            {vaccineStrings.bluetooth_changes_can_take_time}
-          </TextWithIcon>
-
-          <PageButton
-            onPress={() => withLoadingIndicator(() => saveSensor({ macAddress, logInterval }))}
-            text={generalStrings.save}
-            textStyle={localStyles.pageButtonText}
-            style={{ backgroundColor: SUSSOL_ORANGE }}
+        </AfterInteractions>
+      </DataTablePageView>
+      <PaperModalContainer isVisible={open} onClose={toggleOpen}>
+        <View style={{ padding: 20 }}>
+          <SensorPicker
+            text={generalStrings.select}
+            selectSensor={mac => {
+              replaceSensor(mac);
+              toggleOpen();
+            }}
           />
-        </FlexRow>
-      </AfterInteractions>
-    </DataTablePageView>
+        </View>
+      </PaperModalContainer>
+    </>
   );
 };
 
@@ -223,7 +250,10 @@ const dispatchToProps = (dispatch, ownProps) => {
       .then(() => dispatch(goBack()))
       .catch(e => ToastAndroid.show(e.toString(), ToastAndroid.LONG));
 
+  const replaceSensor = macAddress => dispatch(SensorActions.replace(macAddress));
+
   return {
+    replaceSensor,
     blink,
     updateName,
     updateCode,
@@ -271,6 +301,7 @@ SensorEditPageComponent.propTypes = {
   coldCumulativeThreshold: PropTypes.number.isRequired,
   coldConsecutiveThreshold: PropTypes.number.isRequired,
   hotCumulativeThreshold: PropTypes.number.isRequired,
+  replaceSensor: PropTypes.func.isRequired,
 };
 
 export const SensorEditPage = connect(stateToProps, dispatchToProps)(SensorEditPageComponent);

--- a/src/pages/VaccinePage.js
+++ b/src/pages/VaccinePage.js
@@ -24,7 +24,7 @@ import { APP_FONT_FAMILY, DARKER_GREY, BLACK } from '../globalStyles';
 import { gotoFridgeDetailPage, gotoNewSensorPage } from '../navigation/actions';
 import { AfterInteractions } from '../widgets/AfterInteractions';
 import { SensorHeader } from '../widgets/SensorHeader/SensorHeader';
-import { selectSensors } from '../selectors/Entities/sensor';
+import { selectActiveSensors } from '../selectors/Entities/sensor';
 import temperature from '../utilities/temperature';
 import { BreachManUnhappy } from '../widgets/BreachManUnhappy';
 
@@ -135,12 +135,9 @@ const localStyles = StyleSheet.create({
 });
 
 const stateToProps = state => {
-  const { fridge } = state;
-  const { fridges } = fridge;
+  const sensors = selectActiveSensors(state);
 
-  const sensors = selectSensors(state);
-
-  return { fridges, sensors };
+  return { sensors };
 };
 
 const dispatchToProps = dispatch => ({

--- a/src/reducers/Entities/SensorReducer.js
+++ b/src/reducers/Entities/SensorReducer.js
@@ -31,6 +31,7 @@ const initialState = () => ({
   ),
   newId: '',
   editingId: '',
+  replacedId: '',
 });
 
 export const SensorReducer = (state = initialState(), action) => {
@@ -72,6 +73,18 @@ export const SensorReducer = (state = initialState(), action) => {
       return initialState();
     }
 
+    case SENSOR_ACTIONS.REPLACE: {
+      const { payload } = action;
+      const { macAddress, id } = payload;
+      const { byId, editingId } = state;
+
+      const oldSensor = byId[editingId];
+      const newSensor = { ...oldSensor, macAddress, id };
+      const newById = { ...byId, [id]: newSensor };
+
+      return { ...state, byId: newById, replacedId: editingId, editingId: id };
+    }
+
     case SENSOR_ACTIONS.SAVE_NEW: {
       const { byId } = state;
       const { payload } = action;
@@ -92,7 +105,7 @@ export const SensorReducer = (state = initialState(), action) => {
       // Only use plain objects.
       const newById = { ...byId, [id]: getPlainSensor(sensor) };
 
-      return { ...state, byId: newById, editingId: '' };
+      return { ...state, byId: newById, editingId: '', replacedId: '' };
     }
 
     case SENSOR_ACTIONS.UPDATE: {

--- a/src/reducers/Entities/SensorReducer.js
+++ b/src/reducers/Entities/SensorReducer.js
@@ -108,6 +108,18 @@ export const SensorReducer = (state = initialState(), action) => {
       return { ...state, byId: newById, editingId: '', replacedId: '' };
     }
 
+    case SENSOR_ACTIONS.REMOVE: {
+      const { payload } = action;
+      const { id } = payload;
+      const { byId } = state;
+      const oldSensor = byId[id];
+
+      const newSensor = { ...oldSensor, isActive: false };
+      const newById = { ...byId, [id]: newSensor };
+
+      return { ...state, byId: newById };
+    }
+
     case SENSOR_ACTIONS.UPDATE: {
       const { byId } = state;
       const { payload } = action;

--- a/src/selectors/Entities/sensor.js
+++ b/src/selectors/Entities/sensor.js
@@ -9,10 +9,21 @@ export const selectSensorsById = state => {
   return byId;
 };
 
-export const selectSensorByMac = (state, mac) => {
+export const selectSensors = state => {
   const sensorsById = selectSensorsById(state);
-  const foundSensor = Object.values(sensorsById).find(({ macAddress }) => macAddress === mac);
+  return Object.values(sensorsById);
+};
+
+export const selectSensorByMac = (state, mac) => {
+  const sensors = selectSensors(state);
+  const foundSensor = sensors.find(({ macAddress }) => macAddress === mac);
   return foundSensor;
+};
+
+export const selectActiveSensors = state => {
+  const sensors = selectSensors(state);
+  const filtered = sensors.filter(({ isActive }) => isActive);
+  return filtered;
 };
 
 export const selectNewSensor = state => {
@@ -27,16 +38,17 @@ export const selectEditingSensor = state => {
   return byId[editingId];
 };
 
+export const selectReplacedSensor = state => {
+  const sensorState = selectSensorState(state);
+  const { replacedId, byId } = sensorState;
+  return byId[replacedId];
+};
+
 export const selectNewSensorId = state => {
   const sensorState = selectSensorState(state);
   const { newId } = sensorState;
 
   return newId;
-};
-
-export const selectSensors = state => {
-  const sensorsById = selectSensorsById(state);
-  return Object.values(sensorsById);
 };
 
 export const selectIsLowBatteryByMac = (state, mac) => {

--- a/src/selectors/Entities/sensor.js
+++ b/src/selectors/Entities/sensor.js
@@ -52,25 +52,25 @@ export const selectNewSensorId = state => {
 };
 
 export const selectIsLowBatteryByMac = (state, mac) => {
-  const sensor = selectSensorByMac(state, mac);
+  const sensor = selectSensorByMac(state, mac) ?? {};
   const { batteryLevel } = sensor;
   return batteryLevel <= VACCINE_CONSTANTS.LOW_BATTERY_PERCENTAGE;
 };
 
 export const selectIsInHotBreachByMac = (state, mac) => {
-  const sensor = selectSensorByMac(state, mac);
+  const sensor = selectSensorByMac(state, mac) ?? {};
   const { isInHotBreach } = sensor;
   return isInHotBreach;
 };
 
 export const selectIsInColdBreachByMac = (state, mac) => {
-  const sensor = selectSensorByMac(state, mac);
+  const sensor = selectSensorByMac(state, mac) ?? {};
   const { isInColdBreach } = sensor;
   return isInColdBreach;
 };
 
 export const selectIsInBreachByMac = (state, mac) => {
-  const sensor = selectSensorByMac(state, mac);
+  const sensor = selectSensorByMac(state, mac) ?? {};
   const { isInHotBreach, isInColdBreach } = sensor;
   return isInHotBreach || isInColdBreach;
 };

--- a/src/widgets/AfterInteractions.js
+++ b/src/widgets/AfterInteractions.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ActivityIndicator, InteractionManager } from 'react-native';
 
@@ -7,14 +7,11 @@ import { SUSSOL_ORANGE } from '../globalStyles/index';
 
 export const AfterInteractions = ({ children, placeholder }) => {
   const [ready, setReady] = useState(false);
-  const handler = useRef();
 
   useEffect(() => {
-    handler.current = InteractionManager.runAfterInteractions(() => {
+    InteractionManager.runAfterInteractions(() => {
       setReady(true);
-      handler.current = null;
     });
-    return () => handler.current?.cancel();
   }, []);
 
   return ready ? (

--- a/src/widgets/AfterInteractions.js
+++ b/src/widgets/AfterInteractions.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { ActivityIndicator, InteractionManager } from 'react-native';
 
@@ -7,9 +7,14 @@ import { SUSSOL_ORANGE } from '../globalStyles/index';
 
 export const AfterInteractions = ({ children, placeholder }) => {
   const [ready, setReady] = useState(false);
+  const handler = useRef();
 
   useEffect(() => {
-    InteractionManager.runAfterInteractions(() => setReady(true));
+    handler.current = InteractionManager.runAfterInteractions(() => {
+      setReady(true);
+      handler.current = null;
+    });
+    return () => handler.current?.cancel();
   }, []);
 
   return ready ? (

--- a/src/widgets/PaperModal/PaperConfirmModal.js
+++ b/src/widgets/PaperModal/PaperConfirmModal.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { StyleSheet, Text } from 'react-native';
+import PropTypes from 'prop-types';
+import { FlexColumn } from '../FlexColumn';
+import { FlexView } from '../FlexView';
+import { HazardIcon } from '../icons';
+import { Spacer } from '../Spacer';
+import { DARKER_GREY, SUSSOL_ORANGE, WHITE } from '../../globalStyles/index';
+import { FlexRow } from '../FlexRow';
+import { PageButton } from '../PageButton';
+
+export const PaperConfirmModal = ({
+  Icon,
+  questionText,
+  confirmText,
+  cancelText,
+  onConfirm,
+  onCancel,
+}) => (
+  <FlexColumn alignItems="center" justifyContent="center" flex={1} style={{ padding: 20 }}>
+    <FlexView flex={1} alignItems="center" justifyContent="center">
+      {Icon}
+      <Spacer space={30} vertical />
+      <Text style={localStyles.questionText}>{questionText}</Text>
+    </FlexView>
+    <FlexRow justifyContent="space-evenly" alignItems="center" style={{ width: '100%' }} flex={1}>
+      <PageButton onPress={onCancel} text={cancelText} textStyle={{ textTransform: 'uppercase' }} />
+      <PageButton
+        onPress={onConfirm}
+        text={confirmText}
+        textStyle={{ textTransform: 'uppercase', color: WHITE }}
+        style={{ backgroundColor: SUSSOL_ORANGE }}
+      />
+    </FlexRow>
+  </FlexColumn>
+);
+
+const localStyles = StyleSheet.create({
+  questionText: { fontSize: 16, color: DARKER_GREY, fontWeight: '700' },
+});
+
+PaperConfirmModal.defaultProps = {
+  Icon: <HazardIcon size={50} />,
+};
+
+PaperConfirmModal.propTypes = {
+  Icon: PropTypes.node,
+  questionText: PropTypes.string.isRequired,
+  confirmText: PropTypes.string.isRequired,
+  cancelText: PropTypes.string.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};

--- a/src/widgets/PaperModal/PaperConfirmModal.js
+++ b/src/widgets/PaperModal/PaperConfirmModal.js
@@ -24,12 +24,12 @@ export const PaperConfirmModal = ({
       <Text style={localStyles.questionText}>{questionText}</Text>
     </FlexView>
     <FlexRow justifyContent="space-evenly" alignItems="center" style={{ width: '100%' }} flex={1}>
-      <PageButton onPress={onCancel} text={cancelText} textStyle={{ textTransform: 'uppercase' }} />
+      <PageButton onPress={onCancel} text={cancelText} textStyle={localStyles.cancelText} />
       <PageButton
         onPress={onConfirm}
         text={confirmText}
-        textStyle={{ textTransform: 'uppercase', color: WHITE }}
-        style={{ backgroundColor: SUSSOL_ORANGE }}
+        textStyle={localStyles.confirmText}
+        style={localStyles.confirmButton}
       />
     </FlexRow>
   </FlexColumn>
@@ -37,6 +37,9 @@ export const PaperConfirmModal = ({
 
 const localStyles = StyleSheet.create({
   questionText: { fontSize: 16, color: DARKER_GREY, fontWeight: '700' },
+  cancelText: { textTransform: 'uppercase' },
+  confirmText: { textTransform: 'uppercase', color: WHITE },
+  confirmButton: { backgroundColor: SUSSOL_ORANGE },
 });
 
 PaperConfirmModal.defaultProps = {

--- a/src/widgets/PaperModal/PaperModalContainer.js
+++ b/src/widgets/PaperModal/PaperModalContainer.js
@@ -19,7 +19,7 @@ export const PaperModalContainer = ({ isVisible, onClose, children }) => {
   return (
     <Modal
       visible={isVisible}
-      animationType="fades"
+      animationType="fade"
       hardwareAccelerated
       onRequestClose={onClose}
       transparent

--- a/src/widgets/SensorHeader/LastSensorDownload.js
+++ b/src/widgets/SensorHeader/LastSensorDownload.js
@@ -95,7 +95,7 @@ const stateToProps = (state, props) => {
   const isDownloading = selectIsDownloading(state, macAddress);
 
   const sensor = selectSensorByMac(state, macAddress);
-  const { logDelay } = sensor;
+  const { logDelay } = sensor ?? {};
 
   return { lastDownloadTime, lastDownloadFailed, isDownloading, logDelay };
 };

--- a/src/widgets/SensorPicker.js
+++ b/src/widgets/SensorPicker.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/forbid-prop-types */
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { ActivityIndicator, FlatList } from 'react-native';
 import { connect } from 'react-redux';
@@ -29,12 +29,18 @@ export const SensorPickerComponent = ({
   text,
 }) => {
   const isFocused = useIsFocused();
+  const isScanning = useRef();
 
   useEffect(() => {
-    if (isFocused) startScan();
-    else stopScan();
-    return stopScan;
-  }, [startScan]);
+    if (isFocused) {
+      isScanning.current = true;
+      startScan();
+    } else {
+      isScanning.current = false;
+      stopScan();
+    }
+    return () => (isScanning.current ? stopScan() : null);
+  }, [startScan, isFocused]);
 
   return (
     <FlatList

--- a/src/widgets/SensorPicker.js
+++ b/src/widgets/SensorPicker.js
@@ -49,12 +49,16 @@ export const SensorPickerComponent = ({
   );
 };
 
+SensorPickerComponent.defaultProps = {
+  text: vaccineStrings.connect,
+};
+
 SensorPickerComponent.propTypes = {
   macAddresses: PropTypes.array.isRequired,
   startScan: PropTypes.func.isRequired,
   stopScan: PropTypes.func.isRequired,
   selectSensor: PropTypes.func.isRequired,
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string,
 };
 
 const dispatchToProps = dispatch => {

--- a/src/widgets/SensorPicker.js
+++ b/src/widgets/SensorPicker.js
@@ -1,0 +1,72 @@
+/* eslint-disable react/forbid-prop-types */
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { ActivityIndicator, FlatList } from 'react-native';
+import { connect } from 'react-redux';
+import { useIsFocused } from '@react-navigation/native';
+import { SUSSOL_ORANGE } from '../globalStyles/index';
+import { vaccineStrings } from '../localization/index';
+import { ScanRow } from '../pages/NewSensor/ScanRow';
+import { selectScannedSensors } from '../selectors/Bluetooth/sensorScan';
+import { TextWithIcon } from './Typography/index';
+import { SensorScanActions } from '../actions/index';
+
+const Spinner = () => (
+  <TextWithIcon
+    left
+    Icon={<ActivityIndicator color={SUSSOL_ORANGE} />}
+    containerStyle={{ justifyContent: 'center' }}
+  >
+    {vaccineStrings.scanning}
+  </TextWithIcon>
+);
+
+export const SensorPickerComponent = ({
+  macAddresses,
+  startScan,
+  stopScan,
+  selectSensor,
+  text,
+}) => {
+  const isFocused = useIsFocused();
+
+  useEffect(() => {
+    if (isFocused) startScan();
+    else stopScan();
+    return stopScan;
+  }, [startScan]);
+
+  return (
+    <FlatList
+      data={macAddresses}
+      renderItem={({ item }) => (
+        <ScanRow selectSensor={selectSensor} macAddress={item} text={text} />
+      )}
+      keyExtractor={item => item}
+      style={{ height: 360 }}
+      ListFooterComponent={<Spinner />}
+    />
+  );
+};
+
+SensorPickerComponent.propTypes = {
+  macAddresses: PropTypes.array.isRequired,
+  startScan: PropTypes.func.isRequired,
+  stopScan: PropTypes.func.isRequired,
+  selectSensor: PropTypes.func.isRequired,
+  text: PropTypes.string.isRequired,
+};
+
+const dispatchToProps = dispatch => {
+  const startScan = () => dispatch(SensorScanActions.startSensorScan());
+  const stopScan = () => dispatch(SensorScanActions.stopSensorScan());
+
+  return { startScan, stopScan };
+};
+
+const stateToProps = state => {
+  const macAddresses = selectScannedSensors(state);
+  return { macAddresses };
+};
+
+export const SensorPicker = connect(stateToProps, dispatchToProps)(SensorPickerComponent);

--- a/src/widgets/WithFlash.js
+++ b/src/widgets/WithFlash.js
@@ -9,7 +9,7 @@ export const WithFlash = ({ children, condition, style }) => {
   const ref = useConditionalAnimationRef(condition, 'flash', MILLISECONDS.ONE_SECOND);
 
   return (
-    <Animatable.View style={style} ref={ref}>
+    <Animatable.View iterationCount="infinite" animation="flash" style={style} ref={ref}>
       {children}
     </Animatable.View>
   );


### PR DESCRIPTION
Fixes #3273 

## Change summary

- Adds replace sensor functionality
- Adds remove sensor functionality

## Testing

- [ ] When you remove a sensor, the sensor itself is set as isActive= false and removed from the vaccines page list. 
- [ ] Removed sensors are re-findable through scanning for a sensor
- [ ] When connecting/reenabling an old sensor, the old location and configs are reused, but updated with the details set in the new sensor flow
- [ ] When you replace a sensor, the old sensor is set as `isActive = false`, and the location is switched to the new sensor (with the temperature breach configs also)

### Related areas to think about

- I think there might be something here with "last sensor download" - do we want that to actually be last download from the location...? I am not sure!