### PR TITLE
Fix realm explorer crash

### DIFF
--- a/src/pages/RealmExplorer.js
+++ b/src/pages/RealmExplorer.js
@@ -153,7 +153,6 @@ const updateFilteredData = (newFilterString, state) => {
       newFilterString === '' ? searchData.slice() : searchData.filtered(newFilterString).slice();
     return { ...state, filterString: newFilterString, filteredData: newFilteredData };
   } catch (err) {
-    ToastAndroid.show(`Error! ${err.message}`, ToastAndroid.LONG);
     return { ...state, filterString: newFilterString };
   }
 };

--- a/src/pages/RealmExplorer.js
+++ b/src/pages/RealmExplorer.js
@@ -4,11 +4,12 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { View, VirtualizedList, Text, StyleSheet } from 'react-native';
+import { View, VirtualizedList, Text, StyleSheet, ToastAndroid } from 'react-native';
 import PropTypes from 'prop-types';
 
 import { UIDatabase } from '../database/index';
 import { schema } from '../database/schema';
+import { useDebounce } from '../hooks/useDebounce';
 
 import { SearchBar } from '../widgets';
 
@@ -114,18 +115,25 @@ const getInitialState = () => {
 };
 
 const updateSearchData = (newSearchString, state) => {
-  const { searchString } = state;
-  const updateObjectString = newSearchString !== searchString;
-  if (!updateObjectString) return { ...state };
-  const updateObject = REALM_OBJECTS.indexOf(newSearchString) >= 0;
-  const newSearchData = updateObject ? UIDatabase.objects(newSearchString) : {};
-  const newFilteredData = updateObject ? newSearchData.slice() : [];
-  return {
-    ...state,
-    searchString: newSearchString,
-    searchData: newSearchData,
-    filteredData: newFilteredData,
-  };
+  try {
+    const { searchString } = state;
+    const updateObjectString = newSearchString !== searchString;
+    // Some single characters are returning true for 'REALM_OBJECTS.indexOf(newSearchString) >= 0;'
+    // there are no database objects with names shorter than 3 chars; so just skip those
+    if (!updateObjectString || newSearchString.length < 3) return { ...state };
+    const updateObject = REALM_OBJECTS.indexOf(newSearchString) >= 0;
+    const newSearchData = updateObject ? UIDatabase.objects(newSearchString) : {};
+    const newFilteredData = updateObject ? newSearchData.slice() : [];
+    return {
+      ...state,
+      searchString: newSearchString,
+      searchData: newSearchData,
+      filteredData: newFilteredData,
+    };
+  } catch (e) {
+    ToastAndroid.show(`Error! ${e.message}`, ToastAndroid.LONG);
+    return { ...state };
+  }
 };
 
 const getSearchBarRenderer = onSearchChange => {
@@ -222,7 +230,10 @@ export const RealmExplorer = () => {
   const [state, setState] = useState(getInitialState());
 
   const onSearchChange = useCallback(
-    newObjectString => setState(prevState => updateSearchData(newObjectString, prevState)),
+    useDebounce(
+      newObjectString => setState(prevState => updateSearchData(newObjectString, prevState)),
+      750
+    ),
     []
   );
   const onFilterChange = useCallback(

--- a/src/pages/RealmExplorer.js
+++ b/src/pages/RealmExplorer.js
@@ -61,8 +61,6 @@ const parseType = realmType => {
   return typeMapper.get(realmType) || TYPES.OBJECT;
 };
 
-const getRealmObjects = ({ schema: objectSchemas }) => objectSchemas.map(({ name }) => name);
-
 const getRealmObjectsFields = ({ schema: objectSchemas }) =>
   objectSchemas
     .map(({ schema: objectSchema }) => {
@@ -76,8 +74,8 @@ const getRealmObjectsFields = ({ schema: objectSchemas }) =>
     })
     .reduce((acc, object) => ({ ...acc, ...object }));
 
-const REALM_OBJECTS = getRealmObjects(schema);
 const REALM_OBJECTS_FIELDS = getRealmObjectsFields(schema);
+const REALM_OBJECTS = Object.keys(REALM_OBJECTS_FIELDS);
 
 const toCapitalCase = value => value.charAt(0).toUpperCase() + value.slice(1);
 

--- a/src/pages/RealmExplorer.js
+++ b/src/pages/RealmExplorer.js
@@ -15,6 +15,8 @@ import { SearchBar } from '../widgets';
 
 import globalStyles from '../globalStyles';
 
+const DEBOUNCE_TIMEOUT = 750;
+
 const TYPES = {
   BOOLEAN: 'boolean',
   DATE: 'date',
@@ -151,6 +153,7 @@ const updateFilteredData = (newFilterString, state) => {
       newFilterString === '' ? searchData.slice() : searchData.filtered(newFilterString).slice();
     return { ...state, filterString: newFilterString, filteredData: newFilteredData };
   } catch (err) {
+    ToastAndroid.show(`Error! ${err.message}`, ToastAndroid.LONG);
     return { ...state, filterString: newFilterString };
   }
 };
@@ -232,12 +235,15 @@ export const RealmExplorer = () => {
   const onSearchChange = useCallback(
     useDebounce(
       newObjectString => setState(prevState => updateSearchData(newObjectString, prevState)),
-      750
+      DEBOUNCE_TIMEOUT
     ),
     []
   );
   const onFilterChange = useCallback(
-    newFilterString => setState(prevState => updateFilteredData(newFilterString, prevState)),
+    useDebounce(
+      newFilterString => setState(prevState => updateFilteredData(newFilterString, prevState)),
+      DEBOUNCE_TIMEOUT
+    ),
     []
   );
 


### PR DESCRIPTION
Fixes #4092 #3048 

## Change summary

Always thought it odd that the table search wasn't debounced.
Added some debounce, and prevented searching for tables with name < 3 chars
Also caught and toasted the error, if there is one.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Explore. With Realm

### Related areas to think about

Now looking at #3048 to actually show data