### PR TITLE
#4026 Workaround RN password input text style

### DIFF
--- a/src/pages/FirstUsePage.js
+++ b/src/pages/FirstUsePage.js
@@ -17,6 +17,7 @@ import { getAppVersion } from '../settings';
 import { DemoUserModal } from '../widgets/modals';
 
 import globalStyles, { SUSSOL_ORANGE, WARM_GREY } from '../globalStyles';
+import { APP_FONT_FAMILY } from '../globalStyles/fonts';
 
 const STATUSES = {
   UNINITIALISED: 'uninitialised',
@@ -179,7 +180,8 @@ export class FirstUsePageComponent extends React.Component {
           <View style={globalStyles.horizontalContainer}>
             <TextInput
               ref={reference => {
-                this.passwordInputRef = reference;
+                this.passwordInputRef =
+                  reference && reference.setNativeProps({ style: { fontFamily: APP_FONT_FAMILY } });
               }}
               style={globalStyles.authFormTextInputStyle}
               autoCompleteType="password"

--- a/src/pages/FirstUsePage.js
+++ b/src/pages/FirstUsePage.js
@@ -17,7 +17,7 @@ import { getAppVersion } from '../settings';
 import { DemoUserModal } from '../widgets/modals';
 
 import globalStyles, { SUSSOL_ORANGE, WARM_GREY } from '../globalStyles';
-import { APP_FONT_FAMILY } from '../globalStyles/fonts';
+import { FormPasswordInput } from '../widgets/FormInputs/FormPasswordInput';
 
 const STATUSES = {
   UNINITIALISED: 'uninitialised',
@@ -178,26 +178,15 @@ export class FirstUsePageComponent extends React.Component {
             />
           </View>
           <View style={globalStyles.horizontalContainer}>
-            <TextInput
-              ref={reference => {
-                this.passwordInputRef =
-                  reference && reference.setNativeProps({ style: { fontFamily: APP_FONT_FAMILY } });
-              }}
-              style={globalStyles.authFormTextInputStyle}
-              autoCompleteType="password"
-              placeholder="Sync Site Password"
-              placeholderTextColor={SUSSOL_ORANGE}
-              underlineColorAndroid={SUSSOL_ORANGE}
+            <FormPasswordInput
               value={syncSitePassword}
-              secureTextEntry
               editable={status !== STATUSES.INITIALISING}
-              returnKeyType="done"
-              selectTextOnFocus
               onChangeText={this.onChangePassword}
               onSubmitEditing={() => {
                 if (this.passwordInputRef) this.passwordInputRef.blur();
                 if (this.canAttemptLogin) this.onPressConnect();
               }}
+              placeholder="Sync Site Password"
             />
           </View>
           <SyncState style={localStyles.initialisationStateIcon} showText={false} />

--- a/src/widgets/FormInputs/FormPasswordInput.js
+++ b/src/widgets/FormInputs/FormPasswordInput.js
@@ -1,0 +1,72 @@
+/* eslint-disable react/forbid-prop-types */
+/* eslint-disable react/require-default-props */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2021
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TextInput, StyleSheet } from 'react-native';
+
+import globalStyles, { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../../globalStyles/index';
+import { authStrings } from '../../localization/index';
+
+export const FormPasswordInput = ({
+  isEditable,
+  onChangeText,
+  onSubmitEditing,
+  passwordTextStyle,
+  placeholder,
+  placeholderTextColor,
+  returnKeyType,
+  style,
+  underlineColorAndroid,
+  value,
+}) => (
+  // Workaround for Bug in RN 0.64 updating secureTextEntry TextInput style to some kind of
+  // monospaced default
+  <TextInput
+    autoCompleteType="password"
+    editable={isEditable}
+    onChangeText={onChangeText}
+    onSubmitEditing={onSubmitEditing}
+    placeholder={placeholder}
+    placeholderTextColor={placeholderTextColor}
+    ref={reference => reference && reference.setNativeProps({ style: passwordTextStyle })}
+    returnKeyType={returnKeyType}
+    style={style}
+    underlineColorAndroid={underlineColorAndroid}
+    value={value}
+    secureTextEntry
+    selectTextOnFocus
+  />
+);
+
+const localStyles = StyleSheet.create({
+  textStyle: { fontFamily: APP_FONT_FAMILY },
+});
+
+FormPasswordInput.defaultProps = {
+  isEditable: true,
+  placeholder: authStrings.password,
+  placeholderTextColor: SUSSOL_ORANGE,
+  passwordTextStyle: localStyles.textStyle,
+  returnKeyType: 'done',
+  style: globalStyles.authFormTextInputStyle,
+  underlineColorAndroid: SUSSOL_ORANGE,
+  value: '',
+};
+
+FormPasswordInput.propTypes = {
+  isEditable: PropTypes.bool,
+  onChangeText: PropTypes.func,
+  onSubmitEditing: PropTypes.func,
+  passwordTextStyle: PropTypes.object,
+  placeholder: PropTypes.string,
+  placeholderTextColor: PropTypes.string,
+  returnKeyType: PropTypes.string,
+  style: PropTypes.object,
+  underlineColorAndroid: PropTypes.string,
+  value: PropTypes.string,
+};

--- a/src/widgets/modals/DemoUserModal.js
+++ b/src/widgets/modals/DemoUserModal.js
@@ -18,6 +18,7 @@ import { authStrings, generalStrings, demoUserModalStrings } from '../../localiz
 
 import globalStyles, { SUSSOL_ORANGE, GREY, WARM_GREY } from '../../globalStyles';
 import { ModalContainer } from './ModalContainer';
+import { APP_FONT_FAMILY } from '../../globalStyles/fonts';
 
 const STATUS = {
   SUBMIT: 'submit',
@@ -179,6 +180,9 @@ export class DemoUserModal extends React.Component {
             </View>
             <View style={globalStyles.horizontalContainer}>
               <TextInput
+                ref={reference =>
+                  reference && reference.setNativeProps({ style: { fontFamily: APP_FONT_FAMILY } })
+                }
                 style={globalStyles.authFormTextInputStyle}
                 placeholder={authStrings.password}
                 placeholderTextColor={SUSSOL_ORANGE}
@@ -193,6 +197,9 @@ export class DemoUserModal extends React.Component {
             </View>
             <View style={globalStyles.horizontalContainer}>
               <TextInput
+                ref={reference =>
+                  reference && reference.setNativeProps({ style: { fontFamily: APP_FONT_FAMILY } })
+                }
                 style={globalStyles.authFormTextInputStyle}
                 placeholder={authStrings.repeat_password}
                 placeholderTextColor={SUSSOL_ORANGE}

--- a/src/widgets/modals/DemoUserModal.js
+++ b/src/widgets/modals/DemoUserModal.js
@@ -19,6 +19,7 @@ import { authStrings, generalStrings, demoUserModalStrings } from '../../localiz
 import globalStyles, { SUSSOL_ORANGE, GREY, WARM_GREY } from '../../globalStyles';
 import { ModalContainer } from './ModalContainer';
 import { APP_FONT_FAMILY } from '../../globalStyles/fonts';
+import { FormPasswordInput } from '../FormInputs/FormPasswordInput';
 
 const STATUS = {
   SUBMIT: 'submit',
@@ -179,38 +180,21 @@ export class DemoUserModal extends React.Component {
               />
             </View>
             <View style={globalStyles.horizontalContainer}>
-              <TextInput
-                ref={reference =>
-                  reference && reference.setNativeProps({ style: { fontFamily: APP_FONT_FAMILY } })
-                }
-                style={globalStyles.authFormTextInputStyle}
-                placeholder={authStrings.password}
-                placeholderTextColor={SUSSOL_ORANGE}
-                underlineColorAndroid={SUSSOL_ORANGE}
+              <FormPasswordInput
                 value={password}
-                secureTextEntry
                 editable={status !== STATUS.SUBMITTING}
-                returnKeyType="next"
-                selectTextOnFocus
                 onChangeText={this.handleOnChangePassword}
+                returnKeyType="next"
               />
             </View>
             <View style={globalStyles.horizontalContainer}>
-              <TextInput
-                ref={reference =>
-                  reference && reference.setNativeProps({ style: { fontFamily: APP_FONT_FAMILY } })
-                }
-                style={globalStyles.authFormTextInputStyle}
-                placeholder={authStrings.repeat_password}
-                placeholderTextColor={SUSSOL_ORANGE}
-                underlineColorAndroid={SUSSOL_ORANGE}
+              <FormPasswordInput
                 value={repeatPassword}
-                secureTextEntry
                 editable={status !== STATUS.SUBMITTING}
-                returnKeyType="next"
-                selectTextOnFocus
                 onChangeText={this.handleOnChangeRepeatPassword}
                 onSubmitEditing={this.onDemoRequestSubmit}
+                placeholder={authStrings.repeat_password}
+                returnKeyType="next"
               />
             </View>
             <View style={globalStyles.authFormButtonContainer}>

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -23,6 +23,7 @@ import { getModalTitle, MODAL_KEYS } from '../../utilities';
 import { setCurrencyLocalisation } from '../../localization/currency';
 import { setDateLocale } from '../../localization/utilities';
 import { UIDatabase } from '../../database';
+import { APP_FONT_FAMILY } from '../../globalStyles/fonts';
 
 const AUTH_STATUSES = {
   UNAUTHENTICATED: 'unauthenticated',
@@ -194,6 +195,9 @@ export class LoginModal extends React.Component {
               <TextInput
                 ref={reference => {
                   this.passwordInputRef = reference;
+                  this.passwordInputRef =
+                    reference &&
+                    reference.setNativeProps({ style: { fontFamily: APP_FONT_FAMILY } });
                 }}
                 style={globalStyles.authFormTextInputStyle}
                 autoCompleteType="password"

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -23,7 +23,7 @@ import { getModalTitle, MODAL_KEYS } from '../../utilities';
 import { setCurrencyLocalisation } from '../../localization/currency';
 import { setDateLocale } from '../../localization/utilities';
 import { UIDatabase } from '../../database';
-import { APP_FONT_FAMILY } from '../../globalStyles/fonts';
+import { FormPasswordInput } from '../FormInputs/FormPasswordInput';
 
 const AUTH_STATUSES = {
   UNAUTHENTICATED: 'unauthenticated',
@@ -192,22 +192,10 @@ export class LoginModal extends React.Component {
               />
             </View>
             <View style={globalStyles.horizontalContainer}>
-              <TextInput
-                ref={reference => {
-                  this.passwordInputRef =
-                    reference &&
-                    reference.setNativeProps({ style: { fontFamily: APP_FONT_FAMILY } });
-                }}
-                style={globalStyles.authFormTextInputStyle}
-                autoCompleteType="password"
-                placeholder={authStrings.password}
-                placeholderTextColor={SUSSOL_ORANGE}
-                underlineColorAndroid={SUSSOL_ORANGE}
+              <FormPasswordInput
+                ref={this.passwordInputRef}
                 value={password}
-                secureTextEntry
                 editable={authStatus !== AUTH_STATUSES.AUTHENTICATING}
-                returnKeyType="done"
-                selectTextOnFocus
                 onChangeText={text => {
                   this.setState({ password: text, authStatus: AUTH_STATUSES.UNAUTHENTICATED });
                 }}

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -194,7 +194,6 @@ export class LoginModal extends React.Component {
             <View style={globalStyles.horizontalContainer}>
               <TextInput
                 ref={reference => {
-                  this.passwordInputRef = reference;
                   this.passwordInputRef =
                     reference &&
                     reference.setNativeProps({ style: { fontFamily: APP_FONT_FAMILY } });


### PR DESCRIPTION
Fixes #4026 

## Change summary

- Workaround to update `secureTextEntry` input field styles for consistency with other input fields

## Testing

Steps to reproduce or otherwise test the changes of this PR:

Check that the font for password fields looks consistent with other text input fields on the following pages:
- [ ] First-time tablet set up (entering sync site details)
- [ ] Regular login
- [ ] Request demo store
- [ ] Changing sync password (this one still has the weird style but think it doesn't look as bad since there's no other input fields to compare it to?)
![image](https://user-images.githubusercontent.com/65875762/117591264-d0fee880-b187-11eb-963b-d12c109005f0.png)

### Related areas to think about
- If RN fixes this, we might want to get rid of this stuff since it's a bit confusing?