### PR TITLE
#4277 Add remote entries to local entries when populating patient history

### DIFF
--- a/src/hooks/useLocalAndRemoteHistory.js
+++ b/src/hooks/useLocalAndRemoteHistory.js
@@ -24,10 +24,16 @@ const reducer = (state, action) => {
       const { data } = payload;
       const { data: initialData } = state;
       const localIds = initialData.map(history => history.id);
-      const newData = (data ?? []).map(history => ({
-        ...history,
-        isRemote: localIds.includes(history.id) ? '' : '✓',
-      }));
+
+      // Filter out local entries before merging
+      const additionalRemoteRecords = data
+        .filter(record => !localIds.includes(record.id))
+        .map(remoteHistory => ({
+          ...remoteHistory,
+          isRemote: '✓',
+        }));
+      const newData = initialData.concat(additionalRemoteRecords);
+
       return { ...state, data: newData, loading: false, searched: true };
     }
     case 'fetch_start': {


### PR DESCRIPTION
Fixes #4277

## Change summary

- When remote records are fetched, con🐱enate them to the local records instead of replacing 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Follow the steps in #4277 and hopefully the records no longer disappear

### Related areas to think about
N/A