### PR TITLE
#3569  Breaches only create, never continue

### DIFF
--- a/src/actions/BreachActions.js
+++ b/src/actions/BreachActions.js
@@ -2,7 +2,7 @@
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2020
  */
-
+import moment from 'moment';
 import BreachManager from '../bluetooth/BreachManager';
 import { UIDatabase } from '../database';
 
@@ -23,18 +23,24 @@ const createConsecutiveSuccess = (sensor, updatedBreaches, updatedLogs) => ({
 });
 
 const createConsecutiveBreaches = sensor => async dispatch => {
-  const { id } = sensor;
+  const { id: sensorID } = sensor;
 
   try {
-    const logs = await BreachManager().getLogsToCheck(id);
+    const logs = await BreachManager().getLogsToCheck(sensorID);
+    const mappedToPlainObjects = logs.map(({ id, temperature, timestamp }) => ({
+      id,
+      temperature,
+      timestamp: moment(timestamp).unix(),
+    }));
     const configs = sensor.breachConfigs;
-    const mostRecentBreach = await BreachManager().getMostRecentBreach(id);
+    const mostRecentBreach = await BreachManager().getMostRecentBreach(sensorID);
     const [breaches, temperatureLogs] = await BreachManager().createBreaches(
       sensor,
-      logs,
+      mappedToPlainObjects,
       configs,
-      mostRecentBreach
+      mostRecentBreach?.toJSON()
     );
+
     const [updatedBreaches, updatedLogs] = await BreachManager().updateBreaches(
       breaches,
       temperatureLogs

--- a/src/bluetooth/BreachManager.js
+++ b/src/bluetooth/BreachManager.js
@@ -25,8 +25,8 @@ const createBreachRecord = (
     thresholdMaxTemperature,
     thresholdDuration,
     type,
-    startTimestamp,
-    endTimestamp,
+    startTimestamp: new Date(startTimestamp * MILLISECONDS.ONE_SECOND),
+    endTimestamp: endTimestamp ? new Date(endTimestamp * MILLISECONDS.ONE_SECOND) : endTimestamp,
     location,
     acknowledged: false,
   };
@@ -50,7 +50,7 @@ class BreachManager {
 
   closeBreach = (temperatureBreach, time) => {
     // eslint-disable-next-line no-param-reassign
-    temperatureBreach.endTimestamp = time;
+    temperatureBreach.endTimestamp = new Date(time * MILLISECONDS.ONE_SECOND);
     return temperatureBreach;
   };
 
@@ -69,6 +69,7 @@ class BreachManager {
     const { minimumTemperature, maximumTemperature, duration } = config;
     const { timestamp: endTimestamp } = logs[logs.length - 1];
     const { timestamp: startTimestamp } = logs[0];
+
     // logsDuration will be in seconds as it is based on unixtime
     // we are storing duration as milliseconds, so will have to scale to compare
     const logsDuration = MILLISECONDS.ONE_SECOND * (endTimestamp - startTimestamp);
@@ -78,6 +79,7 @@ class BreachManager {
       const { temperature } = log;
       return temperature <= maximumTemperature && temperature >= minimumTemperature;
     });
+
     return temperaturesWithinBounds;
   };
 
@@ -143,6 +145,7 @@ class BreachManager {
           configs,
           potentialBreach
         );
+
         if (willCreateBreach) {
           const newBreach = this.createBreach(
             this.utils.createUuid(),
@@ -150,6 +153,7 @@ class BreachManager {
             config,
             potentialBreach[0].timestamp
           );
+
           currentBreach = newBreach;
           breaches.push(newBreach);
           const updatedLogs = potentialBreach.map(l => this.addLogToBreach(newBreach, l));
@@ -170,17 +174,11 @@ class BreachManager {
   getTemperatureLogsFrom = async (sensorId, timeToCheckFrom) =>
     this.db.getTemperatureLogsFrom(sensorId, timeToCheckFrom);
 
-  getMostRecentBreachLog = async sensorId => {
-    this.db.getMostRecentBreachLog(sensorId);
-  };
+  getMostRecentBreachLog = async sensorId => this.db.getMostRecentBreachLog(sensorId);
 
-  getMostRecentBreach = async sensorId => {
-    this.db.getMostRecentBreach(sensorId);
-  };
+  getMostRecentBreach = async sensorId => this.db.getMostRecentBreach(sensorId);
 
-  getBreachConfigs = async () => {
-    this.db.getBreachConfigs();
-  };
+  getBreachConfigs = async () => this.db.getBreachConfigs();
 }
 
 let BreachManagerInstance;

--- a/src/bluetooth/VaccineDataAccess.js
+++ b/src/bluetooth/VaccineDataAccess.js
@@ -48,12 +48,18 @@ export class VaccineDataAccess {
 
   getSensors = () => this.db.objects(VACCINE_ENTITIES.SENSOR);
 
-  upsertBreaches = breaches =>
+  upsertBreaches = breaches => {
     this.db.write(() => {
       breaches.forEach(breach => {
-        this.db.update(VACCINE_ENTITIES.TEMPERATURE_BREACH, breach);
+        this.db.update(VACCINE_ENTITIES.TEMPERATURE_BREACH, {
+          ...breach,
+          id: breach.id,
+          startTimestamp: new Date(breach.startTimestamp),
+          endTimestamp: breach.endTimestamp ? new Date(breach.endTimestamp) : breach.endTimestamp,
+        });
       });
     });
+  };
 
   upsertSensor = sensor =>
     this.db.write(() => {
@@ -63,7 +69,10 @@ export class VaccineDataAccess {
   upsertTemperatureLog = temperatureLogs =>
     this.db.write(() => {
       temperatureLogs.forEach(log => {
-        this.db.update(VACCINE_ENTITIES.TEMPERATURE_LOG, log);
+        this.db.update(VACCINE_ENTITIES.TEMPERATURE_LOG, {
+          ...log,
+          breach: log.breach ? { id: log.breach.id } : null,
+        });
       });
     });
 }

--- a/src/database/DataTypes/TemperatureBreach.js
+++ b/src/database/DataTypes/TemperatureBreach.js
@@ -82,6 +82,21 @@ export class TemperatureBreach extends Realm.Object {
 
     return temperature >= minimumTemperature && temperature <= maximumTemperature;
   }
+
+  toJSON() {
+    return {
+      id: this.id,
+      startTimestamp: this.startTimestamp.getTime(),
+      endTimestamp: this.endTimestamp?.getTime(),
+      locationID: this.location.id,
+      thresholdMaxTemperature: this.thresholdMaxTemperature,
+      thresholdMinTemperature: this.thresholdMinTemperature,
+      thresholdDuration: this.thresholdDuration,
+      acknowledged: this.acknowledged,
+      type: this.type,
+      sensorID: this.sensor.id,
+    };
+  }
 }
 
 TemperatureBreach.schema = {


### PR DESCRIPTION
Fixes #3569 

## Change summary

- Fair few changes. Primarily this was to ensure breaches are being continued rather than only created. To do this required mainly date format changes, which revealed a few other issues which i'll comment in the PR

## Testing
Set up a new sensor
- [ ] When the sensor goes in to a breach, all the logs for that breach are aggregated into a single temperature breach record
- [ ] When the sensor goes out of the breach, the end timestamp is correctly applied to the breach.

### Related areas to think about

Trying to share the logic between the apps needed more thinking through, this is a bit of a mess sorry :(