### PR TITLE
#4256 Cold chain sensors not showing up on Android 10

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
   <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
   <uses-permission android:name="android.permission.BLUETOOTH_PRIVILEGED" />
   <uses-permission android:name="android.permission.CAMERA" />
-  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <supports-screens android:smallScreens="false" android:normalScreens="false" android:largeScreens="false" android:xlargeScreens="true" android:requiresSmallestWidthDp="720" />
   <application android:name=".MainApplication" android:allowBackup="true" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:theme="@style/AppTheme" android:requestLegacyExternalStorage="true">

--- a/src/actions/PermissionActions.js
+++ b/src/actions/PermissionActions.js
@@ -70,7 +70,7 @@ const requestLocation = () => async (dispatch, getState) => {
   const locationPermission = PermissionSelectors.location(getState());
 
   const result = !locationPermission
-    ? (await request(PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION)) === RESULTS.GRANTED
+    ? (await request(PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION)) === RESULTS.GRANTED
     : true;
 
   dispatch(setLocation(result));
@@ -80,7 +80,7 @@ const requestLocation = () => async (dispatch, getState) => {
 
 const checkPermissions = () => async dispatch => {
   const promises = [
-    check(PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION),
+    check(PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION),
     check(PERMISSIONS.ANDROID.WRITE_EXTERNAL_STORAGE),
     BluetoothStatus.state(),
     SystemSetting.isLocationEnabled(),


### PR DESCRIPTION
Maybe Fixes #4256

## Change summary

Updates Android permissions to FINE_LOCATION from COARSE_LOCATION

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Try to connect to BT sensors on Android 10 

### Related areas to think about
This excerpt from: https://developer.android.com/guide/topics/connectivity/bluetooth/permissions might mean we need ACCESS_BACKGROUND_PERMISSIONS:
- `Services running on Android 10 and higher cannot discover Bluetooth devices unless they have the ACCESS_BACKGROUND_LOCATION permission. For more information on this requirement, see Access location in the background. `

But that is API level 29 (and our minSdk version is 21) so unsure how that works yet - maybe we test this first?