### PR TITLE
#33639 Form schema Toggle component

### DIFF
--- a/src/widgets/JSONForm/JSONForm.js
+++ b/src/widgets/JSONForm/JSONForm.js
@@ -12,7 +12,7 @@ import { JSONFormWidget } from './widgets/index';
 import { JSONFormErrorList } from './JSONFormErrorList';
 import { PageButton } from '../PageButton';
 import { JSONFormContext } from './JSONFormContext';
-import { lotsOfStringInputsSchema } from './testJSON';
+import { booleanSchema } from './testJSON';
 
 const defaultTheme = {
   // Widgets are the lowest level input components. TextInput, Checkbox
@@ -131,7 +131,7 @@ export const JSONForm = React.forwardRef(
             // eslint-disable-next-line no-console
             onSubmit={form => console.log('onSubmit:', form)}
             ref={formRef}
-            schema={lotsOfStringInputsSchema}
+            schema={booleanSchema}
           >
             {children ?? (
               <PageButton

--- a/src/widgets/JSONForm/JSONForm.js
+++ b/src/widgets/JSONForm/JSONForm.js
@@ -123,7 +123,11 @@ export const JSONForm = React.forwardRef(
 
     return (
       <JSONFormContext.Provider value={options}>
-        <ScrollView keyboardDismissMode="none" keyboardShouldPersistTaps="always">
+        <ScrollView
+          keyboardDismissMode="none"
+          keyboardShouldPersistTaps="always"
+          style={{ padding: 20 }}
+        >
           <Form
             onError={() => {
               // placeholder to prevent console.errors when validation fails.

--- a/src/widgets/JSONForm/templates/Field.js
+++ b/src/widgets/JSONForm/templates/Field.js
@@ -17,7 +17,12 @@ export const Field = props => {
   let InvalidMessage = null;
   if (hasError) {
     InvalidMessage = rawErrors?.map(error => (
-      <FormInvalidMessage isValid={!hasError} message={error} textStyle={styles.invalidStyle} />
+      <FormInvalidMessage
+        key={error}
+        isValid={!hasError}
+        message={error}
+        textStyle={styles.invalidStyle}
+      />
     ));
   }
 

--- a/src/widgets/JSONForm/testJSON.js
+++ b/src/widgets/JSONForm/testJSON.js
@@ -158,3 +158,23 @@ export const lotsOfStringInputsSchema = {
     },
   },
 };
+
+export const booleanSchema = {
+  title: 'Boolean',
+  properties: {
+    boolean: { type: 'boolean', title: 'Test boolean', default: true },
+    enum1: {
+      type: 'boolean',
+      title: 'Test Enum - enumNames is not in JSON spec but works.. but doesnt validate',
+      enum: [1, 'some other value'],
+      enumNames: ['AAA', 'BBB'],
+    },
+    enum2: {
+      type: 'boolean',
+      title: 'Testing with enumNames - still not part of the JSON spec, but does validate',
+      enum: [true, false],
+      enumNames: ['Josh', 'Mark'],
+      default: false,
+    },
+  },
+};

--- a/src/widgets/JSONForm/widgets/Checkbox.js
+++ b/src/widgets/JSONForm/widgets/Checkbox.js
@@ -1,10 +1,48 @@
-/* eslint-disable no-console */
+/* eslint-disable react/forbid-prop-types */
 import React from 'react';
-import { Text } from 'react-native';
+import PropTypes from 'prop-types';
+import { StyleSheet } from 'react-native';
+import { SUSSOL_ORANGE, WARMER_GREY } from '../../../globalStyles/colors';
+import { ToggleBar } from '../../index';
 
-export const Checkbox = props => {
-  console.log('-------------------------------------------');
-  console.log('Checkbox - props', props);
-  console.log('-------------------------------------------');
-  return <Text style={{ borderWidth: 1, marginLeft: 10 }}>CheckboxWidget</Text>;
+export const Checkbox = ({ options: { enumOptions }, value, onChange, disabled, readonly }) => {
+  const toggles = enumOptions.map(({ label, value: enumValue }) => ({
+    text: label,
+    isOn: enumValue === value,
+    onPress: () => onChange(enumValue),
+  }));
+
+  return (
+    <ToggleBar
+      isDisabled={disabled || readonly}
+      toggleOnStyle={styles.toggleOnStyle}
+      toggleOffStyle={styles.toggleOffStyle}
+      toggleOnDisabledStyle={styles.toggleOnDisabledStyle}
+      toggles={toggles}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  toggleOnStyle: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: SUSSOL_ORANGE,
+  },
+  toggleOffStyle: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  toggleOnDisabledStyle: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: WARMER_GREY,
+  },
+});
+
+Checkbox.propTypes = {
+  options: PropTypes.object.isRequired,
+  value: PropTypes.bool.isRequired,
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
+  readonly: PropTypes.bool.isRequired,
 };

--- a/src/widgets/JSONForm/widgets/Checkbox.js
+++ b/src/widgets/JSONForm/widgets/Checkbox.js
@@ -19,23 +19,37 @@ export const Checkbox = ({ options: { enumOptions }, value, onChange, disabled, 
       toggleOffStyle={styles.toggleOffStyle}
       toggleOnDisabledStyle={styles.toggleOnDisabledStyle}
       toggles={toggles}
+      style={styles.container}
     />
   );
 };
 
 const styles = StyleSheet.create({
+  container: { borderWidth: 0, width: 150 },
   toggleOnStyle: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: SUSSOL_ORANGE,
+    borderRadius: 20,
+    margin: 5,
   },
-  toggleOffStyle: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  toggleOffStyle: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 20,
+    borderColor: SUSSOL_ORANGE,
+    borderWidth: 1,
+    margin: 5,
+  },
   toggleOnDisabledStyle: {
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: WARMER_GREY,
+    borderRadius: 20,
+    margin: 5,
   },
 });
 


### PR DESCRIPTION
Fixes #3639 

## Change summary

- Simple 'checkbox' component. This is for boolean values so a `Checkbox` is probably the correct choice for this regularly, but we use this `ToggleBar` component in a lot of places and it's kinda easier for now? Although just adding https://github.com/react-native-checkbox/react-native-checkbox would also be easy? I just took the styles and stuff from `FormToggle`

## Testing

Internal

### Related areas to think about

![image](https://user-images.githubusercontent.com/35858975/109480401-5c9d2e80-7ae0-11eb-9fbb-a767ecf33277.png)
