### PR TITLE
#3747 export temperature logs with no logs

### DIFF
--- a/src/utilities/vaccineReport.js
+++ b/src/utilities/vaccineReport.js
@@ -5,7 +5,6 @@ import moment from 'moment';
 import DeviceInfo from 'react-native-device-info';
 import temperature from './temperature';
 import { SECONDS } from './constants';
-import { UIDatabase } from '../database/index';
 import { generalStrings, reportStrings, vaccineStrings } from '../localization/index';
 import { MILLISECONDS_PER_MINUTE } from '../database/utilities/constants';
 
@@ -223,12 +222,7 @@ const writeReport = async content => {
 const getSubject = sensor =>
   `${reportStrings.email_vaccine_report_subject} ${sensor.name ?? sensor.macAddress}`;
 
-export const emailVaccineReport = async (macAddress, user, email, comment) => {
-  const sensor = UIDatabase.get('Sensor', macAddress, 'macAddress');
-
-  if (!sensor) throw new Error('Cannot find sensor');
-  if (sensor?.logs <= 0) throw new Error('No temperature logs');
-
+export const emailVaccineReport = async (sensor, user, email, comment) => {
   const content = await vaccineReport(sensor, user, comment);
   const path = await writeReport(content);
   const subject = getSubject(sensor);

--- a/src/widgets/SensorHeader/ExportTemperatureDataButton.js
+++ b/src/widgets/SensorHeader/ExportTemperatureDataButton.js
@@ -55,8 +55,8 @@ export const ExportTemperatureDataButtonComponent = ({
         reset();
         return cached;
       })
-      // Once permission has been ensured and the dialog is closed, block with a full screen spinner
-      // while generating the report - it could be large.
+      // Once permission has been ensured, the dialog is closed and sensor logs are found,
+      // block with a full screen spinner while generating the report - it could be large.
       .then(({ success, emailValue, commentValue }) => {
         if (success) {
           const sensor = UIDatabase.get('Sensor', macAddress, 'macAddress');

--- a/src/widgets/SensorHeader/ExportTemperatureDataButton.js
+++ b/src/widgets/SensorHeader/ExportTemperatureDataButton.js
@@ -16,13 +16,16 @@ import { emailVaccineReport } from '../../utilities/vaccineReport';
 import { selectCurrentUser } from '../../selectors/user';
 import { useLoadingIndicator } from '../../hooks/index';
 import { BLACK, SUSSOL_ORANGE } from '../../globalStyles/index';
-import { generalStrings } from '../../localization/index';
+import { generalStrings, vaccineStrings } from '../../localization/index';
 import { UIDatabase } from '../../database/index';
 
 const toastReportGenerationFailed = () =>
   ToastAndroid.show(generalStrings.report_generation_failed, ToastAndroid.LONG);
 const toastNoPermission = () =>
   ToastAndroid.show(generalStrings.require_permission_to_send_data, ToastAndroid.LONG);
+const toastNoTemperatures = () => {
+  ToastAndroid.show(vaccineStrings.no_temperatures, ToastAndroid.LONG);
+};
 
 export const ExportTemperatureDataButtonComponent = ({
   macAddress,
@@ -61,7 +64,10 @@ export const ExportTemperatureDataButtonComponent = ({
         if (success) {
           const sensor = UIDatabase.get('Sensor', macAddress, 'macAddress');
           if (!sensor) throw new Error('Cannot find sensor');
-          if (sensor?.logs <= 0) throw new Error('No temperature logs');
+          if (sensor?.logs <= 0) {
+            toastNoTemperatures();
+            return;
+          }
 
           withLoadingIndicator(() =>
             emailVaccineReport(sensor, currentUser, emailValue, commentValue)

--- a/src/widgets/SensorHeader/ExportTemperatureDataButton.js
+++ b/src/widgets/SensorHeader/ExportTemperatureDataButton.js
@@ -17,6 +17,7 @@ import { selectCurrentUser } from '../../selectors/user';
 import { useLoadingIndicator } from '../../hooks/index';
 import { BLACK, SUSSOL_ORANGE } from '../../globalStyles/index';
 import { generalStrings } from '../../localization/index';
+import { UIDatabase } from '../../database/index';
 
 const toastReportGenerationFailed = () =>
   ToastAndroid.show(generalStrings.report_generation_failed, ToastAndroid.LONG);
@@ -58,8 +59,12 @@ export const ExportTemperatureDataButtonComponent = ({
       // while generating the report - it could be large.
       .then(({ success, emailValue, commentValue }) => {
         if (success) {
+          const sensor = UIDatabase.get('Sensor', macAddress, 'macAddress');
+          if (!sensor) throw new Error('Cannot find sensor');
+          if (sensor?.logs <= 0) throw new Error('No temperature logs');
+
           withLoadingIndicator(() =>
-            emailVaccineReport(macAddress, currentUser, emailValue, commentValue)
+            emailVaccineReport(sensor, currentUser, emailValue, commentValue)
           );
         }
       })


### PR DESCRIPTION
Fixes #3747

## Change summary

- Display a user-friendly toast if they attempt to export temperature logs before any logs exist

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- Setup a new sensor with a log delay of 5min and try to export temperature logs before logging is started (from vaccines page).
  - [ ]  Check that a toast is displayed instead of a continuous spinner animation

### Related areas to think about

Might have been better to make the icon in the sensor header trigger the toast instead? Or disable the download icon? I thought this was at least one step better than having to close the app at least 
