### PR TITLE
#2795 supplier credits 0 stock misleading

### DIFF
--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -40,6 +40,7 @@
     "start_typing_to_select_customer": "Start typing to select customer",
     "start_typing_to_select_supplier": "Start typing to select supplier",
     "start_typing_to_select_master_list": "Start typing to select master list",
+    "stock_no_batches": "No batches with stock",
     "stock_quantity_greater_then_zero": "Stock quantity must be greater then zero before finalising",
     "stocktake_no_counted_items": "Can't finalise a stocktake with no counted items",
     "stocktake_invalid_stock": "Stock on hand for these item(s) have changed since this stocktake was last opened (through customer invoice, supplier invoice or another stocktake), both \"Snapshot Quantity\" and \"Actual Quantity\" will be reset",

--- a/src/widgets/modalChildren/SupplierCredit.js
+++ b/src/widgets/modalChildren/SupplierCredit.js
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { View } from 'react-native';
+import { View, Text } from 'react-native';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -27,6 +27,8 @@ import { modalStrings, dispensingStrings } from '../../localization';
 import { DropDown } from '../DropDown';
 import { selectUsingSupplierCreditCategories } from '../../selectors/modules';
 import { UIDatabase } from '../../database/index';
+import { APP_FONT_FAMILY } from '../../globalStyles/fonts';
+import { BLACK } from '../../globalStyles/colors';
 
 const SupplierCreditComponent = ({
   onSortColumn,
@@ -78,26 +80,45 @@ const SupplierCreditComponent = ({
     [columns]
   );
 
+  const dataTableVisible = batches.length;
+  const supplierCreditCategoryVisible = dataTableVisible && usingSupplierCreditCategories;
+
   return (
     <View style={localStyles.mainContainer}>
-      {usingSupplierCreditCategories && (
+      {supplierCreditCategoryVisible ? (
         <DropDown
           headerValue={dispensingStrings.select_a_supplier_credit_category}
           values={categoryNames}
           selectedValue={categoryName}
           onValueChange={onSelectCategory}
         />
+      ) : (
+        <></>
       )}
-      <DataTable
-        renderRow={renderRow}
-        data={batches}
-        renderHeader={renderHeader}
-        keyExtractor={recordKeyExtractor}
-        getItemLayout={getItemLayout}
-        columns={columns}
-      />
+
+      {dataTableVisible ? (
+        <DataTable
+          renderRow={renderRow}
+          data={batches}
+          renderHeader={renderHeader}
+          keyExtractor={recordKeyExtractor}
+          getItemLayout={getItemLayout}
+          columns={columns}
+        />
+      ) : (
+        <View alignItems="center" flex={1}>
+          <FlexRow alignItems="center" flex={1}>
+            <Text style={localStyles.noBatchesFont}>{modalStrings.stock_no_batches}</Text>
+          </FlexRow>
+        </View>
+      )}
       <FlexRow alignItems="flex-end" justifyContent="flex-end">
-        <PageButton text={modalStrings.confirm} onPress={onSave} style={{ margin: 7 }} />
+        <PageButton
+          text={modalStrings.confirm}
+          onPress={onSave}
+          isDisabled={!dataTableVisible}
+          style={{ margin: 7 }}
+        />
       </FlexRow>
     </View>
   );
@@ -125,6 +146,11 @@ export const SupplierCredit = connect(mapStateToProps, mapDispatchToProps)(Suppl
 
 const localStyles = {
   mainContainer: { backgroundColor: WHITE, flex: 1 },
+  noBatchesFont: {
+    fontFamily: APP_FONT_FAMILY,
+    color: BLACK,
+    fontSize: 20,
+  },
 };
 
 SupplierCreditComponent.defaultProps = {

--- a/src/widgets/modalChildren/SupplierCredit.js
+++ b/src/widgets/modalChildren/SupplierCredit.js
@@ -80,7 +80,7 @@ const SupplierCreditComponent = ({
     [columns]
   );
 
-  const dataTableVisible = batches.length;
+  const dataTableVisible = !!batches.length;
   const supplierCreditCategoryVisible = dataTableVisible && usingSupplierCreditCategories;
 
   return (

--- a/src/widgets/modalChildren/SupplierCredit.js
+++ b/src/widgets/modalChildren/SupplierCredit.js
@@ -28,7 +28,7 @@ import { DropDown } from '../DropDown';
 import { selectUsingSupplierCreditCategories } from '../../selectors/modules';
 import { UIDatabase } from '../../database/index';
 import { APP_FONT_FAMILY } from '../../globalStyles/fonts';
-import { BLACK } from '../../globalStyles/colors';
+import { DARKER_GREY } from '../../globalStyles/colors';
 
 const SupplierCreditComponent = ({
   onSortColumn,
@@ -148,7 +148,7 @@ const localStyles = {
   mainContainer: { backgroundColor: WHITE, flex: 1 },
   noBatchesFont: {
     fontFamily: APP_FONT_FAMILY,
-    color: BLACK,
+    color: DARKER_GREY,
     fontSize: 20,
   },
 };


### PR DESCRIPTION
Fixes #2795 

## Change summary
- Disable confirm button, hide supplier credit dropdown and hide table on supplier credit page if no stock available
- When no stock available for return display message "No batches with stock" (as suggested in the issue by @joshxg)

![image](https://user-images.githubusercontent.com/65875762/118908653-e89f5380-b975-11eb-8382-2e91ab2fda54.png)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Try to return stock when there is 0 stock available for return

### Related areas to think about
Don't know if there's any UI convention, made the text big, black and centred? 🤷‍♀️ 
