### PR TITLE
#3673 fix fridge date string overlapping chevron icon

### DIFF
--- a/src/pages/VaccinePage.js
+++ b/src/pages/VaccinePage.js
@@ -117,7 +117,7 @@ const localStyles = StyleSheet.create({
   fridgeDetail: {
     flex: 0,
     height: 60,
-    paddingHorizontal: 10,
+    paddingRight: 40,
     width: 140,
   },
   fridgePaperContentContainer: {

--- a/src/selectors/Entities/temperatureBreachConfig.js
+++ b/src/selectors/Entities/temperatureBreachConfig.js
@@ -36,8 +36,8 @@ export const selectEditingConfigThresholds = state => {
   const coldConsecutiveThreshold = (hotConsecutiveConfig.minimumTemperature ?? 0) - 0.1;
   const hotConsecutiveThreshold = (coldConsecutiveConfig.maximumTemperature ?? 0) + 0.1;
 
-  const coldCumulativeThreshold = (hotCumulativeConfig.minimumTemperature ?? 0) + 0.1;
-  const hotCumulativeThreshold = (coldCumulativeConfig.maximumTemperature ?? 0) - 0.1;
+  const coldCumulativeThreshold = (hotCumulativeConfig.minimumTemperature ?? 0) - 0.1;
+  const hotCumulativeThreshold = (coldCumulativeConfig.maximumTemperature ?? 0) + 0.1;
 
   return {
     coldConsecutiveThreshold,
@@ -71,8 +71,8 @@ export const selectNewConfigThresholds = state => {
   const coldConsecutiveThreshold = (hotConsecutiveConfig.minimumTemperature ?? 0) - 0.1;
   const hotConsecutiveThreshold = (coldConsecutiveConfig.maximumTemperature ?? 0) + 0.1;
 
-  const coldCumulativeThreshold = (hotCumulativeConfig.minimumTemperature ?? 0) + 0.1;
-  const hotCumulativeThreshold = (coldCumulativeConfig.maximumTemperature ?? 0) - 0.1;
+  const coldCumulativeThreshold = (hotCumulativeConfig.minimumTemperature ?? 0) - 0.1;
+  const hotCumulativeThreshold = (coldCumulativeConfig.maximumTemperature ?? 0) + 0.1;
 
   return {
     coldConsecutiveThreshold,


### PR DESCRIPTION
Fixes #3673.

## Change summary

Minor UI fix to prevent `FridgeDisplay` date string overlapping chevron icon.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Setup a sensor with a log interval > 10 minutes (e.g. 15 minutes). View the sensor > 10 minutes after the last temperature log. The date string does not overlap the chevron icon.

### Related areas to think about

N/A.
