### PR TITLE
#4269 Remove supplemental data pre-population

### DIFF
--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -288,7 +288,6 @@ const mapDispatchToProps = dispatch => {
 
       if (selectedPatient) {
         dispatch(NameNoteActions.createSurveyNameNote(selectedPatient));
-        dispatch(VaccinePrescriptionActions.createSupplementaryData());
         dispatch(WizardActions.nextTab());
       }
     });


### PR DESCRIPTION
Fixes #4269

## Change summary

- Don't dispatch an action to prepopulate supplemental data form 
- Prepopulation code is still there (just not called) in case it is needed later (happy to also remove it if that's tidier) 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Have a vaccine supplemental form schema in mSupply (can use https://github.com/openmsupply/mobile/issues/4228). Complete a vaccination, start a new one and navigate to step 3 in Vaccine dispensing. Should be empty form (only form configured defaults should be prepopulated) 

### Related areas to think about
N/A