### PR TITLE
#3774 Ensure vaccine dispensing button is enabled+warn when no stock

### DIFF
--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -252,7 +252,7 @@ class UIDatabase {
       case 'PCDEvents':
         return results.filtered('code == "PCD"');
       case 'Vaccine':
-        return results.filtered('isVaccine == true');
+        return results.filtered('isVaccine == true && isVisible == true');
       default:
         return results;
     }

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -1,5 +1,6 @@
 {
   "gb": {
+    "no_vaccine_stock": "You have no vaccine stock to dispense!",
     "vaccines": "Vaccines",
     "vaccine_dispense_step_one_title": "Step: 1 Select a patient",
     "vaccine_dispense_step_two_title": "Step: 2 Edit the patients details",

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
@@ -27,7 +28,7 @@ import {
   DollarIcon,
 } from '../widgets/icons';
 import { ROUTES } from '../navigation/constants';
-import { buttonStrings, navStrings } from '../localization';
+import { buttonStrings, vaccineStrings, navStrings } from '../localization';
 
 import { SETTINGS_KEYS } from '../settings';
 import { UIDatabase } from '../database';
@@ -51,7 +52,10 @@ import {
 import globalStyles, { SHADOW_BORDER } from '../globalStyles';
 import { UserActions } from '../actions/index';
 import { selectCurrentUserIsAdmin } from '../selectors/user';
-import { selectHasVaccines } from '../selectors/Entities/vaccinePrescription';
+import {
+  selectHasVaccines,
+  selectHaveVaccineStock,
+} from '../selectors/Entities/vaccinePrescription';
 import { SUSSOL_ORANGE } from '../globalStyles/colors';
 
 const exportData = async () => {
@@ -179,7 +183,11 @@ const Menu = ({
           {hasVaccines && usingDispensary && (
             <IconMenuButton
               label={navStrings.vaccine_dispensary}
-              onPress={toVaccineDispensingPage}
+              onPress={() => {
+                selectHaveVaccineStock()
+                  ? toVaccineDispensingPage()
+                  : ToastAndroid.show(vaccineStrings.no_vaccine_stock, ToastAndroid.SHORT);
+              }}
               Icon={<SyringeIcon />}
             />
           )}
@@ -230,7 +238,7 @@ const Menu = ({
         </View>
       </View>
     ),
-    [usingModules, usingDashboard, usingDispensary, usingCashRegister]
+    [usingModules, usingDashboard, usingDispensary, usingCashRegister, hasVaccines]
   );
 
   const OriginalLayout = useCallback(

--- a/src/selectors/Entities/vaccinePrescription.js
+++ b/src/selectors/Entities/vaccinePrescription.js
@@ -75,6 +75,6 @@ export const selectSelectedVaccinator = state => {
 };
 
 export const selectHaveVaccineStock = () =>
-  UIDatabase.objects('Item')
-    .filtered('isVaccine == true')
-    .filtered('subquery(batches, $batches, $batches.numberOfPacks > 0 ).@count > 0').length > 0;
+  UIDatabase.objects('Vaccine').filtered(
+    'subquery(batches, $batches, $batches.numberOfPacks > 0 ).@count > 0'
+  ).length > 0;

--- a/src/selectors/Entities/vaccinePrescription.js
+++ b/src/selectors/Entities/vaccinePrescription.js
@@ -54,7 +54,7 @@ export const selectSelectedRows = createSelector([selectSelectedVaccines], vacci
 );
 
 export const selectSelectedBatchRows = createSelector([selectSelectedBatches], batches =>
-  batches.reduce((acc, itemBatch) => ({ ...acc, [itemBatch.id]: true }), {})
+  batches.reduce((acc, itemBatch) => ({ ...acc, [itemBatch?.id]: true }), {})
 );
 
 export const selectHasVaccines = () => {
@@ -73,3 +73,8 @@ export const selectSelectedVaccinator = state => {
   const { vaccinator } = VaccinePrescriptionState;
   return vaccinator;
 };
+
+export const selectHaveVaccineStock = () =>
+  UIDatabase.objects('Item')
+    .filtered('isVaccine == true')
+    .filtered('subquery(batches, $batches, $batches.numberOfPacks > 0 ).@count > 0').length > 0;


### PR DESCRIPTION
Fixes #3774 

## Change summary

- Updated a callback deps list to ensure the menu page is updated correctly after a sync (jeez there's a lot of memoization here)
- Added a toast when a user has no vaccine stock for the vaccination button

## Testing

- [ ] Enable vaccine dispensing, sync and see the UI update
- [ ] Have no stock and try to vaccinate- see the toast

### Related areas to think about

N/a