### PR TITLE
#4238 show vaccination history when creating an ADR

### DIFF
--- a/src/hooks/useLocalAndRemoteHistory.js
+++ b/src/hooks/useLocalAndRemoteHistory.js
@@ -12,7 +12,7 @@ const initialState = (initialValue = []) => ({
   data: initialValue,
   loading: false,
   error: false,
-  searchedWithNoResults: true,
+  searched: false,
 });
 
 const reducer = (state, action) => {
@@ -28,23 +28,23 @@ const reducer = (state, action) => {
         ...history,
         isRemote: localIds.includes(history.id) ? '' : '✓',
       }));
-      return { ...state, data: newData, loading: false, searchedWithNoResults: false };
+      return { ...state, data: newData, loading: false, searched: true };
     }
     case 'fetch_start': {
       const { loading } = state;
 
       if (loading) return state;
-      return { ...state, loading: true, searchedWithNoResults: false, noMore: false };
+      return { ...state, loading: true, searched: false, noMore: false };
     }
     case 'fetch_no_results': {
-      return { ...state, data: [], searchedWithNoResults: true, loading: false };
+      return { ...state, data: [], searched: true, loading: false };
     }
 
     case 'fetch_error': {
       const { payload } = action;
       const { error } = payload;
 
-      return { ...state, error, loading: false, searchedWithNoResults: false };
+      return { ...state, error, loading: false, searched: true };
     }
 
     case 'clear': {
@@ -69,7 +69,7 @@ export const useLocalAndRemotePatientHistory = ({
   sortKey,
   initialValue = [],
 }) => {
-  const [{ data, loading, searchedWithNoResults, error }, dispatch] = useReducer(
+  const [{ data, loading, searched, error }, dispatch] = useReducer(
     reducer,
     initialValue,
     initialState
@@ -107,7 +107,6 @@ export const useLocalAndRemotePatientHistory = ({
 
   const searchOnline = () => {
     const responseHandler = getPatientHistoryResponseProcessor({ isVaccine, sortKey });
-
     refresh();
     dispatch({ type: 'fetch_start' });
     fetch(
@@ -119,5 +118,5 @@ export const useLocalAndRemotePatientHistory = ({
 
   const throttledSearchOnline = useThrottled(searchOnline, 500, []);
 
-  return [{ data, loading, searchedWithNoResults, error }, throttledSearchOnline];
+  return [{ data, loading, searched, error }, throttledSearchOnline];
 };

--- a/src/hooks/useLocalAndRemoteHistory.js
+++ b/src/hooks/useLocalAndRemoteHistory.js
@@ -64,7 +64,7 @@ const reducer = (state, action) => {
  * having to track multiple.
  */
 export const useLocalAndRemotePatientHistory = ({
-  isVaccine,
+  isVaccineDispensingModal,
   patientId,
   sortKey,
   initialValue = [],
@@ -106,7 +106,10 @@ export const useLocalAndRemotePatientHistory = ({
   }, [fetchError]);
 
   const searchOnline = () => {
-    const responseHandler = getPatientHistoryResponseProcessor({ isVaccine, sortKey });
+    const responseHandler = getPatientHistoryResponseProcessor({
+      isVaccineDispensingModal,
+      sortKey,
+    });
     refresh();
     dispatch({ type: 'fetch_start' });
     fetch(

--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -302,7 +302,7 @@ const Dispensing = ({
         isVisible={isADRModalOpen}
         onClose={cancelCreatingADR}
       >
-        <ADRInput />
+        <ADRInput patientHistory={patientHistory} />
       </ModalContainer>
     </>
   );

--- a/src/widgets/JSONForm/JSONForm.js
+++ b/src/widgets/JSONForm/JSONForm.js
@@ -129,8 +129,15 @@ class FocusController {
 // The underlying Form component takes a prop formData which just seeds the component
 // but does not update the form after that point.
 // So, just never re-render this component.
-const propsAreEqual = (prev, next) =>
-  JSON.stringify(next.surveySchema) === JSON.stringify(prev.surveySchema);
+const propsAreEqual = (prev, next) => {
+  const { surveySchema: previousSchema } = prev;
+  const { surveySchema: nextSchema } = next;
+
+  if (!nextSchema) return true;
+  if (!previousSchema) return false;
+
+  return nextSchema.version === previousSchema.version && nextSchema.type === previousSchema.type;
+};
 
 export const JSONFormComponent = React.forwardRef(
   (

--- a/src/widgets/JSONForm/JSONForm.js
+++ b/src/widgets/JSONForm/JSONForm.js
@@ -129,7 +129,8 @@ class FocusController {
 // The underlying Form component takes a prop formData which just seeds the component
 // but does not update the form after that point.
 // So, just never re-render this component.
-const propsAreEqual = () => true;
+const propsAreEqual = (prev, next) =>
+  JSON.stringify(next.surveySchema) === JSON.stringify(prev.surveySchema);
 
 export const JSONFormComponent = React.forwardRef(
   (

--- a/src/widgets/modalChildren/ADRInput.js
+++ b/src/widgets/modalChildren/ADRInput.js
@@ -54,10 +54,11 @@ export const ADRInputComponent = ({ onCancel, onSave, patient, patientHistory })
   const [ADRSchema, setADRSchema] = useState(UIDatabase.objects('ADRForm')[0]);
   const { jsonSchema, uiSchema, type, version } = UIDatabase.objects('ADRForm')[0];
   const items = getSchemaItems(jsonSchema);
+  const vaccineHistory = patientHistory.filter(h => h.itemBatch?.item?.isVaccine);
   const [{ data, loading, searched }, fetchOnline] = useLocalAndRemotePatientHistory({
     isVaccineDispensingModal: true,
     patientId,
-    initialValue: patientHistory,
+    initialValue: vaccineHistory,
     sortKey: 'itemName',
   });
   const showLoading = items && (loading || !searched);

--- a/src/widgets/modalChildren/ADRInput.js
+++ b/src/widgets/modalChildren/ADRInput.js
@@ -1,30 +1,71 @@
 /* eslint-disable react/forbid-prop-types */
-import React, { useState } from 'react';
-import { StyleSheet } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { ActivityIndicator, StyleSheet, Text } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { JSONForm } from '../JSONForm/JSONForm';
 import { UIDatabase } from '../../database/index';
 import { FlexRow } from '../FlexRow';
+import { FlexView } from '../FlexView';
 import { PageButton } from '../PageButton';
-import { SUSSOL_ORANGE } from '../../globalStyles/colors';
+import { SUSSOL_ORANGE, WHITE } from '../../globalStyles/colors';
 import globalStyles from '../../globalStyles/index';
 import { PatientActions } from '../../actions/PatientActions';
 import { selectCurrentPatient } from '../../selectors/patient';
+import { useLocalAndRemotePatientHistory } from '../../hooks/useLocalAndRemoteHistory';
+import { useLoadingIndicator } from '../../hooks/useLoadingIndicator';
+import { dispensingStrings } from '../../localization';
 
-export const ADRInputComponent = ({ onCancel, onSave, patient }) => {
+const LoadingIndicator = ({ loading }) =>
+  loading && (
+    <FlexView flex={1} justifyContent="center" alignItems="center" style={{ marginTop: 20 }}>
+      <Text style={localStyles.text}>{dispensingStrings.fetching_history}</Text>
+      {loading && (
+        <ActivityIndicator color={SUSSOL_ORANGE} size="small" style={{ marginTop: 10 }} />
+      )}
+    </FlexView>
+  );
+LoadingIndicator.propTypes = {
+  loading: PropTypes.bool.isRequired,
+};
+
+export const ADRInputComponent = ({ onCancel, onSave, patient, patientHistory }) => {
+  const runWithLoadingIndicator = useLoadingIndicator();
   const [{ formData, isValid }, setForm] = useState({ formData: null, isValid: false });
+  const patientId = patient?.id;
+  const [{ data, loading, searched }, fetchOnline] = useLocalAndRemotePatientHistory({
+    isVaccine: true,
+    patientId,
+    initialValue: patientHistory,
+    sortKey: 'itemName',
+  });
+
+  useEffect(
+    () =>
+      runWithLoadingIndicator(() => {
+        fetchOnline();
+      }),
+    [patientId]
+  );
+
+  useEffect(() => {
+    console.info(`cool. searched: ${searched} loading: ${loading}`, data);
+  }, [data]);
 
   return (
     <>
-      <JSONForm
-        onChange={(changed, validator) => {
-          setForm({ formData: changed.formData, isValid: validator(changed.formData) });
-        }}
-        surveySchema={UIDatabase.objects('ADRForm')[0]}
-      >
-        <></>
-      </JSONForm>
+      {loading || !searched ? (
+        <LoadingIndicator loading={loading} />
+      ) : (
+        <JSONForm
+          onChange={(changed, validator) => {
+            setForm({ formData: changed.formData, isValid: validator(changed.formData) });
+          }}
+          surveySchema={UIDatabase.objects('ADRForm')[0]}
+        >
+          <></>
+        </JSONForm>
+      )}
       <FlexRow>
         <PageButton
           onPress={onCancel}
@@ -48,9 +89,15 @@ ADRInputComponent.propTypes = {
   onCancel: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
   patient: PropTypes.object.isRequired,
+  patientHistory: PropTypes.array.isRequired,
 };
 
 const localStyles = StyleSheet.create({
+  text: {
+    fontFamily: globalStyles.APP_FONT_FAMILY,
+    fontSize: globalStyles.APP_GENERAL_FONT_SIZE,
+    color: WHITE,
+  },
   saveButton: {
     ...globalStyles.button,
     flex: 1,

--- a/src/widgets/modalChildren/ADRInput.js
+++ b/src/widgets/modalChildren/ADRInput.js
@@ -42,7 +42,6 @@ export const ADRInputComponent = ({ onCancel, onSave, patient, patientHistory })
   const [{ formData, isValid }, setForm] = useState({ formData: null, isValid: false });
   const patientId = patient?.id;
   const [ADRSchema, setADRSchema] = useState(undefined);
-
   const [{ data, loading, searched }, fetchOnline] = useLocalAndRemotePatientHistory({
     isVaccine: true,
     patientId,
@@ -61,14 +60,13 @@ export const ADRInputComponent = ({ onCancel, onSave, patient, patientHistory })
     }
 
     const newHistory = data.length ? mapHistory(data) : ['nothing'];
-    const { jsonSchema, uiSchema } = UIDatabase.objects('ADRForm')[0];
+    const { jsonSchema, uiSchema, type, version } = UIDatabase.objects('ADRForm')[0];
     const { properties = {} } = jsonSchema;
-
     const { causes = {} } = properties;
     const { items } = causes;
     if (items) {
       items.enum = newHistory;
-      setADRSchema({ uiSchema, jsonSchema });
+      setADRSchema({ uiSchema, jsonSchema, properties: { type, version: version + 1 } });
     }
   }, [data, patientId]);
 

--- a/src/widgets/modalChildren/ADRInput.js
+++ b/src/widgets/modalChildren/ADRInput.js
@@ -53,7 +53,7 @@ export const ADRInputComponent = ({ onCancel, onSave, patient, patientHistory })
   const { jsonSchema, uiSchema, type, version } = UIDatabase.objects('ADRForm')[0];
   const items = getSchemaItems(jsonSchema);
   const [{ data, loading, searched }, fetchOnline] = useLocalAndRemotePatientHistory({
-    isVaccine: true,
+    isVaccineDispensingModal: true,
     patientId,
     initialValue: patientHistory,
     sortKey: 'itemName',

--- a/src/widgets/modalChildren/ADRInput.js
+++ b/src/widgets/modalChildren/ADRInput.js
@@ -13,7 +13,7 @@ import globalStyles from '../../globalStyles/index';
 import { PatientActions } from '../../actions/PatientActions';
 import { selectCurrentPatient } from '../../selectors/patient';
 import { useLocalAndRemotePatientHistory } from '../../hooks/useLocalAndRemoteHistory';
-import { dispensingStrings } from '../../localization';
+import { dispensingStrings, generalStrings, vaccineStrings } from '../../localization';
 
 const getSchemaItems = jsonSchema => {
   const { properties = {} } = jsonSchema;
@@ -24,9 +24,11 @@ const getSchemaItems = jsonSchema => {
 const mapHistory = history =>
   history.map((h, index) => {
     const { prescriberOrVaccinator, itemName, confirmDate } = h;
-    const vaccinator = prescriberOrVaccinator ? `  Vaccinator: ${prescriberOrVaccinator}` : '';
+    const vaccinator = prescriberOrVaccinator
+      ? `  ${vaccineStrings.vaccinator}: ${prescriberOrVaccinator}`
+      : '';
 
-    return `${index + 1}. ${itemName}  Date: ${confirmDate}${vaccinator}`;
+    return `${index + 1}. ${itemName}  ${generalStrings.date}: ${confirmDate}${vaccinator}`;
   });
 
 const LoadingIndicator = ({ loading }) => (

--- a/src/widgets/modalChildren/ADRInput.js
+++ b/src/widgets/modalChildren/ADRInput.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState, useLayoutEffect } from 'react';
 import { ActivityIndicator, StyleSheet, Text } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 import { JSONForm } from '../JSONForm/JSONForm';
 import { UIDatabase } from '../../database/index';
 import { FlexRow } from '../FlexRow';
@@ -24,11 +25,12 @@ const getSchemaItems = jsonSchema => {
 const mapHistory = history =>
   history.map((h, index) => {
     const { prescriberOrVaccinator, itemName, confirmDate } = h;
+    const date = moment(confirmDate).format('DD/MM/YY');
     const vaccinator = prescriberOrVaccinator
       ? `  ${vaccineStrings.vaccinator}: ${prescriberOrVaccinator}`
       : '';
 
-    return `${index + 1}. ${itemName}  ${generalStrings.date}: ${confirmDate}${vaccinator}`;
+    return `${index + 1}. ${itemName}  ${generalStrings.date}: ${date}${vaccinator}`;
   });
 
 const LoadingIndicator = ({ loading }) => (


### PR DESCRIPTION
Fixes #4238 

## Change summary

Modifies an ADR JSON schema in order to inject vaccinations for the current patient.

I'm very sorry.

Not an ideal approach, as it relies on knowledge of the JSON schema by the codebase, however it gives us:
- somewhere to store one-to-many vaccinations against an ADR record
- control to the client about how to present the question (wording, placement, form component)
- as well as whether to display the question

## Testing

To test, you will need this in the ADR JSON schema:

```
    "causes": {
      "title": "Possible causes",
      "description": "Select which vaccinations you think may have caused this reaction",
      "type": "array",
      "items": { "type": "string", "enum": ["No vaccination history"] },
      "uniqueItems": true
    },
```

and I have this in the UI schema for the ADR:
```
  "causes": { "ui:widget": "checkboxes" },
```

Results:

**Searching**
![vax_search](https://user-images.githubusercontent.com/9192912/125870379-2debbc01-c5bc-4901-90eb-0066757cde45.png)

**no history**
![vax_none](https://user-images.githubusercontent.com/9192912/125870387-8a53a5b1-98ee-428c-ab74-be210198f34e.png)

**some vaccinations in history**
![vax_list](https://user-images.githubusercontent.com/9192912/125870392-b78c52ab-1b78-4158-a40b-0f58428fa25c.png)


Steps to reproduce or otherwise test the changes of this PR:

- [ ] Add an ADR without the schema change: behaves as normal, with no search
- [ ] Add an ADR for a patient with no history: will show the checkbox 'No vaccination history'
- [ ] Add an ADR for a patient with history: searches, shows options
- [ ] Only shows vaccinations, not other dispensed items in the history
- [ ] Add when the server is offline: still lets you create an ADR after a short lookup time
- [ ] When the server is offline you can see local patient history

### Related areas to think about

Another thought was to allow all history, by specifying a different element in the schema maybe. Decided not to do that