### PR TITLE
#3925 Update date parser

### DIFF
--- a/src/database/utilities/parsers.js
+++ b/src/database/utilities/parsers.js
@@ -24,7 +24,7 @@ export const parseDate = (ISODate, ISOTime) => {
     ISODate === '0000-00-00T00:00:00' ||
     ISODate === '0000-00-00T00:00:00Z'
   ) {
-    return null;
+    return undefined;
   }
   const date = new Date(ISODate);
   if (ISOTime && ISOTime.length >= 6) {


### PR DESCRIPTION
Fixes #3925

## Change summary

Tested out the proposed solution for #3925 🤣 . Things seem to work as expected.

Record created after syncing requisition with `date_order_received` of 00/00/00:
![image](https://user-images.githubusercontent.com/65875762/118755137-74ed4000-b8bc-11eb-893b-3fdb6d05eec4.png)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Reproduce #3925 with PR and hopefully don't see error

### Related areas to think about
Not sure
