### PR TITLE
#3736 Adjust numberOfUsageDays calculation

### DIFF
--- a/src/utilities/dailyUsage.js
+++ b/src/utilities/dailyUsage.js
@@ -48,7 +48,7 @@ export const dailyUsage = item => {
   const useLookbackDate = amcEnforceLookback || itemAddedDate.isBefore(lookbackDate);
   const startDate = useLookbackDate ? lookbackDate : itemAddedDate;
 
-  const numberOfUsageDays = moment.duration(dateNow.diff(startDate)).asDays();
+  const numberOfUsageDays = Math.max(moment.duration(dateNow.diff(startDate)).asDays(), 1);
 
   const usage = UIDatabase.objects('TransactionBatch')
     .filtered('itemBatch.item.id == $0', itemId)
@@ -60,7 +60,7 @@ export const dailyUsage = item => {
     )
     .reduce((sum, { totalQuantity }) => sum + totalQuantity, 0);
 
-  return usage / (numberOfUsageDays || 1);
+  return usage / numberOfUsageDays;
 };
 
 /**
@@ -81,9 +81,7 @@ export const programDailyUsage = (item, period) => {
   const amcLookback = getAMCLookbackPeriod();
 
   const periodEnd = moment(periodEndDate);
-  const usageStartDate = moment(periodEndDate)
-    .add(1, 'days')
-    .subtract(amcLookback, 'months');
+  const usageStartDate = moment(periodEndDate).add(1, 'days').subtract(amcLookback, 'months');
 
   const numberOfUsageDays = NUMBER_OF_DAYS_IN_A_MONTH * amcLookback;
 


### PR DESCRIPTION
Fixes #3736

## Change summary

Adjust divisor to have min value of 1.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Replicate #3736 and don't see error (monthly usage calculation should be much lower when freshly synced)

- E.g. Before fix with usage of 5 over <= day, expected monthly usage was 6319.84 (or even higher depending on how soon the SR was created)
![image](https://user-images.githubusercontent.com/65875762/113809658-b5857400-97bc-11eb-83a2-17ade34c27b6.png)
- E.g. After fix with usage of 5 over <= 1 day, expected monthly usage is 152.08
![image](https://user-images.githubusercontent.com/65875762/113809489-56bffa80-97bc-11eb-923e-8492b088b87c.png)

### Related areas to think about
- Ran code formatter, it edited `programDailyUsage` but no functional changes 
