### PR TITLE
#3757 fix breach boundary crossing detection

### DIFF
--- a/src/bluetooth/BreachManager.js
+++ b/src/bluetooth/BreachManager.js
@@ -136,7 +136,7 @@ class BreachManager {
       if (configInBreach) {
         // If current log is in breach of the same config as the rest of the stack,
         // push the current log onto the stack
-        if (potentialBreach.configInBreach === configInBreach) {
+        if (potentialBreach.configInBreach?.id === configInBreach.id) {
           potentialBreach.logs.push(log);
         } else {
           // If the log is in breach of a different config as the existing stack,

--- a/src/bluetooth/BreachManager.js
+++ b/src/bluetooth/BreachManager.js
@@ -134,11 +134,6 @@ class BreachManager {
       }
 
       if (configInBreach) {
-        // Assign a config to the stack of logs
-        if (!potentialBreach.configInBreach && !logs) {
-          potentialBreach.configInBreach = configInBreach;
-        }
-
         // If current log is in breach of the same config as the rest of the stack,
         // push the current log onto the stack
         if (potentialBreach.configInBreach === configInBreach) {

--- a/src/bluetooth/BreachManager.js
+++ b/src/bluetooth/BreachManager.js
@@ -175,9 +175,7 @@ class BreachManager {
           );
 
           currentBreach = newBreach;
-
           breaches.push(newBreach);
-
           const updatedLogs = potentialBreach.logs.map(l => this.addLogToBreach(newBreach, l));
           updatedLogs.forEach(ul => temperatureLogs.push(ul));
         }

--- a/src/bluetooth/BreachManager.test.js
+++ b/src/bluetooth/BreachManager.test.js
@@ -347,7 +347,49 @@ describe('BreachManager: createBreaches', () => {
       logsShouldBe,
     ]);
   });
+  it('Creates a single breach when multiple breach boundaries are crossed', async () => {
+    const dummyLocation = { id: 'ABC', description: 'DEF' };
+    const sensor = { id: 'a', location: dummyLocation };
+    const logs = [
+      { id: 'a', temperature: 1, timestamp: 0 },
+      { id: 'b', temperature: 9, timestamp: 1 },
+      { id: 'c', temperature: 9, timestamp: 2 },
+      { id: 'd', temperature: 9, timestamp: 3 },
+    ];
+    const configs = [
+      { id: 'a', duration: 2000, minimumTemperature: 8, maximumTemperature: 999 },
+      { id: 'b', duration: 2000, minimumTemperature: -999, maximumTemperature: 2 },
+    ];
+    const utils = { createUuid: () => '1' };
+    const dbService = {};
 
+    const breachManager = BreachManager(dbService, utils);
+
+    const breachesShouldBe = [
+      {
+        id: '1',
+        acknowledged: false,
+        sensor,
+        thresholdMaxTemperature: 999,
+        thresholdMinTemperature: 8,
+        thresholdDuration: 2000,
+        startTimestamp: new Date(0),
+        endTimestamp: undefined,
+        location: dummyLocation,
+      },
+    ];
+
+    const logsShouldBe = [
+      { id: 'b', breach: breachesShouldBe[0] },
+      { id: 'c', breach: breachesShouldBe[0] },
+      { id: 'd', breach: breachesShouldBe[0] },
+    ];
+
+    await expect(breachManager.createBreaches(sensor, logs, configs)).toEqual([
+      breachesShouldBe,
+      logsShouldBe,
+    ]);
+  });
   it('Creates a simple single breach that is closed', async () => {
     const dummyLocation = { id: 'ABC', description: 'DEF' };
     const sensor = { id: 'a', location: dummyLocation };

--- a/src/bluetooth/BreachManager.test.js
+++ b/src/bluetooth/BreachManager.test.js
@@ -221,7 +221,7 @@ describe('BreachManager: willCloseBreach ', () => {
   });
 });
 
-describe('BreachManager: couldBeInBreach', () => {
+describe('BreachManager: getConfigInBreach', () => {
   it('Correctly determines from one config that a log could be in breach', () => {
     const dbService = {};
     const utils = { createUuid: () => '1' };
@@ -231,7 +231,7 @@ describe('BreachManager: couldBeInBreach', () => {
     const configs = [{ minimumTemperature: 8, maximumTemperature: 999 }];
     const log = { temperature: 10 };
 
-    expect(breachManager.couldBeInBreach(log, configs)).toEqual(true);
+    expect(breachManager.getConfigInBreach(log, configs)).toEqual(configs[0]);
   });
   it('Correctly determines from many configs that a log could be in breach', () => {
     const dbService = {};
@@ -241,11 +241,11 @@ describe('BreachManager: couldBeInBreach', () => {
 
     const configs = [
       { minimumTemperature: 8, maximumTemperature: 999 },
-      { minimumTemperature: 6, maximumTemperature: 999 },
+      { minimumTemperature: -999, maximumTemperature: 2 },
     ];
     const log = { temperature: 10 };
 
-    expect(breachManager.couldBeInBreach(log, configs)).toEqual(true);
+    expect(breachManager.getConfigInBreach(log, configs)).toEqual(configs[0]);
   });
   it('Correctly determines from many configs that a log should not be in breach', () => {
     const dbService = {};
@@ -255,11 +255,11 @@ describe('BreachManager: couldBeInBreach', () => {
 
     const configs = [
       { minimumTemperature: 8, maximumTemperature: 999 },
-      { minimumTemperature: 8, maximumTemperature: 999 },
+      { minimumTemperature: -999, maximumTemperature: 2 },
     ];
     const log = { temperature: 4 };
 
-    expect(breachManager.couldBeInBreach(log, configs)).toEqual(false);
+    expect(breachManager.getConfigInBreach(log, configs)).toEqual(undefined);
   });
   it('Correctly determines from a config that a log should not be in breach', () => {
     const dbService = {};
@@ -270,7 +270,7 @@ describe('BreachManager: couldBeInBreach', () => {
     const configs = [{ minimumTemperature: 8, maximumTemperature: 999 }];
     const log = { temperature: 4 };
 
-    expect(breachManager.couldBeInBreach(log, configs)).toEqual(false);
+    expect(breachManager.getConfigInBreach(log, configs)).toEqual(undefined);
   });
 });
 
@@ -357,8 +357,20 @@ describe('BreachManager: createBreaches', () => {
       { id: 'd', temperature: 9, timestamp: 3 },
     ];
     const configs = [
-      { id: 'a', duration: 2000, minimumTemperature: 8, maximumTemperature: 999 },
-      { id: 'b', duration: 2000, minimumTemperature: -999, maximumTemperature: 2 },
+      {
+        id: 'a',
+        duration: 2000,
+        minimumTemperature: 8,
+        maximumTemperature: 999,
+        type: 'HOT_CONSECUTIVE',
+      },
+      {
+        id: 'b',
+        duration: 2000,
+        minimumTemperature: -999,
+        maximumTemperature: 2,
+        type: 'COLD_CONSECUTIVE',
+      },
     ];
     const utils = { createUuid: () => '1' };
     const dbService = {};
@@ -373,9 +385,10 @@ describe('BreachManager: createBreaches', () => {
         thresholdMaxTemperature: 999,
         thresholdMinTemperature: 8,
         thresholdDuration: 2000,
-        startTimestamp: new Date(0),
+        startTimestamp: new Date(1 * MILLISECONDS.ONE_SECOND),
         endTimestamp: undefined,
         location: dummyLocation,
+        type: 'HOT_CONSECUTIVE',
       },
     ];
 

--- a/src/bluetooth/BreachManager.test.js
+++ b/src/bluetooth/BreachManager.test.js
@@ -259,7 +259,7 @@ describe('BreachManager: getConfigInBreach', () => {
     ];
     const log = { temperature: 4 };
 
-    expect(breachManager.getConfigInBreach(log, configs)).toEqual(undefined);
+    expect(breachManager.getConfigInBreach(log, configs)).toBeUndefined();
   });
   it('Correctly determines from a config that a log should not be in breach', () => {
     const dbService = {};
@@ -270,7 +270,7 @@ describe('BreachManager: getConfigInBreach', () => {
     const configs = [{ minimumTemperature: 8, maximumTemperature: 999 }];
     const log = { temperature: 4 };
 
-    expect(breachManager.getConfigInBreach(log, configs)).toEqual(undefined);
+    expect(breachManager.getConfigInBreach(log, configs)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Fixes #3757

## Change summary

- Added new test for edge case of temperature logs crossing two breach boundaries (e.g. Too cold for one log, then too hot for 3 logs)
- Implemented logic to track which config the stack of 'potentially breach causing logs' is associated with, if a new log comes in associated with a different config to the stack, reset the stack 
- Makes the breach calculation logic even more confusing than before 😿 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Ran unit tests (could also probably be tested by setting up some mock data under the 'Generate vaccine data' button or playing around with the 'DevBleManager' to return fake logs breaching one config first, then breaching another)

### Related areas to think about
- Previous breach calculation logic should work as before
- There's probably a nicer way of doing this 😆 