### PR TITLE
#4095 Check for transactions before summing doses

### DIFF
--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -245,11 +245,7 @@ export class Item extends Realm.Object {
       .filtered("option.type == 'openVialWastage'")
       .filtered('transaction.confirmDate >= $0', fromDate);
 
-    if (transactions.length) {
-      return transactions.sum('doses');
-    }
-
-    return 0;
+    return transactions.length ? transactions.sum('doses') : 0;
   }
 
   /**

--- a/src/database/DataTypes/Item.js
+++ b/src/database/DataTypes/Item.js
@@ -240,11 +240,16 @@ export class Item extends Realm.Object {
   openVialWastage(fromDate) {
     if (!this.isVaccine || !fromDate) return 0;
 
-    return UIDatabase.objects('TransactionBatch')
+    const transactions = UIDatabase.objects('TransactionBatch')
       .filtered("transaction.otherParty.code == 'invad'")
       .filtered("option.type == 'openVialWastage'")
-      .filtered('transaction.confirmDate >= $0', fromDate)
-      .sum('doses');
+      .filtered('transaction.confirmDate >= $0', fromDate);
+
+    if (transactions.length) {
+      return transactions.sum('doses');
+    }
+
+    return 0;
   }
 
   /**


### PR DESCRIPTION
Fixes #4095

## Change summary

- Check filtered transactions before summing doses for openVialWastage
- Not sure why lots of random realm things seem to be breaking 😿 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Repro #4095

### Related areas to think about

Not sure