### PR TITLE
replace mac with id

### DIFF
--- a/src/selectors/Entities/sensor.js
+++ b/src/selectors/Entities/sensor.js
@@ -14,9 +14,9 @@ export const selectSensors = state => {
   return Object.values(sensorsById);
 };
 
-export const selectSensorByMac = (state, mac) => {
+export const selectSensorById = (state, sensorId) => {
   const sensors = selectSensors(state);
-  const foundSensor = sensors.find(({ macAddress }) => macAddress === mac);
+  const foundSensor = sensors.find(({ id }) => id === sensorId);
   return foundSensor;
 };
 
@@ -51,38 +51,38 @@ export const selectNewSensorId = state => {
   return newId;
 };
 
-export const selectIsLowBatteryByMac = (state, mac) => {
-  const sensor = selectSensorByMac(state, mac) ?? {};
+export const selectIsLowBatteryById = (state, id) => {
+  const sensor = selectSensorById(state, id) ?? {};
   const { batteryLevel } = sensor;
   return batteryLevel && batteryLevel <= VACCINE_CONSTANTS.LOW_BATTERY_PERCENTAGE;
 };
 
-export const selectIsInHotBreachByMac = (state, mac) => {
-  const sensor = selectSensorByMac(state, mac) ?? {};
+export const selectIsInHotBreachById = (state, id) => {
+  const sensor = selectSensorById(state, id) ?? {};
   const { isInHotBreach } = sensor;
   return !!isInHotBreach;
 };
 
-export const selectIsInColdBreachByMac = (state, mac) => {
-  const sensor = selectSensorByMac(state, mac) ?? {};
+export const selectIsInColdBreachById = (state, id) => {
+  const sensor = selectSensorById(state, id) ?? {};
   const { isInColdBreach } = sensor;
   return !!isInColdBreach;
 };
 
-export const selectIsInBreachByMac = (state, mac) => {
-  const sensor = selectSensorByMac(state, mac) ?? {};
+export const selectIsInBreachById = (state, id) => {
+  const sensor = selectSensorById(state, id) ?? {};
   const { isInHotBreach, isInColdBreach } = sensor;
   return !!isInHotBreach || !!isInColdBreach;
 };
 
-export const selectIsInDangerByMac = (state, mac) => {
-  const isLowBattery = selectIsLowBatteryByMac(state, mac);
-  const isInBreach = selectIsInBreachByMac(state, mac);
+export const selectIsInDangerById = (state, id) => {
+  const isLowBattery = selectIsLowBatteryById(state, id);
+  const isInBreach = selectIsInBreachById(state, id);
   return isLowBattery || isInBreach;
 };
 
-export const selectCurrentTemperatureByMac = (state, mac) => {
-  const sensor = selectSensorByMac(state, mac);
+export const selectCurrentTemperatureById = (state, id) => {
+  const sensor = selectSensorById(state, id);
   const { currentTemperature } = sensor;
   return currentTemperature;
 };

--- a/src/widgets/SensorHeader/LastSensorDownload.js
+++ b/src/widgets/SensorHeader/LastSensorDownload.js
@@ -16,7 +16,7 @@ import {
   selectLastDownloadTime,
 } from '../../selectors/Bluetooth/sensorDownload';
 import { vaccineStrings } from '../../localization';
-import { selectSensorByMac } from '../../selectors/Entities/sensor';
+import { selectSensorById } from '../../selectors/Entities/sensor';
 
 const formatErrorMessage = status => vaccineStrings[status] ?? '';
 
@@ -102,7 +102,7 @@ const stateToProps = (state, props) => {
   const lastDownloadFailed = selectLastDownloadFailed(state, macAddress);
   const isDownloading = selectIsDownloading(state, macAddress);
 
-  const sensor = selectSensorByMac(state, macAddress);
+  const sensor = selectSensorById(state, macAddress);
   const { isPaused = false, logDelay } = sensor ?? {};
 
   const lastDownloadStatus = selectLastDownloadStatus(state, macAddress);

--- a/src/widgets/SensorHeader/SensorIsInDangerCircle.js
+++ b/src/widgets/SensorHeader/SensorIsInDangerCircle.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { DANGER_RED, FINALISE_GREEN } from '../../globalStyles/index';
 import { Circle } from '../Circle';
 import { WithFlash } from '../WithFlash';
-import { selectIsInDangerByMac } from '../../selectors/Entities/sensor';
+import { selectIsInDangerById } from '../../selectors/Entities/sensor';
 
 export const SensorIsInDangerCircleComponent = ({ isInDanger }) => {
   const backgroundColor = isInDanger ? DANGER_RED : FINALISE_GREEN;
@@ -24,8 +24,8 @@ SensorIsInDangerCircleComponent.propTypes = {
 };
 
 const stateToProps = (state, props) => {
-  const { macAddress } = props;
-  const isInDanger = selectIsInDangerByMac(state, macAddress);
+  const { id } = props;
+  const isInDanger = selectIsInDangerById(state, id);
   return { isInDanger };
 };
 

--- a/src/widgets/SensorStatus.js
+++ b/src/widgets/SensorStatus.js
@@ -15,10 +15,10 @@ import { Rectangle } from './Rectangle';
 import temperature from '../utilities/temperature';
 
 import {
-  selectCurrentTemperatureByMac,
-  selectIsInColdBreachByMac,
-  selectIsInHotBreachByMac,
-  selectIsLowBatteryByMac,
+  selectCurrentTemperatureById,
+  selectIsInColdBreachById,
+  selectIsInHotBreachById,
+  selectIsLowBatteryById,
 } from '../selectors/Entities/sensor';
 
 const BigText = ({ children, colour }) => (
@@ -138,12 +138,12 @@ SensorStatusComponent.propTypes = {
 };
 
 const stateToProps = (state, props) => {
-  const { macAddress } = props;
+  const { id } = props;
 
-  const isInHotBreach = selectIsInHotBreachByMac(state, macAddress);
-  const isInColdBreach = selectIsInColdBreachByMac(state, macAddress);
-  const isLowBattery = selectIsLowBatteryByMac(state, macAddress);
-  const currentTemperature = selectCurrentTemperatureByMac(state, macAddress);
+  const isInHotBreach = selectIsInHotBreachById(state, id);
+  const isInColdBreach = selectIsInColdBreachById(state, id);
+  const isLowBattery = selectIsLowBatteryById(state, id);
+  const currentTemperature = selectCurrentTemperatureById(state, id);
 
   return { isInHotBreach, isInColdBreach, isLowBattery, currentTemperature };
 };


### PR DESCRIPTION
Fixes #4191 

## Change summary

In the scenario given, multiple Sensor objects were using the same macAddress, with one enabled and the others disabled.
One of the disabled ones was in a current breach - and that resulted in the `SensorIsInDangerCircle` showing the breach.

The badge however, was correctly checking `isActive` for each sensor and showing no active breaches.

I've changed all of the status elements to use the sensor id just in case other scenarios come up.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Tricky. Use the provided data, or create by setting up multiple sensors with the same mac address - disable all but one, with an inactive one in a current breach. Good luck!

