### PR TITLE
change code generation method

### DIFF
--- a/src/database/utilities/constants.js
+++ b/src/database/utilities/constants.js
@@ -14,6 +14,7 @@ export const MILLISECONDS_PER_HOUR = MILLISECONDS_PER_MINUTE * MINUTES_PER_HOUR;
 export const MILLISECONDS_PER_DAY = MILLISECONDS_PER_HOUR * HOURS_PER_DAY;
 
 export const NUMBER_OF_DAYS_IN_A_MONTH = 365 / 12;
+export const PATIENT_CODE_LENGTH = 8;
 
 export const NUMBER_SEQUENCE_KEYS = {
   CUSTOMER_INVOICE_NUMBER: 'customer_invoice_serial_number',
@@ -22,7 +23,6 @@ export const NUMBER_SEQUENCE_KEYS = {
   REQUISITION_REQUESTER_REFERENCE: 'requisition_requester_reference',
   STOCKTAKE_SERIAL_NUMBER: 'stocktake_serial_number',
   SUPPLIER_INVOICE_NUMBER: 'supplier_invoice_serial_number',
-  PATIENT_CODE: 'patient_code',
 };
 
 export const NAME_TYPE_KEYS = {

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -8,7 +8,7 @@ import { generateUUID } from 'react-native-database';
 
 import { UIDatabase } from '..';
 import { versionToInteger, formatDateAndTime } from '../../utilities';
-import { NUMBER_OF_DAYS_IN_A_MONTH, NUMBER_SEQUENCE_KEYS } from './constants';
+import { NUMBER_OF_DAYS_IN_A_MONTH, NUMBER_SEQUENCE_KEYS, PATIENT_CODE_LENGTH } from './constants';
 import { generalStrings } from '../../localization';
 import { SETTINGS_KEYS } from '../../settings';
 
@@ -198,13 +198,26 @@ const createPrescriber = (database, prescriberDetails) => {
 };
 
 /**
+ * Check a code for uniqueness
+ */
+const isPatientCodeUnique = (code, database) =>
+  database.objects('Patient').filtered(`code == '${code}'`).length === 0;
+
+/**
  * Gets a unique code for new patient record.
  */
 const getPatientUniqueCode = database => {
-  const { PATIENT_CODE } = NUMBER_SEQUENCE_KEYS;
-  const patientSequenceNumber = getNextNumber(database, PATIENT_CODE);
-  const thisStoreCode = database.getSetting(SETTINGS_KEYS.THIS_STORE_CODE);
-  return `${thisStoreCode}${String(patientSequenceNumber)}`;
+  const id = generateUUID();
+  const syncSiteId = database.getSetting(SETTINGS_KEYS.SYNC_SITE_ID);
+  const syncIdLength = `${syncSiteId}`.length;
+
+  // unlikely, but problematic if the syncId is longer than the requested patient code length
+  const code =
+    syncIdLength >= PATIENT_CODE_LENGTH
+      ? `${syncSiteId}${id.substring(0, 4)}` // increase the length to ensure uniqueness
+      : `${syncSiteId}${id.substring(0, PATIENT_CODE_LENGTH - syncIdLength)}`;
+
+  return isPatientCodeUnique(code, database) ? code : getPatientUniqueCode(id, database);
 };
 
 const createNameNote = (database, { id, data, patientEventID, nameID, entryDate = new Date() }) => {


### PR DESCRIPTION
Fixes #4166 

## Change summary

Generate a patient code independently of the `NumberSequence` as this doesn't guarantee uniqueness

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create patient, reset tablet, create another patient. Check that the code is unique and 8 characters long for both

