### PR TITLE
#4072 remote patient lookup via qr code

### DIFF
--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -7,6 +7,8 @@
     "problem_connecting_please_try_again": "There was a problem connecting with the server for this patient. Please ensure you have an internet connection and try again.",
     "enter_patient_details": "Enter the patient's details to start searching for them, or for other options, use the buttons above",
     "could_not_find_patient": "No patients found that match your search criteria",
+    "could_not_find_patient_qr": "No patients found that match your QR code",
+    "invalid_qr_code": "Invalid QR code",
     "error_communicating_with_server": "There was a problem communicating with the server",
     "select_an_item_before_choosing_the_batch ": "Select an item before choosing the batch",
     "ok_and_next": "OK & Next",

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -40,6 +40,7 @@ const PARAMETERS = {
   lastName: { key: 'last_name', type: TYPES.STRING },
   dateOfBirth: { key: 'dob', type: TYPES.DATE },
   policyNumber: { key: 'policy_number', type: TYPES.STRING },
+  barcode: { key: 'barcode', type: TYPES.STRING },
   registrationCode: { key: 'code', type: TYPES.STRING },
   limit: { key: 'limit', type: TYPES.NUMBER },
   offset: { key: 'offset', type: TYPES.NUMBER },
@@ -104,6 +105,7 @@ const getPrescriberQueryString = ({ firstName = '', lastName = '', registrationC
 const getPatientQueryString = ({
   firstName = '',
   lastName = '',
+  barcode = '',
   dateOfBirth = '',
   policyNumber = '',
   limit = null,
@@ -112,6 +114,7 @@ const getPatientQueryString = ({
   const queryParams = [
     { [PARAMETERS.firstName.key]: firstName, type: PARAMETERS.firstName.type },
     { [PARAMETERS.lastName.key]: lastName, type: PARAMETERS.lastName.type },
+    { [PARAMETERS.barcode.key]: barcode, type: PARAMETERS.barcode.type },
     { [PARAMETERS.dateOfBirth.key]: dateOfBirth, type: PARAMETERS.dateOfBirth.type },
     { [PARAMETERS.policyNumber.key]: policyNumber, type: PARAMETERS.policyNumber.type },
     { [PARAMETERS.offset.key]: offset, type: PARAMETERS.offset.type },

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -156,7 +156,7 @@ const PatientSelectComponent = ({
     // Immediately reject QR code if it is too long (length > 50 chosen somewhat arbitrarily until
     // we get a better idea of the kinds of codes we need to handle in future)
     if (data.length > 50) {
-      ToastAndroid.show('Invalid QR code', ToastAndroid.LONG);
+      ToastAndroid.show(generalStrings.invalid_qr_code, ToastAndroid.LONG);
       return;
     }
 
@@ -175,7 +175,7 @@ const PatientSelectComponent = ({
           if (remotePatient.length) {
             selectPatient(remotePatient[0]);
           } else {
-            throw new Error('No patient found via QR code');
+            throw new Error(generalStrings.could_not_find_patient_qr);
           }
         } catch (error) {
           ToastAndroid.show(error.message, ToastAndroid.LONG);

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -144,7 +144,6 @@ const PatientSelectComponent = ({
 }) => {
   const withLoadingIndicator = useLoadingIndicator();
   const [isQrModalOpen, toggleQrModal] = useToggle();
-  const syncUrl = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_URL);
 
   const hapticFeedBackOptions = {
     enableVibrateFallback: true,
@@ -202,6 +201,7 @@ const PatientSelectComponent = ({
   };
 
   const lookupRemotePatient = async params => {
+    const syncUrl = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_URL);
     const url = `${syncUrl}${getPatientRequestUrl(params)}`;
     const response = await fetch(url, {
       method: 'GET',

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -52,6 +52,12 @@ import { APP_FONT_FAMILY, APP_GENERAL_FONT_SIZE } from '../../globalStyles/fonts
 import { useLoadingIndicator } from '../../hooks/useLoadingIndicator';
 import { useToggle } from '../../hooks/useToggle';
 import { QrScannerModal } from '../modals/QrScannerModal';
+import {
+  getAuthorizationHeader,
+  getPatientRequestUrl,
+  processPatientResponse,
+} from '../../sync/lookupApiUtils';
+import { SETTINGS_KEYS } from '../../settings/index';
 
 const getMessage = (noResults, error) => {
   if (noResults) return generalStrings.could_not_find_patient;
@@ -138,6 +144,7 @@ const PatientSelectComponent = ({
 }) => {
   const withLoadingIndicator = useLoadingIndicator();
   const [isQrModalOpen, toggleQrModal] = useToggle();
+  const syncUrl = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_URL);
 
   const hapticFeedBackOptions = {
     enableVibrateFallback: true,
@@ -145,8 +152,15 @@ const PatientSelectComponent = ({
   };
 
   const onQrCodeRead = ({ data }) => {
-    // TODO: Some validation/data sanitisation might be required here but don't know format yet...
     ReactNativeHapticFeedback.trigger('notificationSuccess', hapticFeedBackOptions);
+
+    // Immediately reject QR code if it is too long (length > 50 chosen somewhat arbitrarily until
+    // we get a better idea of the kinds of codes we need to handle in future)
+    if (data.length > 50) {
+      ToastAndroid.show('Invalid QR code', ToastAndroid.LONG);
+      return;
+    }
+
     toggleQrModal();
 
     const matchedLocalPatient = UIDatabase.objects('Name').filtered('barcode == $0', data)[0];
@@ -155,7 +169,19 @@ const PatientSelectComponent = ({
     if (matchedLocalPatient) {
       selectPatient(matchedLocalPatient);
     } else {
-      ToastAndroid.show('No patient found via QR code', ToastAndroid.LONG);
+      // Do a remote search
+      withLoadingIndicator(async () => {
+        try {
+          const remotePatient = await lookupRemotePatient({ barcode: data });
+          if (remotePatient.length) {
+            selectPatient(remotePatient);
+          } else {
+            throw new Error('No patient found via QR code');
+          }
+        } catch (error) {
+          ToastAndroid.show(error.message, ToastAndroid.LONG);
+        }
+      });
     }
   };
 
@@ -173,6 +199,16 @@ const PatientSelectComponent = ({
   const handleUpdate = (key, value) => {
     updateForm(key, value);
     filter({ ...completedForm, [key]: value });
+  };
+
+  const lookupRemotePatient = async params => {
+    const url = `${syncUrl}${getPatientRequestUrl(params)}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { authorization: getAuthorizationHeader() },
+    });
+    const responseJson = await response.json();
+    return processPatientResponse({ ...response, json: responseJson });
   };
 
   return (

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -174,7 +174,7 @@ const PatientSelectComponent = ({
         try {
           const remotePatient = await lookupRemotePatient({ barcode: data });
           if (remotePatient.length) {
-            selectPatient(remotePatient);
+            selectPatient(remotePatient[0]);
           } else {
             throw new Error('No patient found via QR code');
           }

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -8,7 +8,6 @@ import React, { useMemo, useCallback } from 'react';
 import { View, StyleSheet, ToastAndroid } from 'react-native';
 import { connect, batch } from 'react-redux';
 import PropTypes from 'prop-types';
-import { getAuthHeader } from 'sussol-utilities';
 
 import { SETTINGS_KEYS } from '../../settings';
 import { MODALS } from '../constants';
@@ -34,6 +33,7 @@ import { modalStrings, generalStrings } from '../../localization';
 import { APP_FONT_FAMILY, DARK_GREY, ROW_BLUE, WHITE, SUSSOL_ORANGE } from '../../globalStyles';
 
 import {
+  getAuthorizationHeader,
   getPatientRequestUrl,
   getPrescriberRequestUrl,
   processPatientResponse,
@@ -49,7 +49,7 @@ import { useLoadingIndicator } from '../../hooks/useLoadingIndicator';
 import { DispensaryActions } from '../../actions/DispensaryActions';
 import { NameNoteActions } from '../../actions/Entities/NameNoteActions';
 
-const { SYNC_URL, SYNC_SITE_NAME, SYNC_SITE_PASSWORD_HASH } = SETTINGS_KEYS;
+const { SYNC_URL } = SETTINGS_KEYS;
 
 export const SearchFormComponent = ({
   isPatient,
@@ -68,12 +68,6 @@ export const SearchFormComponent = ({
     () => (isPatient ? getColumns(MODALS.PATIENT_LOOKUP) : getColumns(MODALS.PRESCRIBER_LOOKUP)),
     []
   );
-
-  const getAuthorizationHeader = () => {
-    const username = UIDatabase.getSetting(SYNC_SITE_NAME);
-    const password = UIDatabase.getSetting(SYNC_SITE_PASSWORD_HASH);
-    return getAuthHeader(username, password);
-  };
 
   const lookupRecords = useMemo(() => {
     if (isPatient) {


### PR DESCRIPTION
Fixes #4072 

## Change summary

- Adds remote patient searching by QR code (needs https://github.com/sussol/msupply/pull/8914 to actually work)
- Adds crude validation to reject QR codes that are longer than `50` chars long (sample Vanuatu National ID we have seen is 21 characters long)
- Small side quest to remove the extra `getAuthorizationHeader` method in `SearchForm`

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Have a patient that is not available locally but is available remotely, scan a QR code corresponding to that patient -> should be taken to step 2 of the patient vaccination page with remote patient details pre-populated

### Related areas to think about
Might need to look into different parsers for different countries at some point (instead of storing whole thing, depending on what their National ID QR codes look like...). Either coded in mobile or some kind of store pref in Desktop? 
