### PR TITLE
#3738 fix remote requisition item pruning

### DIFF
--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -390,13 +390,12 @@ export class Requisition extends Realm.Object {
    * @param  {Realm}  database
    */
   pruneRedundantItems(database) {
-    const itemsToPrune = [];
-    this.items.forEach(requisitionItem => {
-      if (!requisitionItem.requisition?.isRemoteOrder && requisitionItem.requiredQuantity === 0) {
-        itemsToPrune.push(requisitionItem);
-      }
-    });
-    database.delete('RequisitionItem', itemsToPrune);
+    if (this.isRemoteOrder) {
+      const itemsToPrune = this.items.filter(
+        requisitionItem => requisitionItem.requiredQuantity === 0
+      );
+      database.delete('RequisitionItem', itemsToPrune);
+    }
   }
 
   get canFinaliseRequest() {


### PR DESCRIPTION
Fixes #3738.

## Change summary

Fixes incorrect conditional logic preventing requisition items from being correctly pruned.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a new supplier requisition. Press `"Create Automatic Order"`. No items with a requested quantity of `0` are added to the requisition.
- [ ] Finalise a supplier requisition with at least one item with a requested quantity of `0` (and one with a requested quantity of more than `0`). Finalise the requisition. All items with requested quantities of `0` are pruned from the requisition.
- [ ] Finalise a customer requisition with at least one item with a requested quantity of `0` (and one with a requested quantity of more than `0`). Finalise the requisition. Toggle `"Customer data"`. All items with requested quantities of `0` are pruned from the requisition.
- [ ] Finalise a customer requisition with at least one item with a requested quantity of `0` (and one with a requested quantity of more than `0`). Finalise the requisition. Toggle `"Supplier data"`. All items with requested quantities of `0` are pruned from the requisition.

### Related areas to think about

These changes should only effect automatic orders and requisition finalisation.
