### PR TITLE
#3495 Show temperature is n/a not 0 on vaccine module page

### DIFF
--- a/src/database/DataTypes/Sensor.js
+++ b/src/database/DataTypes/Sensor.js
@@ -35,10 +35,6 @@ export class Sensor extends Realm.Object {
     return this.sendCommand('*logall');
   }
 
-  get breachConfigIDs() {
-    return this.breachConfigs?.map(({ id }) => id);
-  }
-
   get hasBreached() {
     return this.location?.hasBreached ?? false;
   }

--- a/src/database/DataTypes/Sensor.js
+++ b/src/database/DataTypes/Sensor.js
@@ -35,6 +35,10 @@ export class Sensor extends Realm.Object {
     return this.sendCommand('*logall');
   }
 
+  get breachConfigIDs() {
+    return this.breachConfigs?.map(({ id }) => id);
+  }
+
   get hasBreached() {
     return this.location?.hasBreached ?? false;
   }

--- a/src/utilities/temperature.js
+++ b/src/utilities/temperature.js
@@ -22,7 +22,7 @@
  * }
  */
 class Temperature {
-  constructor(value = 0, options = {}) {
+  constructor(value, options = {}) {
     this.options = { ...DEFAULT_OPTIONS, ...options };
     this.value = value;
   }
@@ -33,6 +33,8 @@ class Temperature {
 
     const metricToUse = asMetric || metric;
 
+    // == null captures both null and undefined
+    if (value == null) return this.options.invalidPattern;
     if (metricToUse === metric) return Number(value).toFixed(precision);
     if (metricToUse === CELSIUS) return Number(celsiusFromFahrenheit(value)).toFixed(precision);
 


### PR DESCRIPTION
Fixes #3495 

## Change summary

- Shows the temperature of a sensor with no logs is N/A instead of `0` by not assigning `0` as a default temperature, and returning the invalid pattern in `.temperature()`

## Testing

- [ ] Add a new sensor, the temperature should be N/A not `0.0`

### Related areas to think about

N/A