### PR TITLE
save addresses correctly

### DIFF
--- a/src/actions/PatientActions.js
+++ b/src/actions/PatientActions.js
@@ -76,8 +76,11 @@ const patientUpdate = patientDetails => async (dispatch, getState) => {
     dateOfBirth: patientDateOfBirth,
     emailAddress: patientEmailAddress,
     phoneNumber: patientPhoneNumber,
-    addressOne: patientLine1,
-    addressTwo: patientLine2,
+    billAddress1: patientLine1,
+    billAddress2: patientLine2,
+    billAddress3: patientLine3,
+    billAddress4: patientLine4,
+    billPostalZipCode: patientPostalZipCode,
     country: patientCountry,
     supplyingStoreId: patientSupplyingStoreId,
     female: patientFemale,
@@ -97,9 +100,9 @@ const patientUpdate = patientDetails => async (dispatch, getState) => {
   const billAddressId = currentBillAddressId;
   const billAddress1 = patientLine1 ?? currentLine1;
   const billAddress2 = patientLine2 ?? currentLine2;
-  const billAddress3 = currentLine3;
-  const billAddress4 = currentLine4;
-  const billPostalZipCode = currentZipCode;
+  const billAddress3 = patientLine3 ?? currentLine3;
+  const billAddress4 = patientLine4 ?? currentLine4;
+  const billPostalZipCode = patientPostalZipCode ?? currentZipCode;
   const country = patientCountry ?? currentCountry;
   const female = patientFemale ?? currentFemale;
   const supplyingStoreId = patientSupplyingStoreId ?? currentSupplyingStoreId;

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -39,6 +39,10 @@ const createAddress = (database, { line1, line2, line3, line4, zipCode } = {}) =
  * @return  {Realm.object}            The Address object described by the params.
  */
 export const getOrCreateAddress = (database, { id, line1, line2, line3, line4, zipCode }) => {
+  // if all properties are undefined, then no filters apply and all addresses are fetched
+  // with the first address returned as the valid matching address
+  if (!id && !line1 && !line2 && !line3 && !line4 && !zipCode) return undefined;
+
   let results = database.objects('Address');
 
   if (typeof id === 'string') {

--- a/src/widgets/modalChildren/ConfirmForm.js
+++ b/src/widgets/modalChildren/ConfirmForm.js
@@ -86,7 +86,7 @@ ConfirmForm.propTypes = {
   confirmText: PropTypes.string,
   textStyle: Text.propTypes.style,
   isOpen: PropTypes.bool.isRequired,
-  questionText: PropTypes.string.isRequired,
+  questionText: PropTypes.string,
   noCancel: PropTypes.bool,
   onCancel: PropTypes.func,
   onConfirm: PropTypes.func,
@@ -106,6 +106,7 @@ ConfirmForm.defaultProps = {
   confirmText: modalStrings.confirm,
   swipeToClose: false, // negating the default.
   backdropPressToClose: false, // negating the default.
+  questionText: '',
 };
 
 const defaultStyles = StyleSheet.create({


### PR DESCRIPTION
Fixes #4138 

## Change summary

Two issues with the addresses on looking up patients ( and prescribers )
- If all the fields are undefined then none of the address fields are strings, so the first address in the database is assigned to the incoming patient
- The properties on the incoming patient were incorrect

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a patient on the server, with an address. Look them up on mobile: the address saved should be correct

