### PR TITLE
#3501 HazardIcon to use the full dataset

### DIFF
--- a/src/pages/FridgeDetailPage.js
+++ b/src/pages/FridgeDetailPage.js
@@ -31,6 +31,7 @@ import { APP_FONT_FAMILY, DARKER_GREY, BLUE_WHITE, WARMER_GREY } from '../global
 import { vaccineStrings } from '../localization/index';
 import { SensorHeader } from '../widgets/SensorHeader/SensorHeader';
 import { BreachManUnhappy } from '../widgets/BreachManUnhappy';
+import { BreachActions } from '../actions/BreachActions';
 
 const BREACH_MAN_UNHAPPY_SIZE = 400;
 const EmptyComponent = ({ sensorName }) => (
@@ -59,6 +60,7 @@ export const FridgeDetailPageComponent = ({
   maximumDate,
   sensor,
   breachBoundaries,
+  onPressBreach,
 }) => {
   const [chartType, setChartType] = useState('bar');
   const getIconButton = type => {
@@ -130,6 +132,7 @@ export const FridgeDetailPageComponent = ({
                     minDomain={minDomain}
                     maxDomain={maxDomain}
                     breachBoundaries={breachBoundaries}
+                    onPressBreach={onPressBreach}
                   />
                 )}
                 {chartType === 'bar' && (
@@ -199,9 +202,11 @@ const stateToProps = (state, props) => {
 const dispatchToProps = dispatch => ({
   onChangeToDate: date => dispatch(FridgeActions.changeToDate(date)),
   onChangeFromDate: date => dispatch(FridgeActions.changeFromDate(date)),
+  onPressBreach: breachId => dispatch(BreachActions.viewFridgeBreach(breachId)),
 });
 
 FridgeDetailPageComponent.propTypes = {
+  onPressBreach: PropTypes.func.isRequired,
   breaches: PropTypes.object.isRequired,
   minLine: PropTypes.array.isRequired,
   maxLine: PropTypes.array.isRequired,

--- a/src/widgets/HazardPoint.js
+++ b/src/widgets/HazardPoint.js
@@ -7,9 +7,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import Svg, { Path, G } from 'react-native-svg';
+import Svg, { Rect, Path, G } from 'react-native-svg';
 
-import { SUSSOL_ORANGE } from '../globalStyles/colors';
+import { SUSSOL_ORANGE, TRANSPARENT } from '../globalStyles/colors';
 
 const hazardPath = `M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423
  23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595
@@ -20,14 +20,22 @@ const hazardPath = `M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.0
  * Custom component for rendering clickable hazard icons.
  */
 export const HazardPoint = props => {
-  const { x, y, onPress, datum } = props;
+  const { x, y, onPress, dataSet, index } = props;
   const { xOffset, yOffset, scale, fill } = hazardPointStyles;
 
-  const onPressWrapper = React.useCallback(() => onPress?.(datum?.id), []);
+  const onPressWrapper = React.useCallback(() => onPress?.(dataSet[index]?.id), []);
 
   return (
     <Svg>
-      <G onPressIn={onPressWrapper} delayPressIn={0}>
+      <G>
+        <Rect
+          x={x + xOffset}
+          y={y + yOffset}
+          width="50"
+          height="50"
+          fill={TRANSPARENT}
+          onPress={onPressWrapper}
+        />
         <Path x={x + xOffset} y={y + yOffset} scale={scale} d={hazardPath} fill={fill} />
       </G>
     </Svg>
@@ -49,5 +57,6 @@ HazardPoint.propTypes = {
   x: PropTypes.number,
   y: PropTypes.number,
   onPress: PropTypes.func,
-  datum: PropTypes.object,
+  index: PropTypes.number.isRequired,
+  dataSet: PropTypes.array.isRequired,
 };

--- a/src/widgets/HazardPoint.js
+++ b/src/widgets/HazardPoint.js
@@ -49,6 +49,7 @@ const hazardPointStyles = {
   yOffset: -33,
   scale: 0.05,
   fill: SUSSOL_ORANGE,
+  index: 0,
 };
 
 // Bug in Victory charts causes required props to be undefined on first render,
@@ -57,6 +58,6 @@ HazardPoint.propTypes = {
   x: PropTypes.number,
   y: PropTypes.number,
   onPress: PropTypes.func,
-  index: PropTypes.number.isRequired,
+  index: PropTypes.number,
   dataSet: PropTypes.array.isRequired,
 };

--- a/src/widgets/HazardPoint.js
+++ b/src/widgets/HazardPoint.js
@@ -28,6 +28,7 @@ export const HazardPoint = props => {
   return (
     <Svg>
       <G>
+        <Path x={x + xOffset} y={y + yOffset} scale={scale} d={hazardPath} fill={fill} />
         <Rect
           x={x + xOffset}
           y={y + yOffset}
@@ -36,7 +37,6 @@ export const HazardPoint = props => {
           fill={TRANSPARENT}
           onPress={onPressWrapper}
         />
-        <Path x={x + xOffset} y={y + yOffset} scale={scale} d={hazardPath} fill={fill} />
       </G>
     </Svg>
   );

--- a/src/widgets/VaccineLineChart.js
+++ b/src/widgets/VaccineLineChart.js
@@ -84,7 +84,7 @@ export const VaccineLineChart = ({
             data={breaches.slice()}
             y={y}
             x={x}
-            dataComponent={<HazardPoint onPress={onPressBreach} />}
+            dataComponent={<HazardPoint dataSet={breaches.slice()} onPress={onPressBreach} />}
           />
         </VictoryChart>
       </Svg>

--- a/src/widgets/modalChildren/BreachDisplay.js
+++ b/src/widgets/modalChildren/BreachDisplay.js
@@ -6,54 +6,27 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { View, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
+import { View, FlatList, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
 import { getPageInfoColumns } from '../../pages/dataTableUtilities';
-import { chunk } from '../../utilities/chunk';
 
 import { BreachChart } from '../BreachChart';
 import { PageInfo } from '../PageInfo/PageInfo';
 
-import { WHITE, SUSSOL_ORANGE } from '../../globalStyles';
+import { WHITE } from '../../globalStyles';
+import { AfterInteractions } from '../AfterInteractions';
 
 const Breach = ({ breach, getInfoColumns }) => {
   const { temperatureLogs } = breach;
 
-  const [chartData, setChartData] = React.useState({ lineData: [], render: false });
-  const { render, lineData } = chartData;
-
-  React.useEffect(() => {
-    const { length: numberOfLogs } = temperatureLogs;
-    setTimeout(() => {
-      const chunkSize = Math.ceil(numberOfLogs / Math.min(numberOfLogs, 30));
-      const chunkedLogs = chunk(temperatureLogs, chunkSize);
-      const mappedLineData = chunkedLogs.map(chunkOfLogs => ({
-        temperature: Math.max(...chunkOfLogs.map(({ temperature }) => temperature)),
-        timestamp: Math.max(...chunkOfLogs.map(({ timestamp }) => timestamp)),
-      }));
-
-      setChartData({ lineData: mappedLineData, render: true });
-    }, 500);
-  }, []);
-
-  const pageInfoColumns = React.useMemo(() => getInfoColumns(breach), [breach]);
-
-  const Display = React.useCallback(
-    () =>
-      render ? (
-        <BreachChart breach={breach} lineData={lineData} />
-      ) : (
-        <ActivityIndicator color={SUSSOL_ORANGE} size="small" />
-      ),
-    [render]
-  );
-
   return (
-    <View style={localStyles.container}>
-      <PageInfo columns={pageInfoColumns} />
-      <Display />
-    </View>
+    <AfterInteractions>
+      <View style={localStyles.container}>
+        <PageInfo columns={getInfoColumns(breach)} />
+        <BreachChart breach={breach} lineData={temperatureLogs.slice()} />
+      </View>
+    </AfterInteractions>
   );
 };
 
@@ -77,7 +50,11 @@ const BreachDisplayComponent = ({ breaches }) => {
     [breaches]
   );
 
-  return <FlatList data={breaches} renderItem={renderItem} />;
+  return (
+    <AfterInteractions>
+      <FlatList data={breaches} renderItem={renderItem} />
+    </AfterInteractions>
+  );
 };
 
 BreachDisplayComponent.propTypes = {


### PR DESCRIPTION
Fixes #3501 

## Change summary

- Seems the `dataComponent` was previously being passed the `datum` component which was a real breach object, and it is now only an object `{x: .., y: ..}`, so, it doesn't have an `id` to pass back to find the breach. So instead, pass the full data set to the icon component as it is passed the `idx` of which data element it is... 
- Also simplified `BreachDisplay` and removed the weird logic which was trying to limit the number of data points and displaying a spinner with `AfterInteractions`
- Also made the hazard icon more clickable by chucking a bigger rect around it, sort of. 

## Testing

- [ ] Clicking a hazard icon on the `FridgeDetailPage` opens a breach modal

### Related areas to think about

There's plenty wrong with the `breachmodal` itself but.. for another issue, I think


![image](https://user-images.githubusercontent.com/35858975/107988715-78f79080-7035-11eb-96fb-aa86f48cf94f.png)
