### PR TITLE
disable blink when downloading

### DIFF
--- a/src/widgets/SensorHeader/BlinkSensorButton.js
+++ b/src/widgets/SensorHeader/BlinkSensorButton.js
@@ -7,6 +7,7 @@ import { IconButton } from '../IconButton';
 import { LightbulbIcon } from '../icons';
 import { SensorBlinkActions } from '../../actions/Bluetooth/SensorBlinkActions';
 import { selectSendingBlinkTo } from '../../selectors/Bluetooth/sensorBlink';
+import { selectIsDownloading } from '../../selectors/Bluetooth/sensorDownload';
 
 export const BlinkSensorButtonComponent = ({ isBlinking, blink, isBlinkDisabled }) =>
   isBlinking ? (
@@ -31,7 +32,8 @@ const stateToProps = (state, props) => {
 
   const sendingBlinkTo = selectSendingBlinkTo(state);
   const isBlinking = sendingBlinkTo === macAddress;
-  const isBlinkDisabled = !isBlinking && !!sendingBlinkTo;
+  const isDownloading = selectIsDownloading(state, macAddress);
+  const isBlinkDisabled = !!sendingBlinkTo || isDownloading;
 
   return { isBlinking, isBlinkDisabled };
 };


### PR DESCRIPTION
Fixes #3587 

## Change summary

Disabled the blink button when a sensor is currently downloading. 
Resolves the problem, and why would anyone want to blink while it was actively downloading?

The blink button disabling logic wasn't clear - so I changed it. There's no reason to include `isBlinking` as this is already handled in the implementation - and I couldn't see why `!isBlinking` == disabled. Surely it should be disabled if it is already blinking?

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Wait fo a sensor to download and try to blink

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
