### PR TITLE
#3533 Sort batches by expiry date

### DIFF
--- a/src/widgets/bottomModals/ItemDetails.js
+++ b/src/widgets/bottomModals/ItemDetails.js
@@ -33,7 +33,7 @@ export const ItemDetailsComponent = ({ item }) => {
   const getRow = (title, info) => ({ info, title });
 
   const getBatchColumn = field =>
-    item.batchesWithStock.map(itemBatch => {
+    item.batchesWithStock.sorted('expiryDate').map(itemBatch => {
       const title = headers[field];
 
       const data = itemBatch[field];


### PR DESCRIPTION
Fixes #3533 

## Change summary

- Sorts by `expiryDate` cause Rowena was complaining

## Testing

- [ ] Go to an SI and add 4 batches, with 3 different expiries (One with none). Check the batches in Current Stock Page. Should be ordered, earliest expiry first. N/A first

### Related areas to think about

N/A