### PR TITLE
#3834 Remove overriding of home store

### DIFF
--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -89,7 +89,7 @@ const generateSyncData = (settings, recordType, record) => {
         date_of_birth: moment(record.dateOfBirth).format(),
         code: record.code,
         email: record.emailAddress,
-        supplying_store_id: settings.get(THIS_STORE_ID),
+        supplying_store_id: record.supplyingStoreID || settings.get(THIS_STORE_ID),
         phone: record.phoneNumber,
         customer: String(record.isCustomer),
         country: record.country,


### PR DESCRIPTION
Fixes #3834 

## Change summary

- Don't override the home store!

## Testing

- [ ] Lookup a patient not from your store. Sync. The home store is not overriden to be the mobile store on desktop.

### Related areas to think about

N/a