### PR TITLE
Remove is_paused from sync

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -1075,7 +1075,6 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         batteryLevel: parseNumber(record.batteryLevel),
         name: record.name,
         isActive: parseBoolean(record.is_active),
-        isPaused: parseBoolean(record.is_paused),
         logDelay: parseDate(record.log_delay_date, record.log_delay_time) ?? new Date(0),
         programmedDate: parseDate(record.programmed_date, record.programmed_time) ?? new Date(),
       });

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -388,7 +388,6 @@ const generateSyncData = (settings, recordType, record) => {
         storeID: settings.get(THIS_STORE_ID),
         locationID: record.location?.id,
         is_active: String(record.isActive ?? true),
-        is_paused: String(record.isPaused ?? false),
         log_delay_time: getTimeString(record.logDelay),
         log_delay_date: getDateString(record.logDelay),
         programmed_time: getTimeString(record.programmedDate),


### PR DESCRIPTION
Fixes #3492 

## Change summary

- Removes `is_paused` from sync - not gonna get the field into desktop before the release

## Testing

- [ ] Sync works after having added a sensor.

### Related areas to think about

N/A