### PR TITLE
#3640 Select widget

### DIFF
--- a/src/widgets/JSONForm/JSONForm.js
+++ b/src/widgets/JSONForm/JSONForm.js
@@ -12,7 +12,7 @@ import { JSONFormWidget } from './widgets/index';
 import { JSONFormErrorList } from './JSONFormErrorList';
 import { PageButton } from '../PageButton';
 import { JSONFormContext } from './JSONFormContext';
-import { booleanSchema } from './testJSON';
+import { selectSchema, selectUiSchema } from './testJSON';
 
 const defaultTheme = {
   // Widgets are the lowest level input components. TextInput, Checkbox
@@ -125,13 +125,14 @@ export const JSONForm = React.forwardRef(
       <JSONFormContext.Provider value={options}>
         <ScrollView keyboardDismissMode="none" keyboardShouldPersistTaps="always">
           <Form
+            uiSchema={selectUiSchema}
             onError={() => {
               // placeholder to prevent console.errors when validation fails.
             }}
             // eslint-disable-next-line no-console
             onSubmit={form => console.log('onSubmit:', form)}
             ref={formRef}
-            schema={booleanSchema}
+            schema={selectSchema}
           >
             {children ?? (
               <PageButton

--- a/src/widgets/JSONForm/testJSON.js
+++ b/src/widgets/JSONForm/testJSON.js
@@ -187,21 +187,18 @@ export const selectSchema = {
       type: 'string',
       title: 'String enum',
       enum: Array.from({ length: 30 }).map((_, i) => String(i)),
+      default: '1',
     },
     test2: {
       type: 'number',
       title: 'Number enum',
       enum: [1, 2, 3],
-      default: 1,
     },
   },
   required: ['test2'],
 };
 
 export const selectUiSchema = {
-  josh: {
-    'ui:emptyValue': '',
-  },
   test2: {
     'ui:placeholder': 'Select an option',
   },

--- a/src/widgets/JSONForm/testJSON.js
+++ b/src/widgets/JSONForm/testJSON.js
@@ -178,3 +178,31 @@ export const booleanSchema = {
     },
   },
 };
+
+export const selectSchema = {
+  title: 'Select',
+  type: 'object',
+  properties: {
+    josh: {
+      type: 'string',
+      title: 'String enum',
+      enum: Array.from({ length: 30 }).map((_, i) => String(i)),
+    },
+    test2: {
+      type: 'number',
+      title: 'Number enum',
+      enum: [1, 2, 3],
+      default: 1,
+    },
+  },
+  required: ['test2'],
+};
+
+export const selectUiSchema = {
+  josh: {
+    'ui:emptyValue': '',
+  },
+  test2: {
+    'ui:placeholder': 'Select an option',
+  },
+};

--- a/src/widgets/JSONForm/widgets/Select.js
+++ b/src/widgets/JSONForm/widgets/Select.js
@@ -1,10 +1,48 @@
-/* eslint-disable no-console */
+/* eslint-disable react/forbid-prop-types */
 import React from 'react';
-import { Text } from 'react-native';
+import PropTypes from 'prop-types';
+import { Picker } from 'react-native';
+import { SUSSOL_ORANGE } from '../../../globalStyles/colors';
 
-export const Select = props => {
-  console.log('-------------------------------------------');
-  console.log('Select - props', props);
-  console.log('-------------------------------------------');
-  return <Text style={{ borderWidth: 1, marginLeft: 10 }}>SelectWidget</Text>;
+export const Select = ({ disabled, readonly, onChange, placeholder, options, value }) => {
+  let pickers = options.enumOptions.map(({ label, value: enumValue }) => (
+    <Picker.Item key={label} label={label} value={enumValue} color={SUSSOL_ORANGE} />
+  ));
+
+  const placeholderItem = (
+    <Picker.Item key={placeholder} label={placeholder} value={placeholder} color={SUSSOL_ORANGE} />
+  );
+
+  pickers = [placeholderItem, ...pickers];
+
+  return (
+    <Picker
+      mode="dropdown"
+      enabled={!(disabled || readonly)}
+      selectedValue={value}
+      onValueChange={chosenValue => {
+        // There is a requirement for 'empty'/placeholder entries to call on change with
+        // undefined: https://github.com/rjsf-team/react-jsonschema-form/pull/451/files
+        // however the placeholder value is passed by default as an empty string.
+        if (chosenValue === '') onChange(undefined);
+        else onChange(chosenValue);
+      }}
+    >
+      {pickers}
+    </Picker>
+  );
+};
+
+Select.defaultProps = {
+  readonly: false,
+  value: '',
+};
+
+Select.propTypes = {
+  options: PropTypes.object.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
+  readonly: PropTypes.bool,
+  placeholder: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
Fixes #3640 

## Change summary

- Adds a select widget
- Just really tested with some basic enums and it seems to work well.
- Went with the built in react-native picker even though it's deprecated because that's just what we have been using. Didn't use the `dropdown` component because it has a funny `header` thing implemented which was being annoying with implementing 'default/placeholder' values, with having the 'header' being selectable, which I didn't want to have to regression test.
- The `react-native-picker` package available to replace the built-in has exactly the same API, just didn't want to add native packages which can make building the app be funny
- I actually like the `mode="dialog"` a little better than "dropdown"?


## Testing

Internal?

### Related areas to think about

![image](https://user-images.githubusercontent.com/35858975/109561846-930b9580-7b42-11eb-8d92-268419d3e3c3.png)
