### PR TITLE
#4105 password not focused

### DIFF
--- a/src/widgets/FormInputs/FormPasswordInput.js
+++ b/src/widgets/FormInputs/FormPasswordInput.js
@@ -5,53 +5,50 @@
  * Sustainable Solutions (NZ) Ltd. 2021
  */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import { TextInput, StyleSheet } from 'react-native';
+import { TextInput } from 'react-native';
 
-import globalStyles, { APP_FONT_FAMILY, SUSSOL_ORANGE } from '../../globalStyles/index';
-import { authStrings } from '../../localization/index';
+import globalStyles, { SUSSOL_ORANGE } from '../../globalStyles';
+import { authStrings } from '../../localization';
 
-export const FormPasswordInput = ({
-  isEditable,
-  onChangeText,
-  onSubmitEditing,
-  passwordTextStyle,
-  placeholder,
-  placeholderTextColor,
-  returnKeyType,
-  style,
-  underlineColorAndroid,
-  value,
-}) => (
-  // Workaround for Bug in RN 0.64 updating secureTextEntry TextInput style to some kind of
-  // monospaced default
-  <TextInput
-    autoCompleteType="password"
-    editable={isEditable}
-    onChangeText={onChangeText}
-    onSubmitEditing={onSubmitEditing}
-    placeholder={placeholder}
-    placeholderTextColor={placeholderTextColor}
-    ref={reference => reference && reference.setNativeProps({ style: passwordTextStyle })}
-    returnKeyType={returnKeyType}
-    style={style}
-    underlineColorAndroid={underlineColorAndroid}
-    value={value}
-    secureTextEntry
-    selectTextOnFocus
-  />
+export const FormPasswordInput = forwardRef(
+  (
+    {
+      isEditable,
+      onChangeText,
+      onSubmitEditing,
+      placeholder,
+      placeholderTextColor,
+      returnKeyType,
+      style,
+      underlineColorAndroid,
+      value,
+    },
+    ref
+  ) => (
+    <TextInput
+      ref={ref}
+      autoCompleteType="password"
+      editable={isEditable}
+      onChangeText={onChangeText}
+      onSubmitEditing={onSubmitEditing}
+      placeholder={placeholder}
+      placeholderTextColor={placeholderTextColor}
+      returnKeyType={returnKeyType}
+      style={style}
+      underlineColorAndroid={underlineColorAndroid}
+      value={value}
+      secureTextEntry
+      selectTextOnFocus
+    />
+  )
 );
-
-const localStyles = StyleSheet.create({
-  textStyle: { fontFamily: APP_FONT_FAMILY },
-});
 
 FormPasswordInput.defaultProps = {
   isEditable: true,
   placeholder: authStrings.password,
   placeholderTextColor: SUSSOL_ORANGE,
-  passwordTextStyle: localStyles.textStyle,
   returnKeyType: 'done',
   style: globalStyles.authFormTextInputStyle,
   underlineColorAndroid: SUSSOL_ORANGE,
@@ -62,7 +59,6 @@ FormPasswordInput.propTypes = {
   isEditable: PropTypes.bool,
   onChangeText: PropTypes.func,
   onSubmitEditing: PropTypes.func,
-  passwordTextStyle: PropTypes.object,
   placeholder: PropTypes.string,
   placeholderTextColor: PropTypes.string,
   returnKeyType: PropTypes.string,

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -188,7 +188,9 @@ export class LoginModal extends React.Component {
             </View>
             <View style={globalStyles.horizontalContainer}>
               <FormPasswordInput
-                ref={this.passwordInputRef}
+                ref={ref => {
+                  this.passwordInputRef = ref;
+                }}
                 value={password}
                 editable={authStatus !== AUTH_STATUSES.AUTHENTICATING}
                 onChangeText={text => {


### PR DESCRIPTION
Fixes #4105

## Change summary

- The issue this component was solving has been fixed here: https://github.com/facebook/react-native/releases/tag/v0.64.2
- Not sure if removing the style thing was a good idea, can revert
- Not sure if the component is needed now, but I guess why not!
- Added `forwardRef` to pass the ref through the custom component

## Testing

- [ ] Go to username, enter one in the login modal and push enter- the password field is focused.

### Related areas to think about

N/A
