### PR TITLE
update logs to save & connectAndDiscover

### DIFF
--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -124,7 +124,7 @@ const downloadLogsFromSensor = sensor => async dispatch => {
             const temperatureLogs = await TemperatureLogManager().createLogs(
               downloadedLogsResult,
               sensor,
-              numberOfLogsToSave,
+              Math.min(numberOfLogsToSave, downloadedLogsResult.length),
               nextTimestamp.unix()
             );
 

--- a/src/bluetooth/BleService.js
+++ b/src/bluetooth/BleService.js
@@ -41,7 +41,8 @@ class BleService {
    * on the device.
    * @param {String} macAddress
    */
-  connectToDevice = async macAddress => this.manager.connectToDevice(macAddress);
+  connectToDevice = async (macAddress, options) =>
+    this.manager.connectToDevice(macAddress, options);
 
   /**
    * Connects to a device with the provided macAddress as well as discovering

--- a/src/bluetooth/BleService.js
+++ b/src/bluetooth/BleService.js
@@ -52,11 +52,16 @@ class BleService {
    * @param {String} macAddress
    */
   connectAndDiscoverServices = async macAddress => {
-    if (!(await this.manager.isDeviceConnected(macAddress))) {
-      await this.connectToDevice(macAddress);
+    // without the cancel & reconnect further commands
+    // were sometimes returning an error: "BleError: Device [mac address] was disconnected"
+    if (await this.manager.isDeviceConnected(macAddress)) {
+      await this.manager.cancelDeviceConnection(macAddress);
     }
 
-    return this.manager.discoverAllServicesAndCharacteristicsForDevice(macAddress);
+    const device = await this.connectToDevice(macAddress, { autoConnect: true });
+    await this.manager.discoverAllServicesAndCharacteristicsForDevice(macAddress);
+
+    return device;
   };
 
   /**


### PR DESCRIPTION
Fixes #4045 #4055 

## Change summary

Disconnect and reconnect code from the cold chain app, which seems to resolve the problem with a ` BleError: Device MA:CA:DD:RE:SS was disconnected` error being thrown quietly, which was preventing logs from being downloaed.

Have included the fix ( from @joshxg :) )for #4045 too.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Download some logs; turn off the tablet for a while. turn on and hopefully, get some more logs.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
