### PR TITLE
#3824 Save NameNote records from remote patients

### DIFF
--- a/src/actions/Entities/NameNoteActions.js
+++ b/src/actions/Entities/NameNoteActions.js
@@ -109,7 +109,21 @@ const saveEditing = optionalNameID => (dispatch, getState) => {
 const createNotes = (nameNotes = []) => {
   UIDatabase.write(() => {
     nameNotes.forEach(nameNote => {
-      UIDatabase.update('NameNote', nameNote);
+      const { patientEventID, nameID } = nameNote;
+      const name = UIDatabase.get('Name', nameID);
+      const patientEvent = UIDatabase.get('PatientEvent', patientEventID);
+
+      if (name && patientEvent) {
+        const toSave = {
+          id: nameNote.id,
+          patientEvent,
+          name,
+          _data: JSON.stringify(nameNote?.data),
+          entryDate: new Date(nameNote?.entryDate),
+        };
+
+        UIDatabase.update('NameNote', toSave);
+      }
     });
   });
 

--- a/src/actions/Entities/NameNoteActions.js
+++ b/src/actions/Entities/NameNoteActions.js
@@ -19,6 +19,7 @@ export const NAME_NOTE_ACTIONS = {
   SELECT: 'NAME_NOTE/select',
   RESET: 'NAME_NOTE/reset',
   UPDATE_DATA: 'NAME_NOTE/updateData',
+  CREATE: 'NAME_NOTE/create',
 };
 
 const ajv = new Ajv(ajvOptions);
@@ -50,6 +51,7 @@ const getMostRecentPCD = patient => {
 
   const { id: pcdEventID } = pcdEvent;
   const { nameNotes = [] } = patient ?? {};
+
   if (!nameNotes.length) return null;
 
   const filtered = nameNotes.filter(({ patientEventID }) => patientEventID === pcdEventID);
@@ -66,6 +68,7 @@ const getMostRecentPCD = patient => {
 const createSurveyNameNote = patient => (dispatch, getState) => {
   // Create the seed PCD, which is either their most recently filled survey or
   // and empty object.
+
   const seedPCD = getMostRecentPCD(patient) ?? createDefaultNameNote(patient.id);
 
   // Get the survey schema as we need an initial validation to determine if
@@ -103,11 +106,22 @@ const saveEditing = optionalNameID => (dispatch, getState) => {
   dispatch(reset());
 };
 
+const createNotes = (nameNotes = []) => {
+  UIDatabase.write(() => {
+    nameNotes.forEach(nameNote => {
+      UIDatabase.update('NameNote', nameNote);
+    });
+  });
+
+  return { type: NAME_NOTE_ACTIONS.CREATE };
+};
+
 const reset = () => ({
   type: NAME_NOTE_ACTIONS.RESET,
 });
 
 export const NameNoteActions = {
+  createNotes,
   reset,
   createSurveyNameNote,
   updateForm,

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -116,6 +116,23 @@ export const getPrescriberRequestUrl = params => {
   return endpoint + queryString;
 };
 
+const processNameNoteResponse = response =>
+  response.map(
+    ({
+      ID: id,
+      data,
+      patient_event_ID: patientEventID,
+      name_ID: nameID,
+      entry_date: entryDate,
+    }) => ({
+      id,
+      data,
+      patientEventID,
+      nameID,
+      entryDate: moment(entryDate).isValid() ? moment(entryDate).toDate() : moment().toDate(),
+    })
+  );
+
 const processInsuranceResponse = response =>
   response.map(
     ({
@@ -179,6 +196,7 @@ export const processPatientResponse = response => {
       last: lastName,
       date_of_birth,
       nameInsuranceJoin,
+      nameNotes,
     }) => ({
       id,
       name,
@@ -195,6 +213,7 @@ export const processPatientResponse = response => {
       lastName,
       dateOfBirth: parseDate(date_of_birth),
       policies: processInsuranceResponse(nameInsuranceJoin),
+      nameNotes: processNameNoteResponse(nameNotes),
     })
   );
 };

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -47,6 +47,7 @@ import {
 } from '../../selectors/dispensary';
 import { useLoadingIndicator } from '../../hooks/useLoadingIndicator';
 import { DispensaryActions } from '../../actions/DispensaryActions';
+import { NameNoteActions } from '../../actions/Entities/NameNoteActions';
 
 const { SYNC_URL, SYNC_SITE_NAME, SYNC_SITE_PASSWORD_HASH } = SETTINGS_KEYS;
 
@@ -175,7 +176,10 @@ const mapDispatchToProps = dispatch => ({
   close: () => dispatch(DispensaryActions.closeLookupModal()),
   selectPatient: async patient => {
     await dispatch(PatientActions.patientUpdate(patient));
-    batch(() => patient.policies.forEach(policy => dispatch(InsuranceActions.update(policy))));
+    batch(() => {
+      patient.policies.forEach(policy => dispatch(InsuranceActions.update(policy)));
+      dispatch(NameNoteActions.createNotes(patient?.nameNotes));
+    });
   },
   selectPrescriber: prescriber => {
     dispatch(PrescriberActions.updatePrescriber(prescriber));


### PR DESCRIPTION
Fixes #3824 

## Change summary

- Saves name notes when theyre searched for and added in vaccine dispensing and normal dispensing

## Testing

- [ ] Search for a patient in vaccination dispensing which is NOT from the mobile store, but does have a previous clinical data - the clinical data is prepopulated on step 2
- [ ] Search for a patient in NORMAL dispensing lookup which is NOT from the mobile store, but does have a previous clinical data - the clinical data is prepopulated on step 2 of vaccination

### Related areas to think about

This is Hard to test because you need to have a patient which has clinical data form that is not from the mobile store.

You can use the following code to create one with footrunner:

```
$nn:=ds.name_note.new()
$nn.ID:=UUID_generate
$nn.data:=data
$nn.name_ID:="SOME PATIENT ID YOU CAN FIND IN RECORD BROWSER"
$nn.patient_event_ID:="295C2B7E53264C1B98ADD57B720F3AF6"
$nn.save()
```
