### PR TITLE
#4010 Add check for dosesPerVial before setting newNumberOfPacks to 0

### DIFF
--- a/src/database/DataTypes/ItemBatch.js
+++ b/src/database/DataTypes/ItemBatch.js
@@ -110,7 +110,11 @@ export class ItemBatch extends Realm.Object {
       throw new Error('Cannot set a negative item batch quantity');
     }
     let newNumberOfPacks = this.packSize ? quantity / this.packSize : 0;
-    if (newNumberOfPacks < 1 / this.dosesPerVial) newNumberOfPacks = 0;
+
+    if (this.dosesPerVial && newNumberOfPacks < 1 / this.dosesPerVial) {
+      newNumberOfPacks = 0;
+    }
+
     this.numberOfPacks = newNumberOfPacks;
   }
 


### PR DESCRIPTION
Fixes #4010 

## Change summary

- Just checks that dosesPerVial exists before setting newNumberOfPacks to 0

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Follow steps in #4010, should be able to see stock quantities update

### Related areas to think about
Targetted `master` just because that's where I found it and thought it would be pretty annoying behaviour people might want fixed, can retarget `develop` if preferred for 8.1.0 (but that might be a while away?)