### PR TITLE
#3705 download state improvements

### DIFF
--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -19,11 +19,13 @@ export const DOWNLOAD_ACTIONS = {
   DOWNLOAD_LOGS_START: 'Bluetooth/downloadLogsStart',
   DOWNLOAD_LOGS_ERROR: 'Bluetooth/downloadLogsError',
   DOWNLOAD_LOGS_COMPLETE: 'Bluetooth/downloadLogsComplete',
+  PASSIVE_DOWNLOAD_START: 'Bluetooth/passiveDownloadStart',
   SENSOR_DOWNLOAD_START: 'Bluetooth/sensorDownloadStart',
   SENSOR_DOWNLOAD_SUCCESS: 'Bluetooth/sensorDownloadSuccess',
   SENSOR_DOWNLOAD_ERROR: 'Bluetooth/sensorDownloadError',
 };
 
+const startPassiveDownloadJob = () => ({ type: DOWNLOAD_ACTIONS.PASSIVE_DOWNLOAD_START });
 const downloadLogsStart = () => ({ type: DOWNLOAD_ACTIONS.DOWNLOAD_LOGS_START });
 const downloadLogsComplete = () => ({ type: DOWNLOAD_ACTIONS.DOWNLOAD_LOGS_COMPLETE });
 const downloadLogsError = error => ({
@@ -175,4 +177,5 @@ const startDownloadAll = () => async (dispatch, getState) => {
 
 export const SensorDownloadActions = {
   startDownloadAll,
+  startPassiveDownloadJob,
 };

--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -51,7 +51,9 @@ const sensorDownloadSuccess = sensor => ({
 const downloadAll = () => async dispatch => {
   dispatch(downloadLogsStart());
   // Ensure there are some sensors which have been assigned a location before syncing.
-  const sensors = UIDatabase.objects('Sensor').filtered('location != null && isActive == true');
+  const sensors = UIDatabase.objects('Sensor').filtered(
+    'location != null && isActive == true && isPaused == false'
+  );
 
   if (!sensors.length) {
     dispatch(downloadLogsError(syncStrings.no_sensors));

--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -51,9 +51,7 @@ const sensorDownloadSuccess = sensor => ({
 const downloadAll = () => async dispatch => {
   dispatch(downloadLogsStart());
   // Ensure there are some sensors which have been assigned a location before syncing.
-  const sensors = UIDatabase.objects('Sensor').filtered(
-    'location != null && isActive == true && isPaused == false'
-  );
+  const sensors = UIDatabase.objects('Sensor').filtered('location != null && isActive == true');
 
   if (!sensors.length) {
     dispatch(downloadLogsError(syncStrings.no_sensors));

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -54,6 +54,7 @@ import { VaccineDataAccess } from './bluetooth/VaccineDataAccess';
 import { UtilService } from './database/utilities/utilService';
 import { SensorDownloadActions } from './actions/Bluetooth/SensorDownloadActions';
 import BreachManager from './bluetooth/BreachManager';
+import { selectIsPassivelyDownloadingTemps } from './selectors/Bluetooth/sensorDownload';
 
 const SYNC_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 const BLUETOOTH_SYNC_INTERVAL = 60 * 1000; // 1 minute in milliseconds.
@@ -102,7 +103,6 @@ class MSupplyMobileAppContainer extends React.Component {
       isInitialised,
       isLoading: false,
       appState: null,
-      isDownloadingTemperatures: false,
     };
   }
 
@@ -110,9 +110,11 @@ class MSupplyMobileAppContainer extends React.Component {
     const { dispatch, usingVaccines, syncTemperatures, requestBluetooth } = this.props;
 
     if (usingVaccines) {
-      const { isDownloadingTemperatures } = this.state;
-      if (!isDownloadingTemperatures) {
+      const { isPassivelyDownloadingTemps } = this.props;
+
+      if (!isPassivelyDownloadingTemps) {
         this.scheduler.schedule(syncTemperatures, BLUETOOTH_SYNC_INTERVAL);
+        dispatch(SensorDownloadActions.startPassiveDownloadJob());
       }
 
       BluetoothStatus.addListener(requestBluetooth);
@@ -297,10 +299,11 @@ const mapStateToProps = state => {
   const isBreachModalOpen = selectIsBreachModalOpen(state);
   const currentUser = selectCurrentUser(state);
   const isSyncing = selectIsSyncing(state);
+  const isPassivelyDownloadingTemps = selectIsPassivelyDownloadingTemps(state);
   const breachModalTitle = selectBreachModalTitle(state);
   return {
     usingVaccines,
-
+    isPassivelyDownloadingTemps,
     isSyncing,
     currentUser,
     finaliseModalOpen,
@@ -321,6 +324,7 @@ MSupplyMobileAppContainer.propTypes = {
   requestBluetooth: PropTypes.func.isRequired,
   syncTemperatures: PropTypes.func.isRequired,
   isSyncing: PropTypes.bool.isRequired,
+  isPassivelyDownloadingTemps: PropTypes.bool.isRequired,
   dispatch: PropTypes.func.isRequired,
   currentUser: PropTypes.object,
   closeSupplierCreditModal: PropTypes.func.isRequired,

--- a/src/reducers/Bluetooth/SensorDownloadReducer.js
+++ b/src/reducers/Bluetooth/SensorDownloadReducer.js
@@ -4,6 +4,7 @@ import { LAST_DOWNLOAD_STATUS } from '../../utilities/modules/vaccines/constants
 
 const initialState = () => ({
   isSyncingTemps: false,
+  isPassivelyDownloadingTemps: false,
   downloadingLogsFrom: '',
   lastDownloadStatus: {},
   lastDownloadTime: {},
@@ -80,6 +81,10 @@ export const SensorDownloadReducer = (state = initialState(), action) => {
         lastDownloadTime: newLastDownloadTime,
         downloadingLogsFrom: '',
       };
+    }
+
+    case DOWNLOAD_ACTIONS.PASSIVE_DOWNLOAD_START: {
+      return { ...state, isPassivelyDownloadingTemps: true };
     }
 
     case DOWNLOAD_ACTIONS.DOWNLOAD_LOGS_START: {

--- a/src/selectors/Bluetooth/sensorDownload.js
+++ b/src/selectors/Bluetooth/sensorDownload.js
@@ -37,6 +37,14 @@ export const selectIsDownloading = (state, macAddress) => {
   return isDownloading;
 };
 
+export const selectIsPassivelyDownloadingTemps = state => {
+  const bluetooth = selectBluetoothState(state);
+  const { download } = bluetooth || {};
+
+  const { isPassivelyDownloadingTemps = false } = download || {};
+  return isPassivelyDownloadingTemps;
+};
+
 export const selectLastDownloadStatus = (state, macAddress) => {
   const bluetooth = selectBluetoothState(state);
   const { download } = bluetooth || {};


### PR DESCRIPTION
Fixes #3705 (or at least improves it)

## Change summary

Have found that if the app is left running long enough the app schedules lots and lots of `startDownloadAll` actions (one job is created each time the main `mSupplyMobileApp` component updates) which eventually gets the app to the point that it's always 'downloading' and will be very difficult to update a sensor's logging interval 😆 . 

https://github.com/openmsupply/mobile/blob/4a79db0e40092612a8eeaacc5d66e084884d99ac/src/mSupplyMobileApp.js#L114

This PR just adds a small update to add some state to track if the passive download has been scheduled at least once.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Re-test #3705 and verify that the sensor log interval can be updated more consistently (it will still fail if there is a download happening in the background but should happen less after this change)
- [ ] Verify downloads are still happening every ~1min in the background (check wifi icon in UI for user testing or console logging for dev testing)

### Related areas to think about
If there are lots of sensors (and especially if one is out of range) it may still be a little difficult to update the sensor interval, but this is more of an edge case...