### PR TITLE
#4139 Include text in touchable bit of the date picker

### DIFF
--- a/src/widgets/DatePickerButton.js
+++ b/src/widgets/DatePickerButton.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/forbid-prop-types */
 /**
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2020
@@ -28,6 +29,8 @@ import { DARK_GREY } from '../globalStyles/index';
 
 export const DatePickerButton = ({
   initialValue,
+  label,
+  labelStyle,
   onDateChanged,
   maximumDate,
   minimumDate,
@@ -46,6 +49,8 @@ export const DatePickerButton = ({
     <IconButton
       isDisabled={isDisabled}
       Icon={<CalendarIcon color={DARK_GREY} />}
+      label={label}
+      labelStyle={labelStyle}
       onPress={openDatePicker}
     />
   );
@@ -68,6 +73,8 @@ export const DatePickerButton = ({
 };
 
 DatePickerButton.defaultProps = {
+  label: null,
+  labelStyle: {},
   minimumDate: undefined,
   maximumDate: undefined,
   isCircle: true,
@@ -82,5 +89,7 @@ DatePickerButton.propTypes = {
   minimumDate: PropTypes.instanceOf(Date),
   isCircle: PropTypes.bool,
   isDisabled: PropTypes.bool,
+  label: PropTypes.string,
+  labelStyle: PropTypes.object,
   mode: PropTypes.string,
 };

--- a/src/widgets/DateRangeSelector.js
+++ b/src/widgets/DateRangeSelector.js
@@ -41,8 +41,9 @@ export const DateRangeSelector = ({
           initialValue={moment(initialStartDate).startOf('day').toDate()}
           onDateChanged={onChangeFromDate}
           isCircle={false}
+          label={formattedStartDate}
+          labelStyle={dateTextStyle}
         />
-        <Text style={dateTextStyle}>{formattedStartDate}</Text>
       </FlexRow>
 
       <FlexRow alignItems="center">
@@ -53,8 +54,9 @@ export const DateRangeSelector = ({
           initialValue={moment(initialEndDate).endOf('day').toDate()}
           onDateChanged={onChangeToDate}
           isCircle={false}
+          label={formattedEndDate}
+          labelStyle={dateTextStyle}
         />
-        <Text style={dateTextStyle}>{formattedEndDate}</Text>
       </FlexRow>
     </View>
   );


### PR DESCRIPTION
Fixes #4139

## Change summary

Pass label through to the `IconButton` to be used inside `TouchableHighlight` container. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] View the fridge detail page for a fridge with some sensor logs and tap the text that displays the date - this should open the DatePicker

### Related areas to think about
Not sure (maybe it's weird to have a label that's only used for the non-circle button?)