### PR TITLE
#4068 Add barcode field to mobile schema

### DIFF
--- a/src/actions/PatientActions.js
+++ b/src/actions/PatientActions.js
@@ -41,6 +41,7 @@ const patientUpdate = patientDetails => async (dispatch, getState) => {
   const {
     id: currentPatientId,
     code: currentCode,
+    barcode: currentBarcode,
     name: currentName,
     firstName: currentFirstName,
     lastName: currentLastName,
@@ -69,6 +70,7 @@ const patientUpdate = patientDetails => async (dispatch, getState) => {
   const {
     id: patientId,
     code: patientCode,
+    barcode: patientBarcode,
     firstName: patientFirstName,
     lastName: patientLastName,
     dateOfBirth: patientDateOfBirth,
@@ -85,6 +87,7 @@ const patientUpdate = patientDetails => async (dispatch, getState) => {
 
   const id = patientId ?? currentPatientId;
   const code = patientCode ?? currentCode;
+  const barcode = patientBarcode ?? currentBarcode;
   const firstName = patientFirstName ?? currentFirstName;
   const lastName = patientLastName ?? currentLastName;
   const name = `${lastName}, ${firstName}` || currentName;
@@ -107,6 +110,7 @@ const patientUpdate = patientDetails => async (dispatch, getState) => {
   const patientRecord = {
     id,
     code,
+    barcode,
     firstName,
     lastName,
     name,

--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -12,6 +12,7 @@ import { PREFERENCE_KEYS } from '../utilities/preferenceConstants';
  *
  * @property  {string}              id
  * @property  {string}              name
+ * @property  {string}              barcode
  * @property  {string}              code
  * @property  {string}              phoneNumber
  * @property  {Address}             billingAddress
@@ -140,6 +141,7 @@ export class Name extends Realm.Object {
     return {
       id: this.id,
       name: this.name,
+      barcode: this.barcode,
       code: this.code,
       dateOfBirth: this.dateOfBirth?.getTime(),
       phoneNumber: this.phoneNumber,
@@ -176,6 +178,7 @@ Name.schema = {
   properties: {
     id: 'string',
     name: { type: 'string', default: 'placeholderName' },
+    barcode: { type: 'string', default: 'placeholderBarcode' },
     code: { type: 'string', default: 'placeholderCode' },
     dateOfBirth: { type: 'date', optional: true },
     phoneNumber: { type: 'string', optional: true },

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -257,7 +257,7 @@ export const schema = {
     VaccineVialMonitorStatus,
     VaccineVialMonitorStatusLog,
   ],
-  schemaVersion: 23,
+  schemaVersion: 24,
 };
 
 export default schema;

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -221,7 +221,7 @@ const createNameNote = (database, { id, data, patientEventID, nameID, entryDate 
 /**
  * Creates a new patient record. Patient details passed can be in the shape:
  *  {
- *    id, code, firstName, lastName, name, dateOfBirth, emailAddress, phoneNumber,
+ *    id, barcode, code, firstName, lastName, name, dateOfBirth, emailAddress, phoneNumber,
  *    billAddress1, billAddress2, billAddress3, billAddress4, billPostalZipCode,
  *    country, female, supplyingStoreId, isActive
  *  }
@@ -229,6 +229,7 @@ const createNameNote = (database, { id, data, patientEventID, nameID, entryDate 
 const createPatient = (database, patientDetails) => {
   const {
     id: patientId,
+    barcode: patientBarcode,
     code: patientCode,
     firstName: patientFirstName,
     lastName: patientLastName,
@@ -253,6 +254,7 @@ const createPatient = (database, patientDetails) => {
   } = patientDetails;
   const id = patientId ?? generateUUID();
   const code = patientCode || getPatientUniqueCode(database);
+  const barcode = patientBarcode || `*${code}*`;
   const firstName = patientFirstName ?? '';
   const lastName = patientLastName ?? '';
   const name = patientName || `${patientLastName}, ${patientFirstName}`;
@@ -290,6 +292,7 @@ const createPatient = (database, patientDetails) => {
     firstName,
     lastName,
     name,
+    barcode,
     code,
     type,
     dateOfBirth,

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -581,6 +581,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
       internalRecord = {
         id: record.ID,
         name: record.name,
+        barcode: record.barcode,
         code: record.code,
         phoneNumber: record.phone,
         billingAddress,

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -252,6 +252,7 @@ export const processPatientResponse = response => {
       ID: id,
       name,
       code,
+      barcode,
       phone: phoneNumber,
       bill_address1: billAddress1,
       bill_address2: billAddress2,
@@ -271,6 +272,7 @@ export const processPatientResponse = response => {
     }) => ({
       id,
       name,
+      barcode,
       code,
       phoneNumber,
       billAddress1,

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -94,7 +94,7 @@ const generateSyncData = (settings, recordType, record) => {
         country: record.country,
         bill_address1: record.addressOne,
         bill_address2: record.addressTwo,
-        barcode: `*${record.code}*`,
+        barcode: record.barcode ?? `*${record.code}*`,
         'charge code': record.code,
         currency_id: defaultCurrency?.id ?? '',
         female: String(record.female),


### PR DESCRIPTION
Fixes #4068

## Change summary

- Add `[name]barcode` to realm schema. 
- Already exists in desktop with placeholder values (in the format `*[name]code*`)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Sync and check realm explorer to see if it's there?

### Related areas to think about

Not sure
