### PR TITLE
show permissions & services status

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react-native-safe-area-context": "^0.7.3",
     "react-native-screens": "^2.2.0",
     "react-native-svg": "^11.0.1",
+    "react-native-system-setting": "^1.7.6",
     "react-native-text-input-mask": "^2.0.0",
     "react-native-timezone": "^1.0.3",
     "react-native-ui-components": "^0.5.0",

--- a/src/actions/PermissionActions.js
+++ b/src/actions/PermissionActions.js
@@ -53,10 +53,10 @@ const requestLocation = () => async (dispatch, getState) => {
   const locationPermission = PermissionSelectors.location(getState());
 
   const result = !locationPermission
-    ? await request(PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION)
+    ? (await request(PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION)) === RESULTS.GRANTED
     : true;
 
-  dispatch(setLocation(result === RESULTS.GRANTED));
+  dispatch(setLocation(result));
 
   return result;
 };

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -61,6 +61,8 @@
     "storage_permission_comment": "Required when emailing vaccine logs",
     "location_permission": "Location",
     "location_permission_comment": "Required to connect to bluetooth sensors",
+    "location_service": "Location Services",
+    "location_service_comment": "Required to connect to bluetooth sensors",
     "bluetooth_permission": "Bluetooth",
     "bluetooth_permission_comment": "Required to connect to bluetooth sensors",
     "permissions_intro_1": "The following permissions services are required by various features of the cold chain functionality.",

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -54,7 +54,15 @@
     "select_vvm_status": "Select vaccine vial monitor status",
     "location_details": "Location Details",
     "requisition_invalid_closing_stock": "Can't finalise a requisition which has items with a negative closing quantity. Please adjust these quantities before trying to finalise!",
-    "requisition_days_out_of_stock": "Can't finalise a requisition with items that have a higher days out of stock value than the length of the requisition's period"
+    "requisition_days_out_of_stock": "Can't finalise a requisition with items that have a higher days out of stock value than the length of the requisition's period",
+    "permissions": "Permissions",
+    "services": "Services",
+    "storage_permission": "Storage",
+    "storage_permission_comment": "Required when emailing vaccine logs",
+    "location_permission": "Location",
+    "location_permission_comment": "Required to connect to bluetooth sensors",
+    "bluetooth_permission": "Bluetooth",
+    "bluetooth_permission_comment": "Required to connect to bluetooth sensors"
   },
   "fr": {
     "add_at_least_one_item_before_finalising": "Vous devez ajouter au moins un article avant de finaliser",

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -62,7 +62,9 @@
     "location_permission": "Location",
     "location_permission_comment": "Required to connect to bluetooth sensors",
     "bluetooth_permission": "Bluetooth",
-    "bluetooth_permission_comment": "Required to connect to bluetooth sensors"
+    "bluetooth_permission_comment": "Required to connect to bluetooth sensors",
+    "permissions_intro_1": "The following permissions services are required by various features of the cold chain functionality.",
+    "permissions_intro_2": "If disabled, you can press an item to enable it."
   },
   "fr": {
     "add_at_least_one_item_before_finalising": "Vous devez ajouter au moins un article avant de finaliser",

--- a/src/reducers/PermissionReducer.js
+++ b/src/reducers/PermissionReducer.js
@@ -5,7 +5,12 @@
 
 import { PERMISSION_ACTIONS } from '../actions/PermissionActions';
 
-const initialState = () => ({ location: false, writeStorage: false, bluetooth: false });
+const initialState = () => ({
+  location: false,
+  writeStorage: false,
+  bluetooth: false,
+  locationService: false,
+});
 
 export const PermissionReducer = (state = initialState(), action) => {
   const { type, payload } = action;
@@ -25,6 +30,11 @@ export const PermissionReducer = (state = initialState(), action) => {
       const { status } = payload;
 
       return { ...state, bluetooth: status };
+    }
+    case PERMISSION_ACTIONS.SET_LOCATION_SERVICE: {
+      const { status } = payload;
+
+      return { ...state, locationService: status };
     }
     default:
       return state;

--- a/src/selectors/permission.js
+++ b/src/selectors/permission.js
@@ -9,6 +9,12 @@ const selectLocationPermission = ({ permission }) => {
   return location;
 };
 
+const selectLocationService = ({ permission }) => {
+  const { locationService } = permission;
+
+  return locationService;
+};
+
 const selectWriteStoragePermission = ({ permission }) => {
   const { writeStorage } = permission;
 
@@ -23,6 +29,7 @@ const selectBluetoothEnabled = ({ permission }) => {
 
 export const PermissionSelectors = {
   location: selectLocationPermission,
+  locationService: selectLocationService,
   writeStorage: selectWriteStoragePermission,
   bluetooth: selectBluetoothEnabled,
 };

--- a/src/widgets/HeaderRight.js
+++ b/src/widgets/HeaderRight.js
@@ -8,8 +8,11 @@ import React from 'react';
 import { SyncState } from './SyncState';
 import { FlexRow } from './FlexRow';
 
+import { SettingsIcon } from './SettingsIcon';
+
 export const HeaderRight = () => (
-  <FlexRow>
+  <FlexRow style={{ alignItems: 'center' }}>
     <SyncState />
+    <SettingsIcon />
   </FlexRow>
 );

--- a/src/widgets/HeaderRight.js
+++ b/src/widgets/HeaderRight.js
@@ -8,7 +8,7 @@ import React from 'react';
 import { SyncState } from './SyncState';
 import { FlexRow } from './FlexRow';
 
-import { SettingsIcon } from './SettingsIcon';
+import { SettingsIcon } from './PermissionSettingsIcon';
 
 export const HeaderRight = () => (
   <FlexRow style={{ alignItems: 'center' }}>

--- a/src/widgets/PaperModal/PaperModalContainer.js
+++ b/src/widgets/PaperModal/PaperModalContainer.js
@@ -13,7 +13,7 @@ import { FlexView } from '../FlexView';
 import { Paper } from '../Paper';
 import { TRANSPARENT_GREY } from '../../globalStyles/index';
 
-export const PaperModalContainer = ({ isVisible, onClose, children }) => {
+export const PaperModalContainer = ({ isVisible, onClose, children, heightFactor }) => {
   const { width, height } = useWindowDimensions();
 
   return (
@@ -32,7 +32,7 @@ export const PaperModalContainer = ({ isVisible, onClose, children }) => {
           style={{ backgroundColor: TRANSPARENT_GREY }}
         >
           <Paper paddingHorizontal={0}>
-            <View style={{ height: height / 2, width: width / 2 }}>
+            <View style={{ height: heightFactor * height, width: width / 2 }}>
               <TouchableWithoutFeedback
                 onPress={() => {
                   /* This Touchable is capturing gestures such that only the transparent overlay
@@ -51,7 +51,12 @@ export const PaperModalContainer = ({ isVisible, onClose, children }) => {
   );
 };
 
+PaperModalContainer.defaultProps = {
+  heightFactor: 0.5,
+};
+
 PaperModalContainer.propTypes = {
+  heightFactor: PropTypes.number,
   isVisible: PropTypes.bool.isRequired,
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]).isRequired,
   onClose: PropTypes.func.isRequired,

--- a/src/widgets/PermissionSettingsIcon.js
+++ b/src/widgets/PermissionSettingsIcon.js
@@ -47,8 +47,10 @@ PermissionRow.propTypes = {
 const SettingsIconComponent = ({
   bluetooth,
   location,
+  locationService,
   requestBluetooth,
   requestLocation,
+  requestLocationService,
   requestWriteStorage,
   usingVaccines,
   writeStorage,
@@ -70,7 +72,11 @@ const SettingsIconComponent = ({
     <>
       <IconButton Icon={icon} containerStyle={{ marginLeft: 8 }} onPress={toggleSettingsModal} />
 
-      <PaperModalContainer isVisible={settingsModalOpen} onClose={toggleSettingsModal}>
+      <PaperModalContainer
+        isVisible={settingsModalOpen}
+        onClose={toggleSettingsModal}
+        heightFactor={0.6}
+      >
         <View style={localStyles.container}>
           <FlexRow
             alignItems="flex-start"
@@ -103,6 +109,12 @@ const SettingsIconComponent = ({
             comment={modalStrings.bluetooth_permission_comment}
             enabled={bluetooth}
           />
+          <PermissionRow
+            onPress={requestLocationService}
+            label={modalStrings.location_service}
+            comment={modalStrings.location_service_comment}
+            enabled={locationService}
+          />
         </View>
       </PaperModalContainer>
     </>
@@ -129,17 +141,20 @@ const stateToProps = state => {
   const bluetooth = PermissionSelectors.bluetooth(state);
   const writeStorage = PermissionSelectors.writeStorage(state);
   const location = PermissionSelectors.location(state);
-  return { bluetooth, location, usingVaccines, writeStorage };
+  const locationService = PermissionSelectors.locationService(state);
+  return { bluetooth, location, locationService, usingVaccines, writeStorage };
 };
 
 const dispatchToProps = dispatch => {
   const requestWriteStorage = () => dispatch(PermissionActions.requestWriteStorage());
   const requestLocation = () => dispatch(PermissionActions.requestLocation());
+  const requestLocationService = () => dispatch(PermissionActions.requestLocationService());
   const requestBluetooth = () => dispatch(PermissionActions.requestBluetooth());
 
   return {
     requestBluetooth,
     requestLocation,
+    requestLocationService,
     requestWriteStorage,
   };
 };
@@ -147,8 +162,10 @@ const dispatchToProps = dispatch => {
 SettingsIconComponent.propTypes = {
   bluetooth: PropTypes.bool.isRequired,
   location: PropTypes.bool.isRequired,
+  locationService: PropTypes.bool.isRequired,
   requestBluetooth: PropTypes.func.isRequired,
   requestLocation: PropTypes.func.isRequired,
+  requestLocationService: PropTypes.func.isRequired,
   requestWriteStorage: PropTypes.func.isRequired,
   usingVaccines: PropTypes.bool.isRequired,
   writeStorage: PropTypes.bool.isRequired,

--- a/src/widgets/PermissionSettingsIcon.js
+++ b/src/widgets/PermissionSettingsIcon.js
@@ -3,7 +3,7 @@
  * Sustainable Solutions (NZ) Ltd. 2021
  */
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import PropTypes from 'prop-types';
@@ -44,8 +44,28 @@ PermissionRow.propTypes = {
   onPress: PropTypes.func.isRequired,
 };
 
+const PermissionChecker = ({ enabled, checkPermissions }) => {
+  const handler = useRef();
+
+  useEffect(() => {
+    if (enabled && handler.current) {
+      clearInterval(handler.current);
+    }
+    if (!enabled) {
+      handler.current = setInterval(() => checkPermissions(), 500);
+    }
+    return () => clearInterval(handler.current);
+  }, [enabled]);
+  return <></>;
+};
+PermissionChecker.propTypes = {
+  enabled: PropTypes.bool.isRequired,
+  checkPermissions: PropTypes.func.isRequired,
+};
+
 const SettingsIconComponent = ({
   bluetooth,
+  checkPermissions,
   location,
   locationService,
   requestBluetooth,
@@ -62,7 +82,7 @@ const SettingsIconComponent = ({
   }
 
   const icon =
-    location && bluetooth && writeStorage ? (
+    location && bluetooth && writeStorage && locationService ? (
       <CogIcon />
     ) : (
       <HazardIcon color={SUSSOL_ORANGE} size={20} />
@@ -116,6 +136,7 @@ const SettingsIconComponent = ({
             enabled={locationService}
           />
         </View>
+        <PermissionChecker checkPermissions={checkPermissions} enabled={locationService} />
       </PaperModalContainer>
     </>
   );
@@ -146,12 +167,14 @@ const stateToProps = state => {
 };
 
 const dispatchToProps = dispatch => {
+  const checkPermissions = () => dispatch(PermissionActions.checkPermissions());
   const requestWriteStorage = () => dispatch(PermissionActions.requestWriteStorage());
   const requestLocation = () => dispatch(PermissionActions.requestLocation());
   const requestLocationService = () => dispatch(PermissionActions.requestLocationService());
   const requestBluetooth = () => dispatch(PermissionActions.requestBluetooth());
 
   return {
+    checkPermissions,
     requestBluetooth,
     requestLocation,
     requestLocationService,
@@ -161,6 +184,7 @@ const dispatchToProps = dispatch => {
 
 SettingsIconComponent.propTypes = {
   bluetooth: PropTypes.bool.isRequired,
+  checkPermissions: PropTypes.func.isRequired,
   location: PropTypes.bool.isRequired,
   locationService: PropTypes.bool.isRequired,
   requestBluetooth: PropTypes.func.isRequired,

--- a/src/widgets/SettingsIcon.js
+++ b/src/widgets/SettingsIcon.js
@@ -1,0 +1,153 @@
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2021
+ */
+
+import React from 'react';
+import { connect } from 'react-redux';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { selectUsingVaccines } from '../selectors/modules';
+import { PermissionSelectors } from '../selectors/permission';
+import { PermissionActions } from '../actions/PermissionActions';
+
+import { useToggle } from '../hooks/index';
+import { CancelIcon, CogIcon, ConfirmIcon, DisabledIcon, HazardIcon } from './icons';
+import { PaperModalContainer } from './PaperModal/PaperModalContainer';
+import { IconButton } from './IconButton';
+import { FlexRow } from './FlexRow';
+
+import { DARK_GREY } from '../globalStyles';
+import { modalStrings } from '../localization';
+
+const PermissionRow = ({ comment, enabled, onPress, label }) => (
+  <TouchableOpacity onPress={enabled ? null : onPress}>
+    <FlexRow alignItems="flex-start" flex={0} style={localStyles.permissionRowContainer}>
+      {enabled ? <ConfirmIcon /> : <DisabledIcon />}
+      <FlexRow style={{ flexDirection: 'column', marginLeft: 10 }}>
+        <Text style={localStyles.permissionRowText}>{label}</Text>
+        <Text style={localStyles.permissionRowComment}>{comment}</Text>
+      </FlexRow>
+    </FlexRow>
+  </TouchableOpacity>
+);
+
+PermissionRow.defaultProps = {
+  comment: '',
+};
+
+PermissionRow.propTypes = {
+  comment: PropTypes.string,
+  enabled: PropTypes.bool.isRequired,
+  label: PropTypes.string.isRequired,
+  onPress: PropTypes.func.isRequired,
+};
+
+const SettingsIconComponent = ({
+  bluetooth,
+  location,
+  requestBluetooth,
+  requestLocation,
+  requestWriteStorage,
+  usingVaccines,
+  writeStorage,
+}) => {
+  const [settingsModalOpen, toggleSettingsModal] = useToggle();
+
+  if (!usingVaccines) {
+    return null;
+  }
+
+  const icon =
+    location && bluetooth && writeStorage ? (
+      <CogIcon color={DARK_GREY} />
+    ) : (
+      <HazardIcon color={DARK_GREY} size={20} />
+    );
+
+  return (
+    <>
+      <IconButton Icon={icon} containerStyle={{ marginLeft: 8 }} onPress={toggleSettingsModal} />
+
+      <PaperModalContainer isVisible={settingsModalOpen} onClose={toggleSettingsModal}>
+        <View style={localStyles.container}>
+          <FlexRow
+            alignItems="flex-start"
+            justifyContent="flex-end"
+            style={localStyles.cancelContainer}
+            flex={0}
+          >
+            <IconButton onPress={toggleSettingsModal} Icon={<CancelIcon />} />
+          </FlexRow>
+
+          <Text style={localStyles.heading}>{modalStrings.permissions}</Text>
+          <PermissionRow
+            onPress={requestWriteStorage}
+            label={modalStrings.storage_permission}
+            comment={modalStrings.storage_permission_comment}
+            enabled={writeStorage}
+          />
+          <PermissionRow
+            onPress={requestLocation}
+            label={modalStrings.location_permission}
+            comment={modalStrings.location_permission_comment}
+            enabled={location}
+          />
+          <Text style={localStyles.heading}>{modalStrings.services}</Text>
+          <PermissionRow
+            onPress={requestBluetooth}
+            label={modalStrings.bluetooth_permission}
+            comment={modalStrings.bluetooth_permission_comment}
+            enabled={bluetooth}
+          />
+        </View>
+      </PaperModalContainer>
+    </>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  cancelContainer: { padding: 5, width: '100%' },
+  container: {
+    justifyContent: 'flex-start',
+    flex: 1,
+    flexDirection: 'column',
+    paddingLeft: 20,
+  },
+  heading: { fontSize: 28, fontWeight: 'bold', marginBottom: 20 },
+  permissionRowComment: {},
+  permissionRowContainer: { marginBottom: 15, marginLeft: 30 },
+  permissionRowText: { fontSize: 18 },
+});
+
+const stateToProps = state => {
+  const usingVaccines = selectUsingVaccines(state);
+  const bluetooth = PermissionSelectors.bluetooth(state);
+  const writeStorage = PermissionSelectors.writeStorage(state);
+  const location = PermissionSelectors.location(state);
+  return { bluetooth, location, usingVaccines, writeStorage };
+};
+
+const dispatchToProps = dispatch => {
+  const requestWriteStorage = () => dispatch(PermissionActions.requestWriteStorage());
+  const requestLocation = () => dispatch(PermissionActions.requestLocation());
+  const requestBluetooth = () => dispatch(PermissionActions.requestBluetooth());
+
+  return {
+    requestBluetooth,
+    requestLocation,
+    requestWriteStorage,
+  };
+};
+
+SettingsIconComponent.propTypes = {
+  bluetooth: PropTypes.bool.isRequired,
+  location: PropTypes.bool.isRequired,
+  requestBluetooth: PropTypes.func.isRequired,
+  requestLocation: PropTypes.func.isRequired,
+  requestWriteStorage: PropTypes.func.isRequired,
+  usingVaccines: PropTypes.bool.isRequired,
+  writeStorage: PropTypes.bool.isRequired,
+};
+export const SettingsIcon = connect(stateToProps, dispatchToProps)(SettingsIconComponent);

--- a/src/widgets/SettingsIcon.js
+++ b/src/widgets/SettingsIcon.js
@@ -18,7 +18,7 @@ import { PaperModalContainer } from './PaperModal/PaperModalContainer';
 import { IconButton } from './IconButton';
 import { FlexRow } from './FlexRow';
 
-import { DARK_GREY } from '../globalStyles';
+import { SUSSOL_ORANGE } from '../globalStyles';
 import { modalStrings } from '../localization';
 
 const PermissionRow = ({ comment, enabled, onPress, label }) => (
@@ -61,9 +61,9 @@ const SettingsIconComponent = ({
 
   const icon =
     location && bluetooth && writeStorage ? (
-      <CogIcon color={DARK_GREY} />
+      <CogIcon />
     ) : (
-      <HazardIcon color={DARK_GREY} size={20} />
+      <HazardIcon color={SUSSOL_ORANGE} size={20} />
     );
 
   return (
@@ -81,6 +81,8 @@ const SettingsIconComponent = ({
             <IconButton onPress={toggleSettingsModal} Icon={<CancelIcon />} />
           </FlexRow>
 
+          <Text>{modalStrings.permissions_intro_1}</Text>
+          <Text style={localStyles.intro}>{modalStrings.permissions_intro_2}</Text>
           <Text style={localStyles.heading}>{modalStrings.permissions}</Text>
           <PermissionRow
             onPress={requestWriteStorage}
@@ -115,10 +117,11 @@ const localStyles = StyleSheet.create({
     flexDirection: 'column',
     paddingLeft: 20,
   },
-  heading: { fontSize: 28, fontWeight: 'bold', marginBottom: 20 },
+  heading: { fontSize: 24, fontWeight: 'bold', marginBottom: 15 },
+  intro: { marginBottom: 15 },
   permissionRowComment: {},
   permissionRowContainer: { marginBottom: 15, marginLeft: 30 },
-  permissionRowText: { fontSize: 18 },
+  permissionRowText: { fontSize: 16, fontWeight: 'bold' },
 });
 
 const stateToProps = state => {

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -59,9 +59,11 @@ export const CloseIcon = ({ size, color }) => <IonIcon name="md-close" size={siz
 CloseIcon.defaultProps = { color: WHITE, size: 36 };
 CloseIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
 
-export const CogIcon = ({ size, color }) => <FAIcon name="cog" size={size} color={color} />;
-CogIcon.defaultProps = { color: GREY, size: 20 };
-CogIcon.propTypes = { color: PropTypes.string, size: PropTypes.number };
+export const CogIcon = ({ size, color, style }) => (
+  <FAIcon name="cog" size={size} color={color} style={style} />
+);
+CogIcon.defaultProps = { color: GREY, size: 20, style: {} };
+CogIcon.propTypes = { color: PropTypes.string, size: PropTypes.number, style: PropTypes.object };
 
 export const ExpandIcon = React.memo(({ style, color, size }) => (
   <FAIcon name="external-link" style={style} size={size} color={color} />
@@ -367,4 +369,14 @@ PlayIcon.propTypes = {
   size: PropTypes.number,
   style: PropTypes.object,
   color: PropTypes.string,
+};
+
+export const DisabledIcon = React.memo(({ style, color, size }) => (
+  <FAIcon name="times-circle" style={style} color={color} size={size} />
+));
+DisabledIcon.defaultProps = { color: FINALISED_RED, size: 40, style: {} };
+DisabledIcon.propTypes = {
+  style: PropTypes.object,
+  color: PropTypes.string,
+  size: PropTypes.number,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8200,6 +8200,11 @@ react-native-svg@^11.0.1:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
 
+react-native-system-setting@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/react-native-system-setting/-/react-native-system-setting-1.7.6.tgz#43633604ac1bd5fd906acdbffa627a1998d2345a"
+  integrity sha512-nBnIK5Xnyu8XRRA3BMzRI54oYlSBKc0oOTQdZOCEeOvn4ltS1nk2shj/vtMQe6khXvuhai3vIc+g7DcsOcr5+w==
+
 react-native-tab-view@^2.15.2:
   version "2.15.2"
   resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-2.15.2.tgz#4bc7832d33a119306614efee667509672a7ee64e"


### PR DESCRIPTION
Fixes #3376 

## Change summary

Adds a wee icon to the top right - showing an exclamation if there's a problem:

![Screenshot_2021-02-11-15-13-30-727](https://user-images.githubusercontent.com/9192912/107597447-8a304e00-6c7f-11eb-99dc-1b289fab3bd9.jpeg)

..or a settings icon if everything is fine:

![Screenshot_2021-02-11-15-11-30-258](https://user-images.githubusercontent.com/9192912/107597454-8ef50200-6c7f-11eb-8b6c-622ea4b7dc11.jpeg)

Pressing the icon shows a modal giving the status of the permission and services required. If something is disabled, pressing that line will prompt to enable:

![Screenshot_2021-02-11-15-13-40-049](https://user-images.githubusercontent.com/9192912/107597519-bc41b000-6c7f-11eb-9250-95ee7ea18e17.jpeg)

![Screenshot_2021-02-11-15-11-37-358](https://user-images.githubusercontent.com/9192912/107597524-c1066400-6c7f-11eb-8ce9-3feb2ca8fe80.jpeg)

One extra item is whether we need to display location services - which we currently don't have in the permissions checks. Was looking at `react-native-connectivity-status` - don't know if we need to do this though? seems to work ok as it is?

Also - I've only shown this when vaccines are enabled, as the permission checks are tied to vaccine enabled also. Should this be changed?

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Disable storage permission and start the app. confirm that the settings icon shows an exclamation sign
- [ ] Press the settings/exclamation icon and confirm the modal shows
- [ ] With storage permission disabled, press the settings/exclamation icon and confirm that the 'Storage' shows as disabled
- [ ] With storage permission disabled, press the settings/exclamation icon. In the modal, press 'Storage'. confirm that the settings prompt shows
- [ ] With the Storage settings prompt showing, press 'deny'. confirm that the 'Storage' permission still shows as disabled
- [ ] With the Storage settings prompt showing, press 'allow'. confirm that the 'Storage' permission shows as enabled
- [ ] In the settings modal, press 'Storage' when storage is enabled. Confirm that the storage prompt does not show
- [ ] With location permission disabled, press the settings/exclamation icon and confirm that the 'Location' shows as disabled
- [ ] With location permission disabled, press the settings/exclamation icon. In the modal, press 'Location'. confirm that the settings prompt shows
- [ ] With the Location settings prompt showing, press 'deny'. confirm that the 'Location' permission still shows as disabled
- [ ] With the Location settings prompt showing, press 'allow'. confirm that the 'Location' permission shows as enabled
- [ ] In the settings modal, press 'Location' when location is enabled. Confirm that the location prompt does not show


