### PR TITLE
add created date

### DIFF
--- a/src/actions/Entities/NameActions.js
+++ b/src/actions/Entities/NameActions.js
@@ -1,6 +1,7 @@
 import { generateUUID } from 'react-native-database';
 import { batch } from 'react-redux';
 import { ToastAndroid } from 'react-native';
+import moment from 'moment';
 import { selectEditingName } from '../../selectors/Entities/name';
 import { createRecord, UIDatabase } from '../../database';
 import { createPatientVisibility } from '../../sync/lookupApiUtils';
@@ -28,6 +29,7 @@ export const createDefaultName = (type = 'patient', id) => ({
   name: '',
   type,
   isEditable: true,
+  createdDate: moment().format(),
 });
 
 const create = name => ({

--- a/src/actions/PatientActions.js
+++ b/src/actions/PatientActions.js
@@ -21,11 +21,13 @@ export const PATIENT_ACTIONS = {
   NEW_ADR: 'Patient/newADR',
   SAVE_ADR: 'Patient/saveADR',
   CANCEL_ADR: 'Patient/cancelADR',
+  REFRESH: 'Patient/refresh',
 };
 
 const closeModal = () => ({ type: PATIENT_ACTIONS.COMPLETE });
 const createPatient = patient => ({ type: PATIENT_ACTIONS.PATIENT_CREATION, payload: { patient } });
 const editPatient = patient => ({ type: PATIENT_ACTIONS.PATIENT_EDIT, payload: { patient } });
+const refresh = () => ({ type: PATIENT_ACTIONS.REFRESH });
 
 const makePatientVisibility = async name => {
   const response = await createPatientVisibility(name);
@@ -52,6 +54,7 @@ const patientUpdate = patientDetails => async (dispatch, getState) => {
     female: currentFemale,
     ethnicity: currentEthnicity,
     nationality: currentNationality,
+    createdDate,
   } = currentPatient ?? {};
 
   const {
@@ -122,6 +125,7 @@ const patientUpdate = patientDetails => async (dispatch, getState) => {
     isActive,
     ethnicity,
     nationality,
+    createdDate,
   };
 
   UIDatabase.write(() => createRecord(UIDatabase, 'Patient', patientRecord));
@@ -174,4 +178,5 @@ export const PatientActions = {
   viewPatientHistory,
   closePatientHistory,
   makePatientVisibility,
+  refresh,
 };

--- a/src/actions/PatientActions.js
+++ b/src/actions/PatientActions.js
@@ -134,6 +134,7 @@ const patientUpdate = patientDetails => async (dispatch, getState) => {
     dispatch(closeModal());
     dispatch(DispensaryActions.closeLookupModal());
     dispatch(DispensaryActions.refresh());
+    dispatch(PatientActions.refresh());
   });
 };
 

--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -165,6 +165,7 @@ export class Name extends Realm.Object {
       ethnicity: this.ethnicity?.toJSON(),
       nameNotes: this.nameNotes?.map(nameNote => nameNote.toObject()),
       isEditable: this.isEditable,
+      createdDate: this.createdDate?.getTime(),
     };
   }
 }
@@ -201,6 +202,7 @@ Name.schema = {
     occupation: { type: 'Occupation', optional: true },
     ethnicity: { type: 'Ethnicity', optional: true },
     nameNotes: { type: 'linkingObjects', objectType: 'NameNote', property: 'name' },
+    createdDate: { type: 'date', optional: true },
   },
 };
 

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -257,7 +257,7 @@ export const schema = {
     VaccineVialMonitorStatus,
     VaccineVialMonitorStatusLog,
   ],
-  schemaVersion: 22,
+  schemaVersion: 24,
 };
 
 export default schema;

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -257,7 +257,7 @@ export const schema = {
     VaccineVialMonitorStatus,
     VaccineVialMonitorStatusLog,
   ],
-  schemaVersion: 24,
+  schemaVersion: 23,
 };
 
 export default schema;

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -246,8 +246,8 @@ const createPatient = (database, patientDetails) => {
     nationality,
     ethnicity,
     nameNotes,
+    createdDate,
   } = patientDetails;
-
   const id = patientId ?? generateUUID();
   const code = patientCode || getPatientUniqueCode(database);
   const firstName = patientFirstName ?? '';
@@ -305,6 +305,7 @@ const createPatient = (database, patientDetails) => {
     isVisible,
     nationality,
     ethnicity,
+    createdDate,
   });
 
   nameNotes?.forEach(nameNote => createNameNote(database, nameNote));

--- a/src/reducers/PatientReducer.js
+++ b/src/reducers/PatientReducer.js
@@ -76,6 +76,10 @@ export const PatientReducer = (state = patientInitialState(), action) => {
       return { ...state, currentPatient: null, creatingADR: false };
     }
 
+    case PATIENT_ACTIONS.REFRESH: {
+      return { ...patientInitialState() };
+    }
+
     default: {
       return state;
     }

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -598,6 +598,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         nationality: database.getOrCreate('Nationality', record.nationality_ID),
         occupation: database.getOrCreate('Occupation', record.occupation_ID),
         ethnicity: database.getOrCreate('Ethnicity', record.ethnicity_ID),
+        createdDate: parseDate(record.created_date),
       };
 
       if (isPatient) internalRecord.isVisible = true;

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -79,7 +79,7 @@ const generateSyncData = (settings, recordType, record) => {
         true
       )[0];
 
-      return {
+      const nameRecord = {
         id: record.id,
         type: record.type,
         first: record.firstName,
@@ -102,6 +102,11 @@ const generateSyncData = (settings, recordType, record) => {
         occupation_ID: record.occupation?.id ?? '',
         ethnicity_ID: record.ethnicity?.id ?? '',
       };
+      if (record.createdDate) {
+        nameRecord.created_date = moment(record.createdDate).format();
+      }
+
+      return nameRecord;
     }
     case 'NumberSequence': {
       const thisStoreId = settings.get(THIS_STORE_ID);

--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/forbid-prop-types */
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { connect } from 'react-redux';
+import { batch, connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { FormControl } from '../FormControl';
 import { PageButton } from '../PageButton';
@@ -145,7 +145,11 @@ const stateToProps = state => {
 const dispatchToProps = dispatch => ({
   onSaveSurvey: () => dispatch(NameNoteActions.saveEditing()),
   onUpdateForm: (form, validator) => dispatch(NameNoteActions.updateForm(form, validator)),
-  onSave: patientDetails => dispatch(PatientActions.patientUpdate(patientDetails)),
+  onSave: patientDetails =>
+    batch(() => {
+      dispatch(PatientActions.patientUpdate(patientDetails));
+      dispatch(PatientActions.refresh());
+    }),
 });
 
 export const PatientEditModal = connect(

--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/forbid-prop-types */
 import React from 'react';
 import { View, StyleSheet } from 'react-native';
-import { batch, connect } from 'react-redux';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { FormControl } from '../FormControl';
 import { PageButton } from '../PageButton';
@@ -145,11 +145,7 @@ const stateToProps = state => {
 const dispatchToProps = dispatch => ({
   onSaveSurvey: () => dispatch(NameNoteActions.saveEditing()),
   onUpdateForm: (form, validator) => dispatch(NameNoteActions.updateForm(form, validator)),
-  onSave: patientDetails =>
-    batch(() => {
-      dispatch(PatientActions.patientUpdate(patientDetails));
-      dispatch(PatientActions.refresh());
-    }),
+  onSave: patientDetails => dispatch(PatientActions.patientUpdate(patientDetails)),
 });
 
 export const PatientEditModal = connect(


### PR DESCRIPTION
Fixes #3977 

## Change summary

Added a created date to patients created using the **Dispensing** or **Vaccinations** routes.
Checked that it doesn't mess with patients who are created locally after looking them up

There was an issue with the state of created patients. The state isn't cleared after creating through dispensing - so if you looked up a patient after previously creating one, the `createdDate` was set to today's date and the patient updated incorrectly on the server.
This has been addressed with the addition of a 'refresh' action after creation.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a patient through dispensing & sync. Should have a created date on the server
- [ ] Create a patient through vaccinations & sync. Should have a created date on the server
- [ ] Create a patient on desktop in a store other than the current mobile store, adjust the created date to something other than today; look up on tablet via dispensing and sync ( optionally after editing ) Created date on server should not change
- [ ] Create a patient on desktop in a store other than the current mobile store, adjust the created date to something other than today; look up on tablet via vaccinations and sync ( optionally after editing ) Created date on server should not change

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
