### PR TITLE
Add nationality/ethnicity to patient lookup

### DIFF
--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -210,6 +210,8 @@ export const processPatientResponse = response => {
       date_of_birth,
       nameInsuranceJoin,
       nameNotes,
+      nationality_ID,
+      ethnicity_ID,
     }) => ({
       id,
       name,
@@ -224,6 +226,8 @@ export const processPatientResponse = response => {
       supplyingStoreId,
       firstName,
       lastName,
+      nationality: UIDatabase.get('Nationality', nationality_ID),
+      ethnicity: UIDatabase.get('Ethnicity', ethnicity_ID),
       dateOfBirth: parseDate(date_of_birth),
       policies: processInsuranceResponse(nameInsuranceJoin),
       nameNotes: processNameNoteResponse(nameNotes),

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -210,6 +210,7 @@ export const processPatientResponse = response => {
       date_of_birth,
       nameInsuranceJoin,
       nameNotes,
+      female,
       nationality_ID,
       ethnicity_ID,
     }) => ({
@@ -231,6 +232,7 @@ export const processPatientResponse = response => {
       dateOfBirth: parseDate(date_of_birth),
       policies: processInsuranceResponse(nameInsuranceJoin),
       nameNotes: processNameNoteResponse(nameNotes),
+      female,
     })
   );
 };


### PR DESCRIPTION
Fixes #3911 

## Change summary

- Saves ethnicity/nationality of a patient when looking up

## Testing

- [ ] Lookup a patient with an ethnicity and/or nationality - it should show on step 2 of vaccine dispensing

### Related areas to think about

N/A
