### PR TITLE
#3493 Default of 100 for battery level

### DIFF
--- a/src/bluetooth/SensorManager.js
+++ b/src/bluetooth/SensorManager.js
@@ -40,7 +40,7 @@ class SensorManager {
       name,
       location,
       logInterval,
-      batteryLevel: 0,
+      batteryLevel: 100,
       isActive: true,
     });
   };

--- a/src/database/DataTypes/Sensor.js
+++ b/src/database/DataTypes/Sensor.js
@@ -118,7 +118,7 @@ Sensor.schema = {
     macAddress: { type: 'string', optional: true },
     name: { type: 'string', default: '' },
     location: { type: 'Location', optional: true },
-    batteryLevel: { type: 'double', default: 0 },
+    batteryLevel: { type: 'double', default: 100 },
     logs: { type: 'linkingObjects', objectType: 'TemperatureLog', property: 'sensor' },
     breaches: { type: 'linkingObjects', objectType: 'TemperatureBreach', property: 'sensor' },
     isActive: { type: 'bool', default: true },


### PR DESCRIPTION
Fixes #3493 

## Change summary

- Adds a default of 100 for the battery level of a sensor. It's not ideal, ideally we'd scan straight away and pick up the real battery level, but that went in the too hard basket - in reality, it won't really be too long before a download occurs and the battery level is picked up correctly

## Testing

- [ ] When adding a sensor the sensor doesn't have a flashing red circle and has a battery level of 100

### Related areas to think about

N/A