### PR TITLE
#4179 - Clicking check connection the sync URL is changed

### DIFF
--- a/src/authentication/SyncAuthenticator.js
+++ b/src/authentication/SyncAuthenticator.js
@@ -25,7 +25,7 @@ const {
   THIS_STORE_NAME_ID,
 } = SETTINGS_KEYS;
 
-export const AUTH_ENDPOINT = '/sync/v3/site';
+const AUTH_ENDPOINT = '/sync/v3/site';
 
 export class SyncAuthenticator {
   constructor(settings) {

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -81,11 +81,11 @@ const Settings = ({
 
   const onCheckConnection = () => {
     //  Hash the password.
-
+    const syncSitePassword = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_SITE_PASSWORD_HASH);
     const syncSiteName = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_SITE_NAME);
     const syncAuthenticator = new SyncAuthenticator(AppSettings);
     syncAuthenticator
-      .authenticate(syncURL, syncSiteName, null, currentUserPasswordHash)
+      .authenticate(syncURL, syncSiteName, null, syncSitePassword)
       .then(() => {
         ToastAndroid.show(buttonStrings.connection_status, ToastAndroid.LONG);
       })

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -37,7 +37,7 @@ import { FlexRow } from '../widgets/FlexRow';
 import globalStyles, { APP_FONT_FAMILY, DARK_GREY, SUSSOL_ORANGE } from '../globalStyles';
 import { FlexView } from '../widgets/FlexView';
 import { MILLISECONDS } from '../utilities/constants';
-import { SyncAuthenticator, AUTH_ENDPOINT } from '../authentication/SyncAuthenticator';
+import { SyncAuthenticator } from '../authentication/SyncAuthenticator';
 
 const exportData = async () => {
   const syncSiteName = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_SITE_NAME);
@@ -81,11 +81,11 @@ const Settings = ({
 
   const onCheckConnection = () => {
     //  Hash the password.
-    const authURL = `${syncURL}${AUTH_ENDPOINT}`;
+
     const syncSiteName = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_SITE_NAME);
     const syncAuthenticator = new SyncAuthenticator(AppSettings);
     syncAuthenticator
-      .authenticate(authURL, syncSiteName, null, currentUserPasswordHash)
+      .authenticate(syncURL, syncSiteName, null, currentUserPasswordHash)
       .then(() => {
         ToastAndroid.show(buttonStrings.connection_status, ToastAndroid.LONG);
       })


### PR DESCRIPTION
Fixes #4170

## Change summary

Explain and justify your changes

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Setup server with mobile version 8.1.0
- [ ] Connect mobile with server
- [ ] Once you are on home page of Mobile
- [ ] Click on Setting
- [ ] Click on `Check connection`
   - [ ] It should alert depending on the status of Sync URL
   - [ ] go back to home page and click on setting
      - [ ] Sync URL should not be changed to something like `SyncURL/sync/v3/site`  

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
