### PR TITLE
#3623 breach filtering by location

### DIFF
--- a/src/bluetooth/BreachManager.test.js
+++ b/src/bluetooth/BreachManager.test.js
@@ -1,3 +1,4 @@
+import { MILLISECONDS } from '../utilities/constants';
 import BreachManager, { destroyBreachManagerInstance } from './BreachManager';
 
 beforeEach(() => {
@@ -13,7 +14,7 @@ describe('BreachManager: closeBreach', () => {
     const breach = { id: 'a' };
     const closedBreach = breachManager.closeBreach(breach, 0);
 
-    expect(closedBreach).toEqual({ ...breach, endTimestamp: 0 });
+    expect(closedBreach).toEqual({ ...breach, endTimestamp: new Date(0) });
   });
 });
 
@@ -45,7 +46,7 @@ describe('BreachManager: createBreach', () => {
       endTimestamp: undefined,
       location: dummyLocation,
       sensor,
-      startTimestamp: 0,
+      startTimestamp: new Date(0),
       thresholdDuration: '1',
       thresholdMaxTemperature: '100',
       thresholdMinTemperature: '0',
@@ -281,7 +282,7 @@ describe('BreachManager: updateBreaches', () => {
     const breachManager = BreachManager(mockDbService);
 
     const breaches = [{ id: 'a' }, { id: 'b' }];
-    const logs = [{ id: 'a', timestamp: 0, temperature: 0 }];
+    const logs = [{ id: 'a', timestamp: new Date(0), temperature: 0 }];
 
     const result = breachManager.updateBreaches(breaches, logs);
 
@@ -330,7 +331,7 @@ describe('BreachManager: createBreaches', () => {
         thresholdMaxTemperature: 999,
         thresholdMinTemperature: 8,
         thresholdDuration: 1000,
-        startTimestamp: 0,
+        startTimestamp: new Date(0),
         endTimestamp: undefined,
         location: dummyLocation,
       },
@@ -378,8 +379,8 @@ describe('BreachManager: createBreaches', () => {
         thresholdMinTemperature: 8,
         thresholdMaxTemperature: 999,
         thresholdDuration: 1000,
-        startTimestamp: 0,
-        endTimestamp: 2,
+        startTimestamp: new Date(0),
+        endTimestamp: new Date(2 * MILLISECONDS.ONE_SECOND),
         location: dummyLocation,
         type: 'HOT_CONSECUTIVE',
       },
@@ -425,11 +426,11 @@ describe('BreachManager: createBreaches', () => {
         id: '1',
         acknowledged: false,
         sensor,
-        startTimestamp: 0,
+        startTimestamp: new Date(0),
         thresholdMinTemperature: 8,
         thresholdMaxTemperature: 999,
         thresholdDuration: 1000,
-        endTimestamp: 2,
+        endTimestamp: new Date(2 * MILLISECONDS.ONE_SECOND),
         location: dummyLocation,
         type: 'HOT_CONSECUTIVE',
       },
@@ -437,7 +438,7 @@ describe('BreachManager: createBreaches', () => {
         id: '1',
         acknowledged: false,
         sensor,
-        startTimestamp: 3,
+        startTimestamp: new Date(3 * MILLISECONDS.ONE_SECOND),
         thresholdMinTemperature: 8,
         thresholdMaxTemperature: 999,
         thresholdDuration: 1000,

--- a/src/selectors/fridge.js
+++ b/src/selectors/fridge.js
@@ -73,8 +73,8 @@ export const selectBreaches = createSelector(
   [selectFromDate, selectToDate, selectSelectedFridgeID],
   (fromDate, toDate, fridgeID) => {
     const breaches = UIDatabase.objects('TemperatureBreach').filtered(
-      '(startTimestamp <= $0 && (endTimestamp >= $0 || endTimestamp == null)) || ' +
-        '(startTimestamp >= $0 && startTimestamp <= $1) && location.id == $2',
+      '((startTimestamp <= $0 && (endTimestamp >= $0 || endTimestamp == null)) || ' +
+        '(startTimestamp >= $0 && startTimestamp <= $1)) && location.id == $2',
       new Date(fromDate),
       new Date(toDate),
       fridgeID


### PR DESCRIPTION
Fixes #3623

## Change summary

- Tiny adjustment to filter expression so only breaches for the current location are shown on the line graph
- Snuck in offroad to fix breach manager tests as there were some timestamping updates made

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Have two sensors setup with breaches
- [ ] Browse to fridge detail for a sensor
- [ ] Verify only breaches for the current sensor are shown

### Related areas to think about
N/A
