### PR TITLE
Fix export messaging

### DIFF
--- a/src/database/UIDatabase.js
+++ b/src/database/UIDatabase.js
@@ -133,10 +133,11 @@ class UIDatabase {
       await RNFS.mkdir(exportFolder);
       await RNFS.copyFile(realmPath, `${exportFolder}/${copyFileName}.realm`);
     } catch (error) {
-      return false;
+      const { message } = error;
+      return { success: false, message };
     }
 
-    return true;
+    return { success: true };
   }
 
   /**

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -28,7 +28,7 @@ import {
   DollarIcon,
 } from '../widgets/icons';
 import { ROUTES } from '../navigation/constants';
-import { buttonStrings, vaccineStrings, navStrings } from '../localization';
+import { buttonStrings, vaccineStrings, navStrings, generalStrings } from '../localization';
 
 import { SETTINGS_KEYS } from '../settings';
 import { UIDatabase } from '../database';
@@ -61,7 +61,9 @@ import { SUSSOL_ORANGE } from '../globalStyles/colors';
 const exportData = async () => {
   const syncSiteName = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_SITE_NAME);
   const { success, message } = await UIDatabase.exportData(syncSiteName);
-  const toastMessage = success ? 'Exported data file' : `Couldn't export data: ${message}`;
+  const toastMessage = success
+    ? generalStrings.exported_data
+    : `${generalStrings.couldnt_export_data}: ${message}`;
   ToastAndroid.show(toastMessage, ToastAndroid.SHORT);
 };
 

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -42,8 +42,10 @@ import { SyncAuthenticator } from '../authentication/SyncAuthenticator';
 const exportData = async () => {
   const syncSiteName = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_SITE_NAME);
 
-  const success = await UIDatabase.exportData(syncSiteName);
-  const toastMessage = success ? generalStrings.exported_data : generalStrings.couldnt_export_data;
+  const { success, message } = await UIDatabase.exportData(syncSiteName);
+  const toastMessage = success
+    ? generalStrings.exported_data
+    : `${generalStrings.couldnt_export_data}: ${message}`;
 
   ToastAndroid.show(toastMessage, ToastAndroid.SHORT);
 };


### PR DESCRIPTION
Doesn't fix #4186 

## Change summary

The export method wasn't displaying error messages, though there was some detail available. 
This doesn't fix the error, but might help diagnose.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Settings > Export data

