### PR TITLE
#4154 Disable import data button while initializing

### DIFF
--- a/src/pages/FirstUsePage.js
+++ b/src/pages/FirstUsePage.js
@@ -213,6 +213,8 @@ export class FirstUsePageComponent extends React.Component {
                 textStyle={globalStyles.authFormButtonText}
                 text={buttonStrings.import_data}
                 onPress={requestImportStorageWritePermission}
+                disabledColor={WARM_GREY}
+                isDisabled={status !== STATUSES.UNINITIALISED && status !== STATUSES.ERROR}
               />
             ) : null}
           </View>


### PR DESCRIPTION
Fixes #4154 

## Change summary
Will disable `Import Data` button while setup initializing from the scratch

## Testing

Steps to reproduce or otherwise test the changes of this PR:

Setup the mobile connection from the scratch to the desktop mSupply

- [ ] `Import Data` button would be disabled while initialization is on process
