### PR TITLE
#426 incorrect version number on install/update

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@
   "globals": {
     "fetch": false
   },
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "plugins": ["prettier"],
   "rules": {
     "arrow-body-style": ["error", "as-needed"],

--- a/package.json
+++ b/package.json
@@ -115,8 +115,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",
+    "@babel/eslint-parser": "^7.14.2",
     "@babel/runtime": "^7.14.0",
-    "babel-eslint": "^10.1.0",
     "babel-preset-react-native": "^4.0.1",
     "eslint": "^7.25",
     "eslint-config-airbnb": "^18.0.1",

--- a/src/pages/FirstUsePage.js
+++ b/src/pages/FirstUsePage.js
@@ -13,8 +13,8 @@ import { Button } from 'react-native-ui-components';
 import { Synchroniser } from '../sync';
 
 import { SyncState } from '../widgets';
-import { getAppVersion } from '../settings';
 import { DemoUserModal } from '../widgets/modals';
+import packageJson from '../../package.json';
 
 import globalStyles, { SUSSOL_ORANGE, WARM_GREY } from '../globalStyles';
 import { FormPasswordInput } from '../widgets/FormInputs/FormPasswordInput';
@@ -30,14 +30,13 @@ export class FirstUsePageComponent extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      appVersion: '',
       serverURL: '',
       syncSiteName: '',
       syncSitePassword: '',
       status: STATUSES.UNINITIALISED,
       isDemoUserModalOpen: false,
     };
-    this.setAppVersion();
+    this.appVersion = packageJson.version;
     this.siteNameInputRef = null;
     this.passwordInputRef = null;
     this.onPressConnect = this.onPressConnect.bind(this);
@@ -56,11 +55,6 @@ export class FirstUsePageComponent extends React.Component {
     } catch (error) {
       this.setState({ status: STATUSES.ERROR });
     }
-  }
-
-  async setAppVersion() {
-    const appVersion = await getAppVersion();
-    this.setState({ appVersion });
   }
 
   get canAttemptLogin() {
@@ -114,14 +108,7 @@ export class FirstUsePageComponent extends React.Component {
   handleDemoModalClose = () => this.setState({ isDemoUserModalOpen: false });
 
   render() {
-    const {
-      appVersion,
-      isDemoUserModalOpen,
-      serverURL,
-      status,
-      syncSiteName,
-      syncSitePassword,
-    } = this.state;
+    const { isDemoUserModalOpen, serverURL, status, syncSiteName, syncSitePassword } = this.state;
 
     return (
       <View style={[globalStyles.verticalContainer, localStyles.verticalContainer]}>
@@ -213,7 +200,7 @@ export class FirstUsePageComponent extends React.Component {
             />
           </View>
         </View>
-        <Text style={globalStyles.authWindowButtonText}> v{appVersion}</Text>
+        <Text style={globalStyles.authWindowButtonText}> v{this.appVersion}</Text>
         <DemoUserModal isOpen={isDemoUserModalOpen} onClose={this.handleDemoModalClose} />
       </View>
     );

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,4 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { MILLISECONDS } from '../utilities/constants';
 
 export const SETTINGS_KEYS = {
@@ -26,9 +25,4 @@ export const SETTINGS_KEYS = {
 export const SETTINGS_DEFAULTS = {
   [SETTINGS_KEYS.SYNC_INTERVAL]: String(MILLISECONDS.TEN_MINUTES),
   [SETTINGS_KEYS.IDLE_LOGOUT_INTERVAL]: String(MILLISECONDS.THREE_MINUTES),
-};
-
-export const getAppVersion = async () => {
-  const appVersion = await AsyncStorage.getItem(SETTINGS_KEYS.APP_VERSION);
-  return appVersion;
 };

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import { Image, Text, TextInput, View } from 'react-native';
 import { Button } from 'react-native-ui-components';
 
-import { SETTINGS_KEYS, getAppVersion } from '../../settings';
+import { SETTINGS_KEYS } from '../../settings';
 
 import globalStyles, { WHITE, SUSSOL_ORANGE, WARM_GREY } from '../../globalStyles';
 import { Flag, IconButton } from '..';
@@ -23,6 +23,7 @@ import { getModalTitle, MODAL_KEYS } from '../../utilities';
 import { setCurrencyLocalisation } from '../../localization/currency';
 import { setDateLocale } from '../../localization/utilities';
 import { UIDatabase } from '../../database';
+import packageJson from '../../../package.json';
 import { FormPasswordInput } from '../FormInputs/FormPasswordInput';
 
 const AUTH_STATUSES = {
@@ -42,9 +43,8 @@ export class LoginModal extends React.Component {
       username: username || '',
       password: '',
       isLanguageModalOpen: false,
-      appVersion: '',
     };
-    this.setAppVersion();
+    this.appVersion = packageJson.version;
     this.passwordInputRef = null;
     this.errorTimeoutId = null;
   }
@@ -95,11 +95,6 @@ export class LoginModal extends React.Component {
     }
   };
 
-  async setAppVersion() {
-    const appVersion = await getAppVersion();
-    this.setState({ appVersion });
-  }
-
   get canAttemptLogin() {
     const { authStatus, username, password } = this.state;
 
@@ -138,7 +133,7 @@ export class LoginModal extends React.Component {
 
   render() {
     const { isAuthenticated, settings } = this.props;
-    const { authStatus, username, password, appVersion, isLanguageModalOpen } = this.state;
+    const { authStatus, username, password, isLanguageModalOpen } = this.state;
     const storeName = UIDatabase.objects('Name').filtered(
       'id == $0',
       settings.get(SETTINGS_KEYS.THIS_STORE_NAME_ID)
@@ -225,7 +220,7 @@ export class LoginModal extends React.Component {
               this.setState({ isLanguageModalOpen: true });
             }}
           />
-          <Text style={globalStyles.authWindowButtonText}>v{appVersion}</Text>
+          <Text style={globalStyles.authWindowButtonText}>v{this.appVersion}</Text>
         </View>
         <ModalContainer
           isVisible={isLanguageModalOpen}

--- a/yarn.lock
+++ b/yarn.lock
@@ -89,6 +89,15 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
+"@babel/eslint-parser@^7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.14.2.tgz#aa6fe7b76378397d643f14dfa8bf920cb6fbddab"
+  integrity sha512-g1YXHASb84MvEkReG/nZ74emTPAMjip1Ey6azZqKTEWidpgEzPGl/uoc6IPJjaMGw424u40sNm1V70tuYOQmeA==
+  dependencies:
+    eslint-scope "^5.1.0"
+    eslint-visitor-keys "^2.1.0"
+    semver "^6.3.0"
+
 "@babel/generator@^7.12.10":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.11.tgz#98a7df7b8c358c9a37ab07a24056853016aba3af"
@@ -370,7 +379,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.7.0":
+"@babel/parser@^7.0.0":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.7.tgz#fee7b39fe809d0e73e5b25eecaf5780ef3d73056"
   integrity sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==
@@ -905,7 +914,7 @@
     "@babel/parser" "^7.12.7"
     "@babel/types" "^7.12.7"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.7.0":
+"@babel/traverse@^7.0.0":
   version "7.12.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.9.tgz#fad26c972eabbc11350e0b695978de6cc8e8596f"
   integrity sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==
@@ -977,7 +986,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.7.0":
+"@babel/types@^7.0.0":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.7.tgz#6039ff1e242640a29452c9ae572162ec9a8f5d13"
   integrity sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==
@@ -2263,18 +2272,6 @@ babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
   integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
-
-babel-eslint@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
-  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.7.0"
-    "@babel/traverse" "^7.7.0"
-    "@babel/types" "^7.7.0"
-    eslint-visitor-keys "^1.0.0"
-    resolve "^1.12.0"
 
 babel-generator@^6.26.0:
   version "6.26.1"
@@ -4440,7 +4437,7 @@ eslint-plugin-react@^7.23.2:
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.4"
 
-eslint-scope@^5.1.1:
+eslint-scope@^5.1.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -4455,7 +4452,7 @@ eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -4464,6 +4461,11 @@ eslint-visitor-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
+eslint-visitor-keys@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint@^7.25:
   version "7.25.0"
@@ -8961,7 +8963,7 @@ resolve@^1.1.6, resolve@^1.14.2:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1:
+resolve@^1.10.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==


### PR DESCRIPTION
Fixes #426 

## Change summary

- In `FirstUsePage` and `LoginModal` read the version from `package.json` rather than trying to access `AsyncStorage`, which doesn't get updated in time when an app is freshly installed to a device.
- Removed `getAppVersion()` from `settings/index.js` as it wasn't used anywhere else (contemplated moving the `package.json` reading to a separate helper under utilities but it's like 1 line so seems redundant?)
- Offroad, migrated a deprecated package `babel-eslint` to `@babel/eslint-parser` as I kept running into the same issue as this guy https://github.com/eslint/eslint/issues/13542 on `FirstLoginPage` when the pre-commit hook runs... as a sidenote, saw a bunch of linting errors running `eslint src` but left them to try not to explode the PR.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] See https://github.com/openmsupply/mobile/issues/426 

### Related areas to think about
Not sure...