### PR TITLE
remove autoconnect option

### DIFF
--- a/src/bluetooth/BleService.js
+++ b/src/bluetooth/BleService.js
@@ -57,7 +57,6 @@ class BleService {
     // Note: adding the option `{ autoConnect: true }` prevents the sensors from connecting sometimes :shrug:
     if (await this.manager.isDeviceConnected(macAddress)) {
       await this.manager.cancelDeviceConnection(macAddress);
-    } else {
     }
 
     const device = await this.connectToDevice(macAddress);

--- a/src/bluetooth/BleService.js
+++ b/src/bluetooth/BleService.js
@@ -41,8 +41,7 @@ class BleService {
    * on the device.
    * @param {String} macAddress
    */
-  connectToDevice = async (macAddress, options) =>
-    this.manager.connectToDevice(macAddress, options);
+  connectToDevice = async macAddress => this.manager.connectToDevice(macAddress);
 
   /**
    * Connects to a device with the provided macAddress as well as discovering
@@ -55,11 +54,14 @@ class BleService {
   connectAndDiscoverServices = async macAddress => {
     // without the cancel & reconnect further commands
     // were sometimes returning an error: "BleError: Device [mac address] was disconnected"
+    // Note: adding the option `{ autoConnect: true }` prevents the sensors from connecting sometimes :shrug:
     if (await this.manager.isDeviceConnected(macAddress)) {
       await this.manager.cancelDeviceConnection(macAddress);
+    } else {
     }
 
-    const device = await this.connectToDevice(macAddress, { autoConnect: true });
+    const device = await this.connectToDevice(macAddress);
+
     await this.manager.discoverAllServicesAndCharacteristicsForDevice(macAddress);
     return device;
   };

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -62,7 +62,7 @@
     "E_UNKNOWN": "Error: unknown error occurred",
     "log_interval_set": "Log interval updated to {0}s",
     "E_SENSOR_SAVE": "Problem saving sensor details",
-    "E_DOWNLOAD_IN_PROGRESS": "A download is in progress, please try again soon",
+    "E_DOWNLOAD_IN_PROGRESS": "Currently downloading temperature logs, please try again soon",
     "E_INVALID_MAC_FORMAT": "Error: invalid mac address format",
     "is_paused": "PAUSED",
     "pause": "Pause",


### PR DESCRIPTION
Fixes #4075 

## Change summary

Removed the option to `autoconnect` as this was causing issues with connecting.
Targeted Master as I thought to push out to Vanuatu ( who are having an issue with sensors, possibly this one? )

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Connect to an existing sensor
- [ ] Remove and reconnect one

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
