### PR TITLE
#3634 JSON Schema TextInput Widget

### DIFF
--- a/src/widgets/JSONForm/JSONForm.js
+++ b/src/widgets/JSONForm/JSONForm.js
@@ -12,6 +12,7 @@ import { JSONFormWidget } from './widgets/index';
 import { JSONFormErrorList } from './JSONFormErrorList';
 import { PageButton } from '../PageButton';
 import { JSONFormContext } from './JSONFormContext';
+import { lotsOfStringInputsSchema } from './testJSON';
 
 const defaultTheme = {
   // Widgets are the lowest level input components. TextInput, Checkbox
@@ -67,7 +68,7 @@ const defaultTheme = {
 
   // ErrorList is a component which is rendered at the top of the form when validation errors
   // occur
-  JSONFormErrorList,
+  ErrorList: JSONFormErrorList,
 
   formContext: JSONFormContext,
 
@@ -77,109 +78,37 @@ const defaultTheme = {
   tagName: JSONFormContainer,
 };
 
-const exampleSchema = {
-  title: 'Object',
-  description: 'Description',
-  type: 'object',
-  properties: {
-    age4: {
-      type: 'integer',
-      title: 'Age',
-    },
-    multipleChoicesList: {
-      type: 'array',
-      title: 'A multiple choices list',
-      items: {
-        type: 'string',
-        enum: ['foo', 'bar', 'fuzz', 'qux'],
-      },
-      uniqueItems: true,
-    },
-    stringEnum: {
-      type: 'string',
-      description: 'string enum',
-      title: 'string enum title',
-      enum: ['a', 'b', 'c'],
-    },
-    numberEnum: {
-      type: 'number',
-      description: 'number enum',
-      title: 'Number enum',
-      enum: [1, 2, 3],
-    },
-    Toggle: {
-      title: 'Toggle',
-      description: 'toggle description',
-      type: 'boolean',
-      oneOf: [
-        {
-          title: 'Enable',
-          const: true,
-        },
-        {
-          title: 'Disable',
-          const: false,
-        },
-      ],
-    },
-    firstName: {
-      type: 'string',
-      title: 'First name',
-      default: 'Chuck',
-    },
-    age: {
-      type: 'integer',
-      title: 'Age',
-    },
-    date: {
-      type: 'string',
-      format: 'date',
-    },
-    age2: {
-      type: 'integer',
-      title: 'Age',
-    },
-    date2: {
-      type: 'string',
-      format: 'date',
-    },
-    age3: {
-      type: 'integer',
-      title: 'Age',
-    },
-    date3: {
-      type: 'string',
-      format: 'date',
-    },
-    items: {
-      type: 'array',
-      items: {
-        type: 'object',
-        anyOf: [
-          {
-            properties: {
-              foo: {
-                type: 'string',
-              },
-            },
-          },
-          {
-            properties: {
-              bar: {
-                title: 'bar title',
-                description: 'bar desc',
-                type: 'string',
-              },
-            },
-          },
-        ],
-      },
-    },
-  },
-};
+class FocusController {
+  registered = [];
+
+  registeredScrollView = null;
+
+  registerScrolllView = ref => {
+    this.registeredScrollView = ref;
+  };
+
+  register = ref => {
+    this.registered.push(ref);
+  };
+
+  next = ref => {
+    const currIdx = this.registered.findIndex(registeredRef => registeredRef === ref);
+
+    const nextIdx = (currIdx + 1) % this.registered.length;
+    const nextRef = this.registered[nextIdx];
+
+    nextRef?.current?.focus?.();
+    this.registeredScrollView?.current?.scrollTo?.({ x: 0, y: 0, animated: true });
+
+    this.currentIdx = nextIdx;
+  };
+}
 
 export const JSONForm = React.forwardRef(
-  ({ theme = defaultTheme, children, options = {} }, ref) => {
+  (
+    { theme = defaultTheme, children, options = { focusController: new FocusController() } },
+    ref
+  ) => {
     const formRef = useRef(null);
 
     const Form = useMemo(() => withTheme(theme), []);
@@ -194,7 +123,7 @@ export const JSONForm = React.forwardRef(
 
     return (
       <JSONFormContext.Provider value={options}>
-        <ScrollView>
+        <ScrollView keyboardDismissMode="none" keyboardShouldPersistTaps="always">
           <Form
             onError={() => {
               // placeholder to prevent console.errors when validation fails.
@@ -202,7 +131,7 @@ export const JSONForm = React.forwardRef(
             // eslint-disable-next-line no-console
             onSubmit={form => console.log('onSubmit:', form)}
             ref={formRef}
-            schema={exampleSchema}
+            schema={lotsOfStringInputsSchema}
           >
             {children ?? (
               <PageButton

--- a/src/widgets/JSONForm/JSONForm.js
+++ b/src/widgets/JSONForm/JSONForm.js
@@ -1,7 +1,7 @@
+/* eslint-disable react/forbid-prop-types */
 /* eslint-disable max-len */
-/* eslint-disable react/destructuring-assignment */
-/* eslint-disable react/prop-types */
 import React, { useImperativeHandle, useMemo, useRef } from 'react';
+import PropTypes from 'prop-types';
 import { ScrollView } from 'react-native';
 import { withTheme } from '@rjsf/core';
 
@@ -104,45 +104,78 @@ class FocusController {
   };
 }
 
-export const JSONForm = React.forwardRef(
-  (
-    { theme = defaultTheme, children, options = { focusController: new FocusController() } },
-    ref
-  ) => {
-    const formRef = useRef(null);
+export const JSONForm = React.forwardRef(({ theme = defaultTheme, children, options }, ref) => {
+  const formRef = useRef(null);
 
-    const Form = useMemo(() => withTheme(theme), []);
+  const Form = useMemo(() => withTheme(theme), []);
 
-    // Attach to the ref passed a method `submit` which will allow a caller
-    // to programmatically call submit
-    useImperativeHandle(ref, () => ({
-      submit: e => {
-        formRef.current?.onSubmit(e);
-      },
-    }));
+  // Attach to the ref passed a method `submit` which will allow a caller
+  // to programmatically call submit
+  useImperativeHandle(ref, () => ({
+    submit: e => {
+      formRef.current?.onSubmit(e);
+    },
+  }));
 
-    return (
-      <JSONFormContext.Provider value={options}>
-        <ScrollView keyboardDismissMode="none" keyboardShouldPersistTaps="always">
-          <Form
-            onError={() => {
-              // placeholder to prevent console.errors when validation fails.
-            }}
-            // eslint-disable-next-line no-console
-            onSubmit={form => console.log('onSubmit:', form)}
-            ref={formRef}
-            schema={lotsOfStringInputsSchema}
-          >
-            {children ?? (
-              <PageButton
-                onPress={e => {
-                  formRef.current?.onSubmit(e);
-                }}
-              />
-            )}
-          </Form>
-        </ScrollView>
-      </JSONFormContext.Provider>
-    );
-  }
-);
+  return (
+    <JSONFormContext.Provider value={options}>
+      <ScrollView keyboardDismissMode="none" keyboardShouldPersistTaps="always">
+        <Form
+          onError={() => {
+            // placeholder to prevent console.errors when validation fails.
+          }}
+          // eslint-disable-next-line no-console
+          onSubmit={form => console.log('onSubmit:', form)}
+          ref={formRef}
+          schema={lotsOfStringInputsSchema}
+        >
+          {children ?? (
+            <PageButton
+              onPress={e => {
+                formRef.current?.onSubmit(e);
+              }}
+            />
+          )}
+        </Form>
+      </ScrollView>
+    </JSONFormContext.Provider>
+  );
+});
+
+JSONForm.defaultProps = {
+  theme: defaultTheme,
+  children: null,
+  options: { focusController: new FocusController() },
+};
+
+JSONForm.propTypes = {
+  children: PropTypes.node,
+  options: PropTypes.object,
+  theme: PropTypes.shape({
+    widgets: PropTypes.shape({
+      TextWidget: PropTypes.func,
+      URLWidget: PropTypes.func,
+      EmailWidget: PropTypes.func,
+      TextareaWidget: PropTypes.func,
+      CheckboxWidget: PropTypes.func,
+      CheckboxesWidget: PropTypes.func,
+      PasswordWidget: PropTypes.func,
+      RadioWidget: PropTypes.func,
+      SelectWidget: PropTypes.func,
+      RangeWidget: PropTypes.func,
+      DateWidget: PropTypes.func,
+    }),
+    fields: PropTypes.shape({
+      TitleField: PropTypes.func,
+      DescriptionField: PropTypes.func,
+      AnyOfField: PropTypes.func,
+      OneOfField: PropTypes.func,
+    }),
+    FieldTemplate: PropTypes.func,
+    ObjectFieldTemplate: PropTypes.func,
+    ArrayFieldTemplate: PropTypes.func,
+    ErrorList: PropTypes.func,
+    formContext: PropTypes.object,
+    tagName: PropTypes.func,
+  }),
+};

--- a/src/widgets/JSONForm/fields/Description.js
+++ b/src/widgets/JSONForm/fields/Description.js
@@ -1,17 +1,27 @@
-/* eslint-disable react/prop-types */
-/* eslint-disable react/destructuring-assignment */
-/* eslint-disable no-console */
 import React from 'react';
-import { Text, View } from 'react-native';
+import { StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { APP_FONT_FAMILY, APP_GENERAL_FONT_SIZE } from '../../../globalStyles/fonts';
+
+import { FormLabel } from '../../FormInputs/FormLabel';
 
 export const Description = props => {
-  console.log('-------------------------------------------');
-  console.log('Description - props', props);
-  console.log('-------------------------------------------');
-  return (
-    <View style={{ borderWidth: 1, marginLeft: 10 }}>
-      <Text>DescriptionField</Text>
-      <Text>{props.description}</Text>
-    </View>
-  );
+  const { description } = props;
+
+  return description ? <FormLabel textStyle={styles.textStyle} value={description} /> : null;
+};
+
+const styles = StyleSheet.create({
+  textStyle: {
+    fontSize: APP_GENERAL_FONT_SIZE,
+    fontFamily: APP_FONT_FAMILY,
+  },
+});
+
+Description.defaultProps = {
+  description: '',
+};
+
+Description.propTypes = {
+  description: PropTypes.string,
 };

--- a/src/widgets/JSONForm/fields/Title.js
+++ b/src/widgets/JSONForm/fields/Title.js
@@ -1,17 +1,34 @@
-/* eslint-disable react/prop-types */
 /* eslint-disable react/destructuring-assignment */
 /* eslint-disable no-console */
 import React from 'react';
-import { Text, View } from 'react-native';
+import PropTypes from 'prop-types';
+import { StyleSheet } from 'react-native';
+import { FormLabel } from '../../FormInputs/FormLabel';
+
+import { APP_FONT_FAMILY, APP_GENERAL_FONT_SIZE } from '../../../globalStyles/fonts';
 
 export const Title = props => {
-  console.log('-------------------------------------------');
-  console.log('Title Field - props', props);
-  console.log('-------------------------------------------');
-  return (
-    <View style={{ borderWidth: 1, marginLeft: 10 }}>
-      <Text>TitleField</Text>
-      <Text>{props.title}</Text>
-    </View>
-  );
+  const { title, isRequired } = props;
+
+  return title ? (
+    <FormLabel textStyle={styles.textStyle} isRequired={isRequired} value={title} />
+  ) : null;
+};
+
+const styles = StyleSheet.create({
+  textStyle: {
+    fontWeight: 'bold',
+    fontSize: APP_GENERAL_FONT_SIZE,
+    fontFamily: APP_FONT_FAMILY,
+  },
+});
+
+Title.defaultProps = {
+  title: '',
+  isRequired: false,
+};
+
+Title.propTypes = {
+  title: PropTypes.string,
+  isRequired: PropTypes.bool,
 };

--- a/src/widgets/JSONForm/templates/Field.js
+++ b/src/widgets/JSONForm/templates/Field.js
@@ -17,7 +17,12 @@ export const Field = props => {
   let InvalidMessage = null;
   if (hasError) {
     InvalidMessage = rawErrors?.map(error => (
-      <FormInvalidMessage isValid={!hasError} message={error} textStyle={styles.invalidStyle} />
+      <FormInvalidMessage
+        key={error}
+        isValid={!hasError}
+        message={error}
+        textStyle={styles.invalidStyle}
+      />
     ));
   }
 

--- a/src/widgets/JSONForm/templates/Field.js
+++ b/src/widgets/JSONForm/templates/Field.js
@@ -1,15 +1,14 @@
-/* eslint-disable react/prop-types */
-/* eslint-disable no-console */
-/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/forbid-prop-types */
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import { StyleSheet } from 'react-native';
 import { FINALISED_RED } from '../../../globalStyles/colors';
 import { APP_FONT_FAMILY, APP_GENERAL_FONT_SIZE } from '../../../globalStyles/fonts';
 import { FormInvalidMessage } from '../../FormInputs/FormInvalidMessage';
 import { Spacer } from '../../Spacer';
 
-export const Field = props => {
-  const { label, fields, required, rawErrors } = props;
+export const Field = ({ label, fields, required, rawErrors, description, children }) => {
   const { TitleField } = fields;
 
   const hasError = rawErrors?.length > 0;
@@ -29,8 +28,8 @@ export const Field = props => {
   return (
     <>
       <TitleField title={label} isRequired={required} />
-      {props.description}
-      {props.children}
+      {description}
+      {children}
       {InvalidMessage}
       <Spacer space={20} vertical />
     </>
@@ -44,3 +43,16 @@ const styles = StyleSheet.create({
     fontSize: APP_GENERAL_FONT_SIZE,
   },
 });
+
+Field.defaultProps = {
+  rawErrors: [],
+};
+
+Field.propTypes = {
+  label: PropTypes.string.isRequired,
+  fields: PropTypes.object.isRequired,
+  required: PropTypes.bool.isRequired,
+  rawErrors: PropTypes.array,
+  description: PropTypes.object.isRequired,
+  children: PropTypes.node.isRequired,
+};

--- a/src/widgets/JSONForm/templates/Field.js
+++ b/src/widgets/JSONForm/templates/Field.js
@@ -2,22 +2,40 @@
 /* eslint-disable no-console */
 /* eslint-disable react/destructuring-assignment */
 import React from 'react';
-import { Text, View } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { FINALISED_RED } from '../../../globalStyles/colors';
+import { APP_FONT_FAMILY, APP_GENERAL_FONT_SIZE } from '../../../globalStyles/fonts';
+import { FormInvalidMessage } from '../../FormInputs/FormInvalidMessage';
+import { Spacer } from '../../Spacer';
 
 export const Field = props => {
-  console.log('-------------------------------------------');
-  console.log('FieldTemplate - props', props);
-  console.log('-------------------------------------------');
-
-  const { title, fields } = props;
+  const { label, fields, required, rawErrors } = props;
   const { TitleField } = fields;
 
+  const hasError = rawErrors?.length > 0;
+
+  let InvalidMessage = null;
+  if (hasError) {
+    InvalidMessage = rawErrors?.map(error => (
+      <FormInvalidMessage isValid={!hasError} message={error} textStyle={styles.invalidStyle} />
+    ));
+  }
+
   return (
-    <View style={{ borderWidth: 1 }}>
-      <Text>FieldTemplate</Text>
-      <TitleField title={title} />
+    <>
+      <TitleField title={label} isRequired={required} />
       {props.description}
       {props.children}
-    </View>
+      {InvalidMessage}
+      <Spacer space={20} vertical />
+    </>
   );
 };
+
+const styles = StyleSheet.create({
+  invalidStyle: {
+    color: FINALISED_RED,
+    fontFamily: APP_FONT_FAMILY,
+    fontSize: APP_GENERAL_FONT_SIZE,
+  },
+});

--- a/src/widgets/JSONForm/templates/Field.js
+++ b/src/widgets/JSONForm/templates/Field.js
@@ -46,12 +46,13 @@ const styles = StyleSheet.create({
 
 Field.defaultProps = {
   rawErrors: [],
+  required: false,
 };
 
 Field.propTypes = {
   label: PropTypes.string.isRequired,
   fields: PropTypes.object.isRequired,
-  required: PropTypes.bool.isRequired,
+  required: PropTypes.bool,
   rawErrors: PropTypes.array,
   description: PropTypes.object.isRequired,
   children: PropTypes.node.isRequired,

--- a/src/widgets/JSONForm/templates/ObjectField.js
+++ b/src/widgets/JSONForm/templates/ObjectField.js
@@ -1,17 +1,4 @@
-/* eslint-disable no-console */
-/* eslint-disable react/prop-types */
-/* eslint-disable react/destructuring-assignment */
-import React from 'react';
-import { View, Text } from 'react-native';
-
 export const ObjectField = props => {
-  console.log('-------------------------------------------');
-  console.log('ObjectField - props', props);
-  console.log('-------------------------------------------');
-  return (
-    <View style={{ marginLeft: 10, borderWidth: 1 }}>
-      <Text>ObjectFieldTemplate</Text>
-      {props.properties.map(element => element.content)}
-    </View>
-  );
+  const { properties } = props;
+  return properties.map(element => element.content);
 };

--- a/src/widgets/JSONForm/testJSON.js
+++ b/src/widgets/JSONForm/testJSON.js
@@ -1,0 +1,160 @@
+export const lotsOfRandomStuffSchema = {
+  title: 'Object',
+  description: 'Description',
+  type: 'object',
+  properties: {
+    age5: {
+      type: 'integer',
+      title: 'Age',
+      description: 'Age description',
+    },
+    age4: {
+      type: 'integer',
+      title: 'Age',
+    },
+    multipleChoicesList: {
+      type: 'array',
+      title: 'A multiple choices list',
+      items: {
+        type: 'string',
+        enum: ['foo', 'bar', 'fuzz', 'qux'],
+      },
+      uniqueItems: true,
+    },
+    stringEnum: {
+      type: 'string',
+      description: 'string enum',
+      title: 'string enum title',
+      enum: ['a', 'b', 'c'],
+    },
+    numberEnum: {
+      type: 'number',
+      description: 'number enum',
+      title: 'Number enum',
+      enum: [1, 2, 3],
+    },
+    Toggle: {
+      title: 'Toggle',
+      description: 'toggle description',
+      type: 'boolean',
+      oneOf: [
+        {
+          title: 'Enable',
+          const: true,
+        },
+        {
+          title: 'Disable',
+          const: false,
+        },
+      ],
+    },
+    firstName: {
+      type: 'string',
+      title: 'First name',
+      default: 'Chuck',
+    },
+    age: {
+      type: 'integer',
+      title: 'Age',
+    },
+    date: {
+      type: 'string',
+      format: 'date',
+    },
+    age2: {
+      type: 'integer',
+      title: 'Age',
+    },
+    date2: {
+      type: 'string',
+      format: 'date',
+    },
+    age3: {
+      type: 'integer',
+      title: 'Age3',
+      errorMessage: {
+        type: 'JOSH',
+      },
+    },
+    date3: {
+      type: 'string',
+      format: 'date',
+    },
+    items: {
+      type: 'array',
+      items: {
+        type: 'object',
+        anyOf: [
+          {
+            properties: {
+              foo: {
+                type: 'string',
+              },
+            },
+          },
+          {
+            properties: {
+              bar: {
+                title: 'bar title',
+                description: 'bar desc',
+                type: 'string',
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
+export const lotsOfStringInputsSchema = {
+  title: 'Object',
+  description: 'Description',
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      title: 'First name',
+      description: 'the first name of the person.. duh!',
+      maxLength: 5,
+    },
+    age: {
+      type: 'integer',
+      title: 'Age',
+      description: 'Age description',
+    },
+    name2: {
+      type: 'string',
+      title: 'First name',
+      description: 'the first name of the person.. duh!',
+      maxLength: 5,
+    },
+    age2: {
+      type: 'integer',
+      title: 'Age',
+      description: 'Age description',
+    },
+    name3: {
+      type: 'string',
+      title: 'First name',
+      description: 'the first name of the person.. duh!',
+      maxLength: 5,
+    },
+    age3: {
+      type: 'integer',
+      title: 'Age',
+      description: 'Age description',
+    },
+    name4: {
+      type: 'string',
+      title: 'First name',
+      description: 'the first name of the person.. duh!',
+      maxLength: 5,
+    },
+    age4: {
+      type: 'integer',
+      title: 'Age',
+      description: 'Age description',
+    },
+  },
+};

--- a/src/widgets/JSONForm/widgets/Text.js
+++ b/src/widgets/JSONForm/widgets/Text.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { TextInput, StyleSheet } from 'react-native';

--- a/src/widgets/JSONForm/widgets/Text.js
+++ b/src/widgets/JSONForm/widgets/Text.js
@@ -1,21 +1,56 @@
 /* eslint-disable no-console */
-import React from 'react';
-import { Text as RNText, View, TextInput } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { TextInput, StyleSheet } from 'react-native';
+import { LIGHT_GREY, SUSSOL_ORANGE } from '../../../globalStyles/colors';
+import { APP_FONT_FAMILY } from '../../../globalStyles/fonts';
+import { useJSONFormOptions } from '../JSONFormContext';
 
-export const Text = props => {
-  console.log('-------------------------------------------');
-  console.log('Text - props', props);
-  console.log('-------------------------------------------');
+export const Text = ({ autofocus, disabled, placeholder, value, onChange }) => {
+  const textInputRef = useRef();
+
+  const { focusController } = useJSONFormOptions();
+
+  useEffect(() => {
+    focusController.register(textInputRef);
+  }, []);
 
   return (
-    <View style={{ borderWidth: 1, marginLeft: 10 }}>
-      <RNText>Text Widget</RNText>
-      <TextInput
-        onChangeText={text => {
-          // eslint-disable-next-line react/prop-types
-          props.onChange(text);
-        }}
-      />
-    </View>
+    <TextInput
+      ref={textInputRef}
+      style={styles.textInputStyle}
+      value={value}
+      placeholderTextColor={LIGHT_GREY}
+      underlineColorAndroid={SUSSOL_ORANGE}
+      placeholder={placeholder}
+      selectTextOnFocus
+      returnKeyType="next"
+      autoCapitalize="none"
+      autoCorrect={false}
+      onChangeText={onChange}
+      onSubmitEditing={() => focusController.next(textInputRef)}
+      editable={!disabled}
+      blurOnSubmit={false}
+      autoFocus={autofocus}
+    />
   );
+};
+
+const styles = StyleSheet.create({
+  textInputStyle: { flex: 1, fontFamily: APP_FONT_FAMILY },
+});
+
+Text.propTypes = {
+  autofocus: PropTypes.bool,
+  disabled: PropTypes.bool,
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+};
+
+Text.defaultProps = {
+  autofocus: false,
+  disabled: false,
+  placeholder: '',
+  value: '',
 };


### PR DESCRIPTION
Fixes #3634 

## Change summary

- Added a Text widget for string types
- Tried to handle focusing the next widget, seems to work OK when you use the virtual keyboard, using enter on my keyboard on the emulator has odd behaviour 🤷 
- Altered description/title fields
- The `FormTextInput` is coupled to tightly to the implementation and can't really be used for this, so just used the style and pretty much most of the same props
- The error messages are the inbuilt ones and need a bit of work to change them
- Open to style suggestions, feel free to commit

## Testing

N/A

### Related areas to think about

![image](https://user-images.githubusercontent.com/35858975/109470483-5acd6e00-7ad4-11eb-904c-6965bd826f02.png)

