### PR TITLE
update created date

### DIFF
--- a/src/actions/Entities/NameActions.js
+++ b/src/actions/Entities/NameActions.js
@@ -98,11 +98,9 @@ const sort = sortKey => ({ type: NAME_ACTIONS.SORT, payload: { sortKey } });
 
 const saveEditing = () => (dispatch, getState) => {
   const currentPatient = selectEditingName(getState());
-  const patientRecord = {
-    ...currentPatient,
-    dateOfBirth: new Date(currentPatient.dateOfBirth),
-    createdDate: new Date(currentPatient?.createdDate),
-  };
+  const createdDate = currentPatient?.createdDate ? new Date(currentPatient.createdDate) : null;
+  const dateOfBirth = new Date(currentPatient.dateOfBirth);
+  const patientRecord = { ...currentPatient, dateOfBirth, createdDate };
 
   UIDatabase.write(() => createRecord(UIDatabase, 'Patient', patientRecord));
   dispatch(reset());


### PR DESCRIPTION
Fixes #3996 

## Change summary

When createdDate is null, which happens for looked-up patients, the `Date` created is `Invalid Date` which throws an error during `saveEditing`

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Look up a patient and vaccinate

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
