### PR TITLE
#3523 Sensor list to update after sync

### DIFF
--- a/src/reducers/Entities/LocationReducer.js
+++ b/src/reducers/Entities/LocationReducer.js
@@ -1,6 +1,7 @@
 import { LOCATION_ACTIONS } from '../../actions/Entities';
 import { UIDatabase } from '../../database';
 import { ROUTES } from '../../navigation/index';
+import { SYNC_TRANSACTION_COMPLETE } from '../../sync/constants';
 
 // Extracts the required fields of a realm instance into a plain JS object
 // which is more suitable to store in redux as immutable updates are simpler.
@@ -10,14 +11,17 @@ const getPlainLocation = (location = {}) => ({
   code: location.code,
 });
 
-const initialState = () => ({
-  byId: UIDatabase.objects('Location').reduce(
+const getById = () =>
+  UIDatabase.objects('Location').reduce(
     (acc, location) => ({
       ...acc,
       [location.id]: getPlainLocation(location),
     }),
     {}
-  ),
+  );
+
+const initialState = () => ({
+  byId: getById(),
   newId: '',
 });
 
@@ -25,6 +29,11 @@ export const LocationReducer = (state = initialState(), action) => {
   const { type } = action;
 
   switch (type) {
+    case SYNC_TRANSACTION_COMPLETE: {
+      const newById = getById();
+      return { ...state, byId: newById };
+    }
+
     case 'Navigation/NAVIGATE': {
       const { params, routeName } = action;
 

--- a/src/reducers/Entities/SensorReducer.js
+++ b/src/reducers/Entities/SensorReducer.js
@@ -3,6 +3,7 @@ import { BREACH_ACTIONS } from '../../actions/BreachActions';
 import { SENSOR_ACTIONS } from '../../actions/Entities/SensorActions';
 import { UIDatabase } from '../../database';
 import { ROUTES } from '../../navigation/index';
+import { SYNC_TRANSACTION_COMPLETE } from '../../sync/constants';
 
 // Extracts the required fields of a realm instance into a plain JS object
 // which is more suitable to store in redux as immutable updates are simpler.
@@ -23,14 +24,17 @@ const getPlainSensor = sensor => ({
   isInColdBreach: sensor?.isInColdBreach,
 });
 
-const initialState = () => ({
-  byId: UIDatabase.objects('Sensor').reduce(
+const getById = () =>
+  UIDatabase.objects('Sensor').reduce(
     (acc, sensor) => ({
       ...acc,
       [sensor.id]: getPlainSensor(sensor),
     }),
     {}
-  ),
+  );
+
+const initialState = () => ({
+  byId: getById(),
   newId: '',
   editingId: '',
   replacedId: '',
@@ -40,6 +44,11 @@ export const SensorReducer = (state = initialState(), action) => {
   const { type } = action;
 
   switch (type) {
+    case SYNC_TRANSACTION_COMPLETE: {
+      const newById = getById();
+      return { ...state, byId: newById };
+    }
+
     case 'Navigation/NAVIGATE': {
       const { params, routeName } = action;
 

--- a/src/reducers/Entities/TemperatureBreachConfigReducer.js
+++ b/src/reducers/Entities/TemperatureBreachConfigReducer.js
@@ -2,6 +2,7 @@
 import { TEMPERATURE_BREACH_CONFIG_ACTIONS } from '../../actions/Entities/TemperatureBreachConfigActions';
 import { UIDatabase } from '../../database';
 import { ROUTES } from '../../navigation/index';
+import { SYNC_TRANSACTION_COMPLETE } from '../../sync/constants';
 
 // Extracts the required fields of a realm instance into a plain JS object
 // which is more suitable to store in redux as immutable updates are simpler.
@@ -16,14 +17,17 @@ const getPlainTemperatureBreachConfiguration = config => ({
   type: config.type,
 });
 
-const initialState = () => ({
-  byId: UIDatabase.objects('TemperatureBreachConfiguration').reduce(
+const getById = () =>
+  UIDatabase.objects('TemperatureBreachConfiguration').reduce(
     (acc, config) => ({
       ...acc,
       [config.id]: getPlainTemperatureBreachConfiguration(config),
     }),
     {}
-  ),
+  );
+
+const initialState = () => ({
+  byId: getById(),
   newIds: [],
   editingIds: [],
 });
@@ -32,6 +36,11 @@ export const TemperatureBreachConfigReducer = (state = initialState(), action) =
   const { type } = action;
 
   switch (type) {
+    case SYNC_TRANSACTION_COMPLETE: {
+      const newById = getById();
+      return { ...state, byId: newById };
+    }
+
     case 'Navigation/NAVIGATE': {
       const { params, routeName } = action;
 


### PR DESCRIPTION
Fixes #3523 

## Change summary

- Update the `SensorReducer`/`LocationReducer`/`ConfigReducer` states after a sync

## Testing

- [ ] Init a store which has a sensor already, it is displayed in the `VaccinePage`

### Related areas to think about

N/A