### PR TITLE
#3778 Defaults when no transactions

### DIFF
--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -49,13 +49,13 @@ const getDefaultVaccine = () => {
     .filtered("type == 'customer_invoice' && (status == 'finalised' || status == 'confirmed')")
     .sorted('confirmDate', true);
 
-  const [item] = mostRecentTrans.items.filtered('item.isVaccine == true');
+  const [item] = mostRecentTrans?.items?.filtered('item.isVaccine == true') ?? [];
 
   return item?.item ?? null;
 };
 
 const getRecommendedBatch = vaccine => {
-  const { batches = [] } = vaccine ?? getDefaultVaccine();
+  const { batches = [] } = vaccine ?? getDefaultVaccine() ?? {};
 
   if (batches?.length) {
     const batchesByExpiry = batches.sorted('expiryDate');


### PR DESCRIPTION
Fixes #3778 

## Change summary

Some defaults to protect the destructuring calls.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] No transactions, try to `Vaccinations`

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
