### PR TITLE
#3811 Patient defaults whenever a field is falsey not just null

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -233,10 +233,10 @@ const createPatient = (database, patientDetails) => {
   } = patientDetails;
 
   const id = patientId ?? generateUUID();
-  const code = patientCode ?? getPatientUniqueCode(database);
+  const code = patientCode || getPatientUniqueCode(database);
   const firstName = patientFirstName ?? '';
   const lastName = patientLastName ?? '';
-  const name = patientName ?? `${patientLastName}, ${patientFirstName}`;
+  const name = patientName || `${patientLastName}, ${patientFirstName}`;
   const dateOfBirth = patientDateOfBirth ?? null;
   const emailAddress = patientEmailAddress ?? '';
   const phoneNumber = patientPhoneNumber ?? '';
@@ -254,7 +254,7 @@ const createPatient = (database, patientDetails) => {
   const female = patientFemale ?? true;
 
   const thisStoreId = database.getSetting(SETTINGS_KEYS.THIS_STORE_ID);
-  const supplyingStoreId = patientSupplyingStoreId ?? thisStoreId;
+  const supplyingStoreId = patientSupplyingStoreId || thisStoreId;
   const thisStoresPatient = supplyingStoreId === thisStoreId;
 
   const isActive = patientIsActive ?? true;


### PR DESCRIPTION
Fixes #3811 

## Change summary

- When creating a patient these values were empty strings, not null/undefiend so defaults weren't used

## Testing

- [ ] Created patients have a `name` and `code` field correctly filled.

### Related areas to think about

N/A