### PR TITLE
#3666 Filter for active VVM Status

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -649,6 +649,7 @@ const createItemBatch = (database, item, batchString, supplier) => {
     // Find a VVM Status with the lowest level to auto assign to new item batches.
     const vaccineVialMonitorStatus = database
       .objects('VaccineVialMonitorStatus')
+      .filtered('isActive == true')
       .sorted('level')[0];
 
     if (itemBatch.shouldApplyVvmStatus(vaccineVialMonitorStatus)) {


### PR DESCRIPTION
Fixes #3666 (partially)

## Change summary

- When auto assigning VVM status to items, filter out inactive ones.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Ensure there are some vaccine items available to the store for testing
- [ ] In Desktop, set the lowest VVM status to inactive (Item -> Vaccines -> Show Vaccine Vial Monitor Status)
- [ ] Try to do a stocktake or create a new supplier invoice and add a vaccine item line
- [ ] The VVM Status should default to the one with the lowest level that is active

### Related areas to think about
- Historic records will not be updated (e.g. unfinalised SI or Stocktakes), a separate issue will be created for this
