### PR TITLE
#3831 Address inconsistencies between dispensing pages

### DIFF
--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -145,6 +145,8 @@ export class Name extends Realm.Object {
       phoneNumber: this.phoneNumber,
       country: this.country,
       billingAddress: this.billingAddress?.toJSON(),
+      addressOne: this.addressOne,
+      addressTwo: this.addressTwo,
       emailAddress: this.emailAddress,
       type: this.type,
       masterLists: this.masterLists,


### PR DESCRIPTION
Fixes #3831

## Change summary

- Adds these fields which the patient input config is looking for, for initial values

## Testing

- [ ] Create a patient in normal dispensing with an address- go to vaccine dispensing, the name is there.

### Related areas to think about

N/a