### PR TITLE
#3488 adjust cumulative breach units

### DIFF
--- a/src/selectors/fridge.js
+++ b/src/selectors/fridge.js
@@ -5,7 +5,8 @@
 import moment from 'moment';
 import { createSelector } from 'reselect';
 import { UIDatabase } from '../database';
-import { chunk } from '../utilities';
+import { chunk, MILLISECONDS } from '../utilities';
+
 import { CHART_CONSTANTS, VACCINE_CONSTANTS } from '../utilities/modules/vaccines/constants';
 
 export const selectSelectedFridgeID = ({ fridge }) => {
@@ -200,10 +201,10 @@ export const selectHotCumulativeBreach = createSelector(
     const { minimumTemperature, duration } = hotCumulativeBreachConfig;
 
     const logsOverThreshold = logs.filtered('temperature >= $0', minimumTemperature);
-    const sum = logsOverThreshold.sum('logInterval') ?? 0;
+    const sum = logsOverThreshold.sum('logInterval') * MILLISECONDS.ONE_SECOND ?? 0;
     const hasCumulativeBreach = sum >= duration && duration;
 
-    return hasCumulativeBreach ? formatTime(sum * 1000) : null;
+    return hasCumulativeBreach ? formatTime(sum) : null;
   }
 );
 
@@ -215,10 +216,10 @@ export const selectColdCumulativeBreach = createSelector(
     const { maximumTemperature, duration } = coldCumulativeBreachConfig;
 
     const logsOverThreshold = logs.filtered('temperature <= $0', maximumTemperature);
-    const sum = logsOverThreshold.sum('logInterval') ?? 0;
+    const sum = logsOverThreshold.sum('logInterval') * MILLISECONDS.ONE_SECOND ?? 0;
     const hasCumulativeBreach = sum >= duration && duration;
 
-    return hasCumulativeBreach ? formatTime(sum * 1000) : null;
+    return hasCumulativeBreach ? formatTime(sum) : null;
   }
 );
 


### PR DESCRIPTION
Fixes #3488 

## Change summary

- Adjusts cumulative breach calculation 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Follow steps in original issue https://github.com/openmsupply/mobile/issues/3488 - a hot cumulative breach should show up for test sensor 2 when the duration is set to 2 minutes, and a cold cumulative breach should show up for test sensor 3 when the duration is set to 2 minutes

### Related areas to think about

- Might be a separate issue that the card doesn't update when a download has occurred in background, to investigate separately
