### PR TITLE
UI changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@bugsnag/react-native": "^7.5.2",
     "@react-native-community/async-storage": "^1.8.1",
+    "@react-native-community/checkbox": "^0.5.7",
     "@react-native-community/datetimepicker": "^3.0.6",
     "@react-native-community/masked-view": "^0.1.7",
     "@react-native-community/slider": "^3.0.3",

--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -16,6 +16,7 @@ export const VACCINE_PRESCRIPTION_ACTIONS = {
   UPDATE: 'VACCINE_PRESCRIPTION/update',
   SAVE_NEW: 'VACCINE_PRESCRIPTION/saveNew',
   SAVE_EDITING: 'VACCINE_PRESCRIPTION/saveEditing',
+  REFUSE_VACCINATION: 'VACCINE_PRESCRIPTION/refuse',
   RESET: 'VACCINE_PRESCRIPTION/reset',
   SELECT_VACCINE: 'VACCINE_PRESCRIPTION/selectVaccine',
   SELECT_BATCH: 'VACCINE_PRESCRIPTION/selectBatch',
@@ -70,6 +71,11 @@ const updateEditing = (value, field) => (dispatch, getState) => {
   dispatch(update(newVaccinePrescriptionId, field, value));
 };
 
+const refuse = value => ({
+  type: VACCINE_PRESCRIPTION_ACTIONS.REFUSE_VACCINATION,
+  payload: { value },
+});
+
 const confirm = () => (dispatch, getState) => {
   const { user } = getState();
   const { currentUser } = user;
@@ -115,6 +121,7 @@ export const VaccinePrescriptionActions = {
   cancel,
   confirm,
   create,
+  refuse,
   reset,
   saveEditing,
   saveNew,

--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -100,8 +100,7 @@ const createPrescription = (patient, currentUser, selectedBatches) => {
 const createRefusalNameNote = name => {
   const [patientEvent] = UIDatabase.objects('PatientEvent').filtered('code == "RV"');
   const id = generateUUID();
-  const _data = {};
-  const newNameNote = { id, name, patientEvent, _data, entryDate: new Date() };
+  const newNameNote = { id, name, patientEvent, entryDate: new Date() };
 
   UIDatabase.write(() => UIDatabase.create('NameNote', newNameNote));
 };

--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -17,7 +17,7 @@ export const VACCINE_PRESCRIPTION_ACTIONS = {
   UPDATE: 'VACCINE_PRESCRIPTION/update',
   SAVE_NEW: 'VACCINE_PRESCRIPTION/saveNew',
   SAVE_EDITING: 'VACCINE_PRESCRIPTION/saveEditing',
-  REFUSE_VACCINATION: 'VACCINE_PRESCRIPTION/refuse',
+  SET_REFUSAL: 'VACCINE_PRESCRIPTION/setRefusal',
   RESET: 'VACCINE_PRESCRIPTION/reset',
   SELECT_VACCINE: 'VACCINE_PRESCRIPTION/selectVaccine',
   SELECT_BATCH: 'VACCINE_PRESCRIPTION/selectBatch',
@@ -72,9 +72,9 @@ const updateEditing = (value, field) => (dispatch, getState) => {
   dispatch(update(newVaccinePrescriptionId, field, value));
 };
 
-const refuse = value => ({
-  type: VACCINE_PRESCRIPTION_ACTIONS.REFUSE_VACCINATION,
-  payload: { value },
+const setRefusal = hasRefused => ({
+  type: VACCINE_PRESCRIPTION_ACTIONS.SET_REFUSAL,
+  payload: { hasRefused },
 });
 
 const createPrescription = (patient, currentUser, selectedBatches) => {
@@ -100,7 +100,7 @@ const createPrescription = (patient, currentUser, selectedBatches) => {
 const createRefusalNameNote = name => {
   const [patientEvent] = UIDatabase.objects('PatientEvent').filtered('code == "RV"');
   const id = generateUUID();
-  const _data = JSON.stringify({ refused: true, date: new Date() });
+  const _data = {};
   const newNameNote = { id, name, patientEvent, _data, entryDate: new Date() };
 
   UIDatabase.write(() => UIDatabase.create('NameNote', newNameNote));
@@ -140,12 +140,12 @@ export const VaccinePrescriptionActions = {
   cancel,
   confirm,
   create,
-  refuse,
   reset,
   saveEditing,
   saveNew,
   selectBatch,
   selectVaccine,
+  setRefusal,
   update,
   updateEditing,
 };

--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -100,8 +100,8 @@ const createPrescription = (patient, currentUser, selectedBatches) => {
 const createRefusalNameNote = name => {
   const [patientEvent] = UIDatabase.objects('PatientEvent').filtered('code == "RV"');
   const id = generateUUID();
-  const data = { refused: true, date: new Date() };
-  const newNameNote = { id, name, patientEvent, data, entryDate: new Date() };
+  const _data = JSON.stringify({ refused: true, date: new Date() });
+  const newNameNote = { id, name, patientEvent, _data, entryDate: new Date() };
 
   UIDatabase.write(() => UIDatabase.create('NameNote', newNameNote));
 };

--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -2,7 +2,10 @@ import { generateUUID } from 'react-native-database';
 import { batch } from 'react-redux';
 
 import { UIDatabase, createRecord } from '../../database';
-import {selectHasRefused,  selectSelectedBatches } from '../../selectors/Entities/vaccinePrescription';
+import {
+  selectHasRefused,
+  selectSelectedBatches,
+} from '../../selectors/Entities/vaccinePrescription';
 import { selectEditingNameId } from '../../selectors/Entities/name';
 import { NameActions } from './NameActions';
 import { NameNoteActions } from './NameNoteActions';

--- a/src/localization/dispensingStrings.json
+++ b/src/localization/dispensingStrings.json
@@ -64,7 +64,8 @@
     "inpatient": "Inpatient",
     "outpatient": "Outpatient",
     "select_the_patient": "Select the patient",
-    "edit_the_patient": "Edit patient details"
+    "edit_the_patient": "Edit patient details",
+    "refused_vaccine": "Refused vaccine"
   },
   "fr": {
     "available_credit": "Crédit disponible",

--- a/src/reducers/Entities/VaccinePrescriptionReducer.js
+++ b/src/reducers/Entities/VaccinePrescriptionReducer.js
@@ -46,7 +46,7 @@ export const VaccinePrescriptionReducer = (state = initialState(), action) => {
         selectedBatches.push(selectedBatch);
       }
 
-      return { ...state, selectedVaccines: [vaccine], selectedBatches };
+      return { ...state, selectedVaccines: [vaccine], selectedBatches, hasRefused: false };
     }
 
     case VACCINE_PRESCRIPTION_ACTIONS.SELECT_BATCH: {
@@ -70,11 +70,15 @@ export const VaccinePrescriptionReducer = (state = initialState(), action) => {
       return { ...state, creating: newPrescription };
     }
 
-    case VACCINE_PRESCRIPTION_ACTIONS.REFUSE_VACCINATION: {
+    case VACCINE_PRESCRIPTION_ACTIONS.SET_REFUSAL: {
       const { payload } = action;
-      const { value } = payload;
+      const { hasRefused } = payload;
 
-      return { ...state, hasRefused: value };
+      if (hasRefused) {
+        return { ...state, hasRefused, selectedVaccines: [], selectedBatches: [] };
+      }
+
+      return { ...state, hasRefused };
     }
 
     default: {

--- a/src/reducers/Entities/VaccinePrescriptionReducer.js
+++ b/src/reducers/Entities/VaccinePrescriptionReducer.js
@@ -50,7 +50,6 @@ export const VaccinePrescriptionReducer = (state = initialState(), action) => {
       return { ...state, selectedBatches: [itemBatch] };
     }
 
-
     case VACCINE_PRESCRIPTION_ACTIONS.SET_REFUSAL: {
       const { payload } = action;
       const { hasRefused } = payload;

--- a/src/reducers/Entities/VaccinePrescriptionReducer.js
+++ b/src/reducers/Entities/VaccinePrescriptionReducer.js
@@ -3,6 +3,7 @@ import { UIDatabase } from '../../database';
 
 const initialState = () => ({
   creating: undefined,
+  hasRefused: false,
   selectedVaccines: [],
   selectedBatches: [],
   vaccines: UIDatabase.objects('Vaccine'),
@@ -68,6 +69,14 @@ export const VaccinePrescriptionReducer = (state = initialState(), action) => {
 
       return { ...state, creating: newPrescription };
     }
+
+    case VACCINE_PRESCRIPTION_ACTIONS.REFUSE_VACCINATION: {
+      const { payload } = action;
+      const { value } = payload;
+
+      return { ...state, hasRefused: value };
+    }
+
     default: {
       return state;
     }

--- a/src/selectors/Entities/vaccinePrescription.js
+++ b/src/selectors/Entities/vaccinePrescription.js
@@ -61,3 +61,9 @@ export const selectHasVaccines = () => {
   const vaccines = UIDatabase.objects('Vaccine');
   return vaccines.length > 0;
 };
+
+export const selectHasRefused = state => {
+  const VaccinePrescriptionState = selectSpecificEntityState(state, 'vaccinePrescription');
+  const { hasRefused } = VaccinePrescriptionState;
+  return hasRefused;
+};

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -411,7 +411,7 @@ const generateSyncData = (settings, recordType, record) => {
         ID: record.id,
         patient_event_ID: record.patientEvent?.id ?? '',
         name_ID: record.name?.id ?? '',
-        entry_date: getDateString(record.entry_date),
+        entry_date: getDateString(record.entryDate),
         data: record.data,
       };
     }

--- a/src/widgets/DataTable/Cell.js
+++ b/src/widgets/DataTable/Cell.js
@@ -18,8 +18,14 @@ import { getAdjustedStyle } from './utilities';
  */
 const Cell = React.memo(
   ({ value, textStyle, viewStyle, width, isLastCell, numberOfLines, debug }) => {
+    // eslint-disable-next-line no-console
     if (debug) console.log(`- Cell: ${value}`);
     const internalViewStyle = getAdjustedStyle(viewStyle, width, isLastCell);
+
+    // When cell values can be floats, cut them off at two DP
+    if (typeof value === 'number' && !Number.isInteger(value)) {
+      value = value?.toFixed?.(2);
+    }
 
     return (
       <View style={internalViewStyle}>

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -7,6 +7,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { StyleSheet, View } from 'react-native';
+// eslint-disable-next-line import/no-unresolved
+import CheckBox from '@react-native-community/checkbox';
 import { batch, connect } from 'react-redux';
 
 import { TABS } from '../constants';
@@ -18,7 +20,6 @@ import { VaccinePrescriptionInfo } from '../VaccinePrescriptionInfo';
 import { PageButtonWithOnePress } from '../PageButtonWithOnePress';
 import { SimpleTable } from '../SimpleTable';
 import { SimpleLabel } from '../SimpleLabel';
-import { Checkbox } from '../JSONForm/widgets/Checkbox';
 
 import { VaccinePrescriptionActions } from '../../actions/Entities/VaccinePrescriptionActions';
 import { goBack } from '../../navigation/actions';
@@ -35,6 +36,7 @@ import { useLoadingIndicator } from '../../hooks/useLoadingIndicator';
 
 import { buttonStrings, dispensingStrings } from '../../localization';
 import globalStyles from '../../globalStyles';
+import { DARKER_GREY, SUSSOL_ORANGE } from '../../globalStyles/colors';
 
 /**
  * Layout component used for a tab within the vaccine prescription wizard.
@@ -89,37 +91,34 @@ const VaccineSelectComponent = ({
     <FlexView style={pageTopViewContainer}>
       <FlexRow style={{ marginBottom: 7 }} justifyContent="flex-end">
         <VaccinePrescriptionInfo />
-        <Checkbox
-          options={{
-            enumOptions: [
-              { label: 'Refuse', value: true },
-              { label: 'Accept', value: false },
-            ],
-          }}
-          onChange={onRefuse}
-          disabled={false}
-          readonly={false}
-          value={hasRefused}
-        />
+        <FlexRow flex={1} alignItems="center">
+          <SimpleLabel
+            text={dispensingStrings.refused_vaccine}
+            size="medium"
+            numberofLines={1}
+            textAlign="right"
+          />
+          <CheckBox
+            onValueChange={onRefuse}
+            value={hasRefused}
+            tintColors={{ true: SUSSOL_ORANGE, false: DARKER_GREY }}
+          />
+        </FlexRow>
       </FlexRow>
 
       <View style={localStyles.container}>
         <View style={localStyles.listContainer}>
-          {!hasRefused && (
-            <>
-              <SimpleLabel text={dispensingStrings.select_item} size="medium" numberOfLines={1} />
-              <SimpleTable
-                columns={vaccineColumns}
-                data={vaccines}
-                disabledRows={disabledVaccineRows}
-                selectedRows={selectedRows}
-                selectRow={onSelectVaccine}
-                style={{ marginTop: 3, height: '90%' }}
-              />
-            </>
-          )}
+          <SimpleLabel text={dispensingStrings.select_item} size="medium" numberOfLines={1} />
+          <SimpleTable
+            columns={vaccineColumns}
+            data={vaccines}
+            disabledRows={disabledVaccineRows}
+            selectedRows={selectedRows}
+            selectRow={onSelectVaccine}
+            style={{ marginTop: 3, height: '90%' }}
+          />
         </View>
-        {selectedVaccine && !hasRefused && (
+        {selectedVaccine && (
           <View style={localStyles.listContainer}>
             <SimpleLabel
               text={dispensingStrings.available_batches}
@@ -156,7 +155,7 @@ const VaccineSelectComponent = ({
 };
 
 const mapDispatchToProps = dispatch => {
-  const onRefuse = value => dispatch(VaccinePrescriptionActions.refuse(value));
+  const onRefuse = value => dispatch(VaccinePrescriptionActions.setRefusal(value));
   const onCancelPrescription = () => dispatch(VaccinePrescriptionActions.cancel());
   const onSelectBatch = itemBatch => dispatch(VaccinePrescriptionActions.selectBatch(itemBatch));
   const onSelectVaccine = vaccine => dispatch(VaccinePrescriptionActions.selectVaccine(vaccine));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,6 +1224,11 @@
   dependencies:
     deep-assign "^3.0.0"
 
+"@react-native-community/checkbox@^0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@react-native-community/checkbox/-/checkbox-0.5.7.tgz#ac818de88736acc1a4539188f2d435cf5e845ae1"
+  integrity sha512-CiHBAMWy5fsFIHLd1pf8frlWrLT8DnCXUSxdlGKazHm7srQSReKH4R5absShjmYOHRo9raWEnKZO/cm7MUDHZg==
+
 "@react-native-community/cli-debugger-ui@^4.13.1":
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.13.1.tgz#07de6d4dab80ec49231de1f1fbf658b4ad39b32c"


### PR DESCRIPTION
Fixes #3683, #3692

## Change summary

Adds a 'checkbox' to the third step, allowing the user to choose 'Refuse' or 'Accept' (default)
If refused, no prescription is created, instead a name note is added to the patient with the event type 'Refused vaccine' or whatever has the code `RV` ( yes, that linking is not ideal )

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go through the vaccine dispensing, on the final step choose 'Refuse' and click 'Confirm'

### Related areas to think about

Some footrunner code to create the required `patient_event`:

```
C_OBJECT($obSurveyPatientEvent)

$obSurveyPatientEvent:=ds.patient_event.new()

// event_type field has these options used elsewhere in the code:
// "DS" : Description / Text
// "NU" : Numeric
// "BO" : Boolean
$obSurveyPatientEvent.ID:=UUID_generate
$obSurveyPatientEvent.code:="RV"
$obSurveyPatientEvent.description:="Refused vaccination"
$obSurveyPatientEvent.event_type:="OB" // Object
$obSurveyPatientEvent.unit:=""

$obSurveyPatientEvent.save()
```