### PR TITLE
#4210 Auto populate form with previously entered values

### DIFF
--- a/src/actions/Entities/NameNoteActions.js
+++ b/src/actions/Entities/NameNoteActions.js
@@ -1,35 +1,16 @@
-import Ajv from 'ajv';
 import { generateUUID } from 'react-native-database';
 import merge from 'lodash.merge';
 import moment from 'moment';
 import { createRecord, UIDatabase } from '../../database/index';
 import { selectCreatingNameNote } from '../../selectors/Entities/nameNote';
 import { selectSurveySchemas } from '../../selectors/formSchema';
-
-const ajvErrors = require('ajv-errors');
-
-const ajvOptions = {
-  errorDataPath: 'property',
-  allErrors: true,
-  multipleOfPrecision: 8,
-  schemaId: 'auto',
-  jsonPointers: true,
-};
+import { validateJsonSchemaData } from '../../utilities/ajvValidator';
 
 export const NAME_NOTE_ACTIONS = {
   SELECT: 'NAME_NOTE/select',
   RESET: 'NAME_NOTE/reset',
   UPDATE_DATA: 'NAME_NOTE/updateData',
   CREATE: 'NAME_NOTE/create',
-};
-
-const ajv = new Ajv(ajvOptions);
-ajvErrors(ajv);
-
-const validateData = (jsonSchema, data) => {
-  if (!jsonSchema) return true;
-  const result = ajv.validate(jsonSchema, data);
-  return result;
 };
 
 const createDefaultNameNote = (nameID = '') => {
@@ -84,7 +65,7 @@ const createSurveyNameNote = patient => (dispatch, getState) => {
   // the seed has any fields which are required to be filled.
   const [surveySchema = {}] = selectSurveySchemas(getState);
   const { jsonSchema } = surveySchema;
-  const isValid = validateData(jsonSchema, newNameNote.data);
+  const isValid = validateJsonSchemaData(jsonSchema, newNameNote.data);
 
   dispatch(select(newNameNote, isValid));
 };

--- a/src/database/DataTypes/Transaction.js
+++ b/src/database/DataTypes/Transaction.js
@@ -590,6 +590,7 @@ export class Transaction extends Realm.Object {
       id: this.id,
       serialNumber: this.serialNumber,
       comment: this.comment,
+      customData: this.customData,
       entryDate: this.entryDate?.getTime(),
       type: this.type,
       status: this.status,

--- a/src/reducers/Entities/VaccinePrescriptionReducer.js
+++ b/src/reducers/Entities/VaccinePrescriptionReducer.js
@@ -12,6 +12,7 @@ const initialState = () => ({
   vaccinator: null,
   bonusDose: false,
   historyIsOpen: false,
+  isSupplementalDataValid: false,
 });
 
 export const VaccinePrescriptionReducer = (state = initialState(), action) => {
@@ -53,6 +54,13 @@ export const VaccinePrescriptionReducer = (state = initialState(), action) => {
       const { supplementalData } = payload;
 
       return { ...state, supplementalData };
+    }
+
+    case VACCINE_PRESCRIPTION_ACTIONS.UPDATE_SUPPLEMENTAL_DATA: {
+      const { payload } = action;
+      const { supplementalData, isSupplementalDataValid } = payload;
+
+      return { ...state, supplementalData, isSupplementalDataValid };
     }
 
     case VACCINE_PRESCRIPTION_ACTIONS.SELECT_VACCINE: {

--- a/src/selectors/Entities/vaccinePrescription.js
+++ b/src/selectors/Entities/vaccinePrescription.js
@@ -99,3 +99,19 @@ export const selectSelectedSupplementalData = state => {
 
   return supplementalData;
 };
+
+export const selectLastSupplementalData = () => {
+  const inQuery = UIDatabase.objects('Transaction')
+    .filtered('customData != $0 AND type != "cash_in" AND type != "cash_out"', null)
+    .map(({ id }) => `transaction.id == "${id}"`)
+    .join(' OR ');
+  const fullQuery = `(${inQuery}) AND itemBatch.item.isVaccine == true`;
+  const result = inQuery
+    ? UIDatabase.objects('TransactionBatch')
+        .filtered(fullQuery)
+        .sorted('transaction.entryDate', true)
+        .slice()
+    : [];
+
+  return result.length ? result[0].transaction.customData : null;
+};

--- a/src/selectors/Entities/vaccinePrescription.js
+++ b/src/selectors/Entities/vaccinePrescription.js
@@ -102,7 +102,7 @@ export const selectSelectedSupplementalData = state => {
 
 export const selectLastSupplementalData = () => {
   const inQuery = UIDatabase.objects('Transaction')
-    .filtered('customData != $0 AND type != "cash_in" AND type != "cash_out"', null)
+    .filtered("type == 'customer_invoice' AND customData != null")
     .map(({ id }) => `transaction.id == "${id}"`)
     .join(' OR ');
   const fullQuery = `(${inQuery}) AND itemBatch.item.isVaccine == true`;

--- a/src/selectors/Entities/vaccinePrescription.js
+++ b/src/selectors/Entities/vaccinePrescription.js
@@ -100,6 +100,13 @@ export const selectSelectedSupplementalData = state => {
   return supplementalData;
 };
 
+export const selectSupplementalDataIsValid = state => {
+  const VaccinePrescriptionState = selectSpecificEntityState(state, 'vaccinePrescription');
+  const { isSupplementalDataValid } = VaccinePrescriptionState;
+
+  return isSupplementalDataValid;
+};
+
 export const selectLastSupplementalData = () => {
   const inQuery = UIDatabase.objects('Transaction')
     .filtered("type == 'customer_invoice' AND customData != null")
@@ -113,5 +120,5 @@ export const selectLastSupplementalData = () => {
         .slice()
     : [];
 
-  return result.length ? result[0].transaction.customData : null;
+  return result.length ? JSON.parse(result[0].transaction.customData) : null;
 };

--- a/src/selectors/Entities/vaccinePrescription.js
+++ b/src/selectors/Entities/vaccinePrescription.js
@@ -113,12 +113,14 @@ export const selectLastSupplementalData = () => {
     .map(({ id }) => `transaction.id == "${id}"`)
     .join(' OR ');
   const fullQuery = `(${inQuery}) AND itemBatch.item.isVaccine == true`;
-  const result = inQuery
-    ? UIDatabase.objects('TransactionBatch')
-        .filtered(fullQuery)
-        .sorted('transaction.entryDate', true)
-        .slice()
-    : [];
 
-  return result.length ? JSON.parse(result[0].transaction.customData) : null;
+  if (inQuery) {
+    const result = UIDatabase.objects('TransactionBatch')
+      .filtered(fullQuery)
+      .sorted('transaction.entryDate', true)
+      .slice();
+    return result.length ? JSON.parse(result[0].transaction.customData) : null;
+  }
+
+  return null;
 };

--- a/src/selectors/formSchema.js
+++ b/src/selectors/formSchema.js
@@ -8,8 +8,10 @@ import { UIDatabase } from '../database/index';
 const PATIENT_SURVEY_TYPE = 'PatientSurvey';
 const VACCINE_SUPPLEMENTAL_DATA = 'VaccineSupplementalData';
 
-export const selectSurveySchemas = () =>
-  UIDatabase.objects('FormSchema').filtered(`type=='${PATIENT_SURVEY_TYPE}'`);
+export const selectSurveySchemas = () => selectFormSchema(`type=='${PATIENT_SURVEY_TYPE}'`);
 
 export const selectSupplementalDataSchemas = () =>
-  UIDatabase.objects('FormSchema').filtered(`type=='${VACCINE_SUPPLEMENTAL_DATA}'`);
+  selectFormSchema(`type=='${VACCINE_SUPPLEMENTAL_DATA}'`);
+
+const selectFormSchema = filter =>
+  UIDatabase.objects('FormSchema').filtered(filter).sorted('version', true);

--- a/src/utilities/ajvValidator.js
+++ b/src/utilities/ajvValidator.js
@@ -1,0 +1,20 @@
+import Ajv from 'ajv';
+
+const ajvErrors = require('ajv-errors');
+
+const ajvOptions = {
+  errorDataPath: 'property',
+  allErrors: true,
+  multipleOfPrecision: 8,
+  schemaId: 'auto',
+  jsonPointers: true,
+};
+
+const ajv = new Ajv(ajvOptions);
+ajvErrors(ajv);
+
+export const validateJsonSchemaData = (jsonSchema, data) => {
+  if (!jsonSchema) return true;
+  const result = ajv.validate(jsonSchema, data);
+  return result;
+};

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -288,6 +288,7 @@ const mapDispatchToProps = dispatch => {
 
       if (selectedPatient) {
         dispatch(NameNoteActions.createSurveyNameNote(selectedPatient));
+        dispatch(VaccinePrescriptionActions.createSupplementaryData());
         dispatch(WizardActions.nextTab());
       }
     });

--- a/src/widgets/Tabs/VaccineSupplementalData.js
+++ b/src/widgets/Tabs/VaccineSupplementalData.js
@@ -24,11 +24,17 @@ import { PageButtonWithOnePress } from '../PageButtonWithOnePress';
 import { VaccinePrescriptionActions } from '../../actions/Entities/index';
 import { WizardActions } from '../../actions/WizardActions';
 import { Paper } from '../Paper';
+import { selectLastSupplementalData } from '../../selectors/Entities/vaccinePrescription';
 
 const { pageTopViewContainer } = globalStyles;
 
 const VaccineSupplementalDataComponent = ({ onCancel, onComplete, siteSchema }) => {
-  const [{ formData, isValid }, setForm] = useState({ formData: null, isValid: false });
+  const lastSupplementalData = selectLastSupplementalData();
+  const [{ formData, isValid }, setForm] = useState({
+    formData: JSON.parse(lastSupplementalData),
+    isValid: lastSupplementalData ?? false,
+  });
+
   return (
     <FlexView style={pageTopViewContainer}>
       <Paper
@@ -37,6 +43,7 @@ const VaccineSupplementalDataComponent = ({ onCancel, onComplete, siteSchema }) 
         style={{ flex: 1 }}
       >
         <JSONForm
+          formData={formData}
           onChange={(changed, validator) => {
             setForm({ formData: changed.formData, isValid: validator(changed.formData) });
           }}

--- a/src/widgets/Tabs/VaccineSupplementalData.js
+++ b/src/widgets/Tabs/VaccineSupplementalData.js
@@ -11,6 +11,7 @@ import { ToastAndroid, View } from 'react-native';
 
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import * as Animatable from 'react-native-animatable';
 import { FlexRow } from '../FlexRow';
 import { FlexView } from '../FlexView';
 
@@ -28,6 +29,7 @@ import {
   selectSelectedSupplementalData,
   selectSupplementalDataIsValid,
 } from '../../selectors/Entities/vaccinePrescription';
+import { AfterInteractions } from '../AfterInteractions';
 
 const { pageTopViewContainer } = globalStyles;
 
@@ -45,16 +47,20 @@ const VaccineSupplementalDataComponent = ({
       contentContainerStyle={{ flex: 1 }}
       style={{ flex: 1 }}
     >
-      <JSONForm
-        formData={formData}
-        surveySchema={siteSchema}
-        onChange={(changed, validator) => {
-          onFormUpdate(changed.formData, validator);
-        }}
-        liveValidate={false}
-      >
-        <View />
-      </JSONForm>
+      <AfterInteractions placeholder={null}>
+        <Animatable.View animation="fadeIn" duration={1000} useNativeDriver style={{ flex: 1 }}>
+          <JSONForm
+            formData={formData}
+            surveySchema={siteSchema}
+            onChange={(changed, validator) => {
+              onFormUpdate(changed.formData, validator);
+            }}
+            liveValidate={false}
+          >
+            <View />
+          </JSONForm>
+        </Animatable.View>
+      </AfterInteractions>
     </Paper>
     <FlexRow flex={0} justifyContent="flex-end" alignItems="flex-end">
       <PageButtonWithOnePress text={buttonStrings.cancel} onPress={onCancel} />


### PR DESCRIPTION
Fixes #4210

## Change summary

- Looks in realm to try to find the last customData entry against a vaccine transaction and prepopulate supplemental data form with it
- Technically (at the moment anyway) these values _shouldn't_ change very often between jabs (might not be true later if some obscure fields are requested...)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Submit vaccine additional data once, do it again and see if form is prepopulated

### Related areas to think about
...
