### PR TITLE
#3585 Correct the conditional on deleting remote orders

### DIFF
--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -593,6 +593,10 @@ export class Transaction extends Realm.Object {
   get hasVaccine() {
     return this.items.some(({ isVaccine }) => isVaccine);
   }
+
+  get isRemoteOrder() {
+    return !this.linkedRequisition;
+  }
 }
 
 Transaction.schema = {

--- a/src/pages/SupplierRequisitionsPage.js
+++ b/src/pages/SupplierRequisitionsPage.js
@@ -180,7 +180,7 @@ export const SupplierRequisitions = ({
       />
       <BottomConfirmModal
         isOpen={hasSelection}
-        questionText={modalStrings.remove_these_items}
+        questionText={modalStrings.delete_these_requisitions}
         onCancel={onDeselectAll}
         onConfirm={onDeleteRecords}
         confirmText={modalStrings.remove}

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -117,7 +117,10 @@ const DataTableRow = React.memo(
             rowIsDisabled ||
             rowIsFinalised ||
             isLinkedToTransaction ||
-            !isRemoteOrder;
+            // If the field `isRemoteOrder is a part of the model for the row
+            // (Transaction/Requisition) then disable all rows which are not
+            // remote orders.
+            (isRemoteOrder != null && !isRemoteOrder);
 
           // Alignment of this particular column. Default to left hand ide.
           const cellAlignment = alignText || 'left';

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -117,7 +117,7 @@ const DataTableRow = React.memo(
             rowIsDisabled ||
             rowIsFinalised ||
             isLinkedToTransaction ||
-            isRemoteOrder;
+            !isRemoteOrder;
 
           // Alignment of this particular column. Default to left hand ide.
           const cellAlignment = alignText || 'left';


### PR DESCRIPTION
Fixes #3585  #3207

## Change summary

- Corrects the conditional on deleting remote orders

## Testing

- [ ] Can delete requisitions/transactions which were created on a mobile store
- [ ] Cannot delete requisitions/transactions which were received via sync
- [ ] String is correct in the modal when deleting a supplier requisition

### Related areas to think about

N/A