### PR TITLE
#3939 can refuse and bonus dose

### DIFF
--- a/src/reducers/Entities/VaccinePrescriptionReducer.js
+++ b/src/reducers/Entities/VaccinePrescriptionReducer.js
@@ -66,7 +66,13 @@ export const VaccinePrescriptionReducer = (state = initialState(), action) => {
       const { hasRefused, selectedVaccines, selectedBatches } = payload;
 
       if (hasRefused) {
-        return { ...state, hasRefused, selectedVaccines: [], selectedBatches: [] };
+        return {
+          ...state,
+          hasRefused,
+          bonusDose: false,
+          selectedVaccines: [],
+          selectedBatches: [],
+        };
       }
 
       return { ...state, hasRefused, selectedVaccines, selectedBatches };

--- a/src/reducers/FormReducer.js
+++ b/src/reducers/FormReducer.js
@@ -57,11 +57,11 @@ export const FormReducer = (state = initialState(), action) => {
           ? { value }
           : policyNumberFamilyState;
 
-        const isPolicyNumberPersonValid = policyNumberPersonState.validator(
+        const isPolicyNumberPersonValid = policyNumberPersonState.validator?.(
           policyNumberPersonValue
         );
 
-        const isPolicyNumberFamilyValid = policyNumberFamilyState.validator(
+        const isPolicyNumberFamilyValid = policyNumberFamilyState.validator?.(
           policyNumberFamilyValue
         );
 
@@ -95,6 +95,8 @@ export const FormReducer = (state = initialState(), action) => {
       }
 
       const configData = formConfig[key];
+
+      if (!configData) return state;
 
       const { validator } = configData;
 

--- a/src/widgets/VaccinePrescriptionInfo.js
+++ b/src/widgets/VaccinePrescriptionInfo.js
@@ -27,7 +27,7 @@ import {
   selectSelectedVaccinator,
 } from '../selectors/Entities/vaccinePrescription';
 import { Spacer } from './Spacer';
-import { BACKGROUND_COLOR } from '../globalStyles/colors';
+import { BACKGROUND_COLOR, LIGHT_GREY } from '../globalStyles/colors';
 import { HistoryIcon } from './icons';
 import { IconButton } from './IconButton';
 
@@ -120,9 +120,10 @@ const VaccinePrescriptionInfoComponent = ({
         <Text style={styles.labelText}>{dispensingStrings.bonus_dose}</Text>
 
         <CheckBox
+          disabled={hasRefused}
           onValueChange={onFoundBonusDose}
           value={foundBonusDose}
-          tintColors={{ true: SUSSOL_ORANGE, false: DARKER_GREY }}
+          tintColors={{ true: SUSSOL_ORANGE, false: hasRefused ? LIGHT_GREY : DARKER_GREY }}
         />
       </FlexRow>
     </FlexRow>


### PR DESCRIPTION
Fixes #3939 

## Change summary

- Was not able to bonus dose as there was no item selected, so no batch to add a bonus dose to. So just remove bonus dosing while refusing

## Testing

- [ ] Can't select bonus dose when refused

### Related areas to think about

@ArpitaSussol Amazing testing- thanks so much!
