### PR TITLE
#4189 improved logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "react-native-barcode-mask": "^1.2.4",
     "react-native-ble-plx": "^2.0.2",
     "react-native-bluetooth-status": "^1.5.1",
+    "react-native-bunyan": "^1.8.12",
     "react-native-camera": "^3.44.0",
     "react-native-database": "^0.3.3",
     "react-native-device-info": "^8.1.2",

--- a/src/bluetooth/BleService.js
+++ b/src/bluetooth/BleService.js
@@ -31,7 +31,7 @@ class BleService {
   constructor(manager = new BleManager()) {
     this.manager = manager;
 
-    logger.trace('BleService constructor', { manager });
+    logger.info('BleService constructor', { manager });
   }
 
   setManager = manager => {
@@ -47,7 +47,7 @@ class BleService {
    * @param {String} macAddress
    */
   connectToDevice = async macAddress => {
-    logger.trace('connectToDevice', { macAddress });
+    logger.info('connectToDevice', { macAddress });
     return this.manager.connectToDevice(macAddress);
   };
 
@@ -60,13 +60,13 @@ class BleService {
    * @param {String} macAddress
    */
   connectAndDiscoverServices = async macAddress => {
-    logger.trace('connectAndDiscoverServices', { macAddress });
+    logger.info('connectAndDiscoverServices', { macAddress });
     // without the cancel & reconnect further commands
     // were sometimes returning an error: "BleError: Device [mac address] was disconnected"
     // Note: adding the option `{ autoConnect: true }` prevents the sensors from
     // connecting sometimes :shrug:
     const deviceIsConnected = await this.manager.isDeviceConnected(macAddress);
-    logger.trace('deviceIsConnected', { deviceIsConnected });
+    logger.info('deviceIsConnected', { deviceIsConnected });
     if (deviceIsConnected) {
       await this.manager.cancelDeviceConnection(macAddress);
     }
@@ -75,7 +75,7 @@ class BleService {
 
     await this.manager.discoverAllServicesAndCharacteristicsForDevice(macAddress);
 
-    logger.trace('Discovered all services and characteristics for device', { macAddress });
+    logger.info('Discovered all services and characteristics for device', { macAddress });
     return device;
   };
 

--- a/src/bluetooth/BleService.js
+++ b/src/bluetooth/BleService.js
@@ -1,10 +1,13 @@
 import { BleManager } from 'react-native-ble-plx';
 import { Buffer } from 'buffer';
 import { BLUETOOTH } from './constants';
+import LoggerService from '../utilities/logging';
 
 const bufferFromBase64 = base64 => Buffer.from(base64, 'base64');
 const stringFromBase64 = base64 => bufferFromBase64(base64).toString('utf-8');
 const base64FromString = string => Buffer.from(string, 'utf-8').toString('base64');
+
+const logger = LoggerService.createLogger('BleService');
 
 /**
  * Interface for interacting with a native Ble Manager for interacting
@@ -27,6 +30,8 @@ const base64FromString = string => Buffer.from(string, 'utf-8').toString('base64
 class BleService {
   constructor(manager = new BleManager()) {
     this.manager = manager;
+
+    logger.trace('BleService constructor', { manager });
   }
 
   setManager = manager => {
@@ -41,7 +46,10 @@ class BleService {
    * on the device.
    * @param {String} macAddress
    */
-  connectToDevice = async macAddress => this.manager.connectToDevice(macAddress);
+  connectToDevice = async macAddress => {
+    logger.trace('connectToDevice', { macAddress });
+    return this.manager.connectToDevice(macAddress);
+  };
 
   /**
    * Connects to a device with the provided macAddress as well as discovering
@@ -52,16 +60,22 @@ class BleService {
    * @param {String} macAddress
    */
   connectAndDiscoverServices = async macAddress => {
+    logger.trace('connectAndDiscoverServices', { macAddress });
     // without the cancel & reconnect further commands
     // were sometimes returning an error: "BleError: Device [mac address] was disconnected"
-    // Note: adding the option `{ autoConnect: true }` prevents the sensors from connecting sometimes :shrug:
-    if (await this.manager.isDeviceConnected(macAddress)) {
+    // Note: adding the option `{ autoConnect: true }` prevents the sensors from
+    // connecting sometimes :shrug:
+    const deviceIsConnected = await this.manager.isDeviceConnected(macAddress);
+    logger.trace('deviceIsConnected', { deviceIsConnected });
+    if (deviceIsConnected) {
       await this.manager.cancelDeviceConnection(macAddress);
     }
 
     const device = await this.connectToDevice(macAddress);
 
     await this.manager.discoverAllServicesAndCharacteristicsForDevice(macAddress);
+
+    logger.trace('Discovered all services and characteristics for device', { macAddress });
     return device;
   };
 
@@ -228,7 +242,9 @@ class BleService {
    */
   downloadLogs = async macAddress => {
     await this.connectAndDiscoverServices(macAddress);
+    logger.info('Download logs connected and discovered services', { macAddress });
     return this.writeAndMonitor(macAddress, BLUETOOTH.COMMANDS.DOWNLOAD, data => {
+      logger.info('Write and monitor found some data!', { data });
       const buffer = Buffer.concat(data.slice(1).map(datum => bufferFromBase64(datum)));
 
       const ind = buffer.findIndex(
@@ -355,6 +371,7 @@ class BleService {
    * @param {Error} error
    */
   downloadLogsWithRetries = async (macAddress, retriesLeft, error) => {
+    logger.info('Starting to download logs', { macAddress, retriesLeft, error });
     if (!retriesLeft) throw error;
 
     return this.downloadLogs(macAddress).catch(err =>

--- a/src/utilities/logging/Engine.js
+++ b/src/utilities/logging/Engine.js
@@ -1,0 +1,61 @@
+import bunyan from 'react-native-bunyan';
+
+// interface LoggingEngine {
+//     trace: (text: string) => void
+//     debug: (text: string) => void
+//     info: (text: string) => void
+//     warn: (text: string) => void
+//     error: (text: string) => void
+//     fatal: (text: string) => void
+//     createChild: (text: string) => void
+// }
+export class BunyanLoggingEngine {
+  streams = [];
+
+  bunyan = null;
+
+  transports = {};
+
+  constructor({ module, transports }) {
+    this.transports = transports;
+    this.streams = Object.values(transports).map(({ level, write, name }) => ({
+      name,
+      level,
+      stream: { write },
+    }));
+
+    this.bunyan = bunyan.createLogger({ name: module, streams: this.streams });
+  }
+
+  trace(text) {
+    this.bunyan.trace(text);
+  }
+
+  debug(text) {
+    this.bunyan.debug(text);
+  }
+
+  info(text) {
+    this.bunyan.info(text);
+  }
+
+  warn(text) {
+    this.bunyan.warn(text);
+  }
+
+  error(text) {
+    this.bunyan.error(text);
+  }
+
+  fatal(text) {
+    this.bunyan.fatal(text);
+  }
+
+  createChild(submodule) {
+    this.bunyan.child({ submodule });
+  }
+
+  setLogLevel(transportKey, newLevel) {
+    this.bunyan.levels(transportKey, newLevel);
+  }
+}

--- a/src/utilities/logging/Engine.js
+++ b/src/utilities/logging/Engine.js
@@ -17,7 +17,6 @@ export class BunyanLoggingEngine {
   bunyan = null;
 
   constructor({ module, transports }) {
-    this.transports = transports;
     const streams = Object.values(transports).map(({ level, write, name }) => ({
       name,
       level,

--- a/src/utilities/logging/Engine.js
+++ b/src/utilities/logging/Engine.js
@@ -14,21 +14,17 @@ import bunyan from 'react-native-bunyan';
 //     setLogLevel(transportKey: string, newLevel: int) => void
 // }
 export class BunyanLoggingEngine {
-  streams = [];
-
   bunyan = null;
-
-  transports = {};
 
   constructor({ module, transports }) {
     this.transports = transports;
-    this.streams = Object.values(transports).map(({ level, write, name }) => ({
+    const streams = Object.values(transports).map(({ level, write, name }) => ({
       name,
       level,
       stream: { write },
     }));
 
-    this.bunyan = bunyan.createLogger({ name: module, streams: this.streams });
+    this.bunyan = bunyan.createLogger({ name: module, streams });
   }
 
   trace(text) {

--- a/src/utilities/logging/Engine.js
+++ b/src/utilities/logging/Engine.js
@@ -1,5 +1,9 @@
 import bunyan from 'react-native-bunyan';
 
+// Logging engine for the Logger class which implements the logic
+// of creating a log format and hands off the log to a transport
+// object.
+//
 // interface LoggingEngine {
 //     trace: (text: string) => void
 //     debug: (text: string) => void
@@ -7,7 +11,7 @@ import bunyan from 'react-native-bunyan';
 //     warn: (text: string) => void
 //     error: (text: string) => void
 //     fatal: (text: string) => void
-//     createChild: (text: string) => void
+//     setLogLevel(transportKey: string, newLevel: int) => void
 // }
 export class BunyanLoggingEngine {
   streams = [];
@@ -49,10 +53,6 @@ export class BunyanLoggingEngine {
 
   fatal(text) {
     this.bunyan.fatal(text);
-  }
-
-  createChild(submodule) {
-    this.bunyan.child({ submodule });
   }
 
   setLogLevel(transportKey, newLevel) {

--- a/src/utilities/logging/Logger.js
+++ b/src/utilities/logging/Logger.js
@@ -39,10 +39,6 @@ export class Logger {
     this.engine.warn(text);
   }
 
-  createChild(submodule) {
-    return this.engine.createChild(submodule);
-  }
-
   setLogLevel(transportName, newLevel) {
     this.engine.setLogLevel(transportName, newLevel);
   }

--- a/src/utilities/logging/Logger.js
+++ b/src/utilities/logging/Logger.js
@@ -1,0 +1,49 @@
+// interface Logger {
+//     trace: (text: string) => void
+//     debug: (text: string) => void
+//     info: (text: string) => void
+//     warn: (text: string) => void
+//     error: (text: string) => void
+//     fatal: (text: string) => void
+//     createChild: (text: string) => void
+//     setLogLevel: (transportName: string, logLevel: number) => void
+// }
+export class Logger {
+  engine = null;
+
+  constructor(engine) {
+    this.engine = engine;
+  }
+
+  trace(text) {
+    this.engine.trace(text);
+  }
+
+  debug(text) {
+    this.engine.debug(text);
+  }
+
+  info(text) {
+    this.engine.info(text);
+  }
+
+  warn(text) {
+    this.engine.warn(text);
+  }
+
+  error(text) {
+    this.engine.warn(text);
+  }
+
+  fatal(text) {
+    this.engine.warn(text);
+  }
+
+  createChild(submodule) {
+    return this.engine.createChild(submodule);
+  }
+
+  setLogLevel(transportName, newLevel) {
+    this.engine.setLogLevel(transportName, newLevel);
+  }
+}

--- a/src/utilities/logging/Service.js
+++ b/src/utilities/logging/Service.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-undef */
+import { BunyanLoggingEngine } from './Engine';
+import { Logger } from './Logger';
+import { consoleTransport, fileTransport } from './Transport';
+
+const createLoggingEngine = options => new BunyanLoggingEngine(options);
+
+export class LoggerService {
+  loggers = {};
+
+  transports = {};
+
+  // type DefaultLogLevel = Record<LoggerName, Record<TransportName, LogLevel>>
+  defaultLogLevels = {};
+
+  constructor(defaultLogLevels = {}) {
+    this.defaultLogLevels = defaultLogLevels;
+
+    if (__DEV__) {
+      this.addTransport('console', consoleTransport);
+    } else {
+      this.addTransport('file', fileTransport);
+    }
+  }
+
+  createLogger(module) {
+    const engine = createLoggingEngine({ module, transports: this.transports });
+    const newLogger = new Logger(engine);
+    this.loggers[module] = newLogger;
+
+    // Get the default log levels for this module:
+    // defaultLogLevels = Record<TransportName, LogLevel>
+    const defaultLogLevels = this.defaultLogLevels[module];
+    if (defaultLogLevels) {
+      // Set the logging level for each transport within the module
+      Object.entries(defaultLogLevels).forEach(([transportName, logLevel]) => {
+        newLogger.setLogLevel(transportName, logLevel);
+      });
+    }
+
+    return newLogger;
+  }
+
+  addTransport(key, transport) {
+    this.transports[key] = transport;
+  }
+}

--- a/src/utilities/logging/Transport.js
+++ b/src/utilities/logging/Transport.js
@@ -1,7 +1,20 @@
 /* eslint-disable no-console */
 import moment from 'moment';
 import RNFS from 'react-native-fs';
-import { LogLevel, logDir, logFileName, logFileDate, logFileSeparator } from './index';
+
+export const LogLevel = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+};
+
+export const logDir = `${RNFS.ExternalStorageDirectoryPath}/Download/mSupplyMobile_data`;
+export const logFileName = 'log.txt';
+export const logFileDate = 'DD-MM-YY';
+export const logFileSeparator = '__';
 
 // interface Transport {
 //     write: (text: string) => void

--- a/src/utilities/logging/Transport.js
+++ b/src/utilities/logging/Transport.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-console */
+import moment from 'moment';
+import RNFS from 'react-native-fs';
+import { LogLevel } from './index';
+
+// interface Transport {
+//     write: (text: string) => void
+//     level: number
+//     name: string
+// }
+
+export const consoleTransport = {
+  name: 'console',
+  level: LogLevel.trace,
+  write: text => {
+    console.log('-------------------------------------------');
+    console.log('text', text);
+    console.log('-------------------------------------------');
+  },
+};
+
+const logDir = `${RNFS.ExternalStorageDirectoryPath}/Download/mSupplyMobile_data`;
+const logFileName = 'log.txt';
+const logFileDate = 'DD-MM-YY';
+const logFileSeparator = '__';
+
+export const fileTransport = {
+  name: 'file',
+  level: LogLevel.info,
+  write: text => {
+    const date = moment().format(logFileDate);
+    // mSupplyMobile_data/DD-MM-YY__log.txt
+    const path = `${logDir}/${date}${logFileSeparator}${logFileName}`;
+    RNFS.appendFile(path, text);
+  },
+};

--- a/src/utilities/logging/Transport.js
+++ b/src/utilities/logging/Transport.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import moment from 'moment';
 import RNFS from 'react-native-fs';
-import { LogLevel } from './index';
+import { LogLevel, logDir, logFileName, logFileDate, logFileSeparator } from './index';
 
 // interface Transport {
 //     write: (text: string) => void
@@ -18,11 +18,6 @@ export const consoleTransport = {
     console.log('-------------------------------------------');
   },
 };
-
-const logDir = `${RNFS.ExternalStorageDirectoryPath}/Download/mSupplyMobile_data`;
-const logFileName = 'log.txt';
-const logFileDate = 'DD-MM-YY';
-const logFileSeparator = '__';
 
 export const fileTransport = {
   name: 'file',

--- a/src/utilities/logging/index.js
+++ b/src/utilities/logging/index.js
@@ -1,0 +1,41 @@
+import RNFS from 'react-native-fs';
+import moment from 'moment';
+
+const logDir = `${RNFS.ExternalStorageDirectoryPath}/Download/mSupplyMobile_data`;
+const logFileName = 'log.txt';
+const logFileDate = 'DD-MM-YY';
+const logFileSeparator = '__';
+
+export const LogLevel = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+};
+
+const logFileFilter = file => file?.includes(`${logFileSeparator}${logFileName}`);
+
+const getExceedsThresholdFilter = (threshold = [5, 'days']) => fileName => {
+  const thresholdDate = moment().subtract(...threshold);
+  const [maybeDate] = fileName.split(logFileSeparator);
+  const asMoment = moment(maybeDate, logFileDate);
+  return asMoment.isBefore(thresholdDate);
+};
+
+export const tidyLogFiles = async () => {
+  try {
+    const files = await RNFS.readdir(logDir);
+
+    return Promise.all(
+      files
+        .filter(logFileFilter)
+        .filter(getExceedsThresholdFilter())
+        .map(fileName => RNFS.unlink(`${logDir}/${fileName}`))
+    );
+  } catch (error) {
+    return null;
+    // Going to just ignore errors for now..?
+  }
+};

--- a/src/utilities/logging/index.js
+++ b/src/utilities/logging/index.js
@@ -17,6 +17,8 @@ export const tidyLogFiles = async () => {
     const files = await RNFS.readdir(logDir);
 
     return Promise.all(
+      // All files with the name {date}__log.txt where the date is some date in the format
+      // DD-MM-YY and is at least 5 days ago.
       files
         .filter(logFileFilter)
         .filter(getExceedsThresholdFilter())

--- a/src/utilities/logging/index.js
+++ b/src/utilities/logging/index.js
@@ -1,10 +1,10 @@
 import RNFS from 'react-native-fs';
 import moment from 'moment';
 
-const logDir = `${RNFS.ExternalStorageDirectoryPath}/Download/mSupplyMobile_data`;
-const logFileName = 'log.txt';
-const logFileDate = 'DD-MM-YY';
-const logFileSeparator = '__';
+export const logDir = `${RNFS.ExternalStorageDirectoryPath}/Download/mSupplyMobile_data`;
+export const logFileName = 'log.txt';
+export const logFileDate = 'DD-MM-YY';
+export const logFileSeparator = '__';
 
 export const LogLevel = {
   trace: 10,

--- a/src/utilities/logging/index.js
+++ b/src/utilities/logging/index.js
@@ -1,7 +1,10 @@
 import RNFS from 'react-native-fs';
 import moment from 'moment';
+import Bugsnag from '@bugsnag/react-native';
 import { LoggerService } from './Service';
 import { logDir, logFileName, logFileDate, logFileSeparator } from './Transport';
+import { SETTINGS_KEYS } from '../../settings';
+import { UIDatabase } from '../../database/index';
 
 const logFileFilter = file => file?.includes(`${logFileSeparator}${logFileName}`);
 
@@ -25,8 +28,13 @@ export const tidyLogFiles = async () => {
         .map(fileName => RNFS.unlink(`${logDir}/${fileName}`))
     );
   } catch (error) {
+    const storeCode = UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_CODE);
+    const syncUrl = UIDatabase.getSetting(SETTINGS_KEYS.SYNC_URL);
+    Bugsnag.notify(error, content => {
+      content.storeCode = storeCode;
+      content.syncUrl = syncUrl;
+    });
     return null;
-    // Going to just ignore errors for now..?
   }
 };
 

--- a/src/utilities/logging/index.js
+++ b/src/utilities/logging/index.js
@@ -1,19 +1,7 @@
 import RNFS from 'react-native-fs';
 import moment from 'moment';
-
-export const logDir = `${RNFS.ExternalStorageDirectoryPath}/Download/mSupplyMobile_data`;
-export const logFileName = 'log.txt';
-export const logFileDate = 'DD-MM-YY';
-export const logFileSeparator = '__';
-
-export const LogLevel = {
-  trace: 10,
-  debug: 20,
-  info: 30,
-  warn: 40,
-  error: 50,
-  fatal: 60,
-};
+import { LoggerService } from './Service';
+import { logDir, logFileName, logFileDate, logFileSeparator } from './Transport';
 
 const logFileFilter = file => file?.includes(`${logFileSeparator}${logFileName}`);
 
@@ -39,3 +27,5 @@ export const tidyLogFiles = async () => {
     // Going to just ignore errors for now..?
   }
 };
+
+export default new LoggerService();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8380,6 +8380,11 @@ react-native-bluetooth-status@^1.5.1:
   dependencies:
     "@cs125/wait-until" "^0.0.3"
 
+react-native-bunyan@^1.8.12:
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/react-native-bunyan/-/react-native-bunyan-1.8.12.tgz#87dc5382f3de8a1fe16873acffe3770ac51c0222"
+  integrity sha512-Gwt8ITf90gZjQCiEWPkAMZNT/i9nIEU3jFy4rE4T4oEu0rigdNrYP24LTAPVSw17HFPgmaOCk3gHT7kOQ0Pc4A==
+
 react-native-camera@^3.44.0:
   version "3.44.0"
   resolved "https://registry.yarnpkg.com/react-native-camera/-/react-native-camera-3.44.0.tgz#8b61972e7fd019927ab68a72e3ecea898f6bcb8b"


### PR DESCRIPTION
Fixes #4189 

## Change summary

OK..

- I added a logging mechanism
- I wanted to use the same thing in cold chain
- Possibly use the same thing for omsupply
- The idea is to do `const logger = LoggerService.createLogger("some key for searching")` in a file and then use that logger throughout the file like in `BleService.
- The `bunyan` thing is awesome and great, but seems to be relatively unmaintained so I wanted to ensure we can replace `bunyan` if needed. Since logging can get so widely spread, I wanted to ensure there was a single place to replace bunyan, so I put it in `engine`..
- I wanted to have an easy and consistent way to log to different streams - i.e. bugsnagging, consoles for debugging, flipper for cold chain, files etc
- I wanted a way to adjust the log levels during runtime and also provide log levels for different devices.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] When using bluetooth, a log file is created with a bunch of logs..
- [ ] When a log file is 5+ days beforehand, when starting mobile it is deleted.

### Related areas to think about

- UI for changing log levels of loggers - need to add maybe in settings.
- Persistently storing log levels, so we can set a log level of trace for bluetooth for a certain install and it will always be set at that rather than hard coded
