### PR TITLE
#4053 Downgrade react-native-svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "react-native-safe-area-context": "^3.2.0",
     "react-native-screens": "^3.1.1",
     "react-native-simple-radio-button": "^2.7.4",
-    "react-native-svg": "^12.1.1",
+    "react-native-svg": "^11.0.1",
     "react-native-system-setting": "^1.7.6",
     "react-native-ui-components": "^0.5.0",
     "react-native-vector-icons": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8488,10 +8488,10 @@ react-native-simple-radio-button@^2.7.4:
   resolved "https://registry.yarnpkg.com/react-native-simple-radio-button/-/react-native-simple-radio-button-2.7.4.tgz#86e2dbe8af9e6bf60eee088f60466f7a975e7758"
   integrity sha512-QOZNmJUn0ViBGU+at7wAG/uGzd5PfXi0kMHr9lfTCLXknW/f9f2fOVjxjdHvOCdf/zA/eMJBjGjtusSDzQf1+w==
 
-react-native-svg@^12.1.1:
-  version "12.1.1"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-12.1.1.tgz#5f292410b8bcc07bbc52b2da7ceb22caf5bcaaee"
-  integrity sha512-NIAJ8jCnXGCqGWXkkJ1GTzO4a3Md5at5sagYV8Vh4MXYnL4z5Rh428Wahjhh+LIjx40EE5xM5YtwyJBqOIba2Q==
+react-native-svg@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-11.0.1.tgz#e92e7e9f9cb2604333fd5014fd4edcf62fea6496"
+  integrity sha512-XriIwSoe9eTtKyqxpNC6POSOqmXAB9mZQOm5tMoaimEqQOMfzgYrBoF9nY6VPGmaH5dRlWBqnnBf389APiZFcQ==
   dependencies:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"


### PR DESCRIPTION
Fixes #4053

## Change summary

- Downgrade `react-native-svg` from `12.1.1` to `11.0.1` until `12.1.1` compatible fix found 🙀 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Enter vaccine module (where a sensor has been setup and has some logs) and view line graph, there should be lines connecting the data points on the first render

### Related areas to think about
Anywhere there are svgs I guess?
