### PR TITLE
#3758 reset log interval on log download

### DIFF
--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -130,7 +130,11 @@ const downloadLogsFromSensor = sensor => async dispatch => {
 
             await TemperatureLogManager().saveLogs(temperatureLogs);
 
-            await BleService().updateLogInterval(macAddress, logInterval);
+            await BleService().updateLogIntervalWithRetries(
+              macAddress,
+              logInterval,
+              VACCINE_CONSTANTS.MAX_BLUETOOTH_COMMAND_ATTEMPTS
+            );
 
             await BleService().clearLogs(macAddress);
 

--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -129,6 +129,9 @@ const downloadLogsFromSensor = sensor => async dispatch => {
             );
 
             await TemperatureLogManager().saveLogs(temperatureLogs);
+
+            await BleService().updateLogInterval(macAddress, logInterval);
+
             await dispatch(BreachActions.createConsecutiveBreaches(sensor));
           } catch (e) {
             dispatch(sensorDownloadError(sensor, DOWNLOADING_ERROR_CODES.E_CANT_CONNECT));

--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -130,6 +130,8 @@ const downloadLogsFromSensor = sensor => async dispatch => {
 
             await TemperatureLogManager().saveLogs(temperatureLogs);
 
+            await BleService().updateLogInterval(macAddress, logInterval);
+
             await BleService().clearLogs(macAddress);
 
             await dispatch(BreachActions.createConsecutiveBreaches(sensor));

--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -130,7 +130,7 @@ const downloadLogsFromSensor = sensor => async dispatch => {
 
             await TemperatureLogManager().saveLogs(temperatureLogs);
 
-            await BleService().updateLogInterval(macAddress, logInterval);
+            await BleService().clearLogs(macAddress);
 
             await dispatch(BreachActions.createConsecutiveBreaches(sensor));
           } catch (e) {

--- a/src/bluetooth/BleService.js
+++ b/src/bluetooth/BleService.js
@@ -194,6 +194,23 @@ class BleService {
     return monitor;
   };
 
+  /** Facade for clearing logs.
+   *
+   * Connects with a sensor and clears all temperature logs.
+   *
+   * Returns a promise which resolves to string 'ok'.
+   *
+   * @param {String} macAddress
+   */
+  clearLogs = async macAddress => {
+    await this.connectAndDiscoverServices(macAddress);
+    return this.writeWithSingleResponse(
+      macAddress,
+      `${BLUETOOTH.COMMANDS.CLEAR}`,
+      stringFromBase64
+    );
+  };
+
   /**
    * Facade for downloading logs.
    *

--- a/src/bluetooth/constants.js
+++ b/src/bluetooth/constants.js
@@ -15,6 +15,7 @@ export const BLUETOOTH = {
   },
   COMMANDS: {
     BLINK: '*blink',
+    CLEAR: '*clr',
     DOWNLOAD: '*logall',
     INFO: '*info',
     UPDATE_LOG_INTERVAL: '*lint',


### PR DESCRIPTION
Fixes #3758.

## Change summary

Resets sensor logs after saving them locally to device.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] On sync, device log count is reset to `0` (view using Tempo Plus 2 app).

### Related areas to think about

N/A.
