### PR TITLE
Reduce svg renders

### DIFF
--- a/src/pages/FridgeDetailPage.js
+++ b/src/pages/FridgeDetailPage.js
@@ -62,7 +62,7 @@ export const FridgeDetailPageComponent = ({
   onChangeToDate,
   onChangeFromDate,
 }) => {
-  const [chartType, setChartType] = useState('bar');
+  const [chartType, setChartType] = useState('line');
 
   const minDate = new Date(minimumDate);
   const maxDate = new Date(maximumDate);
@@ -129,7 +129,7 @@ export const FridgeDetailPageComponent = ({
             Header={<SensorHeader showTitle showCog sensor={sensor} />}
           >
             <AfterInteractions>
-              <FlexRow alignItems="center">
+              <FlexRow alignItems="center" style={{ height: '100%' }}>
                 {chartType === 'line' && (
                   <VaccineLineChart
                     breaches={breaches}

--- a/src/widgets/VaccineLineChart.js
+++ b/src/widgets/VaccineLineChart.js
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import { ActivityIndicator } from 'react-native';
 import { Svg } from 'react-native-svg';
 import { VictoryAxis, VictoryChart, VictoryLine, VictoryScatter } from 'victory-native';
 import PropTypes from 'prop-types';
@@ -40,8 +41,15 @@ export const VaccineLineChart = ({
   ]);
 
   return (
-    <FlexView onLayout={setDimensions} style={{ width: '100%', height: '100%' }}>
-      {!width || !height ? null : (
+    <FlexView
+      onLayout={setDimensions}
+      style={{ width: '100%', height: '100%' }}
+      alignItems="center"
+      justifyContent="center"
+    >
+      {!width || !height ? (
+        <ActivityIndicator size="large" color={SUSSOL_ORANGE} />
+      ) : (
         <Svg>
           <VictoryChart
             width={width}

--- a/src/widgets/VaccineLineChart.js
+++ b/src/widgets/VaccineLineChart.js
@@ -38,56 +38,59 @@ export const VaccineLineChart = ({
   const chartMaxDomain = React.useMemo(() => ({ y: maxDomain + CHART_CONSTANTS.DOMAIN_OFFSET }), [
     maxDomain,
   ]);
+
   return (
-    <FlexView onLayout={setDimensions}>
-      <Svg>
-        <VictoryChart
-          width={width}
-          height={height}
-          minDomain={chartMinDomain}
-          maxDomain={chartMaxDomain}
-          padding={{ top: 20, bottom: 50, right: 10, left: 50 }}
-        >
-          <VictoryAxis
-            offsetX={CHART_CONSTANTS.AXIS_OFFSET}
-            dependentAxis
-            style={chartStyles.axisY}
-            tickFormat={temperatureTickFormatter}
-          />
-          <VictoryAxis
-            offsetY={CHART_CONSTANTS.AXIS_OFFSET}
-            tickFormat={timestampTickFormatter}
-            style={chartStyles.axisX}
-            tickCount={CHART_CONSTANTS.MAX_TICK_COUNTS}
-          />
+    <FlexView onLayout={setDimensions} style={{ width: '100%', height: '100%' }}>
+      {!width || !height ? null : (
+        <Svg>
+          <VictoryChart
+            width={width}
+            height={height}
+            minDomain={chartMinDomain}
+            maxDomain={chartMaxDomain}
+            padding={{ top: 20, bottom: 50, right: 10, left: 50 }}
+          >
+            <VictoryAxis
+              offsetX={CHART_CONSTANTS.AXIS_OFFSET}
+              dependentAxis
+              style={chartStyles.axisY}
+              tickFormat={temperatureTickFormatter}
+            />
+            <VictoryAxis
+              offsetY={CHART_CONSTANTS.AXIS_OFFSET}
+              tickFormat={timestampTickFormatter}
+              style={chartStyles.axisX}
+              tickCount={CHART_CONSTANTS.MAX_TICK_COUNTS}
+            />
 
-          <VictoryLine
-            interpolation={CHART_CONSTANTS.INTERPOLATION}
-            data={minLine}
-            y={y}
-            x={x}
-            style={chartStyles.minLine}
-          />
-          <VictoryLine
-            interpolation={CHART_CONSTANTS.INTERPOLATION}
-            data={maxLine}
-            y={y}
-            x={x}
-            style={chartStyles.maxLine}
-          />
-          <VictoryLine data={maxLine} y={maxBoundary} x={x} style={chartStyles.maxBoundaryLine} />
-          <VictoryLine data={minLine} y={minBoundary} x={x} style={chartStyles.minBoundaryLine} />
+            <VictoryLine
+              interpolation={CHART_CONSTANTS.INTERPOLATION}
+              data={minLine}
+              y={y}
+              x={x}
+              style={chartStyles.minLine}
+            />
+            <VictoryLine
+              interpolation={CHART_CONSTANTS.INTERPOLATION}
+              data={maxLine}
+              y={y}
+              x={x}
+              style={chartStyles.maxLine}
+            />
+            <VictoryLine data={maxLine} y={maxBoundary} x={x} style={chartStyles.maxBoundaryLine} />
+            <VictoryLine data={minLine} y={minBoundary} x={x} style={chartStyles.minBoundaryLine} />
 
-          <VictoryScatter data={maxLine} y={y} x={x} style={chartStyles.maxScatterPlot} />
-          <VictoryScatter data={minLine} y={y} x={x} style={chartStyles.minScatterPlot} />
-          <VictoryScatter
-            data={breaches.slice()}
-            y={y}
-            x={x}
-            dataComponent={<HazardPoint dataSet={breaches.slice()} onPress={onPressBreach} />}
-          />
-        </VictoryChart>
-      </Svg>
+            <VictoryScatter data={maxLine} y={y} x={x} style={chartStyles.maxScatterPlot} />
+            <VictoryScatter data={minLine} y={y} x={x} style={chartStyles.minScatterPlot} />
+            <VictoryScatter
+              data={breaches.slice()}
+              y={y}
+              x={x}
+              dataComponent={<HazardPoint dataSet={breaches.slice()} onPress={onPressBreach} />}
+            />
+          </VictoryChart>
+        </Svg>
+      )}
     </FlexView>
   );
 };
@@ -129,8 +132,8 @@ const chartStyles = {
       size: CHART_CONSTANTS.STROKE_SIZE,
     },
   },
-  maxLine: { data: { stroke: SUSSOL_ORANGE, strokeWidth: CHART_CONSTANTS.STROKE_WIDTH } },
-  minLine: { data: { stroke: COLD_BREACH_BLUE, strokeWidth: CHART_CONSTANTS.STROKE_WIDTH } },
+  maxLine: { data: { stroke: SUSSOL_ORANGE } },
+  minLine: { data: { stroke: COLD_BREACH_BLUE } },
   axisX: { tickLabels: { fontSize: 10, fontFamily: APP_FONT_FAMILY, fill: GREY } },
   axisY: {
     tickLabels: { fontSize: 10, fontFamily: APP_FONT_FAMILY, fill: GREY },

--- a/src/widgets/VaccineLineChart.js
+++ b/src/widgets/VaccineLineChart.js
@@ -38,7 +38,6 @@ export const VaccineLineChart = ({
   const chartMaxDomain = React.useMemo(() => ({ y: maxDomain + CHART_CONSTANTS.DOMAIN_OFFSET }), [
     maxDomain,
   ]);
-
   return (
     <FlexView onLayout={setDimensions}>
       <Svg>
@@ -130,8 +129,8 @@ const chartStyles = {
       size: CHART_CONSTANTS.STROKE_SIZE,
     },
   },
-  maxLine: { data: { stroke: SUSSOL_ORANGE } },
-  minLine: { data: { stroke: COLD_BREACH_BLUE } },
+  maxLine: { data: { stroke: SUSSOL_ORANGE, strokeWidth: CHART_CONSTANTS.STROKE_WIDTH } },
+  minLine: { data: { stroke: COLD_BREACH_BLUE, strokeWidth: CHART_CONSTANTS.STROKE_WIDTH } },
   axisX: { tickLabels: { fontSize: 10, fontFamily: APP_FONT_FAMILY, fill: GREY } },
   axisY: {
     tickLabels: { fontSize: 10, fontFamily: APP_FONT_FAMILY, fill: GREY },


### PR DESCRIPTION
Fixes #4053

If the `<Svg>` renders more than once, the lines don't show 🤷‍♂️ 

Have changed the line chart, so that it only renders the svg component if the dimensions are set. It was rendering twice due to the `onLayout` event.

A side issue is that this invalidates the functioning of `AfterInteractions` so I've added the loading indicator directly into the chart component.