### PR TITLE
Add ArrayFieldTemplate implementation

### DIFF
--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -1,6 +1,8 @@
 {
   "gb": {
     "age": "Age",
+    "remove_item": "REMOVE ITEM",
+    "add_item": "ADD ITEM",
     "search_online": "Search Online",
     "finding_more_patients": "Finding more patients that match your search criteria...",
     "idle_log_out_interval": "Idle logout interval (minutes):",

--- a/src/widgets/JSONForm/templates/ArrayField.js
+++ b/src/widgets/JSONForm/templates/ArrayField.js
@@ -31,10 +31,14 @@ const Divider = () => <View style={styles.divider} />;
 
 const ArrayFieldTemplateItem = ({ index, onDropIndexClick, children }) => (
   <FlexColumn>
-    <CloseButton onPress={onDropIndexClick(index)} />
+    <FlexColumn alignItems="flex-end">
+      <CloseButton onPress={onDropIndexClick(index)} />
+    </FlexColumn>
     {children}
   </FlexColumn>
 );
+
+const isLastItem = (index, items) => items.length - 1 === index;
 
 export const ArrayField = ({ items, onAddClick }) => (
   <FlexColumn flex={1} style={styles.template}>
@@ -42,7 +46,7 @@ export const ArrayField = ({ items, onAddClick }) => (
       // eslint-disable-next-line react/no-array-index-key
       <React.Fragment key={`array_field_template_item${index}`}>
         <ArrayFieldTemplateItem {...item} />
-        <Divider />
+        {!isLastItem(index, items) && <Divider />}
       </React.Fragment>
     ))}
     <FlexColumn alignItems="flex-end" style={{ marginTop: 20 }}>
@@ -60,5 +64,5 @@ const styles = StyleSheet.create({
     borderColor: SHADOW_BORDER,
   },
   divider: { width: '100%', height: 1, marginTop: 20, backgroundColor: DARKER_GREY },
-  text: { fontFamily: APP_FONT_FAMILY, fontSize: 12 },
+  text: { fontFamily: APP_FONT_FAMILY, fontSize: 12, paddingRight: 5 },
 });

--- a/src/widgets/JSONForm/templates/ArrayField.js
+++ b/src/widgets/JSONForm/templates/ArrayField.js
@@ -1,17 +1,64 @@
 /* eslint-disable react/prop-types */
-/* eslint-disable no-console */
-/* eslint-disable react/destructuring-assignment */
 import React from 'react';
-import { View, Text } from 'react-native';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+import { CloseIcon, PlusCircle } from '../../icons';
+import { FlexColumn } from '../../FlexColumn';
+import { FlexRow } from '../../FlexRow';
+import { generalStrings } from '../../../localization';
+import { SHADOW_BORDER, DARKER_GREY, APP_FONT_FAMILY, SUSSOL_ORANGE } from '../../../globalStyles';
 
-export const ArrayField = props => {
-  console.log('-------------------------------------------');
-  console.log('ArrayField - props', props);
-  console.log('-------------------------------------------');
-  return (
-    <View style={{ marginLeft: 10, borderWidth: 1 }}>
-      <Text>ArrayFieldTemplate</Text>
-      {props.children}
-    </View>
-  );
-};
+const StyledText = ({ children }) => <Text style={styles.text}>{children}</Text>;
+
+const AddButton = ({ onPress }) => (
+  <TouchableOpacity onPress={onPress}>
+    <FlexRow alignItems="center">
+      <StyledText>{generalStrings.add_item}</StyledText>
+      <PlusCircle color={SUSSOL_ORANGE} size={20} />
+    </FlexRow>
+  </TouchableOpacity>
+);
+
+const CloseButton = ({ onPress }) => (
+  <TouchableOpacity onPress={onPress}>
+    <FlexRow alignItems="center">
+      <StyledText>{generalStrings.remove_item}</StyledText>
+      <CloseIcon color={SUSSOL_ORANGE} size={15} />
+    </FlexRow>
+  </TouchableOpacity>
+);
+
+const Divider = () => <View style={styles.divider} />;
+
+const ArrayFieldTemplateItem = ({ index, onDropIndexClick, children }) => (
+  <FlexColumn>
+    <CloseButton onPress={onDropIndexClick(index)} />
+    {children}
+  </FlexColumn>
+);
+
+export const ArrayField = ({ items, onAddClick }) => (
+  <FlexColumn flex={1} style={styles.template}>
+    {items.map((item, index) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <React.Fragment key={`array_field_template_item${index}`}>
+        <ArrayFieldTemplateItem {...item} />
+        <Divider />
+      </React.Fragment>
+    ))}
+    <FlexColumn alignItems="flex-end" style={{ marginTop: 20 }}>
+      <AddButton onPress={onAddClick} />
+    </FlexColumn>
+  </FlexColumn>
+);
+
+const styles = StyleSheet.create({
+  template: {
+    borderWidth: 2,
+    padding: 20,
+    borderRadius: 5,
+    margin: 20,
+    borderColor: SHADOW_BORDER,
+  },
+  divider: { width: '100%', height: 1, marginTop: 20, backgroundColor: DARKER_GREY },
+  text: { fontFamily: APP_FONT_FAMILY, fontSize: 12 },
+});


### PR DESCRIPTION
Fixes #4248 

## Change summary

- Adds support for arrays. Didn't add reordering.
- Looks terrible. Not sure how to make it look better :(

## Testing

- [ ] Below schema can be used to test arrays

### Related areas to think about

```
const schema = {
  definitions: {
    patient: {
      type: 'object',
      properties: {
        patientType: {
          title: 'Patient type',
          type: 'string',
          enum: ['Passport', 'Drivers License', 'Other'],
          default: 'Passport',
        },
        patientID: {
          title: 'Patient identification',
          type: 'string',
        },
      },

      dependencies: {
        patientType: {
          oneOf: [
            {
              properties: {
                patientType: {
                  type: 'string',
                  enum: ['Other'],
                },
                otherPatientType: {
                  title: 'What is the identification type?',
                  type: 'string',
                },
              },
            },
            {
              properties: {
                patientType: {
                  type: 'string',
                  enum: ['Passport', 'Drivers License'],
                },
              },
            },
          ],
        },
      },
    },
  },
  type: 'object',
  properties: {
    patientIdentification: {
      type: 'array',
      title: 'Patient identification',
      items: [
        {
          $ref: '#/definitions/patient',
        },
      ],
      additionalItems: {
        $ref: '#/definitions/patient',
      },
    },
  },
};
```