### PR TITLE
#3759 temperature log calculation inaccuracy

### DIFF
--- a/src/bluetooth/TemperatureLogManager.js
+++ b/src/bluetooth/TemperatureLogManager.js
@@ -64,6 +64,8 @@ class TemperatureLogManager {
       const numberOfLogIntervalsUntilNow =
         Math.floor((timeNow - mostRecentLogTime) / logInterval) + 1;
 
+      // This 'lookback' (as opposed to only counting forward) is necessary to account for
+      // potential gaps in logs (e.g. due to battery running out or sensor being paused)
       initial = moment.unix(
         mostRecentLogTime +
           (numberOfLogIntervalsUntilNow * logInterval - maxNumberToSave * logInterval)

--- a/src/bluetooth/TemperatureLogManager.js
+++ b/src/bluetooth/TemperatureLogManager.js
@@ -61,8 +61,6 @@ class TemperatureLogManager {
     if (mostRecentLogTime == null) {
       initial = moment.unix(timeNow).subtract((logsToSave.length - 1) * logInterval, 'seconds');
     } else {
-      initial = moment.unix(mostRecentLogTime).add(logInterval, 's');
-
       const numberOfLogIntervalsUntilNow =
         Math.floor((timeNow - mostRecentLogTime) / logInterval) + 1;
 

--- a/src/bluetooth/TemperatureLogManager.js
+++ b/src/bluetooth/TemperatureLogManager.js
@@ -62,6 +62,14 @@ class TemperatureLogManager {
       initial = moment.unix(timeNow).subtract((logsToSave.length - 1) * logInterval, 'seconds');
     } else {
       initial = moment.unix(mostRecentLogTime).add(logInterval, 's');
+
+      const numberOfLogIntervalsUntilNow =
+        Math.floor((timeNow - mostRecentLogTime) / logInterval) + 1;
+
+      initial = moment.unix(
+        mostRecentLogTime +
+          (numberOfLogIntervalsUntilNow * logInterval - maxNumberToSave * logInterval)
+      );
     }
 
     return logsToSave.map(({ temperature }, i) => {

--- a/src/bluetooth/TemperatureLogManager.test.js
+++ b/src/bluetooth/TemperatureLogManager.test.js
@@ -165,15 +165,22 @@ describe('DownloadManager: createLogs', () => {
 
     const sensor = { id: 'a', logInterval: 300 };
     const maxNumberToSave = 1;
-    const mostRecentLogTime = 0;
-    const timeNow = 600;
+    const mostRecentLogTime = 1;
+    const timeNow = 1200;
 
-    const logs = [{ temperature: 10 }, { temperature: 10 }, { temperature: 10 }];
+    const logs = [
+      { temperature: 10 },
+      { temperature: 11 },
+      { temperature: 12 },
+      { temperature: 13 },
+    ];
+
     const shouldBe = [
       {
         id: '1',
-        temperature: 10,
-        timestamp: new Date(300 * MILLISECONDS.ONE_SECOND),
+        temperature: 13,
+        location: undefined,
+        timestamp: new Date(901 * MILLISECONDS.ONE_SECOND),
         sensor,
         logInterval: 300,
       },


### PR DESCRIPTION
Fixes #3759

## Change summary

- Implemented proposed solution in the original issue (tested and works as expected)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Follow steps in #3759 and verify that when there is a gap in sensor downloads (either from pause button or sensor just dying) the gap is accurately reflected in the logs 

### Related areas to think about
N/A