### PR TITLE
#3857 Set undefined rather than an empty string

### DIFF
--- a/src/widgets/JSONForm/widgets/Text.js
+++ b/src/widgets/JSONForm/widgets/Text.js
@@ -22,7 +22,7 @@ export const Text = ({ autofocus, disabled, placeholder, value, onChange }) => {
       returnKeyType="next"
       autoCapitalize="none"
       autoCorrect={false}
-      onChangeText={onChange}
+      onChangeText={newVal => onChange(newVal || undefined)}
       onSubmitEditing={() => focusController.next(ref)}
       editable={!disabled}
       blurOnSubmit={false}


### PR DESCRIPTION
Fixes #3857 

## Change summary

- An empty string is apparently valid for a required string field. Undefined isn't!

## Testing

- [ ] Patient ID is always required

### Related areas to think about

N/A