### PR TITLE
#3562 Set a logdelay when resuming a sensor

### DIFF
--- a/src/pages/SensorEditPage.js
+++ b/src/pages/SensorEditPage.js
@@ -280,7 +280,12 @@ const dispatchToProps = (dispatch, ownProps) => {
     const field = isHot ? 'minimumTemperature' : 'maximumTemperature';
     dispatch(TemperatureBreachConfigActions.update(id, field, value));
   };
-  const updateIsPaused = isPaused => dispatch(SensorActions.update(sensorID, 'isPaused', isPaused));
+  const updateIsPaused = isPaused => {
+    dispatch(SensorActions.update(sensorID, 'isPaused', isPaused));
+
+    // If resuming, also set the logDelay to now.
+    if (!isPaused) dispatch(SensorActions.update(sensorID, 'logDelay', new Date().getTime()));
+  };
   const saveSensor = sensorToUpdate =>
     dispatch(SensorUpdateActions.updateSensor(sensorToUpdate))
       .then(() => dispatch(SensorActions.save()))


### PR DESCRIPTION
Fixes #3562 

## Change summary

- Technically not quite correct - you could resume while there was a log delay and bring the logdelay forward. Could also set a logdelay when the sensor was never actually paused. I think you very rarely set a sensor up and these edge cases won't hoping practically so I didn't bother accounting for them....... is that bad?

## Testing

- [ ] After resuming a sensor after some X minutes, no logs are saved for the time the sensor was paused.

### Related areas to think about

N/A