### PR TITLE
add ref to FirstUsePage

### DIFF
--- a/src/pages/FirstUsePage.js
+++ b/src/pages/FirstUsePage.js
@@ -174,6 +174,9 @@ export class FirstUsePageComponent extends React.Component {
                 if (this.canAttemptLogin) this.onPressConnect();
               }}
               placeholder="Sync Site Password"
+              ref={ref => {
+                this.passwordInputRef = ref;
+              }}
             />
           </View>
           <SyncState style={localStyles.initialisationStateIcon} showText={false} />


### PR DESCRIPTION
Fixes #4124 

## Change summary

Add the ref which allows focus of password field

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Clear data on the tablet and press enter while focus is on the site name. Should focus the password field
