### PR TITLE
#3463 ability to pause temperature downloading

### DIFF
--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -79,11 +79,11 @@ const downloadLogsFromSensor = sensor => async dispatch => {
   dispatch(sensorDownloadStart(sensor));
 
   try {
-    const { macAddress, logInterval, logDelay } = sensor;
+    const { macAddress, logInterval, logDelay, isPaused } = sensor;
 
     const timeNow = moment();
 
-    if (timeNow.isAfter(moment(logDelay))) {
+    if (timeNow.isAfter(moment(logDelay)) && !isPaused) {
       const downloadedLogsResult =
         (await BleService().downloadLogsWithRetries(
           macAddress,

--- a/src/actions/Entities/SensorActions.js
+++ b/src/actions/Entities/SensorActions.js
@@ -38,9 +38,10 @@ const update = (id, field, value) => ({
 
 const create = macAddress => async dispatch => {
   const defaultSensor = {
+    isPaused: false,
     location: {},
-    logInterval: 300,
     logDelay: new Date().getTime(),
+    logInterval: 300,
     macAddress,
     name: '',
   };

--- a/src/actions/Entities/SensorActions.js
+++ b/src/actions/Entities/SensorActions.js
@@ -78,7 +78,10 @@ const save = () => (dispatch, getState) => {
   location.description = sensor.name;
   UIDatabase.write(() => {
     updatedLocation = UIDatabase.update('Location', location);
-    updatedSensor = UIDatabase.update('Sensor', sensor);
+    updatedSensor = UIDatabase.update('Sensor', {
+      ...sensor,
+      logDelay: new Date(sensor?.logDelay ?? 0),
+    });
     configs.forEach(config =>
       updatedConfigs.push(UIDatabase.update('TemperatureBreachConfiguration', config))
     );

--- a/src/database/DataTypes/Sensor.js
+++ b/src/database/DataTypes/Sensor.js
@@ -106,6 +106,7 @@ Sensor.schema = {
     logs: { type: 'linkingObjects', objectType: 'TemperatureLog', property: 'sensor' },
     breaches: { type: 'linkingObjects', objectType: 'TemperatureBreach', property: 'sensor' },
     isActive: { type: 'bool', default: true },
+    isPaused: { type: 'bool', default: false },
     logInterval: { type: 'int', default: 300 },
     logDelay: { type: 'date', default: new Date(0) },
     programmedDate: { type: 'date', default: new Date() },

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -214,7 +214,7 @@ export const schema = {
     VaccineVialMonitorStatus,
     VaccineVialMonitorStatusLog,
   ],
-  schemaVersion: 18,
+  schemaVersion: 19,
 };
 
 export default schema;

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -54,7 +54,9 @@
     "log_interval_set": "Log interval updated to {0}s",
     "E_SENSOR_SAVE": "Problem saving sensor details",
     "E_INVALID_MAC_FORMAT": "Invalid mac address format",
-    "is_paused": "PAUSED"
+    "is_paused": "PAUSED",
+    "pause": "Pause",
+    "enable": "Enable"
   },
   "fr": {},
   "gil": {},

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -56,7 +56,7 @@
     "E_INVALID_MAC_FORMAT": "Invalid mac address format",
     "is_paused": "PAUSED",
     "pause": "Pause",
-    "enable": "Enable"
+    "resume": "Resume"
   },
   "fr": {},
   "gil": {},

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -53,7 +53,8 @@
     "E_BLUETOOTH_DENIED": "Denied access to the bluetooth adapter",
     "log_interval_set": "Log interval updated to {0}s",
     "E_SENSOR_SAVE": "Problem saving sensor details",
-    "E_INVALID_MAC_FORMAT": "Invalid mac address format"
+    "E_INVALID_MAC_FORMAT": "Invalid mac address format",
+    "is_paused": "PAUSED"
   },
   "fr": {},
   "gil": {},

--- a/src/pages/SensorEditPage.js
+++ b/src/pages/SensorEditPage.js
@@ -128,7 +128,7 @@ export const SensorEditPageComponent = ({
             <View style={localStyles.pauseButtonRow}>
               <IconButton
                 Icon={isPaused ? <PlayIcon /> : <PauseIcon />}
-                label={isPaused ? vaccineStrings.enable : vaccineStrings.pause}
+                label={isPaused ? vaccineStrings.resume : vaccineStrings.pause}
                 labelStyle={localStyles.pauseButtonLabel}
                 onPress={() => updateIsPaused(!isPaused)}
               />

--- a/src/pages/SensorEditPage.js
+++ b/src/pages/SensorEditPage.js
@@ -2,7 +2,7 @@
 /* eslint-disable react/forbid-prop-types */
 /* eslint-disable react/jsx-wrap-multilines */
 import React from 'react';
-import { StyleSheet, ToastAndroid } from 'react-native';
+import { StyleSheet, ToastAndroid, View } from 'react-native';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -15,6 +15,9 @@ import {
   PageButton,
   Paper,
   TextEditor,
+  PauseIcon,
+  PlayIcon,
+  IconButton,
 } from '../widgets';
 import { BreachConfigRow } from './NewSensor/BreachConfigRow';
 import { DurationEditor } from '../widgets/StepperInputs';
@@ -59,6 +62,8 @@ export const SensorEditPageComponent = ({
   coldConsecutiveThreshold,
   hotCumulativeThreshold,
   sensor,
+  isPaused,
+  updateIsPaused,
 }) => {
   const withLoadingIndicator = useLoadingIndicator();
   return (
@@ -119,7 +124,15 @@ export const SensorEditPageComponent = ({
         </Paper>
 
         <Paper>
-          <FlexRow justifyContent="flex-end">
+          <FlexRow justifyContent="flex-end" alignItems="center">
+            <View style={localStyles.pauseButtonRow}>
+              <IconButton
+                Icon={isPaused ? <PlayIcon /> : <PauseIcon />}
+                label={isPaused ? vaccineStrings.enable : vaccineStrings.pause}
+                labelStyle={localStyles.pauseButtonLabel}
+                onPress={() => updateIsPaused(!isPaused)}
+              />
+            </View>
             <DurationEditor
               containerStyle={localStyles.paperContentRow}
               value={logInterval}
@@ -156,6 +169,8 @@ const localStyles = StyleSheet.create({
     textTransform: 'uppercase',
     color: WHITE,
   },
+  pauseButtonLabel: { color: DARKER_GREY, marginLeft: 10 },
+  pauseButtonRow: { marginRight: 100 },
 });
 
 const stateToProps = state => {
@@ -163,7 +178,8 @@ const stateToProps = state => {
   const location = selectEditingLocation(state);
 
   const { code } = location ?? {};
-  const { name, logInterval, macAddress, batteryLevel, lastSyncDate } = sensor ?? {};
+  const { name, logInterval, macAddress, batteryLevel, lastSyncDate, isPaused = false } =
+    sensor ?? {};
   const {
     HOT_CONSECUTIVE: hotConsecutiveConfig = {},
     COLD_CONSECUTIVE: coldConsecutiveConfig = {},
@@ -194,6 +210,7 @@ const stateToProps = state => {
     coldConsecutiveThreshold,
     hotCumulativeThreshold,
     batteryLevel,
+    isPaused,
   };
 };
 
@@ -217,6 +234,7 @@ const dispatchToProps = (dispatch, ownProps) => {
     const field = isHot ? 'minimumTemperature' : 'maximumTemperature';
     dispatch(TemperatureBreachConfigActions.update(id, field, value));
   };
+  const updateIsPaused = isPaused => dispatch(SensorActions.update(sensorID, 'isPaused', isPaused));
   const saveSensor = sensorToUpdate =>
     dispatch(SensorUpdateActions.updateSensor(sensorToUpdate))
       .then(() => dispatch(SensorActions.save()))
@@ -225,6 +243,7 @@ const dispatchToProps = (dispatch, ownProps) => {
 
   return {
     blink,
+    updateIsPaused,
     updateName,
     updateCode,
     updateLogInterval,
@@ -271,6 +290,8 @@ SensorEditPageComponent.propTypes = {
   coldCumulativeThreshold: PropTypes.number.isRequired,
   coldConsecutiveThreshold: PropTypes.number.isRequired,
   hotCumulativeThreshold: PropTypes.number.isRequired,
+  isPaused: PropTypes.bool.isRequired,
+  updateIsPaused: PropTypes.func.isRequired,
 };
 
 export const SensorEditPage = connect(stateToProps, dispatchToProps)(SensorEditPageComponent);

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -175,33 +175,43 @@ const Settings = ({ toRealmExplorer, currentUserPasswordHash, requestStorageWrit
       // create sensors
       createRecord(UIDatabase, 'Sensor', {
         name: 'sensor 1',
-        macAddress: '00:00:00:00:01',
         batteryLevel: 10,
         location: fridge1,
+        logDelay: new Date(0),
+        macAddress: '00:00:00:00:01',
+        programmedDate: new Date(),
       });
       createRecord(UIDatabase, 'Sensor', {
         name: 'sensor 2',
-        macAddress: '00:00:00:00:02',
         batteryLevel: 20,
         location: fridge2,
+        macAddress: '00:00:00:00:02',
+        logDelay: new Date(0),
+        programmedDate: new Date(),
       });
       createRecord(UIDatabase, 'Sensor', {
         name: 'sensor 3',
-        macAddress: '00:00:00:00:03',
         batteryLevel: 30,
         location: fridge3,
+        macAddress: '00:00:00:00:03',
+        logDelay: new Date(0),
+        programmedDate: new Date(),
       });
       createRecord(UIDatabase, 'Sensor', {
         name: 'sensor 4',
-        macAddress: '00:00:00:00:04',
         batteryLevel: 40,
         location: fridge4,
+        macAddress: '00:00:00:00:04',
+        logDelay: new Date(0),
+        programmedDate: new Date(),
       });
       createRecord(UIDatabase, 'Sensor', {
         name: 'sensor 5',
-        macAddress: '00:00:00:00:05',
         batteryLevel: 50,
         location: fridge5,
+        macAddress: '00:00:00:00:05',
+        logDelay: new Date(0),
+        programmedDate: new Date(),
       });
 
       // create some configs

--- a/src/reducers/Entities/SensorReducer.js
+++ b/src/reducers/Entities/SensorReducer.js
@@ -13,6 +13,7 @@ const getPlainSensor = sensor => ({
   locationID: sensor.location?.id,
   breachConfigIDs: sensor?.breachConfigs?.map(({ id }) => id),
   isActive: sensor.isActive,
+  isPaused: sensor.isPaused,
   logInterval: sensor.logInterval,
   logDelay: new Date(sensor.logDelay).getTime(),
   currentTemperature: sensor?.currentTemperature ?? null,

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -1075,6 +1075,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         batteryLevel: parseNumber(record.batteryLevel),
         name: record.name,
         isActive: parseBoolean(record.is_active),
+        isPaused: parseBoolean(record.is_paused),
         logDelay: parseDate(record.log_delay_date, record.log_delay_time) ?? new Date(0),
         programmedDate: parseDate(record.programmed_date, record.programmed_time) ?? new Date(),
       });

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -388,6 +388,7 @@ const generateSyncData = (settings, recordType, record) => {
         storeID: settings.get(THIS_STORE_ID),
         locationID: record.location?.id,
         is_active: String(record.isActive ?? true),
+        is_paused: String(record.isPaused ?? false),
         log_delay_time: getTimeString(record.logDelay),
         log_delay_date: getDateString(record.logDelay),
         programmed_time: getTimeString(record.programmedDate),

--- a/src/widgets/LastSensorDownload.js
+++ b/src/widgets/LastSensorDownload.js
@@ -107,7 +107,7 @@ const stateToProps = (state, props) => {
   const isDownloading = selectIsDownloading(state, macAddress);
 
   const sensor = selectSensorByMac(state, macAddress);
-  const { isPaused = false, logDelay } = sensor;
+  const { isPaused = false, logDelay } = sensor || {};
 
   return { lastDownloadTime, lastDownloadFailed, isDownloading, logDelay, isPaused };
 };

--- a/src/widgets/LastSensorDownload.js
+++ b/src/widgets/LastSensorDownload.js
@@ -22,8 +22,19 @@ const formatLastSyncDate = date => (date ? moment(date).fromNow() : generalStrin
 const formatLogDelay = delay =>
   `${vaccineStrings.logging_delayed_until}: ${moment(delay).format('DD/MM/YYYY @ HH:mm:ss')}`;
 
+const getText = (isPaused, isDelayed, logDelay, lastDownloadTime) => {
+  if (isPaused) {
+    return vaccineStrings.is_paused;
+  }
+  if (isDelayed) {
+    return formatLogDelay(logDelay);
+  }
+  return formatLastSyncDate(lastDownloadTime);
+};
+
 export const LastSensorDownloadComponent = ({
   isDownloading,
+  isPaused,
   lastDownloadFailed,
   lastDownloadTime,
   logDelay,
@@ -53,14 +64,14 @@ export const LastSensorDownloadComponent = ({
         margin={0}
         size="s"
         Icon={
-          lastDownloadFailed || isDelayed ? (
+          lastDownloadFailed || isDelayed || isPaused ? (
             <WifiOffIcon size={20} color={MISTY_CHARCOAL} />
           ) : (
             <WifiIcon size={20} color={MISTY_CHARCOAL} />
           )
         }
       >
-        {isDelayed ? formatLogDelay(logDelay) : formatLastSyncDate(lastDownloadTime)}
+        {getText(isPaused, isDelayed, logDelay, lastDownloadTime)}
       </TextWithIcon>
     </Animatable.View>
   );
@@ -73,6 +84,7 @@ LastSensorDownloadComponent.defaultProps = {
 
 LastSensorDownloadComponent.propTypes = {
   isDownloading: PropTypes.bool.isRequired,
+  isPaused: PropTypes.bool.isRequired,
   lastDownloadFailed: PropTypes.bool.isRequired,
   lastDownloadTime: PropTypes.instanceOf(Date),
   logDelay: PropTypes.number,
@@ -95,9 +107,9 @@ const stateToProps = (state, props) => {
   const isDownloading = selectIsDownloading(state, macAddress);
 
   const sensor = selectSensorByMac(state, macAddress);
-  const { logDelay } = sensor;
+  const { isPaused = false, logDelay } = sensor;
 
-  return { lastDownloadTime, lastDownloadFailed, isDownloading, logDelay };
+  return { lastDownloadTime, lastDownloadFailed, isDownloading, logDelay, isPaused };
 };
 
 export const LastSensorDownload = connect(stateToProps)(LastSensorDownloadComponent);

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -348,3 +348,23 @@ LineChartIcon.propTypes = {
   style: PropTypes.object,
   color: PropTypes.string,
 };
+
+export const PauseIcon = ({ size, style, color }) => (
+  <FAIcon size={size} style={style} color={color} name="pause" />
+);
+PauseIcon.defaultProps = { size: 20, style: {}, color: DARKER_GREY };
+PauseIcon.propTypes = {
+  size: PropTypes.number,
+  style: PropTypes.object,
+  color: PropTypes.string,
+};
+
+export const PlayIcon = ({ size, style, color }) => (
+  <FAIcon size={size} style={style} color={color} name="play" />
+);
+PlayIcon.defaultProps = { size: 20, style: {}, color: DARKER_GREY };
+PlayIcon.propTypes = {
+  size: PropTypes.number,
+  style: PropTypes.object,
+  color: PropTypes.string,
+};


### PR DESCRIPTION
Fixes #3463 

## Change summary

Ability to pause temperature log download for a specific sensor.

- A play/pause icon button on the sensor settings page which toggles the state
- Saved to a new field ( `isPaused` )
- Sensor header shows the disabled wifi icon if the sensor is paused, with the text `PAUSED` ( found that having a pause icon here was confusing, to me at least )
- A sensor that is paused does not download temperature logs
- Couple of offroad fixes ( e.g. saving a sensor wasn't working )

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Edit a sensor. Pause and check that the header shows 'PAUSED' and the icon and text on the button change
- [ ] Edit a sensor. Pause and don't save. Expected result: shouldn't save the state
- [ ] Edit a sensor. Pause and save. Expected result: should save the state
- [ ] Pause a sensor and check that it no longer syncs

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
