### PR TITLE
#3673 fridge display test icon overlap

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "7.0.0-rc7",
+  "version": "7.0.0-rc8",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/pages/VaccinePage.js
+++ b/src/pages/VaccinePage.js
@@ -117,7 +117,7 @@ const localStyles = StyleSheet.create({
   fridgeDetail: {
     flex: 0,
     height: 60,
-    paddingHorizontal: 10,
+    paddingRight: 40,
     width: 140,
   },
   fridgePaperContentContainer: {


### PR DESCRIPTION
Fixes #3673.

## Change summary

Minor UI fix to prevent `FridgeDisplay` date string overlapping chevron icon.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Setup a sensor with a log interval > 10 minutes (e.g. 15 minutes). View the sensor > 10 minutes after the last temperature log. The date string does not overlap the chevron icon.

### Related areas to think about

N/A.
