### PR TITLE
Add VisibleItems filter on UIDatabase

### DIFF
--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -51,6 +51,8 @@ const translateToCoreDatabaseType = type => {
       return 'TransactionCategory';
     case 'PCDEvents':
       return 'PatientEvent';
+    case 'VisibleItem':
+      return 'Item';
     case 'Vaccine':
       return 'Item';
     case 'PatientSurveyForm':
@@ -256,6 +258,8 @@ class UIDatabase {
         return results.filtered('code == "PCD"');
       case 'Vaccine':
         return results.filtered('isVaccine == true && isVisible == true');
+      case 'VisibleItem':
+        return results.filtered('isVisible == true');
       case 'ADRForm':
         return results.filtered("type == 'ADR'").sorted('version', true);
       case 'PatientSurveyForm':

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -197,7 +197,7 @@ const customerRequisitionsInitialiser = () => {
  * @returns  {object}
  */
 const stockInitialiser = () => {
-  const backingData = UIDatabase.objects('Item').sorted('name');
+  const backingData = UIDatabase.objects('VisibleItem').sorted('name');
 
   return {
     backingData,
@@ -279,7 +279,7 @@ const stocktakeBatchInitialiser = stocktakeItem => {
  * @returns  {object}
  */
 const stocktakeManagerInitialiser = stocktake => {
-  const backingData = UIDatabase.objects('Item');
+  const backingData = UIDatabase.objects('VisibleItem');
 
   return {
     stocktake,

--- a/src/reducers/PrescriptionReducer.js
+++ b/src/reducers/PrescriptionReducer.js
@@ -10,7 +10,7 @@ import { PRESCRIPTION_ACTIONS } from '../actions/PrescriptionActions';
 const initialState = () => ({
   currentTab: 0,
   transaction: null,
-  items: UIDatabase.objects('Item').filtered('isVaccine != true'),
+  items: UIDatabase.objects('VisibleItem').filtered('isVaccine != true'),
   itemSearchTerm: '',
   commentModalOpen: false,
 });

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -55,7 +55,7 @@ const DataTablePageModalComponent = ({ isOpen, onClose, modalKey, onSelect, curr
       case MODAL_KEYS.SELECT_ITEM:
         return (
           <AutocompleteSelector
-            options={UIDatabase.objects('Item')}
+            options={UIDatabase.objects('VisibleItem')}
             queryString="name CONTAINS[c] $0 OR code BEGINSWITH[c] $0"
             sortKeyString="name"
             onSelect={onSelect}


### PR DESCRIPTION
Fixes #3920

## Change summary

- Adds a `VisibleItem` filter on `UIDatabase` and used it everywhere(ish) where `UIDatabase.objects("Item")` was used

## Testing

- [ ] Only visible items show up on the `CurrentStockPage` (Go to the server and make a master list NOT visible for your store and those items shouldn't show anymore, unless they are in ANOTHER master list for your store)
- [ ] Only visible items show up on the `StocktakePage` (Go to the server and make a master list NOT visible for your store and those items shouldn't show anymore, unless they are in ANOTHER master list for your store)
- [ ] Only visible items show up on the `PrescriptionPage` (Go to the server and make a master list NOT visible for your store and those items shouldn't show anymore, unless they are in ANOTHER master list for your store)
- [ ] Only visible items show up on the `PrescriptionPage` (Go to the server and make a master list NOT visible for your store and those items shouldn't show anymore, unless they are in ANOTHER master list for your store)


### Related areas to think about

N/A
