### PR TITLE
#3627 fix sensor config reverting location updates

### DIFF
--- a/src/actions/Entities/SensorActions.js
+++ b/src/actions/Entities/SensorActions.js
@@ -177,7 +177,7 @@ const createNew = () => (dispatch, getState) => {
     if (existingLocation) {
       newLocation = UIDatabase.update('Location', {
         id: existingLocation.id,
-        description: sensor.name,
+        description: location.name,
         code: location.code,
       });
     } else {

--- a/src/actions/Entities/SensorActions.js
+++ b/src/actions/Entities/SensorActions.js
@@ -93,9 +93,11 @@ const save = () => (dispatch, getState) => {
       logDelay: new Date(sensor?.logDelay ?? 0),
       location: updatedLocation,
     });
-    configs.forEach(config =>
-      updatedConfigs.push(UIDatabase.update('TemperatureBreachConfiguration', config))
-    );
+
+    configs.forEach(config => {
+      config.location = updatedLocation;
+      updatedConfigs.push(UIDatabase.update('TemperatureBreachConfiguration', config));
+    });
 
     if (replacedSensor) {
       replacedSensor.location = null;

--- a/src/actions/Entities/SensorActions.js
+++ b/src/actions/Entities/SensorActions.js
@@ -178,6 +178,7 @@ const createNew = () => (dispatch, getState) => {
       newLocation = UIDatabase.update('Location', {
         id: existingLocation.id,
         description: sensor.name,
+        code: location.code,
       });
     } else {
       newLocation = createRecord(UIDatabase, 'Location', { ...location, description: sensor.name });

--- a/src/actions/Entities/SensorActions.js
+++ b/src/actions/Entities/SensorActions.js
@@ -95,8 +95,26 @@ const save = () => (dispatch, getState) => {
     });
 
     configs.forEach(config => {
-      config.location = updatedLocation;
-      updatedConfigs.push(UIDatabase.update('TemperatureBreachConfiguration', config));
+      const {
+        id,
+        minimumTemperature,
+        maximumTemperature,
+        duration,
+        description,
+        colour,
+        type,
+      } = config;
+      updatedConfigs.push(
+        UIDatabase.update('TemperatureBreachConfiguration', {
+          id,
+          minimumTemperature,
+          maximumTemperature,
+          duration,
+          description,
+          colour,
+          type,
+        })
+      );
     });
 
     if (replacedSensor) {

--- a/src/database/DataTypes/TemperatureBreachConfiguration.js
+++ b/src/database/DataTypes/TemperatureBreachConfiguration.js
@@ -5,7 +5,20 @@
 
 import Realm from 'realm';
 
-export class TemperatureBreachConfiguration extends Realm.Object {}
+export class TemperatureBreachConfiguration extends Realm.Object {
+  toJSON() {
+    return {
+      id: this.id,
+      minimumTemperature: this.minimumTemperature,
+      maximumTemperature: this.maximumTemperature,
+      duration: this.duration,
+      description: this.description,
+      colour: this.colour,
+      locationID: this.location?.id ?? '',
+      type: this.type,
+    };
+  }
+}
 
 TemperatureBreachConfiguration.schema = {
   name: 'TemperatureBreachConfiguration',


### PR DESCRIPTION
Fixes #3627.

## Change summary

Took me a while to figure this one out! TLDR is that location edits are being overwritten by old location state persisted in the sensor configs. When the config locations are persisted to the database, the previous location updates are "reverted" back to the old state. This can be seen by examining `updatedLocation` after the configs are updated (as it is a live realm object, it reflects the most recent state of the database).

Note: what made this super confusing (for me) was the way concerns overlap between multiple live objects (e.g. as opposed to only updating config fields on the `TemperatureBreachConfiguration` object, linked location objects are also updated). I think some minor refactoring to only update certain fields rather than whole objects could make this code a bit nicer?

Note note: also just realised part of the reason for this is probably the fact that the code would be quite verbose now that realm objects can no longer be destructured!

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Edit an existing sensor code. After saving and navigating back to the sensor edit page, the code has been updated.
- [ ] Delete an existing sensor. After reconnecting the sensor with a new code and navigating back to the sensor edit page, the code has been updated.

### Related areas to think about

Good patterns for updating groups of live realm objects in thunks.
