### PR TITLE
#3852 time picker widget

### DIFF
--- a/src/widgets/DatePickerButton.js
+++ b/src/widgets/DatePickerButton.js
@@ -8,7 +8,7 @@ import DateTimePicker from '@react-native-community/datetimepicker';
 import PropTypes from 'prop-types';
 
 import { CircleButton } from './CircleButton';
-import { CalendarIcon } from './icons';
+import { CalendarIcon, ClockIcon } from './icons';
 
 import { useDatePicker } from '../hooks/useDatePicker';
 import { IconButton } from './IconButton';
@@ -33,10 +33,15 @@ export const DatePickerButton = ({
   minimumDate,
   isCircle,
   isDisabled,
+  mode,
 }) => {
   const [datePickerIsOpen, openDatePicker, datePickerCallback] = useDatePicker(onDateChanged);
   const button = isCircle ? (
-    <CircleButton isDisabled={isDisabled} IconComponent={CalendarIcon} onPress={openDatePicker} />
+    <CircleButton
+      isDisabled={isDisabled}
+      IconComponent={mode === 'time' ? ClockIcon : CalendarIcon}
+      onPress={openDatePicker}
+    />
   ) : (
     <IconButton
       isDisabled={isDisabled}
@@ -53,7 +58,7 @@ export const DatePickerButton = ({
           maximumDate={maximumDate}
           minimumDate={minimumDate}
           onChange={datePickerCallback}
-          mode="date"
+          mode={mode}
           display="spinner"
           value={initialValue}
         />
@@ -67,6 +72,7 @@ DatePickerButton.defaultProps = {
   maximumDate: undefined,
   isCircle: true,
   isDisabled: false,
+  mode: 'date',
 };
 
 DatePickerButton.propTypes = {
@@ -76,4 +82,5 @@ DatePickerButton.propTypes = {
   minimumDate: PropTypes.instanceOf(Date),
   isCircle: PropTypes.bool,
   isDisabled: PropTypes.bool,
+  mode: PropTypes.string,
 };

--- a/src/widgets/JSONForm/JSONForm.js
+++ b/src/widgets/JSONForm/JSONForm.js
@@ -48,6 +48,7 @@ const defaultTheme = {
     SelectWidget: JSONFormWidget.Select,
     RangeWidget: () => null,
     DateWidget: JSONFormWidget.DatePicker,
+    TimeWidget: JSONFormWidget.TimePicker,
   },
 
   // Fields are like containers for a row in the form.

--- a/src/widgets/JSONForm/widgets/TimePicker.js
+++ b/src/widgets/JSONForm/widgets/TimePicker.js
@@ -1,0 +1,59 @@
+/* eslint-disable no-console */
+import React from 'react';
+import { TextInput } from 'react-native';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+
+import { DatePickerButton } from '../../DatePickerButton';
+import { FlexRow } from '../../FlexRow';
+import { useJSONFormOptions } from '../JSONFormContext';
+import { DARKER_GREY, LIGHT_GREY } from '../../../globalStyles/colors';
+
+const regex = new RegExp('^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$');
+
+export const TimePicker = ({ disabled, value, onChange, placeholder, readonly }) => {
+  const { focusController } = useJSONFormOptions();
+  const ref = focusController.useRegisteredRef();
+
+  const initialValue = regex.test(value) ? moment(value, 'hh:mm').toDate() : new Date();
+
+  return (
+    <FlexRow>
+      <TextInput
+        style={{ flex: 1 }}
+        placeholderTextColor={LIGHT_GREY}
+        underlineColorAndroid={DARKER_GREY}
+        placeholder={placeholder}
+        editable={!(readonly || disabled)}
+        value={value}
+        ref={ref}
+        onSubmitEditing={() => focusController.next(ref)}
+        onChangeText={date => onChange(date)}
+        returnKeyType="next"
+        autoCapitalize="none"
+        keyboardType="numeric"
+        autoCorrect={false}
+      />
+      <DatePickerButton
+        mode="time"
+        isDisabled={readonly || disabled}
+        initialValue={initialValue}
+        onDateChanged={date => {
+          onChange(moment(date).format('HH:mm'));
+        }}
+      />
+    </FlexRow>
+  );
+};
+
+TimePicker.defaultProps = {
+  value: '',
+};
+
+TimePicker.propTypes = {
+  disabled: PropTypes.bool.isRequired,
+  value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string.isRequired,
+  readonly: PropTypes.bool.isRequired,
+};

--- a/src/widgets/JSONForm/widgets/index.js
+++ b/src/widgets/JSONForm/widgets/index.js
@@ -2,6 +2,7 @@ import { Checkboxes } from './Checkboxes';
 import { Checkbox } from './Checkbox';
 import { Radio } from './Radio';
 import { DatePicker } from './DatePicker';
+import { TimePicker } from './TimePicker';
 import { Select } from './Select';
 import { Text } from './Text';
 
@@ -10,6 +11,7 @@ export const JSONFormWidget = {
   Checkbox,
   Radio,
   DatePicker,
+  TimePicker,
   Select,
   Text,
 };

--- a/src/widgets/icons.js
+++ b/src/widgets/icons.js
@@ -410,3 +410,13 @@ DollarIcon.propTypes = {
   style: PropTypes.object,
   color: PropTypes.string,
 };
+
+export const ClockIcon = ({ size, style, color }) => (
+  <FAIcon size={size} style={style} color={color} name="clock-o" />
+);
+ClockIcon.defaultProps = { size: 20, style: {}, color: WHITE };
+ClockIcon.propTypes = {
+  size: PropTypes.number,
+  style: PropTypes.object,
+  color: PropTypes.string,
+};


### PR DESCRIPTION
Fixes #3852 

## Change summary

- Quick time picker widget

## Testing

Internal, no testing yet

### Related areas to think about

Used this schema to check it out:

```
const schema = {
      jsonSchema: {
        title: 'A registration form',
        description: 'A simple form example.',
        type: 'object',
        required: ['firstName', 'lastName'],
        properties: {
          firstName: {
            type: 'string',
            title: 'First name',
            default: 'Chuck',
            pattern: '^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$',
            errorMessage: 'Must be a time following the pattern hh:mm, such as 11:01 or 23:01',
          },
          lastName: {
            type: 'string',
            title: 'Last name',
          },
          telephone: {
            type: 'string',
            title: 'Telephone',
            minLength: 10,
          },
        },
      },
      uiSchema: { firstName: { 'ui:widget': 'TimeWidget' } },
    };
```