### PR TITLE
#3475 Adjusting LogInterval to be saved as seconds, displayed as minutes

### DIFF
--- a/src/pages/NewSensor/NewSensorStepThree.js
+++ b/src/pages/NewSensor/NewSensorStepThree.js
@@ -29,6 +29,7 @@ import { useLoadingIndicator } from '../../hooks/useLoadingIndicator';
 import { DARKER_GREY, LIGHT_GREY, SUSSOL_ORANGE, WHITE } from '../../globalStyles';
 import { buttonStrings, vaccineStrings } from '../../localization';
 import { selectNewLocation } from '../../selectors/Entities/location';
+import { SECONDS } from '../../utilities/constants';
 
 export const NewSensorStepThreeComponent = ({
   logInterval,
@@ -63,7 +64,11 @@ export const NewSensorStepThreeComponent = ({
           label={vaccineStrings.logging_interval}
           Icon={<InfoIcon color={DARKER_GREY} />}
         >
-          <DurationEditor value={logInterval} label="" onChange={updateLogInterval} />
+          <DurationEditor
+            value={logInterval / SECONDS.ONE_MINUTE}
+            label=""
+            onChange={updateLogInterval}
+          />
         </EditorRow>
       </Paper>
 
@@ -109,7 +114,8 @@ const dispatchToProps = dispatch => {
   const updateCode = value => dispatch(LocationActions.updateNew(value, 'code'));
   const updateLogDelay = value =>
     dispatch(SensorActions.updateNewSensor(new Date(value).getTime(), 'logDelay'));
-  const updateLogInterval = value => dispatch(SensorActions.updateNewSensor(value, 'logInterval'));
+  const updateLogInterval = value =>
+    dispatch(SensorActions.updateNewSensor(value * SECONDS.ONE_MINUTE, 'logInterval'));
   const previousTab = () => dispatch(WizardActions.previousTab());
   const exit = () => dispatch(goBack());
   const connectToSensor = sensor => () =>

--- a/src/pages/SensorEditPage.js
+++ b/src/pages/SensorEditPage.js
@@ -42,6 +42,7 @@ import { useToggle } from '../hooks/index';
 import { PaperModalContainer } from '../widgets/PaperModal/PaperModalContainer';
 import { SensorPicker } from '../widgets/SensorPicker';
 import { PaperConfirmModal } from '../widgets/PaperModal/PaperConfirmModal';
+import { SECONDS } from '../utilities/constants';
 
 export const SensorEditPageComponent = ({
   logInterval,
@@ -140,7 +141,7 @@ export const SensorEditPageComponent = ({
               </View>
               <DurationEditor
                 containerStyle={localStyles.paperContentRow}
-                value={logInterval}
+                value={logInterval / SECONDS.ONE_MINUTE}
                 onChange={updateLogInterval}
                 label={vaccineStrings.logging_interval}
               />
@@ -252,7 +253,7 @@ const dispatchToProps = (dispatch, ownProps) => {
   const updateName = name => dispatch(SensorActions.update(sensorID, 'name', name));
   const updateCode = code => dispatch(LocationActions.update(locationID, 'code', code));
   const updateLogInterval = logInterval =>
-    dispatch(SensorActions.update(sensorID, 'logInterval', logInterval));
+    dispatch(SensorActions.update(sensorID, 'logInterval', logInterval * SECONDS.ONE_MINUTE));
   const updateDuration = (id, value) =>
     dispatch(
       TemperatureBreachConfigActions.update(id, 'duration', value * MILLISECONDS.ONE_MINUTE)


### PR DESCRIPTION
Fixes #3475 

## Change summary

- Adds dividing by 60 when showing in the UI 

## Testing

- [ ] Editing a seconds log interval is correct in sensor edit page
- [ ] - [ ] Editing a seconds log interval is correct when moving through the new sensor flow

### Related areas to think about

I just like branching apparently