### PR TITLE
#4069 Add check for patient transactions before attempting to filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
       "git add"
     ],
     "*.js": [
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ]
   },
   "dependencies": {

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -269,6 +269,7 @@ const Dispensing = ({
         />
       </ModalContainer>
       <ModalContainer
+        // eslint-disable-next-line max-len
         title={`${dispensingStrings.patient} ${dispensingStrings.history} - ${currentPatient?.name}`}
         onClose={cancelPatientEdit}
         isVisible={patientHistoryModalOpen}
@@ -355,7 +356,10 @@ const mapStateToProps = state => {
   );
   const insuranceModalOpen = selectInsuranceModalOpen(state);
   const data = selectSortedData(state);
-  const patientHistory = patient.currentPatient ? selectSortedPatientHistory({ patient }) : [];
+  const patientHistory =
+    patient.currentPatient && patient.currentPatient.transactions
+      ? selectSortedPatientHistory({ patient })
+      : [];
 
   const [usingPatientsDataSet, usingPrescribersDataSet] = selectDataSetInUse(state);
 


### PR DESCRIPTION
Fixes #4069

## Change summary

- Add check for patient transactions before attempting to filter for history
- Not sure why eslint's `ignoreTemplateLiterals` doesn't seem to be working correctly so there's a weird comment added 🤔
- Also another offroad because of:
<img width="611" alt="Screen Shot 2021-06-02 at 11 29 06 AM" src="https://user-images.githubusercontent.com/65875762/120402248-cc4bdf80-c395-11eb-8c7e-13669ceee8fe.png">

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Attempt to repro #4069

### Related areas to think about
Not sure