### PR TITLE
#4198 save site data on vaccine dispense

### DIFF
--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -6,7 +6,7 @@ import {
   selectFoundBonusDose,
   selectHasRefused,
   selectSelectedBatches,
-  selectSelectedSiteData,
+  selectSelectedSupplementalData,
   selectSelectedVaccinator,
 } from '../../selectors/Entities/vaccinePrescription';
 import { selectEditingNameId } from '../../selectors/Entities/name';
@@ -97,9 +97,9 @@ const selectDefaultVaccine = () => ({
   payload: { selectedVaccines: [getDefaultVaccine()], selectedBatches: [getRecommendedBatch()] },
 });
 
-const selectSupplementalData = siteData => ({
+const selectSupplementalData = supplementalData => ({
   type: VACCINE_PRESCRIPTION_ACTIONS.SELECT_SUPPLEMENTAL_DATA,
-  payload: { siteData },
+  payload: { supplementalData },
 });
 
 const selectVaccine = vaccine => ({
@@ -126,7 +126,13 @@ const setRefusal = hasRefused => ({
   },
 });
 
-const createPrescription = (patient, currentUser, selectedBatches, vaccinator, siteData) => {
+const createPrescription = (
+  patient,
+  currentUser,
+  selectedBatches,
+  vaccinator,
+  supplementalData
+) => {
   UIDatabase.write(() => {
     const prescription = createRecord(
       UIDatabase,
@@ -134,7 +140,7 @@ const createPrescription = (patient, currentUser, selectedBatches, vaccinator, s
       patient,
       currentUser,
       'dispensary',
-      siteData
+      supplementalData
     );
 
     selectedBatches.forEach(itemBatch => {
@@ -167,7 +173,7 @@ const confirm = () => (dispatch, getState) => {
   const patientID = selectEditingNameId(getState());
   const selectedBatches = selectSelectedBatches(getState());
   const vaccinator = selectSelectedVaccinator(getState());
-  const siteData = selectSelectedSiteData(getState());
+  const supplementalData = selectSelectedSupplementalData(getState());
 
   if (hasBonusDoses) {
     UIDatabase.write(() => {
@@ -202,7 +208,7 @@ const confirm = () => (dispatch, getState) => {
   if (hasRefused) {
     createRefusalNameNote(patient);
   } else {
-    createPrescription(patient, currentUser, selectedBatches, vaccinator, siteData);
+    createPrescription(patient, currentUser, selectedBatches, vaccinator, supplementalData);
   }
 };
 

--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -6,6 +6,7 @@ import {
   selectFoundBonusDose,
   selectHasRefused,
   selectSelectedBatches,
+  selectSelectedSiteData,
   selectSelectedVaccinator,
 } from '../../selectors/Entities/vaccinePrescription';
 import { selectEditingNameId } from '../../selectors/Entities/name';
@@ -125,14 +126,15 @@ const setRefusal = hasRefused => ({
   },
 });
 
-const createPrescription = (patient, currentUser, selectedBatches, vaccinator) => {
+const createPrescription = (patient, currentUser, selectedBatches, vaccinator, siteData) => {
   UIDatabase.write(() => {
     const prescription = createRecord(
       UIDatabase,
       'CustomerInvoice',
       patient,
       currentUser,
-      'dispensary'
+      'dispensary',
+      siteData
     );
 
     selectedBatches.forEach(itemBatch => {
@@ -165,6 +167,7 @@ const confirm = () => (dispatch, getState) => {
   const patientID = selectEditingNameId(getState());
   const selectedBatches = selectSelectedBatches(getState());
   const vaccinator = selectSelectedVaccinator(getState());
+  const siteData = selectSelectedSiteData(getState());
 
   if (hasBonusDoses) {
     UIDatabase.write(() => {
@@ -199,7 +202,7 @@ const confirm = () => (dispatch, getState) => {
   if (hasRefused) {
     createRefusalNameNote(patient);
   } else {
-    createPrescription(patient, currentUser, selectedBatches, vaccinator);
+    createPrescription(patient, currentUser, selectedBatches, vaccinator, siteData);
   }
 };
 

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -616,6 +616,7 @@ Transaction.schema = {
     serialNumber: { type: 'string', default: 'placeholderSerialNumber' },
     otherParty: { type: 'Name', optional: true },
     comment: { type: 'string', optional: true },
+    customData: { type: 'string', optional: true },
     entryDate: { type: 'date', optional: true },
     type: { type: 'string', default: 'placeholderType' },
     status: { type: 'string', default: 'new' },

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -257,7 +257,7 @@ export const schema = {
     VaccineVialMonitorStatus,
     VaccineVialMonitorStatusLog,
   ],
-  schemaVersion: 25,
+  schemaVersion: 26,
 };
 
 export default schema;

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -566,7 +566,7 @@ const createCustomerRefundLine = (database, customerCredit, transactionBatch) =>
  * @param   {Name}         customer  Customer associated with invoice.
  * @return  {Transaction}
  */
-const createCustomerInvoice = (database, customer, user, mode = 'store') => {
+const createCustomerInvoice = (database, customer, user, mode = 'store', customData = null) => {
   const { CUSTOMER_INVOICE_NUMBER } = NUMBER_SEQUENCE_KEYS;
   const currentDate = new Date();
   const invoice = database.create('Transaction', {
@@ -581,6 +581,7 @@ const createCustomerInvoice = (database, customer, user, mode = 'store') => {
     otherParty: customer,
     enteredBy: user,
     mode,
+    customData: JSON.stringify(customData),
   });
 
   database.save('Transaction', invoice);

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -566,7 +566,7 @@ const createCustomerRefundLine = (database, customerCredit, transactionBatch) =>
  * @param   {Name}         customer  Customer associated with invoice.
  * @return  {Transaction}
  */
-const createCustomerInvoice = (database, customer, user, customData, mode = 'store') => {
+const createCustomerInvoice = (database, customer, user, mode = 'store', customData = null) => {
   const { CUSTOMER_INVOICE_NUMBER } = NUMBER_SEQUENCE_KEYS;
   const currentDate = new Date();
   const invoice = database.create('Transaction', {

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -566,7 +566,7 @@ const createCustomerRefundLine = (database, customerCredit, transactionBatch) =>
  * @param   {Name}         customer  Customer associated with invoice.
  * @return  {Transaction}
  */
-const createCustomerInvoice = (database, customer, user, mode = 'store', customData = '') => {
+const createCustomerInvoice = (database, customer, user, customData, mode = 'store') => {
   const { CUSTOMER_INVOICE_NUMBER } = NUMBER_SEQUENCE_KEYS;
   const currentDate = new Date();
   const invoice = database.create('Transaction', {
@@ -581,7 +581,7 @@ const createCustomerInvoice = (database, customer, user, mode = 'store', customD
     otherParty: customer,
     enteredBy: user,
     mode,
-    customData: JSON.stringify(customData),
+    customData: customData ? JSON.stringify(customData) : null,
   });
 
   database.save('Transaction', invoice);

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -566,7 +566,7 @@ const createCustomerRefundLine = (database, customerCredit, transactionBatch) =>
  * @param   {Name}         customer  Customer associated with invoice.
  * @return  {Transaction}
  */
-const createCustomerInvoice = (database, customer, user, mode = 'store', customData = null) => {
+const createCustomerInvoice = (database, customer, user, mode = 'store', customData = '') => {
   const { CUSTOMER_INVOICE_NUMBER } = NUMBER_SEQUENCE_KEYS;
   const currentDate = new Date();
   const invoice = database.create('Transaction', {

--- a/src/selectors/Entities/vaccinePrescription.js
+++ b/src/selectors/Entities/vaccinePrescription.js
@@ -92,3 +92,10 @@ export const selectHistoryIsOpen = state => {
   const { historyIsOpen } = VaccinePrescriptionState;
   return historyIsOpen;
 };
+
+export const selectSelectedSiteData = state => {
+  const VaccinePrescriptionState = selectSpecificEntityState(state, 'vaccinePrescription');
+  const { siteData } = VaccinePrescriptionState;
+
+  return siteData;
+};

--- a/src/selectors/Entities/vaccinePrescription.js
+++ b/src/selectors/Entities/vaccinePrescription.js
@@ -93,9 +93,9 @@ export const selectHistoryIsOpen = state => {
   return historyIsOpen;
 };
 
-export const selectSelectedSiteData = state => {
+export const selectSelectedSupplementalData = state => {
   const VaccinePrescriptionState = selectSpecificEntityState(state, 'vaccinePrescription');
-  const { siteData } = VaccinePrescriptionState;
+  const { supplementalData } = VaccinePrescriptionState;
 
-  return siteData;
+  return supplementalData;
 };

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -842,7 +842,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         serialNumber: record.invoice_num,
         otherParty,
         comment: record.comment,
-        customData: record.custom_data ? parseJsonString(record.custom_data) : null,
+        customData: parseJsonString(record.custom_data),
         entryDate: parseDate(record.entry_date),
         type: TRANSACTION_TYPES.translate(record.type, EXTERNAL_TO_INTERNAL),
         status: STATUSES.translate(record.status, EXTERNAL_TO_INTERNAL),

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -842,6 +842,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         serialNumber: record.invoice_num,
         otherParty,
         comment: record.comment,
+        customData: record.custom_data ? parseJsonString(record.custom_data) : null,
         entryDate: parseDate(record.entry_date),
         type: TRANSACTION_TYPES.translate(record.type, EXTERNAL_TO_INTERNAL),
         status: STATUSES.translate(record.status, EXTERNAL_TO_INTERNAL),

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -215,6 +215,7 @@ const generateSyncData = (settings, recordType, record) => {
         name_ID: record.otherParty?.id ?? '',
         invoice_num: record.serialNumber,
         comment: record.comment,
+        custom_data: record.customData,
         entry_date: getDateString(record.entryDate),
         type: TRANSACTION_TYPES.translate(record.type, INTERNAL_TO_EXTERNAL),
         status: STATUSES.translate(record.status, INTERNAL_TO_EXTERNAL),
@@ -524,6 +525,7 @@ export const generateSyncJson = (database, settings, syncOutRecord) => {
       Bugsnag.notify(error);
 
       // Make a nicer message for users and throw it again.
+      // eslint-disable-next-line max-len
       error.message = `There was an error syncing. Contact mSupply mobile support. ${originalMessage}`;
       throw error;
     }

--- a/src/widgets/Tabs/VaccineSupplementalData.js
+++ b/src/widgets/Tabs/VaccineSupplementalData.js
@@ -67,9 +67,9 @@ VaccineSupplementalDataComponent.propTypes = {
 const mapDispatchToProps = dispatch => {
   const onCancel = () => dispatch(VaccinePrescriptionActions.cancel());
 
-  const onComplete = siteData => {
+  const onComplete = supplementalData => {
     batch(() => {
-      dispatch(VaccinePrescriptionActions.selectSupplementalData(siteData));
+      dispatch(VaccinePrescriptionActions.selectSupplementalData(supplementalData));
       dispatch(WizardActions.nextTab());
     });
   };


### PR DESCRIPTION
Fixes #4198

## Change summary

- Adds `Transaction.customData` to mobile schema/sync utils
- Save siteData into `Transaction.customData` when creating a vaccinePrescription if it exists

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a prescription with siteData (needs FormSchema with type `VaccineSite`), check Realm Explorer (and/or export and check the contents that way) and verify that the siteData is saved to the transaction
- [ ] Sync to Desktop - check via record browser that [transact].custom_data contains the site data for the vaccine prescription just created 

### Related areas to think about
Dispensing without siteData (and regular customer invoices) should not create any `customData` for the transactions
