### PR TITLE
#3865 Add different double handling as quantities behaviour

### DIFF
--- a/src/database/DataTypes/StocktakeBatch.js
+++ b/src/database/DataTypes/StocktakeBatch.js
@@ -212,7 +212,7 @@ export class StocktakeBatch extends Realm.Object {
   }
 
   setDoses(database, newValue) {
-    const newCountedTotalQuantity = Number(newValue / this.dosesPerVial).toFixed(2);
+    const newCountedTotalQuantity = Number(newValue / this.dosesPerVial);
     this.countedTotalQuantity = newCountedTotalQuantity;
     database.save('StocktakeBatch', this);
   }

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -42,7 +42,7 @@ export class StocktakeItem extends Realm.Object {
    * @return  {number}
    */
   get countedTotalQuantity() {
-    return getTotal(this.batches, 'countedTotalQuantity').toFixed(2);
+    return getTotal(this.batches, 'countedTotalQuantity');
   }
 
   /**

--- a/src/database/DataTypes/TransactionBatch.js
+++ b/src/database/DataTypes/TransactionBatch.js
@@ -114,11 +114,7 @@ export class TransactionBatch extends Realm.Object {
     if (this.transaction.isConfirmed) {
       // Incoming transactions increase stock levels, while outgoing decrease.
       const inventoryDifference = this.transaction.isIncoming ? difference : -difference;
-
-      this.itemBatch.totalQuantity = Number(
-        (this.itemBatch.totalQuantity += inventoryDifference).toFixed(2)
-      );
-
+      this.itemBatch.totalQuantity += inventoryDifference;
       database.save('ItemBatch', this.itemBatch);
     }
 

--- a/src/database/DataTypes/TransactionItem.js
+++ b/src/database/DataTypes/TransactionItem.js
@@ -145,6 +145,7 @@ export class TransactionItem extends Realm.Object {
     }
 
     const difference = cappedQuantity - this.totalQuantity; // Positive if new quantity is greater.
+
     // Apply the difference to make the new quantity.
     this.allocateDifferenceToBatches(database, difference);
 
@@ -236,7 +237,7 @@ export class TransactionItem extends Realm.Object {
   // eslint-disable-next-line class-methods-use-this
   allocateDifferenceToBatch(database, difference, batch) {
     const batchAddQuantity = batch.getAmountToAllocate(difference);
-    batch.setTotalQuantity(database, Number((batch.totalQuantity + batchAddQuantity).toFixed(2)));
+    batch.setTotalQuantity(database, batch.totalQuantity + batchAddQuantity);
     database.save('TransactionBatch', batch);
     return difference - batchAddQuantity;
   }
@@ -274,20 +275,14 @@ export class TransactionItem extends Realm.Object {
   };
 
   setDoses(database, value) {
-    const newTotalQuantity = Math.min(
-      Number(value / this.dosesPerVial).toFixed(2),
-      this.availableQuantity
-    );
+    const newTotalQuantity = Math.min(Number(value / this.dosesPerVial), this.availableQuantity);
 
     this.setTotalQuantity(database, newTotalQuantity);
   }
 
   setVaccinator(database, vaccinator) {
     this.batches.forEach(batch =>
-      database.update('TransactionBatch', {
-        id: batch.id,
-        medicineAdministrator: vaccinator,
-      })
+      database.update('TransactionBatch', { id: batch.id, medicineAdministrator: vaccinator })
     );
   }
 

--- a/src/utilities/formatters.js
+++ b/src/utilities/formatters.js
@@ -90,3 +90,5 @@ export const formatLogDelay = delay =>
 
 export const formatBatteryLevel = batteryLevel =>
   batteryLevel == null ? generalStrings.not_available : `${batteryLevel}%`;
+
+export const twoDecimalsMax = num => Math.round(num * 100) / 100;

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -21,5 +21,5 @@ export { checkIsObject } from './checkIsObject';
 export { validateReport } from './validateReport';
 export { chunk } from './chunk';
 export { parsePositiveIntegerInterfaceInput } from './parsers';
-export { formatErrorItemNames, roundNumber } from './formatters';
+export { twoDecimalsMax, formatErrorItemNames, roundNumber } from './formatters';
 export { MILLISECONDS } from './constants';

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -37,6 +37,7 @@ import { generalStrings, tableStrings } from '../../localization';
 import { formatStatus, formatDate } from '../../utilities';
 import { formatType } from '../../utilities/formatStatus';
 import { useDebounce } from '../../hooks';
+import { twoDecimalsMax } from '../../utilities/formatters';
 
 /**
  * Wrapper component for a mSupply DataTable page row.
@@ -156,8 +157,8 @@ const DataTableRow = React.memo(
               };
 
               let value = disabledText[columnKey] ? disabledText[columnKey] : rowData[columnKey];
-              if (typeof value === 'number' && !Number.isInteger(value)) {
-                value = rowData[columnKey].toFixed(2);
+              if (typeof value === 'number') {
+                value = twoDecimalsMax(rowData[columnKey]);
               }
 
               const placeholder = extraPlaceholders[columnKey] ?? '';
@@ -274,8 +275,8 @@ const DataTableRow = React.memo(
               }
 
               // When cell values can be floats, cut them off at two DP
-              if (typeof value === 'number' && !Number.isInteger(value)) {
-                value = rowData[columnKey]?.toFixed?.(2);
+              if (typeof value === 'number') {
+                value = twoDecimalsMax(rowData[columnKey]);
               }
 
               const cellErrors = getCellError?.(rowData, columnKey);

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -155,7 +155,11 @@ const DataTableRow = React.memo(
                 [COLUMN_KEYS.DOSES]: isVaccine ? '' : generalStrings.not_available,
               };
 
-              const value = disabledText[columnKey] ? disabledText[columnKey] : rowData[columnKey];
+              let value = disabledText[columnKey] ? disabledText[columnKey] : rowData[columnKey];
+              if (typeof value === 'number' && !Number.isInteger(value)) {
+                value = rowData[columnKey].toFixed(2);
+              }
+
               const placeholder = extraPlaceholders[columnKey] ?? '';
 
               const inputIsDisabled = isDisabled || !!disabledCondition[columnKey];

--- a/src/widgets/bottomModals/ItemDetails.js
+++ b/src/widgets/bottomModals/ItemDetails.js
@@ -15,6 +15,7 @@ import { PageInfo } from '../PageInfo/PageInfo';
 
 import { tableStrings, generalStrings } from '../../localization';
 import { DARKER_GREY, SUSSOL_ORANGE } from '../../globalStyles';
+import { twoDecimalsMax } from '../../utilities/formatters';
 
 export const ItemDetailsComponent = ({ item }) => {
   const headers = {
@@ -28,6 +29,7 @@ export const ItemDetailsComponent = ({ item }) => {
 
   const formatters = {
     expiryDate: expiryDate => formatExpiryDate(expiryDate),
+    numberOfPacks: packs => twoDecimalsMax(packs),
   };
 
   const getRow = (title, info) => ({ info, title });

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -28,6 +28,7 @@ import { RegimenDataModal } from './RegimenDataModal';
 import { StocktakeBatchModal } from './StocktakeBatchModal';
 
 import { generalStrings, modalStrings } from '../../localization';
+import { twoDecimalsMax } from '../../utilities/formatters';
 
 /**
  * Wrapper around ModalContainer, containing common modals used in various
@@ -59,7 +60,7 @@ const DataTablePageModalComponent = ({ isOpen, onClose, modalKey, onSelect, curr
             sortKeyString="name"
             onSelect={onSelect}
             renderLeftText={({ code, name }) => `${code} - ${name}`}
-            renderRightText={({ totalQuantity }) => `${totalQuantity}`}
+            renderRightText={({ totalQuantity }) => `${twoDecimalsMax(totalQuantity)}`}
           />
         );
       case MODAL_KEYS.CONFIRM_USER_PASSWORD:


### PR DESCRIPTION
Fixes #3865 

## Change summary

- So.. just removed all the handling of doubles and only try and handle it at the interface ...??  Think this is better

## Testing

- [ ] Customer invoices doses column when entered, also adjusts the total quantity column to be doses*doses per vial
- [ ] stocktakes doses column when entered, also adjusts the total quantity column to be doses*doses per vial
- [ ] cannot see more than two decimal places for a quantity anywhere in the ui...

### Related areas to think about

N/a
