### PR TITLE
#4089: Hide QR Scan button behind DEV flag

### DIFF
--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 /* eslint-disable react/forbid-prop-types */
 /**
  * mSupply Mobile
@@ -73,7 +74,7 @@ const Header = ({ onSearchOnline, onNewPatient, loading, toggleQrModal }) => (
   <FlexRow justifyContent="center" alignItems="center">
     <Text style={localStyles.text}>{vaccineStrings.vaccine_dispense_step_one_title}</Text>
     <View style={{ flex: 1, marginLeft: 'auto' }} />
-    <PageButton text={modalStrings.qr_scanner_header} onPress={toggleQrModal} />
+    {__DEV__ ? <PageButton text={modalStrings.qr_scanner_header} onPress={toggleQrModal} /> : null}
     <PageButton
       style={{ marginLeft: 10 }}
       text={generalStrings.search_online}


### PR DESCRIPTION
Fixes #4089

## Change summary

- Temporarily hide QR scan button until it is ready for release

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Navigate to patient select screen and verify there is no 'Scan QR Code' button

### Related areas to think about
Possibly could look into implementing an actual feature flag config if this type of thing comes up more frequently.
