### PR TITLE
#3626 Update temperatureBreachConfig thresholds

### DIFF
--- a/src/selectors/Entities/temperatureBreachConfig.js
+++ b/src/selectors/Entities/temperatureBreachConfig.js
@@ -33,11 +33,11 @@ export const selectEditingConfigThresholds = state => {
     COLD_CUMULATIVE: coldCumulativeConfig = {},
   } = editingConfigs;
 
-  const coldConsecutiveThreshold = (hotConsecutiveConfig.minimumTemperature ?? 0) - 0.1;
-  const hotConsecutiveThreshold = (coldConsecutiveConfig.maximumTemperature ?? 0) + 0.1;
+  const coldConsecutiveThreshold = hotConsecutiveConfig.minimumTemperature ?? 0 - 0.1;
+  const hotConsecutiveThreshold = coldConsecutiveConfig.maximumTemperature ?? 0 + 0.1;
 
-  const hotCumulativeThreshold = (coldCumulativeConfig.maximumTemperature ?? 0) - 0.1;
-  const coldCumulativeThreshold = (hotCumulativeConfig.minimumTemperature ?? 0) + 0.1;
+  const coldCumulativeThreshold = hotCumulativeConfig.minimumTemperature ?? 0 + 0.1;
+  const hotCumulativeThreshold = coldCumulativeConfig.maximumTemperature ?? 0 - 0.1;
 
   return {
     coldConsecutiveThreshold,
@@ -71,8 +71,8 @@ export const selectNewConfigThresholds = state => {
   const coldConsecutiveThreshold = hotConsecutiveConfig.minimumTemperature ?? 0 - 0.1;
   const hotConsecutiveThreshold = coldConsecutiveConfig.maximumTemperature ?? 0 + 0.1;
 
-  const hotCumulativeThreshold = coldCumulativeConfig.minimumTemperature ?? 0 - 0.1;
-  const coldCumulativeThreshold = hotCumulativeConfig.maximumTemperature ?? 0 + 0.1;
+  const coldCumulativeThreshold = hotCumulativeConfig.minimumTemperature ?? 0 + 0.1;
+  const hotCumulativeThreshold = coldCumulativeConfig.maximumTemperature ?? 0 - 0.1;
 
   return {
     coldConsecutiveThreshold,

--- a/src/selectors/Entities/temperatureBreachConfig.js
+++ b/src/selectors/Entities/temperatureBreachConfig.js
@@ -33,11 +33,11 @@ export const selectEditingConfigThresholds = state => {
     COLD_CUMULATIVE: coldCumulativeConfig = {},
   } = editingConfigs;
 
-  const coldConsecutiveThreshold = hotConsecutiveConfig.minimumTemperature ?? 0 - 0.1;
-  const hotConsecutiveThreshold = coldConsecutiveConfig.maximumTemperature ?? 0 + 0.1;
+  const coldConsecutiveThreshold = (hotConsecutiveConfig.minimumTemperature ?? 0) - 0.1;
+  const hotConsecutiveThreshold = (coldConsecutiveConfig.maximumTemperature ?? 0) + 0.1;
 
-  const coldCumulativeThreshold = hotCumulativeConfig.minimumTemperature ?? 0 + 0.1;
-  const hotCumulativeThreshold = coldCumulativeConfig.maximumTemperature ?? 0 - 0.1;
+  const coldCumulativeThreshold = (hotCumulativeConfig.minimumTemperature ?? 0) + 0.1;
+  const hotCumulativeThreshold = (coldCumulativeConfig.maximumTemperature ?? 0) - 0.1;
 
   return {
     coldConsecutiveThreshold,
@@ -68,11 +68,11 @@ export const selectNewConfigThresholds = state => {
     COLD_CUMULATIVE: coldCumulativeConfig = {},
   } = newConfigs;
 
-  const coldConsecutiveThreshold = hotConsecutiveConfig.minimumTemperature ?? 0 - 0.1;
-  const hotConsecutiveThreshold = coldConsecutiveConfig.maximumTemperature ?? 0 + 0.1;
+  const coldConsecutiveThreshold = (hotConsecutiveConfig.minimumTemperature ?? 0) - 0.1;
+  const hotConsecutiveThreshold = (coldConsecutiveConfig.maximumTemperature ?? 0) + 0.1;
 
-  const coldCumulativeThreshold = hotCumulativeConfig.minimumTemperature ?? 0 + 0.1;
-  const hotCumulativeThreshold = coldCumulativeConfig.maximumTemperature ?? 0 - 0.1;
+  const coldCumulativeThreshold = (hotCumulativeConfig.minimumTemperature ?? 0) + 0.1;
+  const hotCumulativeThreshold = (coldCumulativeConfig.maximumTemperature ?? 0) - 0.1;
 
   return {
     coldConsecutiveThreshold,


### PR DESCRIPTION
Fixes #3626 

## Change summary

- Super tiny tweak to min/max thresholds so hot > cold when creating and editing breach configs for a sensor

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Try to add new sensor
  - [ ] Try to set hot cumulative <= cold cumulative (shouldn't let you)
  - [ ] Try to set cold cumulative >= hot cumulative (shouldn't let you)
- [ ] Try to edit existing sensor
  - [ ] Try to set hot cumulative <= cold cumulative (shouldn't let you)
  - [ ] Try to set cold cumulative >= hot cumulative (shouldn't let you)

### Related areas to think about
Creating new sensor was allowing hot/cold to be equal, adjusted to align with edit flow (min diff of 0.1)