### PR TITLE
#3528 Cant spread realm objects

### DIFF
--- a/src/actions/InsuranceActions.js
+++ b/src/actions/InsuranceActions.js
@@ -96,9 +96,10 @@ const update = policyDetails => (dispatch, getState) => {
 const select = insurancePolicy => (dispatch, getState) => {
   const { prescription } = getState();
   const { transaction } = prescription;
+  const { id } = transaction;
 
   UIDatabase.write(() => {
-    UIDatabase.update('Transaction', { ...transaction, insurancePolicy });
+    UIDatabase.update('Transaction', { id, insurancePolicy });
   });
 
   dispatch(selectPolicy(insurancePolicy));

--- a/src/actions/PaymentActions.js
+++ b/src/actions/PaymentActions.js
@@ -22,12 +22,10 @@ const creditOverflow = () => ({ type: PAYMENT_ACTIONS.CREDIT_OVERFLOW });
 const choosePaymentType = paymentType => (dispatch, getState) => {
   const { payment } = getState();
   const { transaction } = payment;
+  const { id } = transaction;
 
   UIDatabase.write(() => {
-    UIDatabase.update('Transaction', {
-      ...transaction,
-      paymentType,
-    });
+    UIDatabase.update('Transaction', { id, paymentType });
   });
 
   dispatch({ type: PAYMENT_ACTIONS.CHOOSE_PAYMENT_TYPE, payload: { paymentType } });

--- a/src/actions/PrescriptionActions.js
+++ b/src/actions/PrescriptionActions.js
@@ -63,14 +63,11 @@ const editPatientType = newValue => (dispatch, getState) => {
 const editComment = newValue => (dispatch, getState) => {
   const { prescription } = getState();
   const { transaction } = prescription;
-  const { comment } = transaction;
+  const { id, comment } = transaction;
 
   if (newValue !== comment) {
     UIDatabase.write(() => {
-      UIDatabase.update('Transaction', {
-        ...transaction,
-        comment: newValue,
-      });
+      UIDatabase.update('Transaction', { id, comment: newValue });
     });
 
     dispatch(closeCommentModal());

--- a/src/actions/PrescriptionActions.js
+++ b/src/actions/PrescriptionActions.js
@@ -39,12 +39,10 @@ const cancelPrescription = () => (dispatch, getState) => {
 const editTransactionCategory = newValue => (dispatch, getState) => {
   const { prescription } = getState();
   const { transaction } = prescription;
+  const { id } = transaction;
 
   UIDatabase.write(() => {
-    UIDatabase.update('Transaction', {
-      ...transaction,
-      category: newValue,
-    });
+    UIDatabase.update('Transaction', { id, category: newValue });
   });
 
   dispatch(refresh());
@@ -53,12 +51,10 @@ const editTransactionCategory = newValue => (dispatch, getState) => {
 const editPatientType = newValue => (dispatch, getState) => {
   const { prescription } = getState();
   const { transaction } = prescription;
+  const { id } = transaction;
 
   UIDatabase.write(() => {
-    UIDatabase.update('Transaction', {
-      ...transaction,
-      user1: newValue,
-    });
+    UIDatabase.update('Transaction', { id, user1: newValue });
   });
 
   dispatch(refresh());
@@ -173,12 +169,10 @@ const editQuantity = (id, quantity) => (dispatch, getState) => {
 const assignPrescriber = prescriber => (dispatch, getState) => {
   const { prescription } = getState();
   const { transaction } = prescription;
+  const { id } = transaction;
+
   UIDatabase.write(() => {
-    UIDatabase.update('Transaction', {
-      // Previously used spread, but Realm.Objects don't like being spread it turns out. Issue#3323
-      id: transaction.id,
-      prescriber,
-    });
+    UIDatabase.update('Transaction', { id, prescriber });
   });
 
   batch(() => {

--- a/src/database/DataTypes/RequisitionItem.js
+++ b/src/database/DataTypes/RequisitionItem.js
@@ -155,9 +155,7 @@ export class RequisitionItem extends Realm.Object {
       .join(' OR ')}) AND item = $0`;
 
     // Return the maximum price of all MasterListItems.
-    return UIDatabase.objects('MasterListItem')
-      .filtered(queryString, this.item)
-      .max('price');
+    return UIDatabase.objects('MasterListItem').filtered(queryString, this.item).max('price');
   }
 
   /**
@@ -207,10 +205,7 @@ export class RequisitionItem extends Realm.Object {
   applyReason(database, newOption) {
     if (this.hasVariance) {
       database.write(() => {
-        database.update('RequisitionItem', {
-          ...this,
-          option: newOption,
-        });
+        database.update('RequisitionItem', { id: this.id, option: newOption });
       });
     }
   }

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -264,7 +264,7 @@ export class StocktakeBatch extends Realm.Object {
 
     database.write(() => {
       database.update('StocktakeBatch', {
-        ...this,
+        id: this.id,
         option: isValidPositiveAdjustment || isValidNegativeAdjustment ? newOption : null,
       });
     });

--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -50,9 +50,10 @@ export const editSensorName = (newValue, rowKey, route) => (dispatch, getState) 
   const { data, keyExtractor } = selectPageState(getState());
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
+  const { id } = objectToEdit;
 
   if (objectToEdit) {
-    UIDatabase.write(() => UIDatabase.update('Sensor', { ...objectToEdit, name: newValue }));
+    UIDatabase.write(() => UIDatabase.update('Sensor', { id, name: newValue }));
     dispatch(refreshRow(rowKey, route));
   }
 };
@@ -61,11 +62,10 @@ export const editLocationDescription = (newValue, rowKey, route) => (dispatch, g
   const { data, keyExtractor } = selectPageState(getState());
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
+  const { id } = objectToEdit;
 
   if (objectToEdit) {
-    UIDatabase.write(() =>
-      UIDatabase.update('Location', { ...objectToEdit, description: newValue })
-    );
+    UIDatabase.write(() => UIDatabase.update('Location', { id, description: newValue }));
     dispatch(refreshRow(rowKey, route));
   }
 };
@@ -74,9 +74,10 @@ export const editLocationCode = (newValue, rowKey, route) => (dispatch, getState
   const { data, keyExtractor } = selectPageState(getState());
 
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
+  const { id } = objectToEdit;
 
   if (objectToEdit) {
-    UIDatabase.write(() => UIDatabase.update('Location', { ...objectToEdit, code: newValue }));
+    UIDatabase.write(() => UIDatabase.update('Location', { id, code: newValue }));
     dispatch(refreshRow(rowKey, route));
   }
 };
@@ -94,9 +95,10 @@ export const editBatchDoses = (newValue, rowKey, route) => (dispatch, getState) 
 
 export const editBatchVvmStatus = (vvmStatus, objectType, route) => (dispatch, getState) => {
   const { modalValue, keyExtractor } = selectPageState(getState());
+  const { id = '' } = modalValue ?? {};
 
   UIDatabase.write(() =>
-    UIDatabase.update(objectType, { ...modalValue, vaccineVialMonitorStatus: vvmStatus })
+    UIDatabase.update(objectType, { id, vaccineVialMonitorStatus: vvmStatus })
   );
 
   reduxBatch(() => {
@@ -241,10 +243,12 @@ export const editNegativeAdjustments = (value, rowKey, route) => (dispatch, getS
 export const editBatchName = (value, rowKey, objectType, route) => (dispatch, getState) => {
   const { data, keyExtractor } = selectPageState(getState());
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
+  const { id = '' } = objectToEdit ?? {};
+
   if (objectToEdit) {
     const { batch } = objectToEdit;
     if (value !== batch) {
-      UIDatabase.write(() => UIDatabase.update(objectType, { ...objectToEdit, batch: value }));
+      UIDatabase.write(() => UIDatabase.update(objectType, { id, batch: value }));
       dispatch(refreshRow(rowKey, route));
     }
   }
@@ -254,23 +258,21 @@ export const editSellPrice = (value, rowKey, route) => (dispatch, getState) => {
   const { data, keyExtractor } = selectPageState(getState());
   const objectToEdit = data.find(row => keyExtractor(row) === rowKey);
   const objectDataType = objectToEdit.stocktake ? 'StocktakeBatch' : 'TransactionBatch';
-  const { sellPrice } = objectToEdit;
+  const { sellPrice, id } = objectToEdit;
   const valueAsCurrency = currency(value);
   const { value: currencyValue } = valueAsCurrency;
   if (currencyValue !== sellPrice) {
     UIDatabase.write(() => {
-      UIDatabase.update(objectDataType, { ...objectToEdit, sellPrice: currencyValue });
+      UIDatabase.update(objectDataType, { id, sellPrice: currencyValue });
       dispatch(refreshRow(rowKey, route));
     });
   }
 };
 
 export const editBatchSupplier = (supplier, batch, route) => dispatch => {
+  const { id } = batch;
   UIDatabase.write(() => {
-    UIDatabase.update('StocktakeBatch', {
-      ...batch,
-      supplier,
-    });
+    UIDatabase.update('StocktakeBatch', { id, supplier });
   });
 
   reduxBatch(() => {

--- a/src/pages/dataTableUtilities/actions/pageActions.js
+++ b/src/pages/dataTableUtilities/actions/pageActions.js
@@ -103,12 +103,10 @@ export const closeDatePicker = route => ({
 
 export const editCreatedDate = (value, route) => (dispatch, getState) => {
   const pageObject = selectPageObject(getState());
+  const { id } = pageObject;
 
   UIDatabase.write(() => {
-    UIDatabase.update('Requisition', {
-      ...pageObject,
-      createdDate: value,
-    });
+    UIDatabase.update('Requisition', { id, createdDate: value });
   });
 
   dispatch(closeDatePicker(route));
@@ -116,12 +114,10 @@ export const editCreatedDate = (value, route) => (dispatch, getState) => {
 
 export const editPrescriber = (value, route) => (dispatch, getState) => {
   const pageObject = selectPageObject(getState());
+  const { id } = pageObject;
 
   UIDatabase.write(() => {
-    UIDatabase.update('Transaction', {
-      ...pageObject,
-      prescriber: value,
-    });
+    UIDatabase.update('Transaction', { id, prescriber: value });
   });
 
   dispatch(closeModal(route));
@@ -136,14 +132,11 @@ export const editPrescriber = (value, route) => (dispatch, getState) => {
 export const editPageObjectName = (value, pageObjectType, route) => (dispatch, getState) => {
   const pageObject = selectPageObject(getState());
 
-  const { name } = pageObject;
+  const { id, name } = pageObject;
 
   if (name !== value) {
     UIDatabase.write(() => {
-      UIDatabase.update(pageObjectType, {
-        ...pageObject,
-        name: value,
-      });
+      UIDatabase.update(pageObjectType, { id, name: value });
     });
   }
 
@@ -159,11 +152,11 @@ export const editPageObjectName = (value, pageObjectType, route) => (dispatch, g
 export const editTheirRef = (value, pageObjectType, route) => (dispatch, getState) => {
   const pageObject = selectPageObject(getState());
 
-  const { theirRef } = pageObject;
+  const { theirRef, id } = pageObject;
 
   if (theirRef !== value) {
     UIDatabase.write(() => {
-      UIDatabase.update(pageObjectType, { ...pageObject, theirRef: value });
+      UIDatabase.update(pageObjectType, { id, theirRef: value });
     });
   }
 
@@ -179,11 +172,11 @@ export const editTheirRef = (value, pageObjectType, route) => (dispatch, getStat
 export const editComment = (value, pageObjectType, route) => (dispatch, getState) => {
   const pageObject = selectPageObject(getState());
 
-  const { comment } = pageObject;
+  const { comment, id } = pageObject;
 
   if (comment !== value) {
     UIDatabase.write(() => {
-      UIDatabase.update(pageObjectType, { ...pageObject, comment: value });
+      UIDatabase.update(pageObjectType, { id, comment: value });
     });
   }
 

--- a/src/selectors/newSensor.js
+++ b/src/selectors/newSensor.js
@@ -1,5 +1,5 @@
 export const selectNewSensor = ({ newSensor }) => newSensor;
-
+// TODO
 export const selectHotConsecutiveConfig = ({ newSensor }) => newSensor.HOT_CONSECUTIVE;
 export const selectColdConsecutiveConfig = ({ newSensor }) => newSensor.COLD_CONSECUTIVE;
 export const selectHotCumulativeConfig = ({ newSensor }) => newSensor.HOT_CUMULATIVE;

--- a/src/selectors/newSensor.js
+++ b/src/selectors/newSensor.js
@@ -1,5 +1,5 @@
 export const selectNewSensor = ({ newSensor }) => newSensor;
-// TODO
+
 export const selectHotConsecutiveConfig = ({ newSensor }) => newSensor.HOT_CONSECUTIVE;
 export const selectColdConsecutiveConfig = ({ newSensor }) => newSensor.COLD_CONSECUTIVE;
 export const selectHotCumulativeConfig = ({ newSensor }) => newSensor.HOT_CUMULATIVE;

--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -34,12 +34,15 @@ export const selectCurrentPatient = ({ patient }) => {
 export const selectAvailableCredit = ({ patient }) =>
   currency(patient?.currentPatient?.availableCredit);
 
+// TODO
 export const selectPatientInsurancePolicies = ({ patient }) => {
   const { currentPatient } = patient;
   const { policies } = currentPatient;
   return policies.map(policy => {
-    const { isActive, policyNumber } = policy;
-    return isActive ? policy : { ...policy, policyNumber: `${policyNumber} (inactive)` };
+    const { isActive, policyNumber, id, discountRate } = policy;
+    return isActive
+      ? policy
+      : { isActive, id, discountRate, policyNumber: `${policyNumber} (inactive)` };
   });
 };
 export const selectPatientModalOpen = ({ patient }) => {

--- a/src/widgets/PrescriptionInfo.js
+++ b/src/widgets/PrescriptionInfo.js
@@ -55,7 +55,7 @@ const PrescriptionInfoComponent = ({
   return (
     <FlexRow>
       <FlexColumn flex={1}>
-        <FlexRow alignItems="center" justifyContent="">
+        <FlexRow alignItems="center">
           <FlexView flex={3}>
             <SimpleLabel label={dispensingStrings.patient} size="small" />
             <SimpleLabel text={patientName} size="medium" numberOfLines={1} />
@@ -82,7 +82,7 @@ const PrescriptionInfoComponent = ({
             )}
           </FlexView>
 
-          <FlexRow flex={1} justifyContent="">
+          <FlexRow flex={1}>
             {prescriptionPrescriber && (
               <CircleButton
                 IconComponent={canEditPrescriber ? PencilIcon : BookIcon}


### PR DESCRIPTION
Fixes #3528 #3541 

## Change summary

- Can't spread realm objects, so I did a global search and searched for `...` and then checked if they were a a realm object and changed it. Was super fun

## Testing

### Prescriptions
- [x] Can select an insurance policy when creating a prescription
- [x] Can select a payment type when creating a prescription
- [x] Selecting a prescription category when creating a prescription
- [x] Can select a patient type when creating a prescription
- [x] Can edit a comment when creating a prescription
- [x] Can select a prescriber when creating a prescription
- [ ] When selecting an INACTIVE insurance policy, there is no discount applied

### Supplier requisitions
- [ ] Can apply a reason to a supplier requisition line
- [x] Can edit the comment on a SR

### Customer invoice
- [x] Can edit the their ref
- [x] Can edit the comment on a CI

### Supplier invoice
- [ ] Can apply a VVM status to a supplier invoice line
- [x] Can edit the batch name of a line in a supplier invoice
- [x] Can edit the selling price in a supplier invoice
- [x] Can edit the their ref
- [x] Can edit the comment on a SI

### Stocktake
- [x] Can apply a VVM status to a stocktake batch
- [x] Can edit a supplier of a stocktake batch
- [x] Can apply a reason to a stocktake batch
- [x] Can edit the sell price of a stocktake batch
- [x] Can edit the name of a stocktake (from the stocktake edit page)
- [x] Can edit the comment on a stocktake

### Customer requisition
- [x] Can edit a customer requisitions created date (program CR)
- [x] Can edit the comment on a CR

### Related areas to think about

N/A