### PR TITLE
#3813 Fixing crashes when refusing vaccines

### DIFF
--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -134,21 +134,21 @@ const confirm = () => (dispatch, getState) => {
   const { currentUser } = user;
   const hasRefused = selectHasRefused(getState());
   const patientID = selectEditingNameId(getState());
-  const patient = UIDatabase.get('Name', patientID);
   const selectedBatches = selectSelectedBatches(getState());
   const vaccinator = selectSelectedVaccinator(getState());
-
-  if (hasRefused) {
-    createRefusalNameNote(patient);
-  } else {
-    createPrescription(patient, currentUser, selectedBatches, vaccinator);
-  }
 
   batch(() => {
     dispatch(NameActions.saveEditing());
     dispatch(NameNoteActions.saveEditing());
     dispatch(reset());
   });
+
+  const patient = UIDatabase.get('Name', patientID);
+  if (hasRefused) {
+    createRefusalNameNote(patient);
+  } else {
+    createPrescription(patient, currentUser, selectedBatches, vaccinator);
+  }
 };
 
 const selectVaccinator = vaccinator => ({

--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -123,6 +123,9 @@ const createPrescription = (patient, currentUser, selectedBatches, vaccinator) =
 
 const createRefusalNameNote = name => {
   const [patientEvent] = UIDatabase.objects('PatientEvent').filtered('code == "RV"');
+
+  if (!patientEvent) return;
+
   const id = generateUUID();
   const newNameNote = { id, name, patientEvent, entryDate: new Date() };
 

--- a/src/database/DataTypes/NameNote.js
+++ b/src/database/DataTypes/NameNote.js
@@ -25,7 +25,7 @@ export class NameNote extends Realm.Object {
       entryDate: this.entryDate.getTime(),
       data: this.data,
       nameID: this.name.id,
-      patientEventID: this.patientEvent.id,
+      patientEventID: this.patientEvent?.id,
     };
   }
 }


### PR DESCRIPTION
Fixes #3813 

## Change summary

- Actually start creating name notes for refused vaccines when you're refusing a new patient [The name wasn't saved yet, so not picked up by the query]
- Prevent name notes being created if the patient event is not defined (Should the checkbox be hidden also....?]
- Prevent crashes when a name note doesn't have a patient event

## Testing

- [ ] As per linked issue steps, there is no crash

### Related areas to think about

Not sure what to do about patient events not be defined. I don't like hiding/showing things based on the presence of a record but also don't really want a pref