### PR TITLE
#3328 Add Stocktake correct field

### DIFF
--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -257,7 +257,7 @@ export class Stocktake extends Realm.Object {
 
     if (!this.hasSomeCountedItems) {
       finaliseStatus.success = false;
-      finaliseStatus.errorMessage = modalStrings.stocktake_no_counted_items;
+      finaliseStatus.message = modalStrings.stocktake_no_counted_items;
     }
 
     return finaliseStatus;


### PR DESCRIPTION
Fixes #3328 

## Change summary

- Uses the correct field. Can see it should be `message` in `Requisition.canFinalise` and `Transaction.canFinalise`, used in `FinaliseModal`/`finalise.js`

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Correct message on the finalise modal when trying to finalise a stocktake with no counted items 

### Related areas to think about

N/A