### PR TITLE
#3531 Janky row detail opening

### DIFF
--- a/src/hooks/useKeyboardIsOpen.js
+++ b/src/hooks/useKeyboardIsOpen.js
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react';
+import { Keyboard } from 'react-native';
+
+const KEYBOARD_DID_SHOW = 'keyboardDidShow';
+const KEYBOARD_DID_HIDE = 'keyboardDidHide';
+
+export const useKeyboardIsOpen = () => {
+  const [isOpen, toggle] = useState(false);
+  useEffect(() => {
+    Keyboard.addListener(KEYBOARD_DID_SHOW, () => toggle(true));
+    Keyboard.addListener(KEYBOARD_DID_HIDE, () => toggle(false));
+
+    return () => {
+      Keyboard.removeListener(KEYBOARD_DID_SHOW, () => toggle(true));
+      Keyboard.removeListener(KEYBOARD_DID_HIDE, () => toggle(false));
+    };
+  });
+
+  return isOpen;
+};

--- a/src/widgets/PageInfo/PageInfoColumn.js
+++ b/src/widgets/PageInfo/PageInfoColumn.js
@@ -13,11 +13,12 @@ export const PageInfoColumn = ({
   titleTextAlign,
 }) => (
   <FlexColumn flex={1}>
-    {columnData.map(({ onPress, editableType, title, info }) => (
+    {columnData.map(({ onPress, editableType, title, info }, idx) => (
       <PageInfoRow
         titleTextAlign={titleTextAlign}
         numberOfLines={numberOfLines}
-        key={`${title}${info}`}
+        // eslint-disable-next-line react/no-array-index-key
+        key={`${title}${info}${idx}`}
         isEditingDisabled={isEditingDisabled}
         titleColor={titleColor}
         infoColor={infoColor}

--- a/src/widgets/RowDetail.js
+++ b/src/widgets/RowDetail.js
@@ -55,7 +55,7 @@ export const RowDetailComponent = ({
       return () => Keyboard.removeListener('keyboardDidShow', onClose);
     }
     return null;
-  }, []);
+  }, [dismissOnKeyboardOpen]);
 
   const getDetailComponent = () => {
     switch (detailKey) {
@@ -71,24 +71,24 @@ export const RowDetailComponent = ({
   };
 
   return (
-    <Modal
-      isOpen={isOpen}
-      swipeToClose={swipeToClose}
-      backdropPressToClose={backdropPressToClose}
-      position={position}
-      backdrop={backdrop}
-      style={modalStyle}
-    >
-      {!keyboardIsOpen && (
+    !keyboardIsOpen && (
+      <Modal
+        isOpen={isOpen}
+        swipeToClose={swipeToClose}
+        backdropPressToClose={backdropPressToClose}
+        position={position}
+        backdrop={backdrop}
+        style={modalStyle}
+      >
         <View style={headerRowStyle}>
           <TouchableOpacity onPress={onClose}>
             <CloseIcon />
           </TouchableOpacity>
         </View>
-      )}
 
-      <View style={containerStyle}>{getDetailComponent()}</View>
-    </Modal>
+        <View style={containerStyle}>{getDetailComponent()}</View>
+      </Modal>
+    )
   );
 };
 

--- a/src/widgets/RowDetail.js
+++ b/src/widgets/RowDetail.js
@@ -18,6 +18,7 @@ import { SupplierRequisitionItemDetails } from './SupplierRequisitionItemDetail'
 import { DARKER_GREY } from '../globalStyles';
 import { selectRowDetailIsOpen } from '../selectors/rowDetail';
 import { CustomerRequisitionItemDetails } from './CustomerRequisitionItemDetail';
+import { useKeyboardIsOpen } from '../hooks/useKeyboardIsOpen';
 
 /**
  * Container component for a presentation component that will display
@@ -38,6 +39,8 @@ export const RowDetailComponent = ({
   dismissKeyboardOnOpen,
   dismissOnKeyboardOpen,
 }) => {
+  const keyboardIsOpen = useKeyboardIsOpen();
+
   // This component renders at the bottom of the screen. Dismiss the keyboard when rendering
   // so the full screen isn't covered by keyboard and this modal.
   React.useEffect(() => {
@@ -76,11 +79,13 @@ export const RowDetailComponent = ({
       backdrop={backdrop}
       style={modalStyle}
     >
-      <View style={headerRowStyle}>
-        <TouchableOpacity onPress={onClose}>
-          <CloseIcon />
-        </TouchableOpacity>
-      </View>
+      {!keyboardIsOpen && (
+        <View style={headerRowStyle}>
+          <TouchableOpacity onPress={onClose}>
+            <CloseIcon />
+          </TouchableOpacity>
+        </View>
+      )}
 
       <View style={containerStyle}>{getDetailComponent()}</View>
     </Modal>


### PR DESCRIPTION
Fixes #3531 

## Change summary

- Only try and open the `RowDetail` component when the keyboard is closed.

## Testing

- [ ] Open the row detail from the Current Stock by clicking a row. Close it by opening the keyboard through the search bar - it's not crazy janky
- [ ] Open the row detail from clicking on a row when the keyboard is already open - it's not crazy janky

### Related areas to think about

N/A