### PR TITLE
support for checkoxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@bugsnag/react-native": "^7.9.6",
     "@react-native-async-storage/async-storage": "^1.15.4",
-    "@react-native-community/checkbox": "^0.5.7",
+    "@react-native-community/checkbox": "^0.5.8",
     "@react-native-community/datetimepicker": "^3.4.7",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-native-community/picker": "^1.8.1",

--- a/src/widgets/JSONForm/widgets/Checkboxes.js
+++ b/src/widgets/JSONForm/widgets/Checkboxes.js
@@ -65,7 +65,11 @@ const styles = StyleSheet.create({
 
 Checkboxes.propTypes = {
   disabled: PropTypes.bool,
-  value: PropTypes.oneOf([PropTypes.string, PropTypes.boolean]),
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
   onChange: PropTypes.func.isRequired,
   options: PropTypes.shape({
     enumOptions: PropTypes.arrayOf(PropTypes.any),

--- a/src/widgets/JSONForm/widgets/Checkboxes.js
+++ b/src/widgets/JSONForm/widgets/Checkboxes.js
@@ -1,10 +1,83 @@
-/* eslint-disable no-console */
+/* eslint-disable react/forbid-prop-types */
 import React from 'react';
-import { Text } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
+import PropTypes from 'prop-types';
+import CheckBox from '@react-native-community/checkbox';
 
-export const Checkboxes = props => {
-  console.log('-------------------------------------------');
-  console.log('Checkboxes - props', props);
-  console.log('-------------------------------------------');
-  return <Text style={{ borderWidth: 1, marginLeft: 10 }}>CheckboxesWidget</Text>;
+import { APP_FONT_FAMILY } from '../../../globalStyles/fonts';
+import { SUSSOL_ORANGE } from '../../../globalStyles/colors';
+import { FlexColumn, FlexRow, FlexView } from '../../index';
+
+const selectValue = (value, selected, all) => {
+  const at = all.indexOf(value);
+  const updated = selected.slice(0, at).concat(value, selected.slice(at));
+
+  // As inserting values at predefined index positions doesn't work with empty
+  // arrays, we need to reorder the updated selection to match the initial order
+  return updated.sort((a, b) => all.indexOf(a) > all.indexOf(b));
+};
+
+const deselectValue = (value, selected) => selected.filter(v => v !== value);
+
+export const Checkboxes = ({ disabled, onChange, options, readonly, value: checkboxesValue }) => {
+  const { enumOptions, enumDisabled } = options;
+
+  const _onChange = option => checked => {
+    if (checked) {
+      const all = enumOptions.map(({ value }) => value);
+      onChange(selectValue(option.value, checkboxesValue, all));
+    } else {
+      onChange(deselectValue(option.value, checkboxesValue));
+    }
+  };
+
+  const checkboxes = enumOptions.map(option => {
+    const itemDisabled = enumDisabled && enumDisabled.indexOf(option.value) !== -1;
+    const checked = checkboxesValue.indexOf(option.value) !== -1;
+
+    return (
+      <FlexRow key={`checkbox_row_${option.value}`}>
+        <FlexColumn>
+          <CheckBox
+            value={checked}
+            disabled={disabled || itemDisabled || readonly}
+            onValueChange={_onChange(option)}
+            tintColors={{ true: SUSSOL_ORANGE }}
+          />
+        </FlexColumn>
+        <FlexColumn>
+          <Text style={styles.label} onPress={() => _onChange(option)(!checked)}>
+            {option.label}
+          </Text>
+        </FlexColumn>
+      </FlexRow>
+    );
+  });
+
+  return <FlexView style={styles.root}>{checkboxes}</FlexView>;
+};
+
+const styles = StyleSheet.create({
+  root: { paddingLeft: 10, paddingTop: 10 },
+  row: { flex: 0, flexDirection: 'row' },
+  label: { fontFamily: APP_FONT_FAMILY, marginLeft: 10, marginTop: 7 },
+});
+
+Checkboxes.propTypes = {
+  disabled: PropTypes.bool,
+  value: PropTypes.oneOf([PropTypes.string, PropTypes.boolean]),
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.shape({
+    enumOptions: PropTypes.arrayOf(PropTypes.any),
+    enumDisabled: PropTypes.bool,
+    inline: PropTypes.bool,
+  }),
+  readonly: PropTypes.bool,
+};
+
+Checkboxes.defaultProps = {
+  disabled: false,
+  options: undefined,
+  readonly: false,
+  value: '',
 };

--- a/src/widgets/JSONForm/widgets/Radio.js
+++ b/src/widgets/JSONForm/widgets/Radio.js
@@ -49,7 +49,7 @@ const styles = StyleSheet.create({
 
 Radio.propTypes = {
   disabled: PropTypes.bool,
-  value: PropTypes.oneOf([PropTypes.string, PropTypes.boolean]),
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   onChange: PropTypes.func.isRequired,
   options: PropTypes.shape({
     enumOptions: PropTypes.arrayOf(PropTypes.any),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1387,10 +1387,10 @@
   dependencies:
     deep-assign "^3.0.0"
 
-"@react-native-community/checkbox@^0.5.7":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@react-native-community/checkbox/-/checkbox-0.5.7.tgz#ac818de88736acc1a4539188f2d435cf5e845ae1"
-  integrity sha512-CiHBAMWy5fsFIHLd1pf8frlWrLT8DnCXUSxdlGKazHm7srQSReKH4R5absShjmYOHRo9raWEnKZO/cm7MUDHZg==
+"@react-native-community/checkbox@^0.5.8":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@react-native-community/checkbox/-/checkbox-0.5.8.tgz#a1b50635fd76a07fb53eb4a98120347cb6e75da4"
+  integrity sha512-2ppw40sSqBKSPz75l8rDCvpcvQb/78MtvB5BDtovsJE1kXoUJP4eVLuyLo+LfYdSK9qLD4Llt4bIulr1SI9UIQ==
 
 "@react-native-community/cli-debugger-ui@^5.0.1-alpha.1":
   version "5.0.1-alpha.1"


### PR DESCRIPTION
Fixes #4229 

## Change summary

Adds the checkboxes component, so it is now possible to add this into the JSON form schema:

```
  "causes": {
      "title": "Possible causes",
      "description": "Select which vaccinations you think may have caused this reaction",
      "type": "array",
      "items": {
        "type": "string",
        "enum": ["Option One", "Option Two", "Other"]
      },
      "uniqueItems": true
    },
```

with the UI schema:

```
  "causes": { "ui:widget": "checkboxes" },
```

and get this in the form:

![adr](https://user-images.githubusercontent.com/9192912/125533575-69b2b56f-7f8c-4726-a574-5bd82b247809.png)

There's one glitch - a warning is thrown because the form is passing in a text value for the `value` prop, when the component should receive an array. I've found that ignoring this works for me 🤷‍♂️ 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Add the above to your schema and check the results

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
