### PR TITLE
Add casting of created date

### DIFF
--- a/src/actions/Entities/NameActions.js
+++ b/src/actions/Entities/NameActions.js
@@ -98,7 +98,11 @@ const sort = sortKey => ({ type: NAME_ACTIONS.SORT, payload: { sortKey } });
 
 const saveEditing = () => (dispatch, getState) => {
   const currentPatient = selectEditingName(getState());
-  const patientRecord = { ...currentPatient, dateOfBirth: new Date(currentPatient.dateOfBirth) };
+  const patientRecord = {
+    ...currentPatient,
+    dateOfBirth: new Date(currentPatient.dateOfBirth),
+    createdDate: new Date(currentPatient?.createdDate),
+  };
 
   UIDatabase.write(() => createRecord(UIDatabase, 'Patient', patientRecord));
   dispatch(reset());


### PR DESCRIPTION
Fixes #3992

## Change summary

- Casts `createdDate`

## Testing

- [ ] Create a patient in `dispensing`, then create a vaccine prescription, the prescription is created

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
