### PR TITLE
#4200 dashboard crashes app

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "8.1.1-rc2",
+  "version": "8.1.1-rc3",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "8.1.1-rc3",
+  "version": "8.1.1-rc2",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/widgets/BarChart.js
+++ b/src/widgets/BarChart.js
@@ -21,13 +21,13 @@ import { APP_FONT_FAMILY, GREY, LIGHT_GREY, DARK_GREY, SUSSOL_ORANGE } from '../
 
 export const BarChart = ({ data, width, height }) => {
   const renderYAxis = () => (
-    <VictoryAxis label={data[0].axis_label.y} dependentAxis style={victoryStyles.axisY} />
+    <VictoryAxis label={data[0]?.axis_label?.y} dependentAxis style={victoryStyles.axisY} />
   );
   const renderXAxis = () => {
     const tickTruncate = label => (label.length > 11 ? `${label.slice(0, 11)}...` : label);
     return (
       <VictoryAxis
-        label={data[0].axis_label.x}
+        label={data[0]?.axis_label?.x}
         tickFormat={tickTruncate}
         style={victoryStyles.axisX}
       />

--- a/src/widgets/BarChart.js
+++ b/src/widgets/BarChart.js
@@ -49,12 +49,13 @@ export const BarChart = ({ data, width, height }) => {
   return (
     <VictoryChart width={width} height={height} padding={padding} domainPadding={domainPadding}>
       <VictoryLabel text={data[0].label} x={width / 2} y={30} textAnchor="middle" />
-      {data.map(({ values }) => (
+      {data.map(({ values, index }) => (
         <VictoryBar
           style={style}
           data={values}
           labels={({ datum }) => datum.y}
           labelComponent={<VictoryLabel style={victoryStyles.labelStyle} />}
+          key={index}
         />
       ))}
       {renderYAxis()}

--- a/src/widgets/PieChart.js
+++ b/src/widgets/PieChart.js
@@ -37,7 +37,7 @@ export const PieChart = ({ width, height, data }) => {
   };
 
   const widthPadded = width * (1 - padHorizontal);
-  return data.map(({ values }) => (
+  return data.map(({ values, index }) => (
     <VictoryPie
       width={width}
       height={height}
@@ -49,6 +49,7 @@ export const PieChart = ({ width, height, data }) => {
       labels={({ datum }) => `${datum.x} : ${datum.y}`}
       labelComponent={<VictoryLabel style={style} />}
       data={values}
+      key={index}
     />
   ));
 };

--- a/src/widgets/ReportTable/ReportRow.js
+++ b/src/widgets/ReportTable/ReportRow.js
@@ -20,8 +20,9 @@ import { ReportCell } from './ReportCell';
 export const ReportRow = ({ isHeader, rowData, rowIndex }) => {
   const headerStyle = isHeader ? localStyles.header : null;
   const rowStyle = StyleSheet.flatten([localStyles.container, headerStyle]);
-  const cellsToRender = rowData.map(cell => (
-    <ReportCell key={rowIndex} even={rowIndex % 2 === 0}>
+  const cellsToRender = rowData.map((cell, cellIndex) => (
+    // eslint-disable-next-line react/no-array-index-key
+    <ReportCell key={`${rowIndex}_${cellIndex}`} even={rowIndex % 2 === 0}>
       {cell}
     </ReportCell>
   ));


### PR DESCRIPTION
Fixes #4200 

## Change summary

Using the demo JSON or generated data from mSupply (_this month's transactions_) resulted in this error, which crashes the app.

The schema validation isn't checking for the optional `axis_label`. Rather than updating mSupply to provide these, I went with avoidance instead, to work around the problem.

## Testing

Before testing, you'll need to set up a dashboard:

- enable the dashboard module for your store
- configure a report:
  - dashboard admin: edit 'this months transactions' and add
  - isMobile: True
  - reportType: BarChart
  - ensure it is active
  - Click on 'run report' on the JSON tab to speed up the process
- sync the tablet

Steps to reproduce or otherwise test the changes of this PR:

- [ ] View a bar chart

### Related areas to think about

Have tested the other chart types, this is the only one with an issue