### PR TITLE
#3859 form reducer crash

### DIFF
--- a/src/reducers/FormReducer.js
+++ b/src/reducers/FormReducer.js
@@ -57,11 +57,11 @@ export const FormReducer = (state = initialState(), action) => {
           ? { value }
           : policyNumberFamilyState;
 
-        const isPolicyNumberPersonValid = policyNumberPersonState.validator(
+        const isPolicyNumberPersonValid = policyNumberPersonState.validator?.(
           policyNumberPersonValue
         );
 
-        const isPolicyNumberFamilyValid = policyNumberFamilyState.validator(
+        const isPolicyNumberFamilyValid = policyNumberFamilyState.validator?.(
           policyNumberFamilyValue
         );
 
@@ -95,6 +95,8 @@ export const FormReducer = (state = initialState(), action) => {
       }
 
       const configData = formConfig[key];
+
+      if (!configData) return state;
 
       const { validator } = configData;
 


### PR DESCRIPTION
Fixes #3859 

## Change summary

- There's no form config when exiting the modal, so if there's an update queued up it crashes

## Testing

- [ ] Spam type into the `lastName` field of the patient lookup in the dispensing page, and close it at the same time - the app should not crash

### Related areas to think about

Not ideal ..
