### PR TITLE
#3513 Only show vaccine columns with a vaccine item

### DIFF
--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -589,6 +589,10 @@ export class Transaction extends Realm.Object {
     // not synced before linked items.
     database.save('Transaction', this);
   }
+
+  get hasVaccine() {
+    return this.items.some(({ isVaccine }) => isVaccine);
+  }
 }
 
 Transaction.schema = {

--- a/src/pages/CustomerInvoicePage.js
+++ b/src/pages/CustomerInvoicePage.js
@@ -230,7 +230,7 @@ const mapStateToProps = state => {
   const { pageObject } = customerInvoice ?? {};
   const { isCredit = false } = pageObject ?? {};
   if (isCredit) return { ...customerInvoice, columns: getColumns(ROUTES.CUSTOMER_CREDIT) };
-  if (usingVaccines) {
+  if (usingVaccines && pageObject?.hasVaccine) {
     return { ...customerInvoice, columns: getColumns(ROUTES.CUSTOMER_INVOICE_WITH_VACCINES) };
   }
   return { ...customerInvoice, columns: getColumns(ROUTES.CUSTOMER_INVOICE) };

--- a/src/pages/SupplierInvoicePage.js
+++ b/src/pages/SupplierInvoicePage.js
@@ -215,10 +215,10 @@ const mapStateToProps = state => {
 
   const { pageObject } = supplierInvoice ?? {};
 
-  const { isSupplierInvoice } = pageObject ?? {};
+  const { isSupplierInvoice, hasVaccine } = pageObject ?? {};
 
   const columnsKey =
-    usingPayments || usingVaccines
+    usingPayments || (usingVaccines && hasVaccine)
       ? (usingPayments && ROUTES.SUPPLIER_INVOICE_WITH_PRICES) ||
         ROUTES.SUPPLIER_INVOICE_WITH_VACCINES
       : ROUTES.SUPPLIER_INVOICE;


### PR DESCRIPTION
Fixes #3513 

## Change summary

- Only show vaccine columns on SI/CI when theres a vaccine item present

## Testing

- [ ] When adding a vaccine item to a CI, vaccine items show
- [ ] When adding a vaccine item to an SI, vaccine items show

### Related areas to think about

N/A