### PR TITLE
#233 trim white space off site and user names

### DIFF
--- a/src/pages/FirstUsePage.js
+++ b/src/pages/FirstUsePage.js
@@ -83,7 +83,19 @@ export class FirstUsePageComponent extends React.Component {
     }
   }
 
-  onChangeText = text =>
+  onChangeServerUrl = text =>
+    this.setState({
+      serverURL: text,
+      status: 'uninitialised',
+    });
+
+  onChangeSiteName = text =>
+    this.setState({
+      syncSiteName: text,
+      status: 'uninitialised',
+    });
+
+  onChangePassword = text =>
     this.setState({
       syncSitePassword: text,
       status: 'uninitialised',
@@ -123,8 +135,11 @@ export class FirstUsePageComponent extends React.Component {
               selectTextOnFocus
               autoCapitalize="none"
               autoCorrect={false}
-              onChangeText={text => this.setState({ serverURL: text, status: 'uninitialised' })}
+              onChangeText={this.onChangeServerUrl}
               onSubmitEditing={() => {
+                // Trim URLS. Any leading/trailing spaces lead to invalid URLs.
+                this.setState({ serverURL: serverURL.trim() });
+
                 if (this.siteNameInputRef) this.siteNameInputRef.focus();
               }}
             />
@@ -135,6 +150,7 @@ export class FirstUsePageComponent extends React.Component {
                 this.siteNameInputRef = reference;
               }}
               style={globalStyles.authFormTextInputStyle}
+              autoCompleteType="username"
               placeholderTextColor={SUSSOL_ORANGE}
               underlineColorAndroid={SUSSOL_ORANGE}
               placeholder="Sync Site Name"
@@ -142,8 +158,11 @@ export class FirstUsePageComponent extends React.Component {
               editable={status !== 'initialising'}
               returnKeyType="next"
               selectTextOnFocus
-              onChangeText={text => this.setState({ syncSiteName: text, status: 'uninitialised' })}
+              onChangeText={this.onChangeSiteName}
               onSubmitEditing={() => {
+                // Trim site names. Most users don't intentionally put leading/trailing spaces in!
+                this.setState({ syncSiteName: syncSiteName.trim() });
+
                 if (this.passwordInputRef) this.passwordInputRef.focus();
               }}
             />
@@ -154,6 +173,7 @@ export class FirstUsePageComponent extends React.Component {
                 this.passwordInputRef = reference;
               }}
               style={globalStyles.authFormTextInputStyle}
+              autoCompleteType="password"
               placeholder="Sync Site Password"
               placeholderTextColor={SUSSOL_ORANGE}
               underlineColorAndroid={SUSSOL_ORANGE}
@@ -162,7 +182,7 @@ export class FirstUsePageComponent extends React.Component {
               editable={status !== 'initialising'}
               returnKeyType="done"
               selectTextOnFocus
-              onChangeText={this.onChangeText}
+              onChangeText={this.onChangePassword}
               onSubmitEditing={() => {
                 if (this.passwordInputRef) this.passwordInputRef.blur();
                 if (this.canAttemptLogin) this.onPressConnect();

--- a/src/pages/FirstUsePage.js
+++ b/src/pages/FirstUsePage.js
@@ -18,15 +18,22 @@ import { DemoUserModal } from '../widgets/modals';
 
 import globalStyles, { SUSSOL_ORANGE, WARM_GREY } from '../globalStyles';
 
+const STATUSES = {
+  UNINITIALISED: 'uninitialised',
+  INITIALISING: 'initialising',
+  INITIALISED: 'initialised',
+  ERROR: 'error',
+};
+
 export class FirstUsePageComponent extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       appVersion: '',
-      status: 'uninitialised', // uninitialised, initialising, initialised, error.
       serverURL: '',
       syncSiteName: '',
       syncSitePassword: '',
+      status: STATUSES.UNINITIALISED,
       isDemoUserModalOpen: false,
     };
     this.setAppVersion();
@@ -40,13 +47,13 @@ export class FirstUsePageComponent extends React.Component {
     const { serverURL, syncSiteName, syncSitePassword } = this.state;
 
     try {
-      this.setState({ status: 'initialising' });
+      this.setState({ status: STATUSES.INITIALISING });
       await synchroniser.initialise(serverURL, syncSiteName, syncSitePassword);
-      this.setState({ status: 'initialised' });
+      this.setState({ status: STATUSES.INITIALISED });
 
       onInitialised();
     } catch (error) {
-      this.setState({ status: 'error' });
+      this.setState({ status: STATUSES.ERROR });
     }
   }
 
@@ -59,7 +66,7 @@ export class FirstUsePageComponent extends React.Component {
     const { status, serverURL, syncSiteName, syncSitePassword } = this.state;
 
     return (
-      (status === 'uninitialised' || status === 'error') &&
+      (status === STATUSES.UNINITIALISED || status === STATUSES.ERROR) &&
       serverURL.length > 0 &&
       syncSiteName.length > 0 &&
       syncSitePassword.length > 0
@@ -72,11 +79,11 @@ export class FirstUsePageComponent extends React.Component {
     const { progressMessage, errorMessage, progress, total } = this.props;
 
     switch (status) {
-      case 'initialising':
+      case STATUSES.INITIALISING:
         return `${progressMessage}${total > 0 ? `\n${progress}/${total}` : ''}`;
-      case 'error':
+      case STATUSES.ERROR:
         return `${errorMessage}\nTap to retry.`;
-      case 'initialised':
+      case STATUSES.INITIALISED:
         return 'Success!';
       default:
         return 'Connect';
@@ -86,19 +93,19 @@ export class FirstUsePageComponent extends React.Component {
   onChangeServerUrl = text =>
     this.setState({
       serverURL: text,
-      status: 'uninitialised',
+      status: STATUSES.UNINITIALISED,
     });
 
   onChangeSiteName = text =>
     this.setState({
       syncSiteName: text,
-      status: 'uninitialised',
+      status: STATUSES.UNINITIALISED,
     });
 
   onChangePassword = text =>
     this.setState({
       syncSitePassword: text,
-      status: 'uninitialised',
+      status: STATUSES.UNINITIALISED,
     });
 
   handleDemoModalOpen = () => this.setState({ isDemoUserModalOpen: true });
@@ -130,7 +137,7 @@ export class FirstUsePageComponent extends React.Component {
               underlineColorAndroid={SUSSOL_ORANGE}
               placeholder="Primary Server URL"
               value={serverURL}
-              editable={status !== 'initialising'}
+              editable={status !== STATUSES.INITIALISING}
               returnKeyType="next"
               selectTextOnFocus
               autoCapitalize="none"
@@ -156,7 +163,7 @@ export class FirstUsePageComponent extends React.Component {
               underlineColorAndroid={SUSSOL_ORANGE}
               placeholder="Sync Site Name"
               value={syncSiteName}
-              editable={status !== 'initialising'}
+              editable={status !== STATUSES.INITIALISING}
               returnKeyType="next"
               selectTextOnFocus
               onChangeText={this.onChangeSiteName}
@@ -181,7 +188,7 @@ export class FirstUsePageComponent extends React.Component {
               underlineColorAndroid={SUSSOL_ORANGE}
               value={syncSitePassword}
               secureTextEntry
-              editable={status !== 'initialising'}
+              editable={status !== STATUSES.INITIALISING}
               returnKeyType="done"
               selectTextOnFocus
               onChangeText={this.onChangePassword}
@@ -211,7 +218,7 @@ export class FirstUsePageComponent extends React.Component {
               text="Request a Demo Store"
               onPress={this.handleDemoModalOpen}
               disabledColor={WARM_GREY}
-              isDisabled={status !== 'uninitialised' && status !== 'error'}
+              isDisabled={status !== STATUSES.UNINITIALISED && status !== STATUSES.ERROR}
             />
           </View>
         </View>

--- a/src/pages/FirstUsePage.js
+++ b/src/pages/FirstUsePage.js
@@ -137,10 +137,11 @@ export class FirstUsePageComponent extends React.Component {
               autoCorrect={false}
               onChangeText={this.onChangeServerUrl}
               onSubmitEditing={() => {
+                if (this.siteNameInputRef) this.siteNameInputRef.focus();
+              }}
+              onBlur={() => {
                 // Trim URLS. Any leading/trailing spaces lead to invalid URLs.
                 this.setState({ serverURL: serverURL.trim() });
-
-                if (this.siteNameInputRef) this.siteNameInputRef.focus();
               }}
             />
           </View>
@@ -160,10 +161,11 @@ export class FirstUsePageComponent extends React.Component {
               selectTextOnFocus
               onChangeText={this.onChangeSiteName}
               onSubmitEditing={() => {
+                if (this.passwordInputRef) this.passwordInputRef.focus();
+              }}
+              onBlur={() => {
                 // Trim site names. Most users don't intentionally put leading/trailing spaces in!
                 this.setState({ syncSiteName: syncSiteName.trim() });
-
-                if (this.passwordInputRef) this.passwordInputRef.focus();
               }}
             />
           </View>

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -158,6 +158,7 @@ export class LoginModal extends React.Component {
             <View style={globalStyles.horizontalContainer}>
               <TextInput
                 style={globalStyles.authFormTextInputStyle}
+                autoCompleteType="username"
                 placeholder={authStrings.user_name}
                 placeholderTextColor={SUSSOL_ORANGE}
                 underlineColorAndroid={SUSSOL_ORANGE}
@@ -172,6 +173,8 @@ export class LoginModal extends React.Component {
                   });
                 }}
                 onSubmitEditing={() => {
+                  // Trim usernames. Most users don't intentionally put leading/trailing spaces in!
+                  this.setState({ username: username.trim() });
                   if (this.passwordInputRef) this.passwordInputRef.focus();
                 }}
               />
@@ -182,6 +185,7 @@ export class LoginModal extends React.Component {
                   this.passwordInputRef = reference;
                 }}
                 style={globalStyles.authFormTextInputStyle}
+                autoCompleteType="password"
                 placeholder={authStrings.password}
                 placeholderTextColor={SUSSOL_ORANGE}
                 underlineColorAndroid={SUSSOL_ORANGE}

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -24,12 +24,19 @@ import { setCurrencyLocalisation } from '../../localization/currency';
 import { setDateLocale } from '../../localization/utilities';
 import { UIDatabase } from '../../database';
 
+const AUTH_STATUSES = {
+  UNAUTHENTICATED: 'unauthenticated',
+  AUTHENTICATING: 'authenticating',
+  AUTHENTICATED: 'authenticated',
+  ERROR: 'error',
+};
+
 export class LoginModal extends React.Component {
   constructor(props) {
     super(props);
     const username = props.settings.get(SETTINGS_KEYS.MOST_RECENT_USERNAME);
     this.state = {
-      authStatus: 'unauthenticated', // unauthenticated, authenticating, authenticated, error
+      authStatus: AUTH_STATUSES.UNAUTHENTICATED,
       error: '',
       username: username || '',
       password: '',
@@ -46,9 +53,9 @@ export class LoginModal extends React.Component {
   UNSAFE_componentWillReceiveProps(nextProps) {
     const { authStatus } = this.state;
 
-    if (authStatus === 'authenticated' && !nextProps.isAuthenticated) {
+    if (authStatus === AUTH_STATUSES.AUTHENTICATED && !nextProps.isAuthenticated) {
       this.setState({
-        authStatus: 'unauthenticated',
+        authStatus: AUTH_STATUSES.UNAUTHENTICATED,
         password: '',
       });
     }
@@ -65,23 +72,23 @@ export class LoginModal extends React.Component {
 
     settings.set(SETTINGS_KEYS.MOST_RECENT_USERNAME, username);
 
-    this.setState({ authStatus: 'authenticating' });
+    this.setState({ authStatus: AUTH_STATUSES.AUTHENTICATING });
 
     try {
       const user = await authenticator.authenticate(username, password);
-      this.setState({ authStatus: 'authenticated' });
+      this.setState({ authStatus: AUTH_STATUSES.AUTHENTICATED });
       onAuthentication(user);
     } catch (error) {
       const message = error.message.startsWith('Invalid username or password')
         ? authStrings.invalid_username_or_password
         : error.message;
 
-      this.setState({ authStatus: 'error', error: message });
+      this.setState({ authStatus: AUTH_STATUSES.ERROR, error: message });
       onAuthentication(null);
       if (!error.message.startsWith('Invalid username or password')) {
         // After ten seconds of displaying the error, re-enable the button
         this.errorTimeoutId = setTimeout(() => {
-          this.setState({ authStatus: 'unauthenticated' });
+          this.setState({ authStatus: AUTH_STATUSES.UNAUTHENTICATED });
           this.errorTimeoutId = null;
         }, 10 * 1000);
       }
@@ -96,17 +103,19 @@ export class LoginModal extends React.Component {
   get canAttemptLogin() {
     const { authStatus, username, password } = this.state;
 
-    return authStatus === 'unauthenticated' && username.length > 0 && password.length > 0;
+    return (
+      authStatus === AUTH_STATUSES.UNAUTHENTICATED && username.length > 0 && password.length > 0
+    );
   }
 
   get buttonText() {
     const { authStatus, error } = this.state;
 
     switch (authStatus) {
-      case 'authenticating':
-      case 'authenticated':
+      case AUTH_STATUSES.AUTHENTICATING:
+      case AUTH_STATUSES.AUTHENTICATED:
         return authStrings.logging_in;
-      case 'error':
+      case AUTH_STATUSES.ERROR:
         return error;
       default:
         return authStrings.login;
@@ -164,13 +173,13 @@ export class LoginModal extends React.Component {
                 placeholderTextColor={SUSSOL_ORANGE}
                 underlineColorAndroid={SUSSOL_ORANGE}
                 value={username}
-                editable={authStatus !== 'authenticating'}
+                editable={authStatus !== AUTH_STATUSES.AUTHENTICATING}
                 returnKeyType="next"
                 selectTextOnFocus
                 onChangeText={text => {
                   this.setState({
                     username: text,
-                    authStatus: 'unauthenticated',
+                    authStatus: AUTH_STATUSES.UNAUTHENTICATED,
                   });
                 }}
                 onSubmitEditing={() => {
@@ -194,11 +203,11 @@ export class LoginModal extends React.Component {
                 underlineColorAndroid={SUSSOL_ORANGE}
                 value={password}
                 secureTextEntry
-                editable={authStatus !== 'authenticating'}
+                editable={authStatus !== AUTH_STATUSES.AUTHENTICATING}
                 returnKeyType="done"
                 selectTextOnFocus
                 onChangeText={text => {
-                  this.setState({ password: text, authStatus: 'unauthenticated' });
+                  this.setState({ password: text, authStatus: AUTH_STATUSES.UNAUTHENTICATED });
                 }}
                 onSubmitEditing={() => {
                   if (this.passwordInputRef) this.passwordInputRef.blur();

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -39,6 +39,7 @@ export class LoginModal extends React.Component {
     this.setAppVersion();
     this.passwordInputRef = null;
     this.errorTimeoutId = null;
+    this.onLogin();
   }
 
   // eslint-disable-next-line camelcase, react/sort-comp
@@ -173,9 +174,11 @@ export class LoginModal extends React.Component {
                   });
                 }}
                 onSubmitEditing={() => {
+                  if (this.passwordInputRef) this.passwordInputRef.focus();
+                }}
+                onBlur={() => {
                   // Trim usernames. Most users don't intentionally put leading/trailing spaces in!
                   this.setState({ username: username.trim() });
-                  if (this.passwordInputRef) this.passwordInputRef.focus();
                 }}
               />
             </View>


### PR DESCRIPTION
Fixes #233?

## Change summary

- Added `autoCompleteType` to textInputs. Didn't actually fix the issue unfortunately. Presumably what should be done for android at least.
- Added trimming of strings when submitting server url, site name and user name.

## Testing

**Initialisation/FirstUsePage**
- [ ] When submitting (pressing next or done on virtual keyboard) URL any leading and trailing white space is removed.
- [ ] When submitting site name any leading and trailing white space is removed.
- [ ] When submitting password any leading and trailing white space is **kept**.
- [ ] When changing focus (press/click elsewhere in UI, e.g. another field) from URL any leading and trailing white space is removed.
- [ ] When changing focus from site name any leading and trailing white space is removed.
- [ ] When changing focus from password any leading and trailing white space is **kept**.

**Login Page**
- [ ] When submitting user name any leading and trailing white space is removed.
- [ ] When submitting password any leading and trailing white space is **kept**.
- [ ] When changing focus from user name any leading and trailing white space is removed.
- [ ] When changing focus from password any leading and trailing white space is **kept**.

### Related areas to think about

This is contentious haha. There are conceivably existing users that have a spaces leading or trailing their user name.

Creating patients or prescribers, we could/should(?) trim their names too. Though I think we enter "first" and "last" names separately, should still trim them?