### PR TITLE
#4280 Turn on live validation for the supplemental data form

### DIFF
--- a/src/widgets/Tabs/VaccineSupplementalData.js
+++ b/src/widgets/Tabs/VaccineSupplementalData.js
@@ -55,7 +55,7 @@ const VaccineSupplementalDataComponent = ({
             onChange={(changed, validator) => {
               onFormUpdate(changed.formData, validator);
             }}
-            liveValidate={false}
+            liveValidate={true}
           >
             <View />
           </JSONForm>


### PR DESCRIPTION
Fixes #4280

## Change summary

Switch on live validation for this form

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Have some error messages defined in the JSON Schema for some fields as per the issue, don't fill those fields in on the form -> Should see error messages

### Related areas to think about
- With this enabled the initial form can't have "required" defined for fields that don't exist until parent fields are selected (e.g. "island", "village" at the top level) ... or it will crash 💥 . I think that is another issue to investigate - why so much crashing when the schema is not 100% 😿 
