### PR TITLE
#3517 is paused state is saved

### DIFF
--- a/src/actions/Entities/SensorActions.js
+++ b/src/actions/Entities/SensorActions.js
@@ -127,6 +127,7 @@ const removeSensor = sensorId => dispatch => {
     UIDatabase.update('Sensor', {
       id: sensor.id,
       isActive: false,
+      isPaused: false,
     });
   });
 
@@ -164,6 +165,8 @@ const createNew = () => (dispatch, getState) => {
         ...sensor,
         id: existingSensor.id,
         location: newLocation,
+        isActive: true,
+        isPaused: false,
         logDelay: new Date(sensor?.logDelay ?? 0),
       });
     } else {


### PR DESCRIPTION
Fixes #3517 

## Change summary

- When removing/replacing, explicitly set state correctly.

## Testing

- [ ] When removing a sensor which is paused and readding it, it is not paused.
- [ ] When adding a sensor which was previously removed, it is added to the list of sensors 

### Related areas to think about

N/A