### PR TITLE
#4216 Update patient history lookup to handle empty itemLines

### DIFF
--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -215,7 +215,7 @@ export const getPatientHistoryResponseProcessor = ({
         ID: id,
         quantity: totalQuantity,
         item_name: itemName,
-        itemLine = null,
+        itemLine,
         medicineAdministrator,
       }) => {
         const receivedItemLine = itemLine || { item: { doses: 0, code: 'N/A' } };

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -215,10 +215,11 @@ export const getPatientHistoryResponseProcessor = ({
         ID: id,
         quantity: totalQuantity,
         item_name: itemName,
-        itemLine,
+        itemLine = null,
         medicineAdministrator,
       }) => {
-        const { item } = itemLine;
+        const receivedItemLine = itemLine || { item: { doses: 0, code: 'N/A' } };
+        const { item } = receivedItemLine;
         const { code: itemCode, doses } = item;
         const prescriber = clinician
           ? `${clinician.first_name} ${clinician.last_name}`.trim()
@@ -227,7 +228,7 @@ export const getPatientHistoryResponseProcessor = ({
           ? `${medicineAdministrator.first_name} ${medicineAdministrator.last_name}`.trim()
           : generalStrings.not_available;
 
-        if (isVaccineDispensingModal && !item.is_vaccine) return;
+        if (isVaccineDispensingModal && !item?.is_vaccine) return;
         const confirmDate = parseDate(confirm_date);
 
         patientHistory.push({


### PR DESCRIPTION
Fixes #4216

## Change summary

- Populates some default data in if there is no `itemLine` present in the transaction

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Replicate #4216 (point to https://tonga-vax.msupply.org:2048 and look up super-secret patient that is missing itemLines)

### Related areas to think about
N/A
