### PR TITLE
#3955 Avoid creating prescriptions with no lines

### DIFF
--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -22,6 +22,7 @@ export const VACCINE_PRESCRIPTION_ACTIONS = {
   SELECT_VACCINATOR: 'VACCINE_PRESCRIPTION/selectVaccinator',
   SET_BONUS_DOSE: 'VACCINE_PRESCRIPTION/setBonusDose',
   TOGGLE_HISTORY: 'VACCINE_PRESCRIPTION/toggleHistory',
+  SELECT_DEFAULT_VACCINE: 'VACCINE_PRESCRIPTION/selectDefaultVaccine',
 };
 
 const createDefaultVaccinePrescription = () => ({
@@ -82,13 +83,16 @@ const create = () => ({
   payload: {
     prescription: createDefaultVaccinePrescription(),
     vaccinator: getDefaultVaccinator(),
-    selectedVaccines: [getDefaultVaccine()],
-    selectedBatches: [getRecommendedBatch()],
   },
 });
 
 const reset = () => ({
   type: VACCINE_PRESCRIPTION_ACTIONS.RESET,
+});
+
+const selectDefaultVaccine = () => ({
+  type: VACCINE_PRESCRIPTION_ACTIONS.SELECT_DEFAULT_VACCINE,
+  payload: { selectedVaccines: [getDefaultVaccine()], selectedBatches: [getRecommendedBatch()] },
 });
 
 const selectVaccine = vaccine => ({
@@ -224,4 +228,5 @@ export const VaccinePrescriptionActions = {
   confirmAndRepeat,
   setBonusDose,
   toggleHistory,
+  selectDefaultVaccine,
 };

--- a/src/reducers/Entities/VaccinePrescriptionReducer.js
+++ b/src/reducers/Entities/VaccinePrescriptionReducer.js
@@ -17,6 +17,13 @@ export const VaccinePrescriptionReducer = (state = initialState(), action) => {
   const { type } = action;
 
   switch (type) {
+    case VACCINE_PRESCRIPTION_ACTIONS.SELECT_DEFAULT_VACCINE: {
+      const { payload } = action;
+      const { selectedVaccines, selectedBatches } = payload;
+
+      return { ...state, selectedVaccines, selectedBatches };
+    }
+
     case WIZARD_ACTIONS.SWITCH_TAB: {
       const { payload } = action;
       const { tab } = payload;
@@ -35,9 +42,9 @@ export const VaccinePrescriptionReducer = (state = initialState(), action) => {
     case VACCINE_PRESCRIPTION_ACTIONS.CREATE: {
       const { payload } = action;
 
-      const { prescription, vaccinator, selectedVaccines, selectedBatches } = payload;
+      const { prescription, vaccinator } = payload;
 
-      return { ...state, creating: prescription, vaccinator, selectedVaccines, selectedBatches };
+      return { ...state, creating: prescription, vaccinator };
     }
 
     case VACCINE_PRESCRIPTION_ACTIONS.SELECT_VACCINE: {

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useNavigation } from '@react-navigation/native';
 import { Text, StyleSheet } from 'react-native';
 import { batch, connect } from 'react-redux';
 import { TABS } from '../constants';
@@ -38,6 +39,7 @@ import { DARKER_GREY } from '../../globalStyles/colors';
 import { AfterInteractions } from '../AfterInteractions';
 import { Paper } from '../Paper';
 import { VaccinePrescriptionInfo } from '../VaccinePrescriptionInfo';
+import { useNavigationFocus } from '../../hooks/useNavigationFocus';
 
 const ListEmptyComponent = () => (
   <FlexView flex={1} justifyContent="center" alignItems="center">
@@ -72,6 +74,7 @@ const VaccineSelectComponent = ({
   selectedVaccine,
   vaccines,
   okAndRepeat,
+  selectDefaultVaccine,
 }) => {
   const { pageTopViewContainer } = globalStyles;
   const vaccineColumns = React.useMemo(() => getColumns(TABS.ITEM), []);
@@ -99,6 +102,9 @@ const VaccineSelectComponent = ({
     () => runWithLoadingIndicator(okAndRepeat),
     [okAndRepeat]
   );
+
+  const navigation = useNavigation();
+  useNavigationFocus(navigation, selectDefaultVaccine);
 
   return (
     <FlexView style={pageTopViewContainer}>
@@ -163,6 +169,7 @@ const mapDispatchToProps = dispatch => {
   const onCancelPrescription = () => dispatch(VaccinePrescriptionActions.cancel());
   const onSelectBatch = itemBatch => dispatch(VaccinePrescriptionActions.selectBatch(itemBatch));
   const onSelectVaccine = vaccine => dispatch(VaccinePrescriptionActions.selectVaccine(vaccine));
+  const selectDefaultVaccine = () => dispatch(VaccinePrescriptionActions.selectDefaultVaccine());
 
   const onConfirm = () =>
     batch(() => {
@@ -178,6 +185,7 @@ const mapDispatchToProps = dispatch => {
     onRefuse,
     onSelectBatch,
     onSelectVaccine,
+    selectDefaultVaccine,
   };
 };
 
@@ -210,6 +218,7 @@ VaccineSelectComponent.defaultProps = {
 };
 
 VaccineSelectComponent.propTypes = {
+  selectDefaultVaccine: PropTypes.func.isRequired,
   okAndRepeat: PropTypes.func.isRequired,
   onCancelPrescription: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,


### PR DESCRIPTION
Fixes #3955

## Change summary

- Always try to select a deafult vaccine when navigating to select vaccine tab

## Testing

- [ ] Cannot create a prescription with no lines

### Related areas to think about

N/A
