### PR TITLE
#3972 Fix dispensing RSOD

### DIFF
--- a/src/selectors/prescriber.js
+++ b/src/selectors/prescriber.js
@@ -32,7 +32,11 @@ export const selectFilteredPrescribers = createSelector(
     const [lastName, firstName] = searchTerm.split(',').map(name => name.trim());
 
     const queryString = 'lastName BEGINSWITH[c] $0 AND firstName BEGINSWITH[c] $1';
-    const newData = UIDatabase.objects('Prescriber').filtered(queryString, lastName, firstName);
+    const newData = UIDatabase.objects('Prescriber').filtered(
+      queryString,
+      lastName ?? '',
+      firstName ?? ''
+    );
 
     return newData;
   }


### PR DESCRIPTION
Fixes #3972 

## Change summary

- Default to empty string if no first or last name provided when searching for prescribers (was undefined when going from patient -> prescriber selection. (Maybe making it not undefined is a better fix?)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Repro #3972 and check for no RSOD

### Related areas to think about
- Other areas where prescribers are searchable (checked prescriber lookup)
