### PR TITLE
Updating Github Pages theme to Just the Docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-theme: jekyll-theme-leap-day
+remote_theme: pmarsceill/just-the-docs


### PR DESCRIPTION
Fixes #?

## Change summary

Updating the Jekyll theme used by Github Pages to build the static site for the docs. 

## Testing

Check out https://openmsupply.github.io/mobile/ 

- [ ] Do something

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
