### PR TITLE
#3768 Remove afterinteractions from breach display

### DIFF
--- a/src/database/utilities/dataGenerators.js
+++ b/src/database/utilities/dataGenerators.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { ToastAndroid } from 'react-native';
 import BreachManager from '../../bluetooth/BreachManager';
 import { VaccineDataAccess } from '../../bluetooth/VaccineDataAccess';
@@ -170,7 +171,11 @@ export const createVaccineData = () => {
   const promises = sensors.map(sensor => {
     const [breaches, logs] = breachManager.createBreaches(
       sensor,
-      sensor.logs.sorted('timestamp'),
+      sensor.logs.sorted('timestamp').map(({ id, temperature, timestamp }) => ({
+        id,
+        temperature,
+        timestamp: moment(timestamp).unix(),
+      })),
       configs
     );
     return breachManager.updateBreaches(breaches, logs);

--- a/src/widgets/modalChildren/BreachDisplay.js
+++ b/src/widgets/modalChildren/BreachDisplay.js
@@ -15,7 +15,6 @@ import { BreachChart } from '../BreachChart';
 import { PageInfo } from '../PageInfo/PageInfo';
 
 import { WHITE } from '../../globalStyles';
-import { AfterInteractions } from '../AfterInteractions';
 
 const Breach = ({ breach, getInfoColumns }) => {
   const { temperatureLogs } = breach;
@@ -25,12 +24,10 @@ const Breach = ({ breach, getInfoColumns }) => {
   });
 
   return (
-    <AfterInteractions>
-      <View style={localStyles.container}>
-        <PageInfo columns={getInfoColumns(breach)} />
-        <BreachChart breach={breach} lineData={lineData} />
-      </View>
-    </AfterInteractions>
+    <View style={localStyles.container}>
+      <PageInfo columns={getInfoColumns(breach)} />
+      <BreachChart breach={breach} lineData={lineData} />
+    </View>
   );
 };
 
@@ -54,11 +51,7 @@ const BreachDisplayComponent = ({ breaches }) => {
     [breaches]
   );
 
-  return (
-    <AfterInteractions>
-      <FlatList data={breaches} renderItem={renderItem} />
-    </AfterInteractions>
-  );
+  return <FlatList data={breaches} renderItem={renderItem} />;
 };
 
 BreachDisplayComponent.propTypes = {


### PR DESCRIPTION
Fixes #3768 

## Change summary

- After interactions needs to be nested within the stack navigator, the breach modal is at the root and so isn't in a stack nav, so causes a crash. Not the best solution, but a solution..

## Testing

- [ ] Opening the breach modal does not crash the app

### Related areas to think about

Also quick fix to the vaccine generated data