### PR TITLE
#3529 should force sensor name and code

### DIFF
--- a/src/actions/Entities/SensorActions.js
+++ b/src/actions/Entities/SensorActions.js
@@ -83,6 +83,7 @@ const save = () => (dispatch, getState) => {
   const updatedConfigs = [];
 
   location.description = sensor.name;
+  location.code = location.code || sensor.name;
 
   UIDatabase.write(() => {
     updatedLocation = UIDatabase.update('Location', location);

--- a/src/pages/NewSensor/NewSensorStepThree.js
+++ b/src/pages/NewSensor/NewSensorStepThree.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/forbid-prop-types */
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import moment from 'moment';
 import { ToastAndroid, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
@@ -26,10 +26,11 @@ import { WizardActions, LocationActions, SensorActions } from '../../actions';
 import { SensorUpdateActions } from '../../actions/Bluetooth/SensorUpdateActions';
 import { useLoadingIndicator } from '../../hooks/useLoadingIndicator';
 import { DARKER_GREY, LIGHT_GREY, SUSSOL_ORANGE, WHITE } from '../../globalStyles';
-import { buttonStrings, vaccineStrings } from '../../localization';
+import { buttonStrings, vaccineStrings, formInputStrings } from '../../localization';
 import { selectNewLocation } from '../../selectors/Entities/location';
 import { SECONDS } from '../../utilities/constants';
 import { VACCINE_CONSTANTS } from '../../utilities/modules/vaccines/constants';
+import { FormInvalidMessage } from '../../widgets/FormInputs/FormInvalidMessage';
 
 export const NewSensorStepThreeComponent = ({
   logInterval,
@@ -51,6 +52,11 @@ export const NewSensorStepThreeComponent = ({
     moment(logDelay).subtract(VACCINE_CONSTANTS.DEFAULT_LOGGING_DELAY_MINUTES, 'm')
   );
   const logDelayAsMinutes = moment.duration(moment(logDelay).diff(startingTime.current)).minutes();
+  const [isFormValid, setIsFormValid] = useState(!!name);
+  const handleUpdateName = newName => {
+    setIsFormValid(!!newName);
+    updateName(newName);
+  };
 
   return (
     <TabContainer>
@@ -60,7 +66,10 @@ export const NewSensorStepThreeComponent = ({
           label={vaccineStrings.sensor_name}
           Icon={<InfoIcon color={DARKER_GREY} />}
         >
-          <TextEditor size="large" value={name} onChangeText={updateName} />
+          <FlexRow style={{ flexDirection: 'column' }}>
+            <TextEditor size="large" value={name} onChangeText={handleUpdateName} />
+            <FormInvalidMessage isValid={!!name} message={formInputStrings.is_required} />
+          </FlexRow>
           <TextEditor label={vaccineStrings.sensor_code} value={code} onChangeText={updateCode} />
         </EditorRow>
 
@@ -115,6 +124,7 @@ export const NewSensorStepThreeComponent = ({
           style={{ backgroundColor: SUSSOL_ORANGE }}
           textStyle={{ color: WHITE, textTransform: 'capitalize' }}
           onPress={() => withLoadingIndicator(connectToSensor({ macAddress, logInterval }))}
+          isDisabled={!isFormValid}
         />
       </FlexRow>
     </TabContainer>

--- a/src/pages/SensorEditPage.js
+++ b/src/pages/SensorEditPage.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-curly-newline */
 /* eslint-disable react/forbid-prop-types */
 /* eslint-disable react/jsx-wrap-multilines */
-import React from 'react';
+import React, { useState } from 'react';
 import { StyleSheet, ToastAndroid, View } from 'react-native';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -25,7 +25,13 @@ import { TextWithIcon } from '../widgets/Typography';
 
 import { useLoadingIndicator } from '../hooks/useLoadingIndicator';
 
-import { generalStrings, vaccineStrings, modalStrings, navStrings } from '../localization';
+import {
+  generalStrings,
+  vaccineStrings,
+  modalStrings,
+  navStrings,
+  formInputStrings,
+} from '../localization';
 import { APP_FONT_FAMILY, DARKER_GREY, LIGHT_GREY, SUSSOL_ORANGE, WHITE } from '../globalStyles';
 import { SensorActions } from '../actions';
 import { SensorBlinkActions } from '../actions/Bluetooth/SensorBlinkActions';
@@ -46,6 +52,7 @@ import { PaperModalContainer } from '../widgets/PaperModal/PaperModalContainer';
 import { SensorPicker } from '../widgets/SensorPicker';
 import { PaperConfirmModal } from '../widgets/PaperModal/PaperConfirmModal';
 import { SECONDS } from '../utilities/constants';
+import { FormInvalidMessage } from '../widgets/FormInputs/FormInvalidMessage';
 
 export const SensorEditPageComponent = ({
   logInterval,
@@ -75,6 +82,12 @@ export const SensorEditPageComponent = ({
   const withLoadingIndicator = useLoadingIndicator();
   const [replaceModalOpen, toggleReplaceModal] = useToggle();
   const [removeModalOpen, toggleRemoveModal] = useToggle();
+  const [isFormValid, setIsFormValid] = useState(!!name);
+
+  const handleUpdateName = newName => {
+    setIsFormValid(!!newName);
+    updateName(newName);
+  };
 
   return (
     <>
@@ -86,7 +99,10 @@ export const SensorEditPageComponent = ({
               Icon={<InfoIcon color={DARKER_GREY} />}
               containerStyle={localStyles.paperContentRow}
             >
-              <TextEditor size="large" value={name} onChangeText={updateName} />
+              <FlexRow style={{ flexDirection: 'column' }}>
+                <TextEditor size="large" value={name} onChangeText={handleUpdateName} />
+                <FormInvalidMessage isValid={!!name} message={formInputStrings.is_required} />
+              </FlexRow>
               <TextEditor
                 label={vaccineStrings.sensor_code}
                 value={code}
@@ -171,6 +187,7 @@ export const SensorEditPageComponent = ({
               text={generalStrings.save}
               textStyle={localStyles.pageButtonText}
               style={{ backgroundColor: SUSSOL_ORANGE }}
+              isDisabled={!isFormValid}
             />
           </FlexRow>
         </AfterInteractions>


### PR DESCRIPTION
Fixes #3529 

## Change summary

Adds validation to the new sensor and sensor edit pages.
Defaults the code of the new location to be the name of the sensor, if no code is specified.. open to better suggestions on that one.

Side note: was amused to find that you can use emojis as the name..

![Screenshot_2021-02-22-16-37-51-910](https://user-images.githubusercontent.com/9192912/108664598-f3de1100-7537-11eb-85be-aa533010111a.jpeg)


## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Edit a sensor, verify that you are unable to save until a name is specified
- [ ] Edit a sensor, clear the `Code` field. Verify that the name is copied to the code field after saving
- [ ] Create a sensor and verify that a name is required
- [ ] Create a sensor with a blank code and verify that the name is used for the code

