### PR TITLE
filter patient search form on change

### DIFF
--- a/src/actions/Entities/NameActions.js
+++ b/src/actions/Entities/NameActions.js
@@ -60,7 +60,7 @@ const select = name => ({
   payload: { name },
 });
 
-const filter = searchParameters => ({ type: NAME_ACTIONS.FILTER, payload: { searchParameters } });
+const filter = (key, value) => ({ type: NAME_ACTIONS.FILTER, payload: { key, value } });
 
 const sort = sortKey => ({ type: NAME_ACTIONS.SORT, payload: { sortKey } });
 

--- a/src/reducers/Entities/NameReducer.js
+++ b/src/reducers/Entities/NameReducer.js
@@ -56,8 +56,10 @@ export const NameReducer = (state = initialState(), action) => {
     }
 
     case NAME_ACTIONS.FILTER: {
+      const { searchParameters: oldParameters } = state;
       const { payload } = action;
-      const { searchParameters } = payload;
+      const { key, value } = payload;
+      const searchParameters = { ...oldParameters, [key]: value };
 
       return { ...state, searchParameters };
     }

--- a/src/selectors/Entities/name.js
+++ b/src/selectors/Entities/name.js
@@ -2,6 +2,7 @@ import { createSelector } from 'reselect';
 import moment from 'moment';
 import { UIDatabase } from '../../database';
 import { selectSpecificEntityState } from './index';
+import { DATE_FORMAT } from '../../utilities/constants';
 
 export const selectEditingNameId = state => {
   const NameState = selectSpecificEntityState(state, 'name');
@@ -43,9 +44,14 @@ export const selectFilteredPatients = createSelector([selectSearchParameters], s
     return patients;
   }
 
-  const dob = moment(dateOfBirth).startOf('day').toDate();
-  const dayAfterDOB = moment(dob).endOf('day').toDate();
-  return patients.filtered('dateOfBirth >= $0 AND dateOfBirth < $1', dob, dayAfterDOB);
+  const dob = moment(dateOfBirth, DATE_FORMAT.DD_MM_YYYY, null, true);
+  if (!dob.isValid()) {
+    return patients;
+  }
+
+  const dayOfDOB = dob.startOf('day').toDate();
+  const dayAfterDOB = dob.endOf('day').toDate();
+  return patients.filtered('dateOfBirth >= $0 AND dateOfBirth < $1', dayOfDOB, dayAfterDOB);
 });
 
 export const selectSortedPatients = createSelector(

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -15,3 +15,7 @@ export const MILLISECONDS = {
 export const SECONDS = {
   ONE_MINUTE: 60,
 };
+
+export const DATE_FORMAT = {
+  DD_MM_YYYY: 'DD/MM/YYYY',
+};

--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -7,6 +7,7 @@ import moment from 'moment';
 import { UIDatabase } from '../database';
 
 import { formInputStrings } from '../localization';
+import { DATE_FORMAT } from './constants';
 
 /**
  * File contains constants and config objects which declaritively define
@@ -111,7 +112,7 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     invalidMessage: formInputStrings.must_be_a_date,
     isRequired: true,
     validator: input => {
-      let inputDate = moment(input, 'DD/MM/YYYY', null, true);
+      let inputDate = moment(input, DATE_FORMAT.DD_MM_YYYY, null, true);
       if (typeof input === 'number') {
         inputDate = moment(input);
       }
@@ -293,7 +294,7 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     isRequired: false,
     validator: input => {
       if (!input) return true;
-      const inputDate = moment(input, 'DD/MM/YYYY', null, true);
+      const inputDate = moment(input, DATE_FORMAT.DD_MM_YYYY, null, true);
       const isValid = inputDate.isValid();
       const isDateOfBirth = inputDate.isSameOrBefore(new Date());
       return isValid && isDateOfBirth;

--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -276,7 +276,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   } = ownProps;
   const onInitialiseForm = () => initialiseForm(inputConfig);
   const onUpdateForm = (key, value) =>
-    onUpdate && !isDisabled ? onUpdate(key, value) : updateForm(key, value);
+    !isDisabled && (onUpdate ? onUpdate(key, value) : updateForm(key, value));
   const onSaveForm = () =>
     confirmOnSave && !isConfirmFormOpen ? showConfirmForm() : onSave(completedForm);
   const onCancelForm = () =>

--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -48,6 +48,7 @@ import { useDebounce } from '../hooks/useDebounce';
  * @param {bool}  isDisabled      Indicator whether this Form is disabled.
  * @param {Array} inputConfig     Configuration array of input config objects.
  *                                See { getFormInputConfig } from src/utilities/formInputConfigs.
+ * @param {func}  onUpdate        Callback invoked when a field value is changed (key,value) => null
  */
 const FormControlComponent = ({
   // Form state
@@ -271,9 +272,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     cancelButtonText,
     onCancel,
     canSave = true, // if not specified by calling component, set default
+    onUpdate,
   } = ownProps;
   const onInitialiseForm = () => initialiseForm(inputConfig);
-  const onUpdateForm = (key, value) => !isDisabled && updateForm(key, value);
+  const onUpdateForm = (key, value) =>
+    onUpdate && !isDisabled ? onUpdate(key, value) : updateForm(key, value);
   const onSaveForm = () =>
     confirmOnSave && !isConfirmFormOpen ? showConfirmForm() : onSave(completedForm);
   const onCancelForm = () =>
@@ -327,6 +330,7 @@ FormControlComponent.defaultProps = {
   cancelButtonText: modalStrings.cancel,
   shouldAutoFocus: true,
   canSave: true,
+  onUpdate: undefined,
 };
 
 FormControlComponent.propTypes = {
@@ -349,6 +353,9 @@ FormControlComponent.propTypes = {
   onSaveForm: PropTypes.func.isRequired,
   onCancelForm: PropTypes.func.isRequired,
   shouldAutoFocus: PropTypes.bool,
+  // Prop is used in merge props
+  // eslint-disable-next-line react/no-unused-prop-types
+  onUpdate: PropTypes.func,
 };
 
 export const FormControl = connect(

--- a/src/widgets/FormInputs/FormDateInput.js
+++ b/src/widgets/FormInputs/FormDateInput.js
@@ -18,6 +18,7 @@ import { CalendarIcon } from '../icons';
 import { CircleButton } from '../CircleButton';
 import { FormLabel } from './FormLabel';
 import { FormInvalidMessage } from './FormInvalidMessage';
+import { DATE_FORMAT } from '../../utilities/constants';
 
 /**
  * Form input for entering dates. Renders a TextInput as well as a button, opening a
@@ -59,12 +60,12 @@ export const FormDateInput = React.forwardRef(
     if (onValidate(value)) {
       initialValue = moment(value);
     } else if (typeof value === 'number' && onValidate(value)) {
-      initialValue = moment(new Date(), 'DD/MM/YYYY');
+      initialValue = moment(new Date(), DATE_FORMAT.DD_MM_YYYY);
     }
 
     const [inputState, setInputState] = React.useState({
       isValid: true,
-      inputValue: initialValue.isValid() ? moment(initialValue).format('DD/MM/YYYY') : '',
+      inputValue: initialValue.isValid() ? moment(initialValue).format(DATE_FORMAT.DD_MM_YYYY) : '',
       pickerSeedValue: initialValue.isValid() ? initialValue.toDate() : new Date(),
       datePickerOpen: false,
     });
@@ -72,7 +73,7 @@ export const FormDateInput = React.forwardRef(
     const { inputValue, isValid, pickerSeedValue, datePickerOpen } = inputState;
 
     const onUpdate = (newValue, validity = true, pickerVisibility = false) => {
-      const newDate = moment(newValue, 'DD/MM/YYYY');
+      const newDate = moment(newValue, DATE_FORMAT.DD_MM_YYYY);
       const newValidity = onValidate(newValue);
       const updatedIsValid = validity && newValidity;
 
@@ -106,7 +107,7 @@ export const FormDateInput = React.forwardRef(
       if (!timestamp) {
         setInputState(state => ({ ...state, datePickerOpen: false }));
       } else {
-        const newDate = moment(new Date(timestamp)).format('DD/MM/YYYY');
+        const newDate = moment(new Date(timestamp)).format(DATE_FORMAT.DD_MM_YYYY);
         onUpdate(newDate, true);
       }
     };

--- a/src/widgets/StepperInputs/DateEditor.js
+++ b/src/widgets/StepperInputs/DateEditor.js
@@ -12,6 +12,7 @@ import { Incrementor } from './Incrementor';
 import { useOptimisticUpdating, useDatePicker } from '../../hooks';
 import { generalStrings } from '../../localization';
 import { APP_FONT_FAMILY, DARKER_GREY } from '../../globalStyles';
+import { DATE_FORMAT } from '../../utilities/constants';
 
 export const DateEditor = ({
   label,
@@ -24,7 +25,7 @@ export const DateEditor = ({
   maximumDate,
 }) => {
   const adjustValue = (toUpdate, addend) => moment(toUpdate).add(addend, stepUnit).toDate();
-  const formatter = toFormat => moment(toFormat).format('DD/MM/YYYY');
+  const formatter = toFormat => moment(toFormat).format(DATE_FORMAT.DD_MM_YYYY);
   const wrappedDatePicker = timestamp => onPress(new Date(timestamp));
 
   const [datePickerIsOpen, openDatePicker, onPickDate] = useDatePicker(wrappedDatePicker);

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -66,7 +66,7 @@ const PatientSelectComponent = ({
   const columns = React.useMemo(() => getColumns(MODALS.PATIENT_LOOKUP), []);
   const { pageTopViewContainer } = globalStyles;
   const keyboardIsOpen = useKeyboardIsOpen();
-  const debouncedFilter = useDebounce(onFilterData, 500);
+  const debouncedFilter = useDebounce(onFilterData, 300);
   const handleUpdate = (key, value) => {
     updateForm(key, value);
     debouncedFilter(key, value);

--- a/src/widgets/modals/CashTransactionModal.js
+++ b/src/widgets/modals/CashTransactionModal.js
@@ -31,6 +31,7 @@ import { PencilIcon, ChevronDownIcon } from '../icons';
 import globalStyles, { WARM_GREY, SUSSOL_ORANGE, COMPONENT_HEIGHT } from '../../globalStyles';
 import { buttonStrings, dispensingStrings, generalStrings } from '../../localization';
 import { FlexRow } from '../FlexRow';
+import { DATE_FORMAT } from '../../utilities/constants';
 
 const CashTransactionModalComponent = ({
   name,
@@ -98,7 +99,9 @@ const CashTransactionModalComponent = ({
     if (isCustomer) {
       if (isPatient) {
         return `${dispensingStrings.patient} \n ${dispensingStrings.date_of_birth}: ${
-          dateOfBirth ? moment(dateOfBirth).format('DD/MM/YYYY') : generalStrings.not_available
+          dateOfBirth
+            ? moment(dateOfBirth).format(DATE_FORMAT.DD_MM_YYYY)
+            : generalStrings.not_available
         }`;
       }
       return dispensingStrings.customer;


### PR DESCRIPTION
Fixes #3711 

## Change summary

Removes the search button from the patient form again.. adds in a debounced onChange filter instead

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Search for patients in step #1
- [ ] Lookup patients in normal dispensing to check nothing else is broken

### Related areas to think about

The debounce on the date field is making it s-u-p-e-r-s-l-o-w when typing. Still works though, and that's outside of these changes, so won't address it here.