### PR TITLE
#3557 Merge state ratehr than overwriting after a sync occurs

### DIFF
--- a/src/reducers/Entities/LocationReducer.js
+++ b/src/reducers/Entities/LocationReducer.js
@@ -22,8 +22,12 @@ export const LocationReducer = (state = initialState(), action) => {
 
   switch (type) {
     case SYNC_TRANSACTION_COMPLETE: {
+      const { byId } = state;
+
       const newById = getById();
-      return { ...state, byId: newById };
+      const mergedById = { ...byId, ...newById };
+
+      return { ...state, byId: mergedById };
     }
 
     case 'Navigation/NAVIGATE': {

--- a/src/reducers/Entities/SensorReducer.js
+++ b/src/reducers/Entities/SensorReducer.js
@@ -26,8 +26,12 @@ export const SensorReducer = (state = initialState(), action) => {
 
   switch (type) {
     case SYNC_TRANSACTION_COMPLETE: {
+      const { byId } = state;
+
       const newById = getById();
-      return { ...state, byId: newById };
+      const mergedById = { ...byId, ...newById };
+
+      return { ...state, byId: mergedById };
     }
 
     case 'Navigation/NAVIGATE': {

--- a/src/reducers/Entities/TemperatureBreachConfigReducer.js
+++ b/src/reducers/Entities/TemperatureBreachConfigReducer.js
@@ -24,8 +24,12 @@ export const TemperatureBreachConfigReducer = (state = initialState(), action) =
 
   switch (type) {
     case SYNC_TRANSACTION_COMPLETE: {
+      const { byId } = state;
+
       const newById = getById();
-      return { ...state, byId: newById };
+      const mergedById = { ...byId, ...newById };
+
+      return { ...state, byId: mergedById };
     }
 
     case 'Navigation/NAVIGATE': {


### PR DESCRIPTION
Fixes #3557 

## Change summary

- Added merged state rather than overwriting in Location/Sensor/Config reducers

## Testing

- [ ] When creating a sensor, wait for a sync to occur (Manually triggering should work I think). The state should be exactly the same.

### Related areas to think about

N/A
