### PR TITLE
resolve type warnings

### DIFF
--- a/src/pages/CashRegisterPage.js
+++ b/src/pages/CashRegisterPage.js
@@ -201,7 +201,7 @@ CashRegister.propTypes = {
   isAscending: PropTypes.bool.isRequired,
   modalKey: PropTypes.string.isRequired,
   keyExtractor: PropTypes.func.isRequired,
-  pageInfoColumns: PropTypes.object.isRequired,
+  pageInfoColumns: PropTypes.array.isRequired,
   columns: PropTypes.array.isRequired,
   transactionType: PropTypes.string.isRequired,
   onFilterData: PropTypes.func.isRequired,

--- a/src/selectors/cashTransaction.js
+++ b/src/selectors/cashTransaction.js
@@ -87,7 +87,7 @@ const selectIsValid = createSelector(
     !!amount &&
     amount > currency(0) &&
     (type === CASH_TRANSACTION_TYPES.CASH_IN || !!reason) &&
-    paymentType
+    !!paymentType
 );
 
 export const CashTransactionSelectors = {


### PR DESCRIPTION
Fixes #4126 

## Change summary

Resolve a warning when loading the screen and when submitting a payment.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

In develop mode:
- [ ] Open the cash register; expected result: no warning
- [ ] Create a payment; expected result: no warning
