### PR TITLE
#3633 fix permissions modal intro string

### DIFF
--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -65,7 +65,7 @@
     "location_service_comment": "Required to connect to bluetooth sensors",
     "bluetooth_permission": "Bluetooth",
     "bluetooth_permission_comment": "Required to connect to bluetooth sensors",
-    "permissions_intro_1": "The following permissions and services are required by various features of the cold chain functionality.",
+    "permissions_intro_1": "The following permissions and services are required for cold chain functionality.",
     "permissions_intro_2": "If disabled, you can press an item to enable it."
   },
   "fr": {

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -65,7 +65,7 @@
     "location_service_comment": "Required to connect to bluetooth sensors",
     "bluetooth_permission": "Bluetooth",
     "bluetooth_permission_comment": "Required to connect to bluetooth sensors",
-    "permissions_intro_1": "The following permissions services are required by various features of the cold chain functionality.",
+    "permissions_intro_1": "The following permissions and services are required by various features of the cold chain functionality.",
     "permissions_intro_2": "If disabled, you can press an item to enable it."
   },
   "fr": {


### PR DESCRIPTION
Fixes #3633.

## Change summary

Nit fix for permission modal intro string.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Permissions modal reads: `"The following permissions and services are required by various features of the cold chain functionality."`

### Related areas to think about

@RowenaN has suggested a few other minor changes, but I think this one is the highest priority for the upcoming release!
