### PR TITLE
#4055 sensor logs patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,6 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "16.13.1",
-    "react-devtools": "^3",
-    "react-devtools-core": "^4.4.0",
     "react-native": "0.63.4",
     "react-native-animatable": "^1.3.3",
     "react-native-ble-plx": "^2.0.2",
@@ -111,6 +109,7 @@
     "react-redux": "^7.2.2",
     "realm": "^10.0.1",
     "redux": "^4.0.5",
+    "redux-logger": "^3.0.6",
     "redux-persist": "^6.0.0",
     "redux-persist-error-handler": "^0.1.1",
     "redux-thunk": "^2.3.0",
@@ -134,6 +133,7 @@
     "husky": "^4.2.3",
     "lint-staged": "^10.0.8",
     "metro-react-native-babel-preset": "^0.59.0",
-    "prettier": "^2.2.1"
+    "prettier": "^2.2.1",
+    "react-devtools": "^4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "16.13.1",
+    "react-devtools": "^3",
+    "react-devtools-core": "^4.4.0",
     "react-native": "0.63.4",
     "react-native-animatable": "^1.3.3",
     "react-native-ble-plx": "^2.0.2",
@@ -109,7 +111,6 @@
     "react-redux": "^7.2.2",
     "realm": "^10.0.1",
     "redux": "^4.0.5",
-    "redux-logger": "^3.0.6",
     "redux-persist": "^6.0.0",
     "redux-persist-error-handler": "^0.1.1",
     "redux-thunk": "^2.3.0",
@@ -133,7 +134,6 @@
     "husky": "^4.2.3",
     "lint-staged": "^10.0.8",
     "metro-react-native-babel-preset": "^0.59.0",
-    "prettier": "^2.2.1",
-    "react-devtools": "^4"
+    "prettier": "^2.2.1"
   }
 }

--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -124,7 +124,7 @@ const downloadLogsFromSensor = sensor => async dispatch => {
             const temperatureLogs = await TemperatureLogManager().createLogs(
               downloadedLogsResult,
               sensor,
-              numberOfLogsToSave,
+              Math.min(numberOfLogsToSave, downloadedLogsResult.length),
               nextTimestamp.unix()
             );
 

--- a/src/bluetooth/BleService.js
+++ b/src/bluetooth/BleService.js
@@ -41,7 +41,8 @@ class BleService {
    * on the device.
    * @param {String} macAddress
    */
-  connectToDevice = async macAddress => this.manager.connectToDevice(macAddress);
+  connectToDevice = async (macAddress, options) =>
+    this.manager.connectToDevice(macAddress, options);
 
   /**
    * Connects to a device with the provided macAddress as well as discovering
@@ -52,11 +53,15 @@ class BleService {
    * @param {String} macAddress
    */
   connectAndDiscoverServices = async macAddress => {
-    if (!(await this.manager.isDeviceConnected(macAddress))) {
-      await this.connectToDevice(macAddress);
+    // without the cancel & reconnect further commands
+    // were sometimes returning an error: "BleError: Device [mac address] was disconnected"
+    if (await this.manager.isDeviceConnected(macAddress)) {
+      await this.manager.cancelDeviceConnection(macAddress);
     }
 
-    return this.manager.discoverAllServicesAndCharacteristicsForDevice(macAddress);
+    const device = await this.connectToDevice(macAddress, { autoConnect: true });
+    await this.manager.discoverAllServicesAndCharacteristicsForDevice(macAddress);
+    return device;
   };
 
   /**


### PR DESCRIPTION
Fixes #4055 ( but in master, so we can release it )

## Change summary

fixes an issue with the sensor connection that was preventing logs from downloading.

## Testing

Steps to reproduce or otherwise test the changes of this PR:
- [ ] Suggest changing the sync interval to 1 minute before you start with this
- [ ] Configure a sensor and wait for some logs to download. Close mSupply mobile (TM) and wait for several sync intervals to pass. Start mobile again and check the chart after logs have downloaded

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
