### PR TITLE
#3975 Add state resetting

### DIFF
--- a/src/reducers/PatientReducer.js
+++ b/src/reducers/PatientReducer.js
@@ -32,13 +32,27 @@ export const PatientReducer = (state = patientInitialState(), action) => {
     case PATIENT_ACTIONS.PATIENT_EDIT: {
       const { payload } = action;
       const { patient } = payload;
-      return { ...state, isEditing: true, currentPatient: patient };
+      return {
+        ...state,
+        isEditing: true,
+        currentPatient: patient,
+        isCreating: false,
+        creatingADR: false,
+        viewingHistory: false,
+      };
     }
 
     case PATIENT_ACTIONS.PATIENT_CREATION: {
       const { payload } = action;
       const { patient } = payload;
-      return { ...state, currentPatient: patient, isCreating: true };
+      return {
+        ...state,
+        currentPatient: patient,
+        isCreating: true,
+        isEditing: false,
+        creatingADR: false,
+        viewingHistory: false,
+      };
     }
 
     case PATIENT_ACTIONS.COMPLETE: {
@@ -57,18 +71,34 @@ export const PatientReducer = (state = patientInitialState(), action) => {
     case PATIENT_ACTIONS.VIEW_HISTORY: {
       const { payload } = action;
       const { patient } = payload;
+
       return { ...state, currentPatient: patient, viewingHistory: true };
     }
 
     case PATIENT_ACTIONS.CLOSE_HISTORY: {
-      return { ...state, currentPatient: null, viewingHistory: false };
+      return {
+        ...state,
+        currentPatient: null,
+        viewingHistory: false,
+        isEditing: false,
+        isCreating: false,
+        creatingADR: false,
+      };
     }
 
     case PATIENT_ACTIONS.NEW_ADR: {
       const { payload } = action;
       const { patient } = payload;
 
-      return { ...state, isADRModalOpen: true, currentPatient: patient, creatingADR: true };
+      return {
+        ...state,
+        isADRModalOpen: true,
+        currentPatient: patient,
+        creatingADR: true,
+        viewingHistory: false,
+        isEditing: false,
+        isCreating: false,
+      };
     }
 
     case PATIENT_ACTIONS.SAVE_ADR:


### PR DESCRIPTION
Fixes #3975 

## Change summary

- As per the issue, you can get an error state for this reducer if you click history then really quickly open the ADR modal, then close the ADR modal. This fixes that

## Testing

- [ ] Click history then really quickly open the ADR modal, then close the ADR modal-  app doesn't crash

### Related areas to think about

Someone actually did this in prod!
