### PR TITLE
#3364 disable location for non-vaccine items

### DIFF
--- a/src/pages/dataTableUtilities/constants.js
+++ b/src/pages/dataTableUtilities/constants.js
@@ -29,7 +29,7 @@ export const COLUMN_KEYS = {
   COST_PRICE: 'costPriceString',
   COUNTED_TOTAL_QUANTITY: 'countedTotalQuantity',
   CREATED_DATE: 'createdDate',
-  CURRENT_LOCATION: 'currentLocation',
+  CURRENT_LOCATION: 'currentLocationName',
   CURRENT_VVM_STATUS: 'currentVvmStatusName',
   DATE_OF_BIRTH: 'dateOfBirth',
   DESCRIPTION: 'description',

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -1130,7 +1130,7 @@ const COLUMNS = () => ({
   },
   [COLUMN_NAMES.LOCATION]: {
     type: COLUMN_TYPES.DROP_DOWN,
-    key: 'currentLocationName',
+    key: COLUMN_KEYS.CURRENT_LOCATION,
     title: tableStrings.location,
     alignText: 'left',
     sortable: false,

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -341,6 +341,7 @@ const DataTableRow = React.memo(
               const { isVaccine = false, hasVariance = false } = rowData ?? {};
 
               const disabledConditions = {
+                [COLUMN_KEYS.CURRENT_LOCATION]: !isVaccine,
                 [COLUMN_KEYS.CURRENT_VVM_STATUS]: !isVaccine,
                 [COLUMN_KEYS.REASON_TITLE]: !hasVariance,
               };


### PR DESCRIPTION
Fixes #3364,

## Change summary

- Disables location cell for non-vaccine items.
- Fixes `CURRENT_LOCATION` column key typo.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a supplier invoice with a vaccine and non-vaccine item. The vaccine item location is orange and editable.
- [ ] Create a supplier invoice with a vaccine and non-vaccine item. The non-vaccine item location is grey and non-editable.

### Related areas to think about

N/A.