### PR TITLE
#3720 Calculate open vial wastage from openVialWastage options

### DIFF
--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -243,7 +243,7 @@ export class Item extends Realm.Object {
     return UIDatabase.objects('TransactionBatch')
       .filtered("transaction.otherParty.code == 'invad'")
       .filtered("option.type == 'openVialWastage'")
-      .filtered('confirmDate >= $0', fromDate)
+      .filtered('transaction.confirmDate >= $0', fromDate)
       .sum('doses');
   }
 

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -237,37 +237,14 @@ export class Item extends Realm.Object {
     return this.totalQuantity + reductions - additions;
   }
 
-  /**
-   * A vaccine item can have multiple doses per 'unit' or 'pack'. For example, you can have
-   * a single vaccine which has two doses. Once a vaccine has been opened, the doses must be
-   * given quickly. When recording outgoing stock, the doses and quantity (or number of packs)
-   * are recorded separately. The amount of open vial wastage (that is, the amount of doses
-   * which are left in a vial and wasted) is the difference between the total number of 'packs'
-   * that are outgoing, multiplied by the amount of doses in each pack and the total number of
-   * doses actually given.
-   *
-   * @param  {Date} fromDate The date to calculate the open vial wastage from.
-   * @return {Number} the number of DOSES wasted.
-   */
   openVialWastage(fromDate) {
     if (!this.isVaccine || !fromDate) return 0;
 
-    const customerInvoiceTransactionItems = this.transactionItems.filtered(
-      "transaction.confirmDate >= $0 && transaction.type == 'customer_invoice'",
-      fromDate
-    );
-
-    const totalDosesPossible = customerInvoiceTransactionItems.reduce(
-      (dosesPossible, { batches }) => dosesPossible + batches.sum('numberOfPacks') * this.doses,
-      0
-    );
-
-    const totalDosesGiven = customerInvoiceTransactionItems.reduce(
-      (dosesGiven, { batches }) => dosesGiven + batches.sum('doses'),
-      0
-    );
-
-    return totalDosesPossible - totalDosesGiven;
+    return UIDatabase.objects('TransactionBatch')
+      .filtered("transaction.otherParty.code == 'invad'")
+      .filtered("option.type == 'openVialWastage'")
+      .filtered('confirmDate >= $0', fromDate)
+      .sum('doses');
   }
 
   /**

--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -324,6 +324,7 @@ export class StocktakeBatch extends Realm.Object {
       const snapshotDifference = Math.abs(this.difference);
       transactionBatch.setTotalQuantity(database, snapshotDifference);
       transactionBatch.doses = this.doses;
+      transactionBatch.option = this.option;
       database.save('TransactionBatch', transactionBatch);
 
       if (!this.itemBatch.totalQuantity) this.itemBatch.leaveLocation(database);

--- a/src/database/DataTypes/TransactionBatch.js
+++ b/src/database/DataTypes/TransactionBatch.js
@@ -255,6 +255,7 @@ TransactionBatch.schema = {
     vaccineVialMonitorStatus: { type: 'VaccineVialMonitorStatus', optional: true },
     sentPackSize: { type: 'double', default: 0 },
     medicineAdministrator: { type: 'MedicineAdministrator', optional: true },
+    option: { type: 'Options', optional: true },
   },
 };
 


### PR DESCRIPTION
Fixes #3720

## Change summary

- Fixes a bug where the reason applied to a stocktake batch was not being copied over to the inventory adjustment
- Uses open vial wastage reasons to calculate open vial wastage

## Testing

- [ ] Recorded open and closed vial wastage shows when clicking on a vaccine row in a supplier requisition

### Related areas to think about

![image](https://user-images.githubusercontent.com/35858975/110724154-1f703380-827a-11eb-9290-604dea466b7c.png)

