### PR TITLE
#3477 regex used from user input non defensively

### DIFF
--- a/src/widgets/Step.js
+++ b/src/widgets/Step.js
@@ -89,7 +89,7 @@ export const Step = memo(props => {
     const icons = {
       ERROR: <Ionicons name="ios-close" color="red" size={30} />,
       COMPLETE: <Ionicons name="md-checkmark" color="green" size={30} />,
-      CURRENT: <Ionicons name="md-arrow-round-forward" color={SUSSOL_ORANGE} size={30} />,
+      CURRENT: <Ionicons name="arrow-forward" color={SUSSOL_ORANGE} size={30} />,
       INCOMPLETE: null,
     };
 

--- a/src/widgets/modalChildren/AutocompleteSelector.js
+++ b/src/widgets/modalChildren/AutocompleteSelector.js
@@ -38,10 +38,7 @@ export const AutocompleteSelector = ({
    * by two query strings. And concat A to B - A.
    */
   const filterResultData = () => {
-    let data = options
-      .filtered(queryString, queryText)
-      .sorted(sortKeyString)
-      .slice();
+    let data = options.filtered(queryString, queryText).sorted(sortKeyString).slice();
 
     if (queryStringSecondary) {
       data = data.concat(
@@ -57,15 +54,12 @@ export const AutocompleteSelector = ({
    * Ignores case. Querying a realm result with filtered is more performant,
    * so have two cases for each.
    */
-  const filterArrayData = () => {
-    const regexFilter = RegExp(queryText, 'i');
-
-    return options.filter(
+  const filterArrayData = () =>
+    options.filter(
       optionItem =>
-        regexFilter.test(optionItem[primaryFilterProperty]) ||
-        regexFilter.test(optionItem[secondaryFilterProperty])
+        optionItem[primaryFilterProperty]?.toLowerCase()?.includes(queryText) ||
+        optionItem[secondaryFilterProperty]?.toLowerCase()?.includes(queryText)
     );
-  };
 
   /**
    * Delegator of filtering process. Check if the object is a realm


### PR DESCRIPTION
Fixes #3477 

## Change summary

- Removes the use of the regex - safest option 🤷 
- Changed icon name. Uhh.. I dunno what's going on but couldn't open the modal without this. Unsure if this is happening in prod ooooops?

## Testing

- [ ] Entering `(ab` into the modal selector which opens after trying to select a `PROGRAM` in the `by program modal` does not crash the app

### Related areas to think about

N/A