### PR TITLE
Add bonus dose checkbox to vaccine prescription

### DIFF
--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -150,12 +150,12 @@ const confirm = () => (dispatch, getState) => {
   const { user } = getState();
   const { currentUser } = user;
   const hasRefused = selectHasRefused(getState());
-  const hasBonusDoes = selectFoundBonusDose(getState());
+  const hasBonusDoses = selectFoundBonusDose(getState());
   const patientID = selectEditingNameId(getState());
   const selectedBatches = selectSelectedBatches(getState());
   const vaccinator = selectSelectedVaccinator(getState());
 
-  if (hasBonusDoes) {
+  if (hasBonusDoses) {
     UIDatabase.write(() => {
       const stocktake = createRecord(UIDatabase, 'Stocktake', currentUser, 'bonus_dose');
       const [selectedBatch] = selectedBatches;

--- a/src/localization/dispensingStrings.json
+++ b/src/localization/dispensingStrings.json
@@ -1,5 +1,6 @@
 {
   "gb": {
+    "bonus_dose": "Bonus dose",
     "receipt_for_invoice": "Receipt for invoice(s)",
     "available_batches": "Available batches",
     "available_credit": "Available credit",

--- a/src/reducers/Entities/VaccinePrescriptionReducer.js
+++ b/src/reducers/Entities/VaccinePrescriptionReducer.js
@@ -9,6 +9,7 @@ const initialState = () => ({
   selectedBatches: [],
   vaccines: UIDatabase.objects('Vaccine').sorted('name'),
   vaccinator: null,
+  bonusDose: false,
 });
 
 export const VaccinePrescriptionReducer = (state = initialState(), action) => {
@@ -68,6 +69,13 @@ export const VaccinePrescriptionReducer = (state = initialState(), action) => {
       }
 
       return { ...state, hasRefused, selectedVaccines, selectedBatches };
+    }
+
+    case VACCINE_PRESCRIPTION_ACTIONS.SET_BONUS_DOSE: {
+      const { payload } = action;
+      const { toggle } = payload;
+
+      return { ...state, bonusDose: toggle };
     }
 
     default: {

--- a/src/selectors/Entities/vaccinePrescription.js
+++ b/src/selectors/Entities/vaccinePrescription.js
@@ -80,3 +80,9 @@ export const selectHaveVaccineStock = () =>
   UIDatabase.objects('Vaccine').filtered(
     'subquery(batches, $batches, $batches.numberOfPacks > 0 ).@count > 0'
   ).length > 0;
+
+export const selectFoundBonusDose = state => {
+  const VaccinePrescriptionState = selectSpecificEntityState(state, 'vaccinePrescription');
+  const { bonusDose } = VaccinePrescriptionState;
+  return bonusDose;
+};

--- a/src/widgets/VaccinePrescriptionInfo.js
+++ b/src/widgets/VaccinePrescriptionInfo.js
@@ -21,6 +21,7 @@ import { UIDatabase } from '../database/index';
 import { DropDown } from './DropDown';
 import { VaccinePrescriptionActions } from '../actions/Entities/index';
 import {
+  selectFoundBonusDose,
   selectHasRefused,
   selectSelectedVaccinator,
 } from '../selectors/Entities/vaccinePrescription';
@@ -68,6 +69,8 @@ const VaccinePrescriptionInfoComponent = ({
   vaccinator,
   onRefuse,
   hasRefused,
+  onFoundBonusDose,
+  foundBonusDose,
 }) => (
   <Paper
     headerText={vaccineStrings.vaccine_dispense_step_three_title}
@@ -96,6 +99,15 @@ const VaccinePrescriptionInfoComponent = ({
           tintColors={{ true: SUSSOL_ORANGE, false: DARKER_GREY }}
         />
       </FlexRow>
+      <FlexRow flex={0} alignItems="center" justifyContent="space-between">
+        <Text style={styles.labelText}>{dispensingStrings.bonus_dose}</Text>
+
+        <CheckBox
+          onValueChange={onFoundBonusDose}
+          value={foundBonusDose}
+          tintColors={{ true: SUSSOL_ORANGE, false: DARKER_GREY }}
+        />
+      </FlexRow>
     </FlexRow>
   </Paper>
 );
@@ -104,19 +116,22 @@ const mapDispatchToProps = dispatch => {
   const onSelectVaccinator = vaccinator =>
     dispatch(VaccinePrescriptionActions.selectVaccinator(vaccinator));
   const onRefuse = value => dispatch(VaccinePrescriptionActions.setRefusal(value));
+  const onFoundBonusDose = value => dispatch(VaccinePrescriptionActions.setBonusDose(value));
 
-  return { onSelectVaccinator, onRefuse };
+  return { onSelectVaccinator, onRefuse, onFoundBonusDose };
 };
 
 const mapStateToProps = state => {
   const patientName = selectFullName(state);
   const hasRefused = selectHasRefused(state);
   const vaccinator = selectSelectedVaccinator(state);
+  const foundBonusDose = selectFoundBonusDose(state);
 
   return {
     patientName,
     vaccinator,
     hasRefused,
+    foundBonusDose,
   };
 };
 
@@ -130,6 +145,8 @@ VaccinePrescriptionInfoComponent.propTypes = {
   vaccinator: PropTypes.object,
   onRefuse: PropTypes.func.isRequired,
   hasRefused: PropTypes.bool.isRequired,
+  onFoundBonusDose: PropTypes.func.isRequired,
+  foundBonusDose: PropTypes.bool.isRequired,
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Fixes #3921

## Change summary

- I know this is not a good spot. I didn't know where to put it..

## Testing

- [ ] When the `bonus dose` checkbox is checked, in addition to the prescription, a stocktake is created with 1 line and 1 dose.

### Related areas to think about

N/A
