### PR TITLE
#4164 RN cant reload old state

### DIFF
--- a/android/app/src/main/java/com/msupplymobile/MainActivity.java
+++ b/android/app/src/main/java/com/msupplymobile/MainActivity.java
@@ -12,7 +12,7 @@ import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
 public class MainActivity extends ReactActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
-      super.onCreate(savedInstanceState);
+      super.onCreate(null);
     }
 
     /**


### PR DESCRIPTION
Fixes #4164 - maybe

## Change Summary

The bugsnag [error](https://app.bugsnag.com/sustainable-solutions-nz-ltd/msupply-mobile/errors/60a2e05739beba00077b18ff?event_id=60d381f7007f57f947be0000&i=gh&m=ci) has a link to this github comment https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067 where we find out our `MainActivity` is configured incorrectly!

## Testing

- [ ] The app still runs..?

### Related areas to think about

- I can't reproduce the error, but the people said to do this so..
