### PR TITLE
Add sensor to TemperatureLog incomingSync

### DIFF
--- a/src/reducers/Entities/LocationReducer.js
+++ b/src/reducers/Entities/LocationReducer.js
@@ -21,6 +21,7 @@ export const LocationReducer = (state = initialState(), action) => {
   const { type } = action;
 
   switch (type) {
+    case INITIALISE_FINISHED:
     case SYNC_TRANSACTION_COMPLETE: {
       const { byId } = state;
 

--- a/src/reducers/Entities/SensorReducer.js
+++ b/src/reducers/Entities/SensorReducer.js
@@ -3,7 +3,7 @@ import { BREACH_ACTIONS } from '../../actions/BreachActions';
 import { SENSOR_ACTIONS } from '../../actions/Entities/SensorActions';
 import { UIDatabase } from '../../database';
 import { ROUTES } from '../../navigation/index';
-import { SYNC_TRANSACTION_COMPLETE } from '../../sync/constants';
+import { INITIALISE_FINISHED, SYNC_TRANSACTION_COMPLETE } from '../../sync/constants';
 
 const getById = () =>
   UIDatabase.objects('Sensor').reduce(
@@ -25,6 +25,7 @@ export const SensorReducer = (state = initialState(), action) => {
   const { type } = action;
 
   switch (type) {
+    case INITIALISE_FINISHED:
     case SYNC_TRANSACTION_COMPLETE: {
       const { byId } = state;
 

--- a/src/reducers/Entities/TemperatureBreachConfigReducer.js
+++ b/src/reducers/Entities/TemperatureBreachConfigReducer.js
@@ -23,6 +23,7 @@ export const TemperatureBreachConfigReducer = (state = initialState(), action) =
   const { type } = action;
 
   switch (type) {
+    case INITIALISE_FINISHED:
     case SYNC_TRANSACTION_COMPLETE: {
       const { byId } = state;
 

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -1026,6 +1026,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         location: database.getOrCreate('Location', record.location_ID),
         breach: database.getOrCreate('TemperatureBreach', record.temperature_breach_ID),
         logInterval: parseNumber(record.log_interval),
+        sensor: database.getOrCreate('Sensor', record.sensor_ID),
       });
       break;
     }


### PR DESCRIPTION
Fixes #4151 

## Change summary

- Adds sensor to temperature log for incoming sync, ensuring temperature logs are related to a sensor when reinitialized.
- Offroad: Added hydrating of the entity stores after a reinit - currently on a full init the entity stores and refreshed, so you for example, get an empty sensor page- work around of some navigating can get you the state back but I don't want to have to explain more "Oh just navigate to this page and then that page and then presto boomo" or "have you tried restarting the app?"

## Testing

- [ ] Setup a mobile with a sensor and some temperature logs. Reinitialize. Check the records/current temperature of the sensor
- [ ] On the first navigation to 

### Related areas to think about

N/A
