### PR TITLE
#4097 stocktake batch modal crash

### DIFF
--- a/src/widgets/modals/DataTablePageModal.js
+++ b/src/widgets/modals/DataTablePageModal.js
@@ -246,7 +246,7 @@ const DataTablePageModalComponent = ({ isOpen, onClose, modalKey, onSelect, curr
 
         return (
           <GenericChoiceList
-            data={UIDatabase.objects('VaccineVialMonitorStatus').filtered('isActive == True')}
+            data={UIDatabase.objects('VaccineVialMonitorStatus').filtered('isActive == true')}
             highlightValue={currentVvmStatusName}
             onPress={onSelect}
             keyToDisplay="description"

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -252,7 +252,7 @@ export const StocktakeBatchModalComponent = ({
       case MODAL_KEYS.SELECT_VVM_STATUS:
         return (
           <GenericChoiceList
-            data={UIDatabase.objects('VaccineVialMonitorStatus').filtered('isActive == True')}
+            data={UIDatabase.objects('VaccineVialMonitorStatus').filtered('isActive == true')}
             highlightValue={currentVvmStatusName}
             onPress={onApplyStocktakeBatchVvmStatus}
             keyToDisplay="description"


### PR DESCRIPTION
Fixes #4097

## Change summary

- Changed query from `UIDatabase.objects('VaccineVialMonitorStatus').filtered('isActive == True')` to  `UIDatabase.objects('VaccineVialMonitorStatus').filtered('isActive == true')`
- No idea why the capitalisation matters now but didn't before (couldn't see anything in realm release notes? 🤷‍♀️ )

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Try to repro #4097

### Related areas to think about

N/A
