### PR TITLE
Add safety around dose setting on an item batch

### DIFF
--- a/src/database/DataTypes/ItemBatch.js
+++ b/src/database/DataTypes/ItemBatch.js
@@ -109,7 +109,9 @@ export class ItemBatch extends Realm.Object {
     if (quantity < 0) {
       throw new Error('Cannot set a negative item batch quantity');
     }
-    this.numberOfPacks = this.packSize ? quantity / this.packSize : 0;
+    let newNumberOfPacks = this.packSize ? quantity / this.packSize : 0;
+    if (newNumberOfPacks < 1 / this.dosesPerVial) newNumberOfPacks = 0;
+    this.numberOfPacks = newNumberOfPacks;
   }
 
   /**


### PR DESCRIPTION
Fixes #3948 

## Change summary

- I could recreate some variant of the bug by adding some quantity of an item with 12 doses / vial then dispensed all except for the last quantity. Then I dispensed the very last dose to a patient, and that patient got an extra line with some very tiny amount which seems to be just some 'leftover' quantity from adding/subtracting n stuff.
- So, made the assumption that 1 dose is the absolute minimum quantity an item batch should have (greater than zero) and after having set the quantity of the item batch, if there is still some tiny amount left that is less then one dose, just set it to zero.
- The assumption doesn't work if the doses per vial <1

## Testing

- [ ] Have 1 vaccine with 12 doses/vial. Give yourself some quantity. Then, dispense all. On the very LAST dose when dispensing through vaccine dispensing, the patient is only given 1 LINE in the transaction, and the ITEM BATCH now has ZERO quantity.

### Related areas to think about

N/A
