### PR TITLE
#3613 JSONForm in PatientEditModal

### DIFF
--- a/src/actions/Entities/NameNoteActions.js
+++ b/src/actions/Entities/NameNoteActions.js
@@ -71,9 +71,12 @@ const updateForm = (data, errors) => ({
   payload: { data, errors },
 });
 
-const saveEditing = () => (dispatch, getState) => {
+const saveEditing = optionalNameID => (dispatch, getState) => {
   const { nameID, patientEventID, ...nameNote } = selectCreatingNameNote(getState()) ?? {};
-  UIDatabase.write(() => createRecord(UIDatabase, 'NameNote', nameNote, patientEventID, nameID));
+
+  UIDatabase.write(() =>
+    createRecord(UIDatabase, 'NameNote', nameNote, patientEventID, nameID || optionalNameID)
+  );
   dispatch(reset());
 };
 

--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -139,7 +139,7 @@ export class Name extends Realm.Object {
       dateOfBirth: this.dateOfBirth?.getTime(),
       phoneNumber: this.phoneNumber,
       country: this.country,
-      billingAddress: this.billingAddress.toJSON(),
+      billingAddress: this.billingAddress?.toJSON(),
       emailAddress: this.emailAddress,
       type: this.type,
       masterLists: this.masterLists,

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -38,6 +38,8 @@ import { selectPatientModalOpen, selectCanEditPatient } from '../selectors/patie
 
 import globalStyles from '../globalStyles';
 import { dispensingStrings } from '../localization';
+import { PatientEditModal } from '../widgets/modalChildren/PatientEditModal';
+import { selectSurveySchemas } from '../selectors/formSchema';
 
 const Dispensing = ({
   data,
@@ -73,7 +75,6 @@ const Dispensing = ({
   editPatient,
   createPatient,
   cancelPatientEdit,
-  savePatient,
   viewPatientHistory,
 
   // Prescriber variables
@@ -214,11 +215,12 @@ const Dispensing = ({
         noCancel
         isVisible={patientEditModalOpen}
       >
-        <FormControl
+        <PatientEditModal
+          patient={currentPatient}
           isDisabled={!canEditPatient}
-          onSave={savePatient}
           onCancel={cancelPatientEdit}
           inputConfig={getFormInputConfig('patient', currentPatient)}
+          surveySchema={selectSurveySchemas()[0]}
         />
       </ModalContainer>
       <ModalContainer
@@ -347,7 +349,6 @@ const mapDispatchToProps = dispatch => ({
   editPatient: patient => dispatch(PatientActions.editPatient(UIDatabase.get('Name', patient))),
   createPatient: () => dispatch(PatientActions.createPatient()),
   cancelPatientEdit: () => dispatch(PatientActions.closeModal()),
-  savePatient: patientDetails => dispatch(PatientActions.patientUpdate(patientDetails)),
   viewPatientHistory: rowKey =>
     dispatch(PatientActions.viewPatientHistory(UIDatabase.get('Name', rowKey))),
 
@@ -389,7 +390,6 @@ Dispensing.propTypes = {
   editPatient: PropTypes.func.isRequired,
   patientEditModalOpen: PropTypes.bool.isRequired,
   createPatient: PropTypes.func.isRequired,
-  savePatient: PropTypes.func.isRequired,
   cancelPatientEdit: PropTypes.func.isRequired,
   currentPatient: PropTypes.object,
   canEditPatient: PropTypes.bool.isRequired,

--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -267,6 +267,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     showSaveButton,
     cancelButtonText,
     onCancel,
+    canSave,
   } = ownProps;
   const onInitialiseForm = () => initialiseForm(inputConfig);
   const onUpdateForm = (key, value) => !isDisabled && updateForm(key, value);
@@ -280,7 +281,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     completedForm,
     inputConfig,
     isDisabled,
-    canSaveForm,
+    canSaveForm: canSave && canSaveForm,
     saveButtonText,
     isConfirmFormOpen,
     confirmText,
@@ -321,9 +322,13 @@ FormControlComponent.defaultProps = {
   showSaveButton: true,
   cancelButtonText: modalStrings.cancel,
   shouldAutoFocus: true,
+  canSave: true,
 };
 
 FormControlComponent.propTypes = {
+  // Prop is used in merge props
+  // eslint-disable-next-line react/no-unused-prop-types
+  canSave: PropTypes.bool,
   form: PropTypes.object,
   completedForm: PropTypes.object,
   inputConfig: PropTypes.array.isRequired,

--- a/src/widgets/Tabs/PatientEdit.js
+++ b/src/widgets/Tabs/PatientEdit.js
@@ -80,23 +80,21 @@ const PatientEditComponent = ({
         </View>
 
         <View style={localStyles.verticalSeparator} />
-        <View style={localStyles.formContainer}>
-          {surveySchema && <View style={localStyles.verticalSeparator} />}
-          {surveySchema && (
-            <View style={localStyles.formContainer}>
-              <JSONForm
-                ref={formRef}
-                surveySchema={surveySchema}
-                formData={surveyFormData}
-                onChange={data => {
-                  updateForm(data.formData, data.errors);
-                }}
-              >
-                <View />
-              </JSONForm>
-            </View>
-          )}
-        </View>
+        {surveySchema && (
+          <View style={localStyles.formContainer}>
+            <View style={localStyles.verticalSeparator} />
+            <JSONForm
+              ref={formRef}
+              surveySchema={surveySchema}
+              formData={surveyFormData}
+              onChange={data => {
+                updateForm(data.formData, data.errors);
+              }}
+            >
+              <View />
+            </JSONForm>
+          </View>
+        )}
       </View>
 
       <FlexRow justifyContent="flex-end" alignItems="flex-end">

--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -42,8 +42,8 @@ export const PatientEditModalComponent = ({
         onCancel={onCancel}
         inputConfig={inputConfig}
       />
-      <View style={styles.formContainer}>
-        {surveySchema && surveyForm && (
+      {!surveySchema && surveyForm && (
+        <View style={styles.formContainer}>
           <JSONForm
             surveySchema={surveySchema}
             formData={surveyForm}
@@ -53,8 +53,8 @@ export const PatientEditModalComponent = ({
           >
             <></>
           </JSONForm>
-        )}
-      </View>
+        </View>
+      )}
     </FlexRow>
   );
 };

--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -9,6 +9,7 @@ import { JSONForm } from '../JSONForm/JSONForm';
 import { NameNoteActions } from '../../actions/Entities/NameNoteActions';
 import { selectNameNoteIsValid, selectCreatingNameNote } from '../../selectors/Entities/nameNote';
 import { PatientActions } from '../../actions/PatientActions';
+import { generateUUID } from '../../database/index';
 
 export const PatientEditModalComponent = ({
   isDisabled,
@@ -23,8 +24,10 @@ export const PatientEditModalComponent = ({
   nameNoteIsValid,
 }) => {
   const onSaveWithForm = completedForm => {
-    onSaveSurvey();
-    onSave(completedForm);
+    const id = generateUUID();
+
+    onSave({ id, ...completedForm });
+    onSaveSurvey(id);
   };
 
   useEffect(() => {
@@ -90,15 +93,15 @@ const stateToProps = state => {
   const nameNoteIsValid = selectNameNoteIsValid(state);
   const nameNote = selectCreatingNameNote(state);
 
-  return { nameNoteIsValid, surveyForm: nameNote?.data ?? {} };
+  return { nameNoteIsValid, surveyForm: nameNote?.data ?? null };
 };
 
 const dispatchToProps = (dispatch, ownProps) => {
   const { patient } = ownProps;
-  const { id } = patient;
+  const { id = '' } = patient ?? {};
   return {
     onOpen: () => dispatch(NameNoteActions.createSurveyNameNote(id)),
-    onSaveSurvey: () => dispatch(NameNoteActions.saveEditing()),
+    onSaveSurvey: optionalNameID => dispatch(NameNoteActions.saveEditing(optionalNameID)),
     onUpdateForm: form => dispatch(NameNoteActions.updateForm(form)),
     onSave: patientDetails => dispatch(PatientActions.patientUpdate(patientDetails)),
   };

--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -1,0 +1,107 @@
+/* eslint-disable react/forbid-prop-types */
+import React, { useEffect } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { FormControl } from '../FormControl';
+import { FlexRow } from '../FlexRow';
+import { JSONForm } from '../JSONForm/JSONForm';
+import { NameNoteActions } from '../../actions/Entities/NameNoteActions';
+import { selectNameNoteIsValid, selectCreatingNameNote } from '../../selectors/Entities/nameNote';
+import { PatientActions } from '../../actions/PatientActions';
+
+export const PatientEditModalComponent = ({
+  isDisabled,
+  onSave,
+  onCancel,
+  inputConfig,
+  surveySchema,
+  surveyForm,
+  onOpen,
+  onSaveSurvey,
+  onUpdateForm,
+  nameNoteIsValid,
+}) => {
+  const onSaveWithForm = completedForm => {
+    onSaveSurvey();
+    onSave(completedForm);
+  };
+
+  useEffect(() => {
+    if (surveySchema) {
+      onOpen();
+    }
+  }, []);
+
+  return (
+    <FlexRow flex={1}>
+      <FormControl
+        canSave={nameNoteIsValid}
+        isDisabled={isDisabled}
+        onSave={surveySchema ? onSaveWithForm : onSave}
+        onCancel={onCancel}
+        inputConfig={inputConfig}
+      />
+      <View style={styles.formContainer}>
+        {surveySchema && surveyForm && (
+          <JSONForm
+            surveySchema={surveySchema}
+            formData={surveyForm}
+            onChange={({ formData, errors }) => {
+              onUpdateForm(formData, errors);
+            }}
+          >
+            <></>
+          </JSONForm>
+        )}
+      </View>
+    </FlexRow>
+  );
+};
+
+const styles = StyleSheet.create({
+  formContainer: {
+    flex: 1,
+    backgroundColor: 'white',
+  },
+});
+
+PatientEditModalComponent.defaultProps = {
+  isDisabled: false,
+  surveyForm: null,
+  surveySchema: null,
+  nameNoteIsValid: true,
+};
+
+PatientEditModalComponent.propTypes = {
+  isDisabled: PropTypes.bool,
+  onSave: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  inputConfig: PropTypes.array.isRequired,
+  surveyForm: PropTypes.object,
+  nameNoteIsValid: PropTypes.bool,
+  surveySchema: PropTypes.object,
+  onOpen: PropTypes.func.isRequired,
+  onSaveSurvey: PropTypes.func.isRequired,
+  onUpdateForm: PropTypes.func.isRequired,
+};
+
+const stateToProps = state => {
+  const nameNoteIsValid = selectNameNoteIsValid(state);
+  const nameNote = selectCreatingNameNote(state);
+
+  return { nameNoteIsValid, surveyForm: nameNote?.data ?? null };
+};
+
+const dispatchToProps = (dispatch, ownProps) => {
+  const { patient } = ownProps;
+  const { id } = patient;
+  return {
+    onOpen: () => dispatch(NameNoteActions.createSurveyNameNote(id)),
+    onSaveSurvey: () => dispatch(NameNoteActions.saveEditing()),
+    onUpdateForm: form => dispatch(NameNoteActions.updateForm(form)),
+    onSave: patientDetails => dispatch(PatientActions.patientUpdate(patientDetails)),
+  };
+};
+
+export const PatientEditModal = connect(stateToProps, dispatchToProps)(PatientEditModalComponent);

--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -42,7 +42,7 @@ export const PatientEditModalComponent = ({
         onCancel={onCancel}
         inputConfig={inputConfig}
       />
-      {!surveySchema && surveyForm && (
+      {surveySchema && surveyForm && (
         <View style={styles.formContainer}>
           <JSONForm
             surveySchema={surveySchema}
@@ -90,7 +90,7 @@ const stateToProps = state => {
   const nameNoteIsValid = selectNameNoteIsValid(state);
   const nameNote = selectCreatingNameNote(state);
 
-  return { nameNoteIsValid, surveyForm: nameNote?.data ?? null };
+  return { nameNoteIsValid, surveyForm: nameNote?.data ?? {} };
 };
 
 const dispatchToProps = (dispatch, ownProps) => {


### PR DESCRIPTION
Fixes #3616 

## Change summary

- Adds a `PatientEditModal` component to encapsulate some of the code a little
- Adds `JSONForm` into `PatientEditModal` in a somewhat crude way
- Adds creating new name notes from the `PatientEditModal`

## Testing

- [ ]  When editing a patient, can fill the survey with some details and have a name note created
- [ ] When editing a patient, can only save the form when all values, including those of the survey are valid
- [ ] No changes to behaviour when no survey

### Related areas to think about

![image](https://user-images.githubusercontent.com/35858975/110230367-4e825e80-7f75-11eb-9c62-f93230f592c6.png)


Few issues to come out of this
- Tidy up UI of this modal
- Create some sort of `touched` state which gets set after an `update` action, and only save/create a new name note if the form has been touched (Could check if the actual diff is different also, but a simple `touched` is gonna catch the majority of cases and is a bit simpler. Although could just do a `JSON.stringify` compare of the new name note data and the old name note data to see if anything has changed to check also.
- I don't really like the implementation in general, but I think we are gonna do more work in this area with AEFI's so kinda just wanna have it working and spend time on the area when we're doing AEFI's, otherwise we might do something we have to change when we do AEFI's anyway. Also AEFI's.