### PR TITLE
#3880 Add check before creating a name note

### DIFF
--- a/src/actions/Entities/NameNoteActions.js
+++ b/src/actions/Entities/NameNoteActions.js
@@ -101,7 +101,13 @@ const updateForm = (data, validator) => ({
 
 const saveEditing = () => (dispatch, getState) => {
   const nameNote = selectCreatingNameNote(getState()) ?? {};
-  UIDatabase.write(() => createRecord(UIDatabase, 'NameNote', nameNote));
+  const patient = UIDatabase.get('Name', nameNote?.nameID);
+  const isDirty = JSON.stringify(patient?.mostRecentPCD?.data) !== JSON.stringify(nameNote?.data);
+
+  if (isDirty) {
+    UIDatabase.write(() => createRecord(UIDatabase, 'NameNote', nameNote));
+  }
+
   dispatch(reset());
 };
 


### PR DESCRIPTION
Fixes #3880 

## Change summary

- Adds a quick check before creating a name note to see if anythings changed

## Testing

- [ ] Name notes are only created when something has changed

### Related areas to think about

N/A
