### PR TITLE
#3847 Don't create visibility for new patients created on mobile

### DIFF
--- a/src/actions/PatientActions.js
+++ b/src/actions/PatientActions.js
@@ -30,8 +30,9 @@ const editPatient = patient => ({
 });
 
 const makePatientVisibility = async name => {
-  const response = createPatientVisibility(name);
-  return response.ok;
+  const response = await createPatientVisibility(name);
+
+  return response;
 };
 
 const patientUpdate = patientDetails => async (dispatch, getState) => {

--- a/src/actions/PatientActions.js
+++ b/src/actions/PatientActions.js
@@ -3,11 +3,10 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import { ToastAndroid } from 'react-native';
 import { batch } from 'react-redux';
 
 import { createRecord, UIDatabase } from '../database';
-import { generalStrings } from '../localization/index';
+
 import { createPatientVisibility } from '../sync/lookupApiUtils';
 import { DispensaryActions } from './DispensaryActions';
 
@@ -29,6 +28,11 @@ const editPatient = patient => ({
     patient,
   },
 });
+
+const makePatientVisibility = async name => {
+  const response = createPatientVisibility(name);
+  return response.ok;
+};
 
 const patientUpdate = patientDetails => async (dispatch, getState) => {
   const { patient } = getState();
@@ -122,26 +126,13 @@ const patientUpdate = patientDetails => async (dispatch, getState) => {
     nationality,
   };
 
-  try {
-    const response = await createPatientVisibility(patientRecord);
+  UIDatabase.write(() => createRecord(UIDatabase, 'Patient', patientRecord));
 
-    if (response) {
-      UIDatabase.write(() => createRecord(UIDatabase, 'Patient', patientRecord));
-
-      batch(() => {
-        dispatch(closeModal());
-        dispatch(DispensaryActions.closeLookupModal());
-        dispatch(DispensaryActions.refresh());
-      });
-    } else {
-      ToastAndroid.show(generalStrings.problem_connecting_please_try_again, ToastAndroid.LONG);
-    }
-
-    return response.ok;
-  } catch {
-    ToastAndroid.show(generalStrings.problem_connecting_please_try_again, ToastAndroid.LONG);
-    return false;
-  }
+  batch(() => {
+    dispatch(closeModal());
+    dispatch(DispensaryActions.closeLookupModal());
+    dispatch(DispensaryActions.refresh());
+  });
 };
 
 const sortPatientHistory = sortKey => ({
@@ -164,4 +155,5 @@ export const PatientActions = {
   sortPatientHistory,
   viewPatientHistory,
   closePatientHistory,
+  makePatientVisibility,
 };

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -5,7 +5,7 @@
  */
 
 import React, { useMemo, useCallback } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, ToastAndroid } from 'react-native';
 import { connect, batch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { getAuthHeader } from 'sussol-utilities';
@@ -175,11 +175,17 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => ({
   close: () => dispatch(DispensaryActions.closeLookupModal()),
   selectPatient: async patient => {
-    await dispatch(PatientActions.patientUpdate(patient));
-    batch(() => {
-      patient.policies.forEach(policy => dispatch(InsuranceActions.update(policy)));
-      dispatch(NameNoteActions.createNotes(patient?.nameNotes));
-    });
+    const result = await dispatch(PatientActions.makePatientVisibility(patient));
+
+    if (result) {
+      await dispatch(PatientActions.patientUpdate(patient));
+      batch(() => {
+        patient.policies.forEach(policy => dispatch(InsuranceActions.update(policy)));
+        dispatch(NameNoteActions.createNotes(patient?.nameNotes));
+      });
+    } else {
+      ToastAndroid.show(generalStrings.problem_connecting_please_try_again, ToastAndroid.LONG);
+    }
   },
   selectPrescriber: prescriber => {
     dispatch(PrescriberActions.updatePrescriber(prescriber));

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -175,7 +175,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => ({
   close: () => dispatch(DispensaryActions.closeLookupModal()),
   selectPatient: async patient => {
-    const result = await dispatch(PatientActions.makePatientVisibility(patient));
+    const result = await PatientActions.makePatientVisibility(patient);
 
     if (result) {
       await dispatch(PatientActions.patientUpdate(patient));


### PR DESCRIPTION
Fixes #3847 

## Change summary

- Move the create visibility fetch to the search form not the action used when creating a new patient

## Testing

- [ ] Can create new patients
- [ ] When looking up a patient from the lookup API, a name store join is created on the server

### Related areas to think about

N/a