### PR TITLE
#3803 ADR Modal

### DIFF
--- a/src/actions/DispensaryActions.js
+++ b/src/actions/DispensaryActions.js
@@ -15,8 +15,6 @@ export const DISPENSARY_ACTIONS = {
   REFRESH: 'Dispensary/refresh',
   OPEN_LOOKUP_MODAL: 'Dispensary/openLookupModal',
   CLOSE_LOOKUP_MODAL: 'Dispensary/closeLookupModal',
-  OPEN_ADR_MODAL: 'Dispensary/openADRModal',
-  CLOSE_ADR_MODAL: 'Dispensary/closeADRModal',
 };
 
 const filter = searchTerm => ({ type: DISPENSARY_ACTIONS.FILTER, payload: { searchTerm } });
@@ -30,9 +28,6 @@ const switchDataSet = () => (dispatch, getState) =>
   });
 
 const refresh = () => ({ type: DISPENSARY_ACTIONS.REFRESH });
-
-const openADRModal = () => ({ type: DISPENSARY_ACTIONS.OPEN_ADR_MODAL });
-const closeADRModal = () => ({ type: DISPENSARY_ACTIONS.CLOSE_ADR_MODAL });
 
 const openLookupModal = () => ({ type: DISPENSARY_ACTIONS.OPEN_LOOKUP_MODAL });
 
@@ -50,6 +45,4 @@ export const DispensaryActions = {
   refresh,
   openLookupModal,
   closeLookupModal,
-  openADRModal,
-  closeADRModal,
 };

--- a/src/actions/PatientActions.js
+++ b/src/actions/PatientActions.js
@@ -8,6 +8,7 @@ import { batch } from 'react-redux';
 
 import { createRecord, UIDatabase } from '../database';
 import { generalStrings } from '../localization/index';
+import { selectCurrentUser } from '../selectors/user';
 import { createPatientVisibility } from '../sync/lookupApiUtils';
 import { DispensaryActions } from './DispensaryActions';
 
@@ -18,6 +19,9 @@ export const PATIENT_ACTIONS = {
   CLOSE_HISTORY: 'Patient/closeHistory',
   SORT_HISTORY: 'Patient/sortHistory',
   COMPLETE: 'Patient/complete',
+  NEW_ADR: 'Patient/newADR',
+  SAVE_ADR: 'Patient/saveADR',
+  CANCEL_ADR: 'Patient/cancelADR',
 };
 
 const closeModal = () => ({ type: PATIENT_ACTIONS.COMPLETE });
@@ -156,7 +160,27 @@ const viewPatientHistory = patient => ({
 
 const closePatientHistory = () => ({ type: PATIENT_ACTIONS.CLOSE_HISTORY });
 
+const openADRModal = patientID => {
+  const patient = UIDatabase.get('Name', patientID);
+  return { type: PATIENT_ACTIONS.NEW_ADR, payload: { patient } };
+};
+
+const closeADRModal = () => ({ type: PATIENT_ACTIONS.CANCEL_ADR });
+
+const saveADR = (patient, formData) => (dispatch, getState) => {
+  const user = selectCurrentUser(getState());
+
+  UIDatabase.write(() => {
+    createRecord(UIDatabase, 'AdverseDrugReaction', patient, formData, user);
+  });
+
+  dispatch({ type: PATIENT_ACTIONS.SAVE_ADR });
+};
+
 export const PatientActions = {
+  saveADR,
+  openADRModal,
+  closeADRModal,
   createPatient,
   patientUpdate,
   editPatient,

--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -256,7 +256,7 @@ class UIDatabase {
       case 'Vaccine':
         return results.filtered('isVaccine == true && isVisible == true');
       case 'ADRForm':
-        return results.filtered("type == 'adr'");
+        return results.filtered("type == 'ADR'");
       default:
         return results;
     }

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -1174,6 +1174,26 @@ const createNameNote = (database, nameNote, patientEventID, nameID) => {
   return null;
 };
 
+const createAdverseDrugReaction = (database, patient, formData, user) => {
+  const formSchema = database.objects('ADRForm')[0];
+  const entryDate = new Date();
+
+  if (!formSchema) return null;
+
+  const newADR = UIDatabase.update('AdverseDrugReaction', {
+    id: generateUUID(),
+    name: patient,
+    user,
+    formSchema,
+    entryDate,
+  });
+
+  newADR.data = formData;
+  database.save('AdverseDrugReaction', newADR);
+
+  return newADR;
+};
+
 /**
  * Create a record of the given type, taking care of linkages, generating IDs, serial
  * numbers, current dates, and inserting sensible defaults.
@@ -1265,6 +1285,8 @@ export const createRecord = (database, type, ...args) => {
       return createTemperatureBreachConfiguration(database, ...args);
     case 'NameNote':
       return createNameNote(database, ...args);
+    case 'AdverseDrugReaction':
+      return createAdverseDrugReaction(database, ...args);
     default:
       throw new Error(`Cannot create a record with unsupported type: ${type}`);
   }

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -1,5 +1,6 @@
 {
   "gb": {
+    "adr_form_for": "ADR Form for:",
     "are_you_sure_delete_sensor": "Are you sure you want to delete this sensor?",
     "add_at_least_one_item_before_finalising": "You need to add at least one item before finalising",
     "and": "and",

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -31,18 +31,19 @@ import {
   selectDataSetInUse,
   selectSortedData,
   selectLookupModalOpen,
-  selectADRModalOpen,
 } from '../selectors/dispensary';
 import { selectPrescriberModalOpen, selectCanEditPrescriber } from '../selectors/prescriber';
 import { selectInsuranceModalOpen, selectCanEditInsurancePolicy } from '../selectors/insurance';
 import { selectPatientModalOpen, selectCanEditPatient } from '../selectors/patient';
 
 import globalStyles from '../globalStyles';
-import { dispensingStrings } from '../localization';
+import { dispensingStrings, modalStrings } from '../localization';
 import { PatientEditModal } from '../widgets/modalChildren/PatientEditModal';
 import { selectSurveySchemas } from '../selectors/formSchema';
 import { NameNoteActions } from '../actions/Entities/NameNoteActions';
 import { createDefaultName } from '../actions/Entities/NameActions';
+import { SUSSOL_ORANGE } from '../globalStyles/colors';
+import { ADRInput } from '../widgets/modalChildren/ADRInput';
 
 const Dispensing = ({
   data,
@@ -280,8 +281,12 @@ const Dispensing = ({
       >
         <SearchForm />
       </ModalContainer>
-      <ModalContainer title="ADR" isVisible={isADRModalOpen} onClose={cancelCreatingADR}>
-        <></>
+      <ModalContainer
+        title={`${modalStrings.adr_form_for} ${currentPatient?.name}`}
+        isVisible={isADRModalOpen}
+        onClose={cancelCreatingADR}
+      >
+        <ADRInput />
       </ModalContainer>
     </>
   );
@@ -299,6 +304,27 @@ const localStyles = {
   button: {
     marginHorizontal: 2.5,
   },
+  saveButton: {
+    ...globalStyles.button,
+    flex: 1,
+    backgroundColor: SUSSOL_ORANGE,
+    alignSelf: 'center',
+  },
+  saveButtonTextStyle: {
+    ...globalStyles.buttonText,
+    color: 'white',
+    fontSize: 14,
+  },
+  cancelButton: {
+    ...globalStyles.button,
+    flex: 1,
+    alignSelf: 'center',
+  },
+  cancelButtonTextStyle: {
+    ...globalStyles.buttonText,
+    color: SUSSOL_ORANGE,
+    fontSize: 14,
+  },
 };
 
 const mapStateToProps = state => {
@@ -306,7 +332,6 @@ const mapStateToProps = state => {
   const { sortKey, isAscending, searchTerm, columns } = dispensary;
 
   const isLookupModalOpen = selectLookupModalOpen(state);
-  const isADRModalOpen = selectADRModalOpen(state);
 
   const { currentPatient } = patient;
   const { currentPrescriber } = prescriber;
@@ -316,7 +341,9 @@ const mapStateToProps = state => {
   const canEditPrescriber = selectCanEditPrescriber(state);
   const canEditPatient = selectCanEditPatient(state);
   const canEditInsurancePolicy = selectCanEditInsurancePolicy(state);
-  const [patientEditModalOpen, patientHistoryModalOpen] = selectPatientModalOpen(state);
+  const [patientEditModalOpen, patientHistoryModalOpen, isADRModalOpen] = selectPatientModalOpen(
+    state
+  );
   const insuranceModalOpen = selectInsuranceModalOpen(state);
   const data = selectSortedData(state);
 
@@ -358,8 +385,8 @@ const mapDispatchToProps = dispatch => ({
   refreshData: () => dispatch(DispensaryActions.refresh()),
   switchDataset: () => dispatch(DispensaryActions.switchDataSet()),
 
-  createADR: () => dispatch(DispensaryActions.openADRModal()),
-  cancelCreatingADR: () => dispatch(DispensaryActions.closeADRModal()),
+  createADR: patientID => dispatch(PatientActions.openADRModal(patientID)),
+  cancelCreatingADR: () => dispatch(PatientActions.closeADRModal()),
   lookupRecord: () => dispatch(DispensaryActions.openLookupModal()),
   cancelLookupRecord: () => dispatch(DispensaryActions.closeLookupModal()),
 

--- a/src/reducers/DispensaryReducer.js
+++ b/src/reducers/DispensaryReducer.js
@@ -97,14 +97,6 @@ export const DispensaryReducer = (state = initialState(), action) => {
       return { ...state, isLookupModalOpen: false };
     }
 
-    case DISPENSARY_ACTIONS.OPEN_ADR_MODAL: {
-      return { ...state, isADRModalOpen: true };
-    }
-
-    case DISPENSARY_ACTIONS.CLOSE_ADR_MODAL: {
-      return { ...state, isADRModalOpen: false };
-    }
-
     default:
       return state;
   }

--- a/src/reducers/PatientReducer.js
+++ b/src/reducers/PatientReducer.js
@@ -10,6 +10,7 @@ const patientInitialState = () => ({
   currentPatient: null,
   isEditing: false,
   isCreating: false,
+  creatingADR: false,
   viewingHistory: false,
   sortKey: 'itemName',
   isAscending: true,
@@ -61,6 +62,18 @@ export const PatientReducer = (state = patientInitialState(), action) => {
 
     case PATIENT_ACTIONS.CLOSE_HISTORY: {
       return { ...state, currentPatient: null, viewingHistory: false };
+    }
+
+    case PATIENT_ACTIONS.NEW_ADR: {
+      const { payload } = action;
+      const { patient } = payload;
+
+      return { ...state, isADRModalOpen: true, currentPatient: patient, creatingADR: true };
+    }
+
+    case PATIENT_ACTIONS.SAVE_ADR:
+    case PATIENT_ACTIONS.CANCEL_ADR: {
+      return { ...state, currentPatient: null, creatingADR: false };
     }
 
     default: {

--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -47,9 +47,8 @@ export const selectPatientInsurancePolicies = ({ patient }) => {
   });
 };
 export const selectPatientModalOpen = ({ patient }) => {
-  const { isCreating, isEditing } = patient;
-  const { viewingHistory } = patient;
-  return [isCreating || isEditing, viewingHistory];
+  const { creatingADR, viewingHistory, isCreating, isEditing } = patient;
+  return [isCreating || isEditing, viewingHistory, creatingADR];
 };
 
 export const selectCanEditPatient = ({ patient }) => {

--- a/src/widgets/modalChildren/ADRInput.js
+++ b/src/widgets/modalChildren/ADRInput.js
@@ -1,0 +1,87 @@
+/* eslint-disable react/forbid-prop-types */
+import React, { useState } from 'react';
+import { StyleSheet } from 'react-native';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { JSONForm } from '../JSONForm/JSONForm';
+import { UIDatabase } from '../../database/index';
+import { FlexRow } from '../FlexRow';
+import { PageButton } from '../PageButton';
+import { SUSSOL_ORANGE } from '../../globalStyles/colors';
+import globalStyles from '../../globalStyles/index';
+import { PatientActions } from '../../actions/PatientActions';
+import { selectCurrentPatient } from '../../selectors/patient';
+
+export const ADRInputComponent = ({ onCancel, onSave, patient }) => {
+  const [{ formData, isValid }, setForm] = useState({ formData: null, isValid: false });
+
+  return (
+    <>
+      <JSONForm
+        onChange={(changed, validator) => {
+          setForm({ form: changed.formData, isValid: validator(changed.formData) });
+        }}
+        surveySchema={UIDatabase.objects('ADRForm')[0]}
+      >
+        <></>
+      </JSONForm>
+      <FlexRow>
+        <PageButton
+          onPress={onCancel}
+          style={localStyles.cancelButton}
+          textStyle={localStyles.cancelButtonTextStyle}
+          text="CANCEL"
+        />
+        <PageButton
+          isDisabled={!isValid}
+          onPress={() => onSave(patient, formData)}
+          style={localStyles.saveButton}
+          textStyle={localStyles.saveButtonTextStyle}
+          text="SAVE"
+        />
+      </FlexRow>
+    </>
+  );
+};
+
+ADRInputComponent.propTypes = {
+  onCancel: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+  patient: PropTypes.object.isRequired,
+};
+
+const localStyles = StyleSheet.create({
+  saveButton: {
+    ...globalStyles.button,
+    flex: 1,
+    backgroundColor: SUSSOL_ORANGE,
+    alignSelf: 'center',
+  },
+  saveButtonTextStyle: {
+    ...globalStyles.buttonText,
+    color: 'white',
+    fontSize: 14,
+  },
+  cancelButton: {
+    ...globalStyles.button,
+    flex: 1,
+    alignSelf: 'center',
+  },
+  cancelButtonTextStyle: {
+    ...globalStyles.buttonText,
+    color: SUSSOL_ORANGE,
+    fontSize: 14,
+  },
+});
+
+const stateToProps = state => {
+  const patient = selectCurrentPatient(state);
+  return { patient };
+};
+
+const dispatchToProps = dispatch => ({
+  onCancel: () => dispatch(PatientActions.closeADRModal()),
+  onSave: (patient, formData) => dispatch(PatientActions.saveADR(patient, formData)),
+});
+
+export const ADRInput = connect(stateToProps, dispatchToProps)(ADRInputComponent);

--- a/src/widgets/modalChildren/ADRInput.js
+++ b/src/widgets/modalChildren/ADRInput.js
@@ -19,7 +19,7 @@ export const ADRInputComponent = ({ onCancel, onSave, patient }) => {
     <>
       <JSONForm
         onChange={(changed, validator) => {
-          setForm({ form: changed.formData, isValid: validator(changed.formData) });
+          setForm({ formData: changed.formData, isValid: validator(changed.formData) });
         }}
         surveySchema={UIDatabase.objects('ADRForm')[0]}
       >


### PR DESCRIPTION
Fixes #3803 

## Change summary

- Adds an ADR modal to create new ADRs

## Testing

**NOTE: Need some footrunner for an ADR form- will becoming soon**

- [ ] Can create a new ADR, save it and sync it to the server - checking in the record browser, all the fields are filled correctly
- [ ] Cannot create an ADR which is not valid

### Related areas to think about


