### PR TITLE
#3767 Remove isSyncing prop from root container

### DIFF
--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -26,7 +26,6 @@ import { SyncAuthenticator, UserAuthenticator } from './authentication';
 
 import { LoadingIndicatorContext } from './context/LoadingIndicatorContext';
 import { selectTitle } from './selectors/supplierCredit';
-import { selectIsSyncing } from './selectors/sync';
 import { selectCurrentUser } from './selectors/user';
 import { selectUsingVaccines } from './selectors/modules';
 
@@ -173,10 +172,10 @@ class MSupplyMobileAppContainer extends React.Component {
   };
 
   synchronise = async () => {
-    const { dispatch, isSyncing } = this.props;
+    const { dispatch } = this.props;
     const { isInitialised } = this.state;
 
-    if (!isInitialised || isSyncing) return;
+    if (!isInitialised) return;
 
     try {
       const syncUrl = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_URL);
@@ -298,13 +297,12 @@ const mapStateToProps = state => {
   const usingVaccines = selectUsingVaccines(state);
   const isBreachModalOpen = selectIsBreachModalOpen(state);
   const currentUser = selectCurrentUser(state);
-  const isSyncing = selectIsSyncing(state);
+
   const isPassivelyDownloadingTemps = selectIsPassivelyDownloadingTemps(state);
   const breachModalTitle = selectBreachModalTitle(state);
   return {
     usingVaccines,
     isPassivelyDownloadingTemps,
-    isSyncing,
     currentUser,
     finaliseModalOpen,
     supplierCreditModalOpen,
@@ -323,7 +321,6 @@ MSupplyMobileAppContainer.propTypes = {
   usingVaccines: PropTypes.bool.isRequired,
   requestBluetooth: PropTypes.func.isRequired,
   syncTemperatures: PropTypes.func.isRequired,
-  isSyncing: PropTypes.bool.isRequired,
   isPassivelyDownloadingTemps: PropTypes.bool.isRequired,
   dispatch: PropTypes.func.isRequired,
   currentUser: PropTypes.object,


### PR DESCRIPTION
Fixes #3767 

## Change summary

- The last prop to remove to stop the root re-rendering constantly during sync woo (this has been like 2 years of removing props from this component 🤣 
- It's use to stop the synchronise func being executed - but it can't be executed if not initialised and the button is disabled if already syncing so it's redundant

## Testing

Internal

### Related areas to think about

N?A
