### PR TITLE
#3553 Unable to save a sensor

### DIFF
--- a/src/database/DataTypes/Sensor.js
+++ b/src/database/DataTypes/Sensor.js
@@ -84,6 +84,10 @@ export class Sensor extends Realm.Object {
 
     return isOngoing && isHot;
   }
+
+  get locationID() {
+    return this.location?.id;
+  }
 }
 
 Sensor.schema = {


### PR DESCRIPTION
Fixes #3553 

## Change summary

- Adds `locationID` to the sensor model which is the field which is on the plain object, which is what the sensor is when navigating from the `VaccinePage`.

## Testing

- [ ] Editing a sensor from the `FridgeDetailPage` can be saved.

### Related areas to think about

N/A