### PR TITLE
#3739 hide vaccine button behind DEV env check

### DIFF
--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -113,6 +113,20 @@ const Settings = ({ toRealmExplorer, currentUserPasswordHash, requestStorageWrit
     []
   );
 
+  const VaccineButton = () => {
+    // eslint-disable-next-line no-undef
+    if (__DEV__) {
+      return (
+        <MenuButton
+          text="Generate vaccine data"
+          onPress={() => withLoadingIndicator(createVaccineData)}
+        />
+      );
+    }
+
+    return null;
+  };
+
   const pageInfoColumns = useMemo(
     () => [
       [
@@ -321,10 +335,7 @@ const Settings = ({ toRealmExplorer, currentUserPasswordHash, requestStorageWrit
         <View>
           <MenuButton text={buttonStrings.realm_explorer} onPress={toRealmExplorer} />
           <MenuButton text={buttonStrings.export_data} onPress={requestStorageWritePermission} />
-          <MenuButton
-            text="Generate vaccine data"
-            onPress={() => withLoadingIndicator(createVaccineData)}
-          />
+          <VaccineButton />
         </View>
       </View>
 


### PR DESCRIPTION
Fixes #3739

## Change summary

- Don't display 'Generate vaccine data' button unless in DEV mode

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] In release build check that in the settings menu there is no button to generate vaccine data and the page is not broken

### Related areas to think about
N/A