### PR TITLE
#3732: Add logInterval to incoming and outgoing sync utils

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -1075,6 +1075,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         batteryLevel: parseNumber(record.batteryLevel),
         name: record.name,
         isActive: parseBoolean(record.is_active),
+        logInterval: parseNumber(record.logInterval),
         logDelay: parseDate(record.log_delay_date, record.log_delay_time) ?? new Date(0),
         programmedDate: parseDate(record.programmed_date, record.programmed_time) ?? new Date(),
       });

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -390,6 +390,7 @@ const generateSyncData = (settings, recordType, record) => {
         is_active: String(record.isActive ?? true),
         log_delay_time: getTimeString(record.logDelay),
         log_delay_date: getDateString(record.logDelay),
+        logInterval: String(record.logInterval),
         programmed_time: getTimeString(record.programmedDate),
         programmed_date: getDateString(record.programmedDate),
       };


### PR DESCRIPTION
Fixes #3732

## Change summary

- Add log interval to sync utils

## Testing

Steps to reproduce or otherwise test the changes of this PR:

1. - [ ] Add a sensor in mobile - note log interval
2. - [ ] Sync
3. - [ ] Check Desktop for Sensor record and verify log interval matches what was set up in mobile (I can see the schema but not sure how to verify the record)
4. - [ ] Uninstall mobile (or if there is another way to clear all saved data 🤷 )
5. - [ ] Reinstall mobile 
6. - [ ] Sync
7. - [ ] Check the sensor exists in mobile with the log interval that was originally set up in step 1

### Related areas to think about

