### PR TITLE
#4174 alert if patient already vaccinated in same day

### DIFF
--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -6,7 +6,7 @@
     "and": "and",
     "cancel": "Cancel",
     "confirm": "Confirm",
-    "confirm_double_dose": "This patient already has a vaccination recorded for today, do you want to proceed?",
+    "confirm_double_dose": "This patient already has a vaccination recorded within the last 24 hours, do you want to proceed?",
     "create": "Create",
     "delete_these_fridges": "Are you sure you want to delete these fridges?",
     "create_cash_transaction": "Create new cash transaction",

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -6,6 +6,7 @@
     "and": "and",
     "cancel": "Cancel",
     "confirm": "Confirm",
+    "confirm_double_dose": "This patient already has a vaccination recorded for today, do you want to proceed?",
     "create": "Create",
     "delete_these_fridges": "Are you sure you want to delete these fridges?",
     "create_cash_transaction": "Create new cash transaction",

--- a/src/selectors/Entities/name.js
+++ b/src/selectors/Entities/name.js
@@ -4,6 +4,7 @@ import { UIDatabase } from '../../database';
 import { selectSpecificEntityState } from './index';
 import { DATE_FORMAT } from '../../utilities/constants';
 import { PREFERENCE_KEYS } from '../../database/utilities/preferenceConstants';
+import { MILLISECONDS_PER_DAY } from '../../database/utilities/constants';
 
 export const selectEditingNameId = state => {
   const NameState = selectSpecificEntityState(state, 'name');
@@ -88,10 +89,9 @@ export const selectVaccinePatientHistory = state => {
   return inQuery ? UIDatabase.objects('TransactionBatch').filtered(fullQuery).slice() : [];
 };
 
-export const selectWasPatientVaccinatedToday = state => {
+export const selectWasPatientVaccinatedWithinOneDay = state => {
   const history = selectVaccinePatientHistory(state);
+  const oneDayAgo = new Date().getTime() - MILLISECONDS_PER_DAY;
 
-  const currentDate = new Date();
-  return !!history.filter(historyRecord => historyRecord.confirmDate >= currentDate.getDate() - 1)
-    .length;
+  return !!history.filter(historyRecord => historyRecord.confirmDate.getTime() >= oneDayAgo).length;
 };

--- a/src/selectors/Entities/name.js
+++ b/src/selectors/Entities/name.js
@@ -87,3 +87,11 @@ export const selectVaccinePatientHistory = state => {
   const fullQuery = `(${inQuery}) AND ${baseQueryString} AND itemBatch.item.isVaccine == true`;
   return inQuery ? UIDatabase.objects('TransactionBatch').filtered(fullQuery).slice() : [];
 };
+
+export const selectWasPatientVaccinatedToday = state => {
+  const history = selectVaccinePatientHistory(state);
+
+  const currentDate = new Date();
+  return !!history.filter(historyRecord => historyRecord.confirmDate >= currentDate.getDate() - 1)
+    .length;
+};

--- a/src/selectors/Entities/name.js
+++ b/src/selectors/Entities/name.js
@@ -93,5 +93,5 @@ export const selectWasPatientVaccinatedWithinOneDay = state => {
   const history = selectVaccinePatientHistory(state);
   const oneDayAgo = new Date().getTime() - MILLISECONDS_PER_DAY;
 
-  return !!history.filter(historyRecord => historyRecord.confirmDate.getTime() >= oneDayAgo).length;
+  return !!history.filter(historyRecord => historyRecord.confirmDate.getTime() > oneDayAgo).length;
 };

--- a/src/widgets/PaperModal/PaperConfirmModal.js
+++ b/src/widgets/PaperModal/PaperConfirmModal.js
@@ -36,7 +36,7 @@ export const PaperConfirmModal = ({
 );
 
 const localStyles = StyleSheet.create({
-  questionText: { fontSize: 16, color: DARKER_GREY, fontWeight: '700' },
+  questionText: { fontSize: 16, color: DARKER_GREY, fontWeight: '700', textAlign: 'center' },
   cancelText: { textTransform: 'uppercase' },
   confirmText: { textTransform: 'uppercase', color: WHITE },
   confirmButton: { backgroundColor: SUSSOL_ORANGE },

--- a/src/widgets/PaperModal/PaperConfirmModal.js
+++ b/src/widgets/PaperModal/PaperConfirmModal.js
@@ -8,7 +8,6 @@ import { Spacer } from '../Spacer';
 import { DARKER_GREY, SUSSOL_ORANGE, WHITE } from '../../globalStyles/index';
 import { FlexRow } from '../FlexRow';
 import { PageButton } from '../PageButton';
-import { PageButtonWithOnePress } from '../PageButtonWithOnePress';
 
 export const PaperConfirmModal = ({
   Icon,
@@ -17,7 +16,6 @@ export const PaperConfirmModal = ({
   cancelText,
   onConfirm,
   onCancel,
-  withOnePress,
 }) => (
   <FlexColumn alignItems="center" justifyContent="center" flex={1} style={{ padding: 20 }}>
     <FlexView flex={1} alignItems="center" justifyContent="center">
@@ -27,21 +25,12 @@ export const PaperConfirmModal = ({
     </FlexView>
     <FlexRow justifyContent="space-evenly" alignItems="center" style={{ width: '100%' }} flex={1}>
       <PageButton onPress={onCancel} text={cancelText} textStyle={localStyles.cancelText} />
-      {withOnePress ? (
-        <PageButtonWithOnePress
-          onPress={onConfirm}
-          text={confirmText}
-          textStyle={localStyles.confirmText}
-          style={localStyles.confirmButton}
-        />
-      ) : (
-        <PageButton
-          onPress={onConfirm}
-          text={confirmText}
-          textStyle={localStyles.confirmText}
-          style={localStyles.confirmButton}
-        />
-      )}
+      <PageButton
+        onPress={onConfirm}
+        text={confirmText}
+        textStyle={localStyles.confirmText}
+        style={localStyles.confirmButton}
+      />
     </FlexRow>
   </FlexColumn>
 );
@@ -55,7 +44,6 @@ const localStyles = StyleSheet.create({
 
 PaperConfirmModal.defaultProps = {
   Icon: <HazardIcon size={50} />,
-  withOnePress: false,
 };
 
 PaperConfirmModal.propTypes = {
@@ -65,5 +53,4 @@ PaperConfirmModal.propTypes = {
   cancelText: PropTypes.string.isRequired,
   onConfirm: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-  withOnePress: PropTypes.bool,
 };

--- a/src/widgets/PaperModal/PaperConfirmModal.js
+++ b/src/widgets/PaperModal/PaperConfirmModal.js
@@ -8,6 +8,7 @@ import { Spacer } from '../Spacer';
 import { DARKER_GREY, SUSSOL_ORANGE, WHITE } from '../../globalStyles/index';
 import { FlexRow } from '../FlexRow';
 import { PageButton } from '../PageButton';
+import { PageButtonWithOnePress } from '../PageButtonWithOnePress';
 
 export const PaperConfirmModal = ({
   Icon,
@@ -16,6 +17,7 @@ export const PaperConfirmModal = ({
   cancelText,
   onConfirm,
   onCancel,
+  withOnePress,
 }) => (
   <FlexColumn alignItems="center" justifyContent="center" flex={1} style={{ padding: 20 }}>
     <FlexView flex={1} alignItems="center" justifyContent="center">
@@ -25,12 +27,21 @@ export const PaperConfirmModal = ({
     </FlexView>
     <FlexRow justifyContent="space-evenly" alignItems="center" style={{ width: '100%' }} flex={1}>
       <PageButton onPress={onCancel} text={cancelText} textStyle={localStyles.cancelText} />
-      <PageButton
-        onPress={onConfirm}
-        text={confirmText}
-        textStyle={localStyles.confirmText}
-        style={localStyles.confirmButton}
-      />
+      {withOnePress ? (
+        <PageButtonWithOnePress
+          onPress={onConfirm}
+          text={confirmText}
+          textStyle={localStyles.confirmText}
+          style={localStyles.confirmButton}
+        />
+      ) : (
+        <PageButton
+          onPress={onConfirm}
+          text={confirmText}
+          textStyle={localStyles.confirmText}
+          style={localStyles.confirmButton}
+        />
+      )}
     </FlexRow>
   </FlexColumn>
 );
@@ -44,6 +55,7 @@ const localStyles = StyleSheet.create({
 
 PaperConfirmModal.defaultProps = {
   Icon: <HazardIcon size={50} />,
+  withOnePress: false,
 };
 
 PaperConfirmModal.propTypes = {
@@ -53,4 +65,5 @@ PaperConfirmModal.propTypes = {
   cancelText: PropTypes.string.isRequired,
   onConfirm: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
+  withOnePress: PropTypes.bool,
 };

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -165,38 +165,24 @@ const VaccineSelectComponent = ({
 
       <FlexRow flex={1} alignItems="flex-end" justifyContent="flex-end">
         <PageButtonWithOnePress text={buttonStrings.cancel} onPress={onCancelPrescription} />
-
-        {wasVaccinatedToday() ? (
-          <PageButton
-            text={buttonStrings.confirm}
-            style={{ marginLeft: 'auto' }}
-            isDisabled={!selectedBatches && !hasRefused}
-            onPress={toggleConfirmDoubleDoseModal}
-          />
-        ) : (
-          <PageButtonWithOnePress
-            text={buttonStrings.confirm}
-            style={{ marginLeft: 'auto' }}
-            isDisabled={!selectedBatches && !hasRefused}
-            onPress={confirmPrescription}
-          />
-        )}
-
-        {wasVaccinatedToday() ? (
-          <PageButton
-            text={generalStrings.ok_and_next}
-            style={{ marginLeft: 5 }}
-            isDisabled={!selectedBatches && !hasRefused}
-            onPress={toggleConfirmAndRepeatDoubleDoseModal}
-          />
-        ) : (
-          <PageButtonWithOnePress
-            text={generalStrings.ok_and_next}
-            style={{ marginLeft: 5 }}
-            isDisabled={!selectedBatches && !hasRefused}
-            onPress={confirmAndRepeatPrescription}
-          />
-        )}
+        <PageButton
+          debounceTimer={1000}
+          text={buttonStrings.confirm}
+          style={{ marginLeft: 'auto' }}
+          isDisabled={!selectedBatches && !hasRefused}
+          onPress={wasVaccinatedToday() ? toggleConfirmDoubleDoseModal : confirmPrescription}
+        />
+        <PageButton
+          debounceTimer={1000}
+          text={generalStrings.ok_and_next}
+          style={{ marginLeft: 5 }}
+          isDisabled={!selectedBatches && !hasRefused}
+          onPress={
+            wasVaccinatedToday()
+              ? toggleConfirmAndRepeatDoubleDoseModal
+              : confirmAndRepeatPrescription
+          }
+        />
       </FlexRow>
       <PaperModalContainer
         isVisible={confirmDoubleDoseModalOpen}

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -106,11 +106,9 @@ const VaccineSelectComponent = ({
   const wasVaccinatedToday = () => {
     const currentDate = new Date();
 
-    return !!(
-      vaccinePatientHistory.length &&
-      vaccinePatientHistory.filter(history => history.confirmDate >= currentDate.getDate() - 1)
-        .length
-    );
+    return !!vaccinePatientHistory.filter(
+      history => history.confirmDate >= currentDate.getDate() - 1
+    ).length;
   };
 
   const confirmPrescription = React.useCallback(() => runWithLoadingIndicator(onConfirm), [
@@ -167,7 +165,7 @@ const VaccineSelectComponent = ({
       <FlexRow flex={1} alignItems="flex-end" justifyContent="flex-end">
         <PageButtonWithOnePress text={buttonStrings.cancel} onPress={onCancelPrescription} />
 
-        {wasVaccinatedToday ? (
+        {wasVaccinatedToday() ? (
           <PageButton
             text={buttonStrings.confirm}
             style={{ marginLeft: 'auto' }}
@@ -183,7 +181,7 @@ const VaccineSelectComponent = ({
           />
         )}
 
-        {wasVaccinatedToday ? (
+        {wasVaccinatedToday() ? (
           <PageButton
             text={generalStrings.ok_and_next}
             style={{ marginLeft: 5 }}

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -41,7 +41,7 @@ import { AfterInteractions } from '../AfterInteractions';
 import { Paper } from '../Paper';
 import { VaccinePrescriptionInfo } from '../VaccinePrescriptionInfo';
 import { useNavigationFocus } from '../../hooks/useNavigationFocus';
-import { selectWasPatientVaccinatedToday } from '../../selectors/Entities/name';
+import { selectWasPatientVaccinatedWithinOneDay } from '../../selectors/Entities/name';
 import { PaperModalContainer } from '../PaperModal/PaperModalContainer';
 import { PaperConfirmModal } from '../PaperModal/PaperConfirmModal';
 import { useToggle } from '../../hooks/useToggle';
@@ -81,7 +81,7 @@ const VaccineSelectComponent = ({
   vaccines,
   okAndRepeat,
   selectDefaultVaccine,
-  wasPatientVaccinatedToday,
+  wasPatientVaccinatedWithinOneDay,
 }) => {
   const { pageTopViewContainer } = globalStyles;
   const [confirmDoubleDoseModalOpen, toggleConfirmDoubleDoseModal] = useToggle();
@@ -172,7 +172,9 @@ const VaccineSelectComponent = ({
           text={buttonStrings.confirm}
           style={{ marginLeft: 'auto' }}
           isDisabled={!selectedBatches && !hasRefused}
-          onPress={wasPatientVaccinatedToday ? toggleConfirmDoubleDoseModal : confirmPrescription}
+          onPress={
+            wasPatientVaccinatedWithinOneDay ? toggleConfirmDoubleDoseModal : confirmPrescription
+          }
         />
         <PageButton
           debounceTimer={1000}
@@ -180,7 +182,7 @@ const VaccineSelectComponent = ({
           style={{ marginLeft: 5 }}
           isDisabled={!selectedBatches && !hasRefused}
           onPress={
-            wasPatientVaccinatedToday
+            wasPatientVaccinatedWithinOneDay
               ? toggleConfirmAndRepeatDoubleDoseModal
               : confirmAndRepeatPrescription
           }
@@ -233,7 +235,7 @@ const mapStateToProps = state => {
   const vaccines = selectVaccines(state);
   const [selectedVaccine] = selectedVaccines;
   const vaccinator = selectSelectedVaccinator(state);
-  const wasPatientVaccinatedToday = selectWasPatientVaccinatedToday(state);
+  const wasPatientVaccinatedWithinOneDay = selectWasPatientVaccinatedWithinOneDay(state);
 
   return {
     vaccinator,
@@ -243,7 +245,7 @@ const mapStateToProps = state => {
     selectedRows,
     selectedVaccine,
     vaccines,
-    wasPatientVaccinatedToday,
+    wasPatientVaccinatedWithinOneDay,
   };
 };
 
@@ -266,7 +268,7 @@ VaccineSelectComponent.propTypes = {
   selectedRows: PropTypes.object,
   selectedBatches: PropTypes.array,
   selectedVaccine: PropTypes.object,
-  wasPatientVaccinatedToday: PropTypes.bool.isRequired,
+  wasPatientVaccinatedWithinOneDay: PropTypes.bool.isRequired,
   vaccines: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
 };
 

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -121,6 +121,16 @@ const VaccineSelectComponent = ({
     [okAndRepeat]
   );
 
+  const onModalClose = confirmDoubleDoseModalOpen
+    ? toggleConfirmDoubleDoseModal
+    : toggleConfirmAndRepeatDoubleDoseModal;
+
+  const modalOnConfirm = confirmDoubleDoseModalOpen
+    ? confirmPrescription
+    : confirmAndRepeatPrescription;
+
+  const isModalOpen = confirmDoubleDoseModalOpen || confirmAndRepeatDoubleDoseModalOpen;
+
   const navigation = useNavigation();
   useNavigationFocus(navigation, selectDefaultVaccine);
 
@@ -184,28 +194,13 @@ const VaccineSelectComponent = ({
           }
         />
       </FlexRow>
-      <PaperModalContainer
-        isVisible={confirmDoubleDoseModalOpen}
-        onClose={toggleConfirmDoubleDoseModal}
-      >
+      <PaperModalContainer isVisible={isModalOpen} onClose={onModalClose}>
         <PaperConfirmModal
           questionText={modalStrings.confirm_double_dose}
           confirmText={modalStrings.confirm}
           cancelText={modalStrings.cancel}
-          onConfirm={confirmPrescription}
-          onCancel={toggleConfirmDoubleDoseModal}
-        />
-      </PaperModalContainer>
-      <PaperModalContainer
-        isVisible={confirmAndRepeatDoubleDoseModalOpen}
-        onClose={toggleConfirmAndRepeatDoubleDoseModal}
-      >
-        <PaperConfirmModal
-          questionText={modalStrings.confirm_double_dose}
-          confirmText={modalStrings.confirm}
-          cancelText={modalStrings.cancel}
-          onConfirm={confirmAndRepeatPrescription}
-          onCancel={toggleConfirmAndRepeatDoubleDoseModal}
+          onConfirm={modalOnConfirm}
+          onCancel={onModalClose}
         />
       </PaperModalContainer>
     </FlexView>

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -208,7 +208,6 @@ const VaccineSelectComponent = ({
           cancelText={modalStrings.cancel}
           onConfirm={confirmPrescription}
           onCancel={toggleConfirmDoubleDoseModal}
-          withOnePress={true}
         />
       </PaperModalContainer>
       <PaperModalContainer
@@ -221,7 +220,6 @@ const VaccineSelectComponent = ({
           cancelText={modalStrings.cancel}
           onConfirm={confirmAndRepeatPrescription}
           onCancel={toggleConfirmAndRepeatDoubleDoseModal}
-          withOnePress={true}
         />
       </PaperModalContainer>
     </FlexView>

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -125,7 +125,7 @@ const VaccineSelectComponent = ({
     ? toggleConfirmDoubleDoseModal
     : toggleConfirmAndRepeatDoubleDoseModal;
 
-  const modalOnConfirm = confirmDoubleDoseModalOpen
+  const onModalConfirm = confirmDoubleDoseModalOpen
     ? confirmPrescription
     : confirmAndRepeatPrescription;
 
@@ -199,7 +199,7 @@ const VaccineSelectComponent = ({
           questionText={modalStrings.confirm_double_dose}
           confirmText={modalStrings.confirm}
           cancelText={modalStrings.cancel}
-          onConfirm={modalOnConfirm}
+          onConfirm={onModalConfirm}
           onCancel={onModalClose}
         />
       </PaperModalContainer>

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -41,7 +41,7 @@ import { AfterInteractions } from '../AfterInteractions';
 import { Paper } from '../Paper';
 import { VaccinePrescriptionInfo } from '../VaccinePrescriptionInfo';
 import { useNavigationFocus } from '../../hooks/useNavigationFocus';
-import { selectVaccinePatientHistory } from '../../selectors/Entities/name';
+import { selectWasPatientVaccinatedToday } from '../../selectors/Entities/name';
 import { PaperModalContainer } from '../PaperModal/PaperModalContainer';
 import { PaperConfirmModal } from '../PaperModal/PaperConfirmModal';
 import { useToggle } from '../../hooks/useToggle';
@@ -81,7 +81,7 @@ const VaccineSelectComponent = ({
   vaccines,
   okAndRepeat,
   selectDefaultVaccine,
-  vaccinePatientHistory,
+  wasPatientVaccinatedToday,
 }) => {
   const { pageTopViewContainer } = globalStyles;
   const [confirmDoubleDoseModalOpen, toggleConfirmDoubleDoseModal] = useToggle();
@@ -103,14 +103,6 @@ const VaccineSelectComponent = ({
     [vaccines]
   );
   const runWithLoadingIndicator = useLoadingIndicator();
-
-  const wasVaccinatedToday = () => {
-    const currentDate = new Date();
-
-    return !!vaccinePatientHistory.filter(
-      history => history.confirmDate >= currentDate.getDate() - 1
-    ).length;
-  };
 
   const confirmPrescription = React.useCallback(() => runWithLoadingIndicator(onConfirm), [
     onConfirm,
@@ -180,7 +172,7 @@ const VaccineSelectComponent = ({
           text={buttonStrings.confirm}
           style={{ marginLeft: 'auto' }}
           isDisabled={!selectedBatches && !hasRefused}
-          onPress={wasVaccinatedToday() ? toggleConfirmDoubleDoseModal : confirmPrescription}
+          onPress={wasPatientVaccinatedToday ? toggleConfirmDoubleDoseModal : confirmPrescription}
         />
         <PageButton
           debounceTimer={1000}
@@ -188,7 +180,7 @@ const VaccineSelectComponent = ({
           style={{ marginLeft: 5 }}
           isDisabled={!selectedBatches && !hasRefused}
           onPress={
-            wasVaccinatedToday()
+            wasPatientVaccinatedToday
               ? toggleConfirmAndRepeatDoubleDoseModal
               : confirmAndRepeatPrescription
           }
@@ -241,7 +233,7 @@ const mapStateToProps = state => {
   const vaccines = selectVaccines(state);
   const [selectedVaccine] = selectedVaccines;
   const vaccinator = selectSelectedVaccinator(state);
-  const vaccinePatientHistory = selectVaccinePatientHistory(state);
+  const wasPatientVaccinatedToday = selectWasPatientVaccinatedToday(state);
 
   return {
     vaccinator,
@@ -251,7 +243,7 @@ const mapStateToProps = state => {
     selectedRows,
     selectedVaccine,
     vaccines,
-    vaccinePatientHistory,
+    wasPatientVaccinatedToday,
   };
 };
 
@@ -274,7 +266,7 @@ VaccineSelectComponent.propTypes = {
   selectedRows: PropTypes.object,
   selectedBatches: PropTypes.array,
   selectedVaccine: PropTypes.object,
-  vaccinePatientHistory: PropTypes.array.isRequired,
+  wasPatientVaccinatedToday: PropTypes.bool.isRequired,
   vaccines: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
 };
 

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -84,7 +84,8 @@ const VaccineSelectComponent = ({
   vaccinePatientHistory,
 }) => {
   const { pageTopViewContainer } = globalStyles;
-  const [doubleDoseModalOpen, toggleDoubleDoseModal] = useToggle();
+  const [confirmDoubleDoseModalOpen, toggleConfirmDoubleDoseModal] = useToggle();
+  const [confirmAndRepeatDoubleDoseModalOpen, toggleConfirmAndRepeatDoubleDoseModal] = useToggle();
   const vaccineColumns = React.useMemo(() => getColumns(TABS.ITEM), []);
   const batchColumns = React.useMemo(() => getColumns(TABS.VACCINE_BATCH), []);
   const disabledVaccineRows = React.useMemo(
@@ -170,7 +171,7 @@ const VaccineSelectComponent = ({
             text={buttonStrings.confirm}
             style={{ marginLeft: 'auto' }}
             isDisabled={!selectedBatches && !hasRefused}
-            onPress={toggleDoubleDoseModal}
+            onPress={toggleConfirmDoubleDoseModal}
           />
         ) : (
           <PageButtonWithOnePress
@@ -186,7 +187,7 @@ const VaccineSelectComponent = ({
             text={generalStrings.ok_and_next}
             style={{ marginLeft: 5 }}
             isDisabled={!selectedBatches && !hasRefused}
-            onPress={toggleDoubleDoseModal}
+            onPress={toggleConfirmAndRepeatDoubleDoseModal}
           />
         ) : (
           <PageButtonWithOnePress
@@ -197,13 +198,30 @@ const VaccineSelectComponent = ({
           />
         )}
       </FlexRow>
-      <PaperModalContainer isVisible={doubleDoseModalOpen} onClose={toggleDoubleDoseModal}>
+      <PaperModalContainer
+        isVisible={confirmDoubleDoseModalOpen}
+        onClose={toggleConfirmDoubleDoseModal}
+      >
         <PaperConfirmModal
           questionText={modalStrings.confirm_double_dose}
           confirmText={modalStrings.confirm}
           cancelText={modalStrings.cancel}
           onConfirm={confirmPrescription}
-          onCancel={toggleDoubleDoseModal}
+          onCancel={toggleConfirmDoubleDoseModal}
+          withOnePress={true}
+        />
+      </PaperModalContainer>
+      <PaperModalContainer
+        isVisible={confirmAndRepeatDoubleDoseModalOpen}
+        onClose={toggleConfirmAndRepeatDoubleDoseModal}
+      >
+        <PaperConfirmModal
+          questionText={modalStrings.confirm_double_dose}
+          confirmText={modalStrings.confirm}
+          cancelText={modalStrings.cancel}
+          onConfirm={confirmAndRepeatPrescription}
+          onCancel={toggleConfirmAndRepeatDoubleDoseModal}
+          withOnePress={true}
         />
       </PaperModalContainer>
     </FlexView>


### PR DESCRIPTION
Fixes #4174

## Change summary

- Pop up a modal asking the user to confirm if they want to proceed if a patient has already received a vaccine in the same day. Originally had a check if vaccine with the same item id as the vaccination in the history was selected but thought it might be too restrictive (sometimes it's bad to have more than 1 shot even if they are different shots? 🤷‍♀️ )
- Also I think this is a bit hacky so I would be keen to hear if there is a better way to do this without creating two modals 😭 , had some struggles trying to make the confirm button function conditional on which button (Confirm vs OK & Next was pressed)
- Also some weird stuff with the Confirm and OK & Next buttons because the `withOnePress` meant if the user cancelled out of the modal they wouldn't be able to press it again...also made the confirm button on the modal optionally one pressable only...I feel like there must be a better way to do this too haha.
 
## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Vaccinate a patient, try to vaccinate them again, should get a popup:
![image](https://user-images.githubusercontent.com/65875762/123882484-fc899c80-d99a-11eb-8dd5-246df5fd0346.png)

### Related areas to think about
N/A
