### PR TITLE
#3787 Make sensor removal navigate to vaccine page

### DIFF
--- a/src/pages/SensorEditPage.js
+++ b/src/pages/SensorEditPage.js
@@ -4,7 +4,7 @@
 import React, { useState } from 'react';
 import { StyleSheet, ToastAndroid, View } from 'react-native';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect, batch } from 'react-redux';
 
 import {
   DataTablePageView,
@@ -44,7 +44,7 @@ import {
 } from '../selectors/Entities/temperatureBreachConfig';
 import { LocationActions, TemperatureBreachConfigActions } from '../actions/Entities/index';
 import { selectEditingLocation } from '../selectors/Entities/location';
-import { goBack } from '../navigation/actions';
+import { goBack, goToVaccines } from '../navigation/actions';
 import { SensorHeader } from '../widgets/SensorHeader/SensorHeader';
 import { MILLISECONDS } from '../utilities/index';
 import { useToggle } from '../hooks/index';
@@ -281,7 +281,13 @@ const dispatchToProps = (dispatch, ownProps) => {
 
   const remove = () => {
     dispatch(SensorActions.removeSensor(sensorID));
-    dispatch(goBack());
+
+    batch(() => {
+      dispatch(SensorActions.reset());
+      dispatch(LocationActions.reset());
+      dispatch(TemperatureBreachConfigActions.reset());
+      dispatch(goToVaccines());
+    });
   };
   const blink = macAddress => dispatch(SensorBlinkActions.startSensorBlink(macAddress));
   const updateName = name => dispatch(SensorActions.update(sensorID, 'name', name));


### PR DESCRIPTION
Fixes #3787 

## Change summary

- A super minor update to make the app navigate to the vaccine/cold chain page whenever a sensor is removed (as opposed to previously where if the settings page was navigated to from the `fridgeDetail` page, the app would navigate back to that instead and display sensor details for a sensor that was just removed.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Attempt to reproduce #3787 (hopefully you can't)

### Related areas to think about
Don't think there are other places where a sensor can be removed in the app?
