### PR TITLE
#3899 Dispatch StocktakeItem refresh when editing StocktakeBatch doses

### DIFF
--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -142,9 +142,10 @@ export const StocktakeBatchModalComponent = ({
     dispatch(PageActions.editStocktakeBatchExpiryDate(date, rowKey, columnKey));
   const onEditSellPrice = (newValue, rowKey) =>
     dispatch(PageActions.editSellPrice(newValue, rowKey));
-
-  const onEditBatchDoses = (newValue, rowKey) =>
+  const onEditBatchDoses = (newValue, rowKey) => {
     dispatch(PageActions.editBatchDoses(newValue, rowKey));
+    reduxDispatch(PageActions.refreshRow(stocktakeItem.id, ROUTES.STOCKTAKE_EDITOR));
+  };
 
   const onSelectLocation = rowKey =>
     dispatch(PageActions.openModal(MODAL_KEYS.SELECT_LOCATION, rowKey));


### PR DESCRIPTION
Fixes #3899 

## Change summary

- dispatches and action to refresh the stocktake item when editing a stocktake batch dose

## Testing

- [ ] Edit a stocktake batch dose- the underlying stocktake item is re-rendered also

### Related areas to think about

N/A
