### PR TITLE
#3742 fix breach report details

### DIFF
--- a/src/localization/reportStrings.json
+++ b/src/localization/reportStrings.json
@@ -11,7 +11,7 @@
     "field_exported_by": "Exported by",
     "field_job_description": "Job description",
     "field_logging_start": "Logging start",
-    "field_logging_interval": "Logging start",
+    "field_logging_interval": "Logging interval",
     "field_max_temperature": "Maximum temperature",
     "field_min_temperature": "Minimum temperature",
     "field_number_breaches": "Number of consecutive breaches",

--- a/src/utilities/vaccineReport.js
+++ b/src/utilities/vaccineReport.js
@@ -83,7 +83,7 @@ const createGeneralSection = async (sensor, user, comment) => {
 const createLoggingSection = sensor => {
   const title = SECTION_TITLES.LOGGING;
 
-  const parser = getParser(SENSOR_STATS_SECTION_FIELDS);
+  const parser = getParser(LOGGING_SECTION_FIELDS);
 
   const data = {
     [LOGGING_SECTION_FIELDS.LOGGING_START]: moment(sensor.firstLog?.timestamp).format(

--- a/src/utilities/vaccineReport.js
+++ b/src/utilities/vaccineReport.js
@@ -7,6 +7,7 @@ import temperature from './temperature';
 import { SECONDS } from './constants';
 import { UIDatabase } from '../database/index';
 import { generalStrings, reportStrings, vaccineStrings } from '../localization/index';
+import { MILLISECONDS_PER_MINUTE } from '../database/utilities/constants';
 
 const SECTION_TITLES = {
   LOGGING: reportStrings.title_logging,
@@ -115,7 +116,9 @@ const createBreachConfigSection = breachConfigs => {
 
   const data = breachConfigs.map(config => ({
     [BREACH_CONFIG_SECTION_FIELDS.TYPE]: CONFIG_TYPE_TO_NAME[config?.type],
-    [BREACH_CONFIG_SECTION_FIELDS.DURATION]: `${config.duration / 60} ${generalStrings.minutes}`,
+    [BREACH_CONFIG_SECTION_FIELDS.DURATION]: `${config.duration / MILLISECONDS_PER_MINUTE} ${
+      generalStrings.minutes
+    }`,
     [BREACH_CONFIG_SECTION_FIELDS.TEMPERATURE]: config.type.includes('HOT')
       ? `${generalStrings.above} ${temperature(config.minimumTemperature).format()}`
       : `${generalStrings.below} ${temperature(config.maximumTemperature).format()}`,

--- a/src/utilities/vaccineReport.js
+++ b/src/utilities/vaccineReport.js
@@ -18,10 +18,10 @@ const SECTION_TITLES = {
 };
 
 const CONFIG_TYPE_TO_NAME = {
-  HOT_CONSECUTIVE: vaccineStrings.hot_consecutive,
-  HOT_CUMULATIVE: vaccineStrings.hot_cumulative,
-  COLD_CONSECUTIVE: vaccineStrings.cold_consecutive,
-  COLD_CUMULATIVE: vaccineStrings.cold_cumulative,
+  HOT_CONSECUTIVE: vaccineStrings.hot_consecutive_breach,
+  HOT_CUMULATIVE: vaccineStrings.hot_cumulative_breach,
+  COLD_CONSECUTIVE: vaccineStrings.cold_consecutive_breach,
+  COLD_CUMULATIVE: vaccineStrings.cold_cumulative_breach,
 };
 
 const GENERAL_SECTION_FIELDS = {


### PR DESCRIPTION
Fixes #3742 

## Change summary

- Fix breach config duration units
- Fix breach type strings
- Fix logging section to use correct headers/keys

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Reproduce #3742 
- [ ] Check breach duration config setting is correctly reported in minutes for each config type
- [ ] Check the breach types are correctly displayed
- [ ] Check that the logging section displays the logging start date/time and the logging interval

### Related areas to think about
N/A
