### PR TITLE
#3505 remove warnings

### DIFF
--- a/src/database/DataTypes/Location.js
+++ b/src/database/DataTypes/Location.js
@@ -109,6 +109,7 @@ Location.schema = {
       type: 'linkingObjects',
       objectType: 'LocationMovement',
       property: 'location',
+      default: [],
     },
     sensors: {
       type: 'linkingObjects',

--- a/src/database/DataTypes/Location.js
+++ b/src/database/DataTypes/Location.js
@@ -109,7 +109,6 @@ Location.schema = {
       type: 'linkingObjects',
       objectType: 'LocationMovement',
       property: 'location',
-      default: [],
     },
     sensors: {
       type: 'linkingObjects',

--- a/src/main.js
+++ b/src/main.js
@@ -35,6 +35,10 @@ const App = () => {
   );
 };
 
-LogBox.ignoreLogs(['Setting a timer', 'componentWillMount']);
+LogBox.ignoreLogs([
+  'Setting a timer',
+  'componentWillMount',
+  'Non-serializable values were found in the navigation state',
+]);
 
 AppRegistry.registerComponent(appName, () => App);

--- a/src/pages/FridgeDetailPage.js
+++ b/src/pages/FridgeDetailPage.js
@@ -205,6 +205,11 @@ const dispatchToProps = dispatch => ({
   onPressBreach: breachId => dispatch(BreachActions.viewFridgeBreach(breachId)),
 });
 
+FridgeDetailPageComponent.defaultProps = {
+  minimumDate: null,
+  maximumDate: null,
+};
+
 FridgeDetailPageComponent.propTypes = {
   onPressBreach: PropTypes.func.isRequired,
   breaches: PropTypes.object.isRequired,
@@ -216,8 +221,8 @@ FridgeDetailPageComponent.propTypes = {
   onChangeFromDate: PropTypes.func.isRequired,
   fromDate: PropTypes.instanceOf(Date).isRequired,
   toDate: PropTypes.instanceOf(Date).isRequired,
-  minimumDate: PropTypes.instanceOf(Date).isRequired,
-  maximumDate: PropTypes.instanceOf(Date).isRequired,
+  minimumDate: PropTypes.instanceOf(Date),
+  maximumDate: PropTypes.instanceOf(Date),
   sensor: PropTypes.object.isRequired,
   breachBoundaries: PropTypes.object.isRequired,
 };

--- a/src/pages/NewSensor/NewSensorStepThree.js
+++ b/src/pages/NewSensor/NewSensorStepThree.js
@@ -153,7 +153,7 @@ const stateToProps = state => {
   const { logInterval, logDelay, name, macAddress } = newSensor ?? {};
   const { code } = location ?? {};
 
-  return { logInterval, logDelay: new Date(logDelay), name, code, macAddress };
+  return { logInterval, logDelay: new Date(logDelay).getTime(), name, code, macAddress };
 };
 
 NewSensorStepThreeComponent.defaultProps = {

--- a/src/selectors/Entities/sensor.js
+++ b/src/selectors/Entities/sensor.js
@@ -60,13 +60,13 @@ export const selectIsLowBatteryByMac = (state, mac) => {
 export const selectIsInHotBreachByMac = (state, mac) => {
   const sensor = selectSensorByMac(state, mac) ?? {};
   const { isInHotBreach } = sensor;
-  return isInHotBreach;
+  return !!isInHotBreach;
 };
 
 export const selectIsInColdBreachByMac = (state, mac) => {
   const sensor = selectSensorByMac(state, mac) ?? {};
   const { isInColdBreach } = sensor;
-  return isInColdBreach;
+  return !!isInColdBreach;
 };
 
 export const selectIsInBreachByMac = (state, mac) => {

--- a/src/selectors/Entities/sensor.js
+++ b/src/selectors/Entities/sensor.js
@@ -72,7 +72,7 @@ export const selectIsInColdBreachByMac = (state, mac) => {
 export const selectIsInBreachByMac = (state, mac) => {
   const sensor = selectSensorByMac(state, mac) ?? {};
   const { isInHotBreach, isInColdBreach } = sensor;
-  return isInHotBreach || isInColdBreach;
+  return !!isInHotBreach || !!isInColdBreach;
 };
 
 export const selectIsInDangerByMac = (state, mac) => {

--- a/src/widgets/BreachCard.js
+++ b/src/widgets/BreachCard.js
@@ -63,7 +63,7 @@ BreachCardComponent.defaultProps = {
   message: '',
 };
 BreachCardComponent.propTypes = {
-  breachCount: PropTypes.number,
+  breachCount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   config: PropTypes.shape({
     type: PropTypes.string.isRequired,
     breachCount: PropTypes.number,

--- a/src/widgets/BreachCard.js
+++ b/src/widgets/BreachCard.js
@@ -57,22 +57,13 @@ const BreachCardComponent = ({ config }) => {
   );
 };
 
-BreachCardComponent.defaultProps = {
-  breachCount: 0,
-  headerText: '',
-  message: '',
-};
 BreachCardComponent.propTypes = {
-  breachCount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   config: PropTypes.shape({
     type: PropTypes.string.isRequired,
-    breachCount: PropTypes.number,
+    breachCount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     headerText: PropTypes.string,
     message: PropTypes.string,
   }).isRequired,
-  headerText: PropTypes.string,
-  message: PropTypes.string,
-  type: PropTypes.string.isRequired,
 };
 
 const localStyles = StyleSheet.create({

--- a/src/widgets/BreachCard.js
+++ b/src/widgets/BreachCard.js
@@ -59,6 +59,7 @@ const BreachCardComponent = ({ config }) => {
 
 BreachCardComponent.defaultProps = {
   breachCount: 0,
+  headerText: '',
   message: '',
 };
 BreachCardComponent.propTypes = {
@@ -69,7 +70,7 @@ BreachCardComponent.propTypes = {
     headerText: PropTypes.string,
     message: PropTypes.string,
   }).isRequired,
-  headerText: PropTypes.string.isRequired,
+  headerText: PropTypes.string,
   message: PropTypes.string,
   type: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
Fixes #3505 

## Change summary

Removed the cause of some errors and suppressed the non-serializable state one. As far as I could make out, that doesn't affect us and my attempts at creating a plain object instead of the realm object were a little more complicated than I think is needed.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] * Warning: Failed prop type: Invalid prop logDelay of type date supplied to LastSensorDownloadComponent  : this was on returning to the vaccine page after adding a sensor. A number is given when viewing the list i.e. after fetching from db, but that page was formatting as a date
- [ ] * Warning: Non-serializable values were found in the navigation state. Check: fridgeDetail > params.fridge.locationMovements() : this can be seen when viewing any vaccine detail page
- [ ] * Warning: Failed prop type: The prop headerText is marked as required in BreachCardComponent  : View any vaccine page
- [ ] * Warning: Failed prop type: Invalid prop config.breachCount of type string supplied to BreachCardComponent  : View a vaccine page with a cumulative breach
- [ ] * Warning: Failed prop type: The prop isInDanger is marked as required in SensorIsInDangerCircleComponent :  Add a sensor, page two
- [ ] * Warning: Failed prop type: The prop condition is marked as required in WithFlash  : Add a sensor, page two and on the  Vaccines page
- [ ] * Warning: Failed prop type: The prop maximumDate is marked as required in FridgeDetailPageComponent  : Vaccine Detail page when no logs are recorded
- [ ] * Warning: Failed prop type: The prop minimumDate is marked as required in FridgeDetailPageComponent :  Vaccine Detail page when no logs are recorded
