### PR TITLE
#4071 QR code patient lookup - local search implementation

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -198,6 +198,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-haptic-feedback')
     implementation project(':react-native-ble-plx')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"

--- a/android/app/src/main/java/com/msupplymobile/MainApplication.java
+++ b/android/app/src/main/java/com/msupplymobile/MainApplication.java
@@ -14,6 +14,7 @@ import com.facebook.react.ReactInstanceManager;
 import com.facebook.soloader.SoLoader;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import com.mkuczera.RNReactNativeHapticFeedbackPackage;
 
 public class MainApplication extends Application implements ReactApplication {
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,3 +5,5 @@ include ':react-native-datetimepicker'
 project(':react-native-datetimepicker').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/datetimepicker/android')
 include ':app'
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
+include ':react-native-haptic-feedback'
+project(':react-native-haptic-feedback').projectDir = new File(rootProject.projectDir, 	'../node_modules/react-native-haptic-feedback/android')

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-native-device-info": "^8.1.2",
     "react-native-fs": "^2.17.0",
     "react-native-gesture-handler": "^1.10.3",
+    "react-native-haptic-feedback": "^1.11.0",
     "react-native-localization": "^2.1.7",
     "react-native-mail": "^6.1.0",
     "react-native-modalbox": "^2.0.0",

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -9,6 +9,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { ActivityIndicator, Keyboard, StyleSheet, Text, ToastAndroid, View } from 'react-native';
+import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 
 import { batch, connect } from 'react-redux';
 
@@ -138,8 +139,14 @@ const PatientSelectComponent = ({
   const withLoadingIndicator = useLoadingIndicator();
   const [isQrModalOpen, toggleQrModal] = useToggle();
 
+  const hapticFeedBackOptions = {
+    enableVibrateFallback: true,
+    ignoreAndroidSystemSettings: false,
+  };
+
   const onQrCodeRead = ({ data }) => {
     // TODO: Some validation/data sanitisation might be required here but don't know format yet...
+    ReactNativeHapticFeedback.trigger('notificationSuccess', hapticFeedBackOptions);
     toggleQrModal();
 
     const matchedLocalPatient = UIDatabase.objects('Name').filtered('barcode == $0', data)[0];

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -139,9 +139,17 @@ const PatientSelectComponent = ({
   const [isQrModalOpen, toggleQrModal] = useToggle();
 
   const onQrCodeRead = ({ data }) => {
-    // TODO: Some validation might be good here but don't know format..
+    // TODO: Some validation/data sanitisation might be required here but don't know format yet...
     toggleQrModal();
-    ToastAndroid.show(`${data} scanned`, ToastAndroid.LONG);
+
+    const matchedLocalPatient = UIDatabase.objects('Name').filtered('barcode == $0', data)[0];
+
+    // Do local search
+    if (matchedLocalPatient) {
+      selectPatient(matchedLocalPatient);
+    } else {
+      ToastAndroid.show('No patient found via QR code', ToastAndroid.LONG);
+    }
   };
 
   const [

--- a/yarn.lock
+++ b/yarn.lock
@@ -8427,6 +8427,11 @@ react-native-gesture-handler@^1.10.3:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
+react-native-haptic-feedback@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-1.11.0.tgz#adfd841f3b67046532f912c6ec827aea0037d8ad"
+  integrity sha512-KTIy7lExwMtB6pOpCARyUzFj5EzYTh+A1GN/FB5Eb0LrW5C6hbb1kdj9K2/RHyZC+wyAJD1M823ZaDCU6n6cLA==
+
 react-native-iphone-x-helper@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"


### PR DESCRIPTION
Fixes #4071

## Change summary

- Adds some code to do some sort of local searching and select the patient if there is a match

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Scan a QR code that contains a matching barcode for a patient. 

Some test codes (needs to exist in mobile for lookup to work):
`placeHolderBarcode`:
![placeholderBarcode](https://user-images.githubusercontent.com/65875762/121824649-cfce5780-cd01-11eb-8cfc-2a272d149556.png)

`*asdasdasd*` (matches Jose Abad):
![_asdasdasd_](https://user-images.githubusercontent.com/65875762/121824676-0906c780-cd02-11eb-8afc-3c939a98d12b.png)

### Related areas to think about

