### PR TITLE
#3527 no vvm status records handling

### DIFF
--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -71,7 +71,8 @@
     "from": "from",
     "no_locations_for_batch": "This item is restricted to locations of type {0} and none are available. Contact your administrator.",
     "no_locations": "You don't have any locations to assign! Contact your administrator.",
-    "no_options": "No options available. Please contact your administrator!"
+    "no_options": "No options available. Please contact your administrator!",
+    "no_vvm_status": "No vaccine vial monitor statuses available. Please contact your administrator!"
   },
   "fr": {
     "must_be_a_number_between": "Doit être un nombre entre",

--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -72,7 +72,8 @@
     "no_locations_for_batch": "This item is restricted to locations of type {0} and none are available. Contact your administrator.",
     "no_locations": "You don't have any locations to assign! Contact your administrator.",
     "no_options": "No options available. Please contact your administrator!",
-    "no_vvm_status": "No vaccine vial monitor statuses available. Please contact your administrator!"
+    "no_vvm_status": "No vaccine vial monitor statuses available. Please contact your administrator!",
+    "no_reasons": "No requisition line variance reasons available. Please contact your administrator!"
   },
   "fr": {
     "must_be_a_number_between": "Doit être un nombre entre",

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -182,7 +182,9 @@ const DataTablePageModalComponent = ({ isOpen, onClose, modalKey, onSelect, curr
         );
       case MODAL_KEYS.REQUISITION_REASON: {
         const { reasonTitle } = currentValue;
-        const reasonsSelection = UIDatabase.objects('RequisitionReason');
+        const reasonsSelection = UIDatabase.objects('RequisitionReason').filtered(
+          'isActive == true'
+        );
 
         return (
           <GenericChoiceList
@@ -190,6 +192,7 @@ const DataTablePageModalComponent = ({ isOpen, onClose, modalKey, onSelect, curr
             highlightValue={reasonTitle}
             keyToDisplay="title"
             onPress={onSelect}
+            placeholderText={generalStrings.no_reasons}
           />
         );
       }

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -238,12 +238,14 @@ const DataTablePageModalComponent = ({ isOpen, onClose, modalKey, onSelect, curr
       }
       case MODAL_KEYS.SELECT_VVM_STATUS: {
         const { currentVvmStatusName } = currentValue;
+
         return (
           <GenericChoiceList
-            data={UIDatabase.objects('VaccineVialMonitorStatus')}
+            data={UIDatabase.objects('VaccineVialMonitorStatus').filtered('isActive == True')}
             highlightValue={currentVvmStatusName}
             onPress={onSelect}
             keyToDisplay="description"
+            placeholderText={generalStrings.no_vvm_status}
           />
         );
       }

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -25,7 +25,7 @@ import globalStyles from '../../globalStyles';
 
 import { UIDatabase } from '../../database';
 import { ModalContainer } from './ModalContainer';
-import { buttonStrings } from '../../localization';
+import { buttonStrings, generalStrings } from '../../localization';
 
 import { selectUsingPayments, selectUsingHideSnapshotColumn } from '../../selectors/modules';
 import { AutocompleteSelector } from '../modalChildren';
@@ -229,10 +229,11 @@ export const StocktakeBatchModalComponent = ({
       case MODAL_KEYS.SELECT_VVM_STATUS:
         return (
           <GenericChoiceList
-            data={UIDatabase.objects('VaccineVialMonitorStatus')}
+            data={UIDatabase.objects('VaccineVialMonitorStatus').filtered('isActive == True')}
             highlightValue={currentVvmStatusName}
             onPress={onApplyStocktakeBatchVvmStatus}
             keyToDisplay="description"
+            placeholderText={generalStrings.no_vvm_status}
           />
         );
       default:


### PR DESCRIPTION
Fixes #3527 

## Change summary

Added placeholder when no vvm statuses are available. In supplier invoices and stocktake batches.
Slight detour: also handled the 'isActive == false' state, as that helped me test.
Diversion: noticed that the requisition lines were not handling the placeholder either
Full offroad: added the `isActive` check for reasons too

## Testing

Note: when testing, you have to have a supplier invoice with a vaccine in it; and the vaccines enabled; AND the payment module disabled; otherwise the payment columns show in supplier invoices, and not the vaccine columns 🙄 

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Check for no VVM status in supplier invoice and stocktake batch
- [ ] Check for no active VVM status in blah blah blah
- [ ] Check for no reasons in a program-based supplier requisition
- [ ] and make sure that inactive ones are ok for these too

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
