### PR TITLE
add reset option

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "react-native-permissions": "^3.0.0",
     "react-native-popover-view": "^3.1.1",
     "react-native-reanimated": "^1.7.0",
+    "react-native-restart": "^0.0.22",
     "react-native-safe-area-context": "^0.7.3",
     "react-native-screens": "^2.2.0",
     "react-native-simple-radio-button": "^2.7.4",

--- a/src/localization/buttonStrings.json
+++ b/src/localization/buttonStrings.json
@@ -32,7 +32,8 @@
     "use_suggested_quantities": "Use Suggested Quantities",
     "view_regimen_data": "View Regimen Data",
     "supply_data": "Supply Data",
-    "customer_data": "Customer Data"
+    "customer_data": "Customer Data",
+    "factory_reset": "Factory Reset"
   },
   "fr": {
     "cancel": "Annuler",

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -45,6 +45,7 @@
     "stocktake_invalid_stock": "Stock on hand for these item(s) have changed since this stocktake was last opened (through customer invoice, supplier invoice or another stocktake), both \"Snapshot Quantity\" and \"Actual Quantity\" will be reset",
     "select_a_reason": "Select a reason",
     "confirm_password": "Please confirm your user password",
+    "confirm_factory_reset": "Please confirm your user password to continue. \nBe aware that a factory reset will delete all local data. \nYou will need to re-enter sync site details, and re-sync all data.",
     "select_master_lists": "Select master list",
     "customer_no_masterlist_available": "This customer has no master lists!",
     "supplier_no_masterlist_available": "Your store has no master lists!",

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 
 import ValidUrl from 'valid-url';
 import { Dimensions, Text, View, ToastAndroid, TouchableOpacity } from 'react-native';
+import RNRestart from 'react-native-restart';
 import { hashPassword } from 'sussol-utilities';
 import { Button } from 'react-native-ui-components';
 
@@ -65,6 +66,7 @@ const Settings = ({ toRealmExplorer, currentUserPasswordHash, requestStorageWrit
   const closeModal = () => setState({ ...state, modalKey: '' });
   const openModal = newModalKey => setState({ ...state, modalKey: newModalKey });
   const onSave = () => openModal(MODAL_KEYS.CONFIRM_USER_PASSWORD);
+  const onReset = () => openModal(MODAL_KEYS.CONFIRM_FACTORY_RESET);
 
   const editSyncURL = newSyncURL => {
     if (!ValidUrl.isWebUri(newSyncURL)) ToastAndroid.show('Not a valid URL', ToastAndroid.LONG);
@@ -115,6 +117,21 @@ const Settings = ({ toRealmExplorer, currentUserPasswordHash, requestStorageWrit
     closeModal();
   };
 
+  const reset = enteredPassword => {
+    const passwordMatch = hashPassword(enteredPassword) === currentUserPasswordHash;
+    const toastMessage = passwordMatch
+      ? generalStrings.new_details_saved
+      : generalStrings.new_details_not_saved;
+
+    if (passwordMatch) {
+      UIDatabase.write(() => UIDatabase.deleteAll());
+      RNRestart.Restart();
+    } else {
+      ToastAndroid.show(toastMessage, ToastAndroid.LONG);
+    }
+    closeModal();
+  };
+
   const getModalSelect = () => {
     switch (modalKey) {
       case MODAL_KEYS.SYNC_URL_EDIT:
@@ -123,6 +140,8 @@ const Settings = ({ toRealmExplorer, currentUserPasswordHash, requestStorageWrit
         return editSyncPassword;
       case MODAL_KEYS.CONFIRM_USER_PASSWORD:
         return save;
+      case MODAL_KEYS.CONFIRM_FACTORY_RESET:
+        return reset;
       default:
         return null;
     }
@@ -222,6 +241,7 @@ const Settings = ({ toRealmExplorer, currentUserPasswordHash, requestStorageWrit
         <View>
           <MenuButton text={buttonStrings.realm_explorer} onPress={toRealmExplorer} />
           <MenuButton text={buttonStrings.export_data} onPress={requestStorageWritePermission} />
+          <MenuButton text={buttonStrings.factory_reset} onPress={onReset} />
           <VaccineButton />
         </View>
       </View>

--- a/src/utilities/getModalTitle.js
+++ b/src/utilities/getModalTitle.js
@@ -12,6 +12,7 @@ import {
 } from '../localization';
 
 export const MODAL_KEYS = {
+  CONFIRM_FACTORY_RESET: 'confirmFactoryReset',
   CONFIRM_USER_PASSWORD: 'confirmUserPassword',
   CREATE_CASH_TRANSACTION: 'createCashTransaction',
   SYNC_URL_EDIT: 'syncUrlEdit',
@@ -90,6 +91,8 @@ export const getModalTitle = modalKey => {
       return authStrings.warning_sync_edit;
     case MODAL_KEYS.CONFIRM_USER_PASSWORD:
       return modalStrings.confirm_password;
+    case MODAL_KEYS.CONFIRM_FACTORY_RESET:
+      return modalStrings.confirm_factory_reset;
     case MODAL_KEYS.SELECT_MASTER_LISTS:
       return modalStrings.select_master_lists;
     case MODAL_KEYS.SELECT_LOCATION:

--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -64,6 +64,7 @@ const DataTablePageModalComponent = ({ isOpen, onClose, modalKey, onSelect, curr
           />
         );
       case MODAL_KEYS.CONFIRM_USER_PASSWORD:
+      case MODAL_KEYS.CONFIRM_FACTORY_RESET:
       case MODAL_KEYS.SYNC_URL_EDIT:
       case MODAL_KEYS.SYNC_PASSWORD_EDIT:
       case MODAL_KEYS.STOCKTAKE_NAME_EDIT:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8311,6 +8311,11 @@ react-native-reanimated@^1.7.0:
   dependencies:
     fbjs "^1.0.0"
 
+react-native-restart@^0.0.22:
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/react-native-restart/-/react-native-restart-0.0.22.tgz#81fcb7f31e35951d85410c68b9556acf3ab88705"
+  integrity sha512-XwCqAMAKsO8yCM3xACPFKvkDQZe41lcavOuO0gUEu803IuTLtciualCq/qs83ryRDCDh1jkXYRqFjsGjLMCN3Q==
+
 react-native-safe-area-context@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.7.3.tgz#ad6bd4abbabe195332c53810e4ce5851eb21aa2a"


### PR DESCRIPTION
Fixes #3968 

## Change summary

Adds a button to settings: `Factory Reset` which prompts for the user's password and gives a small warning
If confirmed, the database is cleared and the app reloaded.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Settings: Factory Reset: cancel - should just return to the settings page
- [ ] Settings: Factory Reset: wrong password - toast showing that password is wrong and returns to the settings page
- [ ] Settings: Factory Reset: correct password - returns to the initial setup page

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
