### PR TITLE
#3770 Update createRecord to save prescriber gender

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -154,6 +154,7 @@ const createPrescriber = (database, prescriberDetails) => {
     emailAddress: prescriberEmailAddress,
     storeId: prescriberStoreId,
     isActive: prescriberIsActive,
+    female: prescriberIsFemale,
   } = prescriberDetails;
 
   const id = prescriberId ?? generateUUID();
@@ -173,6 +174,7 @@ const createPrescriber = (database, prescriberDetails) => {
 
   const isVisible = true;
   const isActive = prescriberIsActive ?? true;
+  const female = prescriberIsFemale ?? false;
 
   const prescriber = database.update('Prescriber', {
     id,
@@ -186,6 +188,7 @@ const createPrescriber = (database, prescriberDetails) => {
     fromThisStore,
     isVisible,
     isActive,
+    female,
   });
   return prescriber;
 };

--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -47,6 +47,7 @@ const FORM_INPUT_KEYS = {
   EMAIL: 'emailAddress',
   ETHNICITY: 'ethnicity',
   FIRST_NAME: 'firstName',
+  GENDER: 'gender',
   IS_ACTIVE: 'isActive',
   LAST_NAME: 'lastName',
   NATIONALITY: 'nationality',


### PR DESCRIPTION
Fixes #3770

## Change summary

- Updated createRecord to include the female boolean field

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a new prescriber with gender `female`, do lookup and confirm prescriber saved as female
- [ ] Create a male prescriber (confirm saved as male), edit to `female` and confirm prescriber saved as female

### Related areas to think about
Not really sure of any