### PR TITLE
#4239 catch invalid json schemas

### DIFF
--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -2,7 +2,7 @@
   "gb": {
     "oh_no": "Oh no!",
     "please_contact_your_administrator": "Please contact your Administrator.",
-    "theres_been_an_error_with_this_forms_configuration": "Theres been an error with this forms configuration.",
+    "theres_been_an_error_with_this_forms_configuration": "There's been an error with this form's configuration.",
     "age": "Age",
     "remove_item": "REMOVE ITEM",
     "add_item": "ADD ITEM",

--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -1,5 +1,8 @@
 {
   "gb": {
+    "oh_no": "Oh no!",
+    "please_contact_your_administrator": "Please contact your Administrator.",
+    "theres_been_an_error_with_this_forms_configuration": "Theres been an error with this forms configuration.",
     "age": "Age",
     "remove_item": "REMOVE ITEM",
     "add_item": "ADD ITEM",

--- a/src/widgets/JSONForm/JSONForm.js
+++ b/src/widgets/JSONForm/JSONForm.js
@@ -177,7 +177,14 @@ export const JSONFormComponent = React.forwardRef(
     const [hasSchemaError, setSchemaError] = useState(false);
 
     const { uiSchema, jsonSchema } = surveySchema;
-    const validator = useMemo(() => ajv.compile(jsonSchema), [jsonSchema]);
+    const validator = useMemo(() => {
+      try {
+        return ajv.compile(jsonSchema);
+      } catch (e) {
+        logger.error(`Invalid JSON Schema ${e} - ${JSON.stringify(jsonSchema)}`);
+        return setSchemaError(true);
+      }
+    }, [jsonSchema]);
     const Form = useMemo(() => withTheme(theme), []);
     // Attach to the ref passed a method `submit` which will allow a caller
     // to programmatically call submit
@@ -237,7 +244,11 @@ export const JSONFormComponent = React.forwardRef(
                 if (errorHandler?.addError) errorHandler.addError(message);
               } catch (e) {
                 setSchemaError(true);
-                logger.error(`Invalid JSON Schema ${dataPath} - ${message} - ${e}`);
+                logger.error(
+                  `Invalid JSON Schema ${dataPath} - ${message} - ${e} - ${JSON.stringify(
+                    jsonSchema
+                  )}`
+                );
               }
             });
 

--- a/src/widgets/JSONForm/JSONForm.js
+++ b/src/widgets/JSONForm/JSONForm.js
@@ -1,6 +1,8 @@
+/* eslint-disable max-classes-per-file */
 /* eslint-disable react/forbid-prop-types */
 /* eslint-disable max-len */
-import React, { useEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import { Text } from 'react-native';
 import PropTypes from 'prop-types';
 import pointer from 'json-pointer';
 import { withTheme } from '@rjsf/core';
@@ -12,7 +14,14 @@ import { JSONFormWidget } from './widgets/index';
 import { JSONFormErrorList } from './JSONFormErrorList';
 import { PageButton } from '../PageButton';
 import { JSONFormContext } from './JSONFormContext';
-import { useDebounce } from '../../hooks/useDebounce';
+import { useDebounce } from '../../hooks';
+import LoggerService from '../../utilities/logging';
+import { FlexColumn } from '../FlexColumn';
+import { BreachManUnhappy } from '../BreachManUnhappy';
+import { APP_FONT_FAMILY, DARKER_GREY, GREY } from '../../globalStyles';
+import { generalStrings } from '../../localization';
+
+const logger = LoggerService.createLogger('JSONForm');
 
 const ajvErrors = require('ajv-errors');
 
@@ -126,6 +135,24 @@ class FocusController {
   };
 }
 
+// eslint-disable-next-line react/prop-types
+const ErrorHeader = ({ children }) => (
+  <Text style={{ fontFamily: APP_FONT_FAMILY, fontSize: 20, color: DARKER_GREY }}>{children}</Text>
+);
+// eslint-disable-next-line react/prop-types
+const ErrorMessage = ({ children }) => (
+  <Text style={{ fontFamily: APP_FONT_FAMILY, textAlign: 'center', color: GREY }}>{children}</Text>
+);
+
+export const InvalidSchema = () => (
+  <FlexColumn flex={1} justifyContent="center" alignItems="center">
+    <BreachManUnhappy size={250} />
+    <ErrorHeader>{generalStrings.oh_no}</ErrorHeader>
+    <ErrorMessage>{generalStrings.theres_been_an_error_with_this_forms_configuration}</ErrorMessage>
+    <ErrorMessage>{generalStrings.please_contact_your_administrator}</ErrorMessage>
+  </FlexColumn>
+);
+
 // The underlying Form component takes a prop formData which just seeds the component
 // but does not update the form after that point.
 // So, just never re-render this component.
@@ -147,6 +174,8 @@ export const JSONFormComponent = React.forwardRef(
   ) => {
     if (!surveySchema) return null;
 
+    const [hasSchemaError, setSchemaError] = useState(false);
+
     const { uiSchema, jsonSchema } = surveySchema;
     const validator = useMemo(() => ajv.compile(jsonSchema), [jsonSchema]);
     const Form = useMemo(() => withTheme(theme), []);
@@ -165,7 +194,9 @@ export const JSONFormComponent = React.forwardRef(
 
     const debouncedOnChange = useDebounce(onChange, 500);
 
-    return (
+    return hasSchemaError ? (
+      <InvalidSchema />
+    ) : (
       <JSONFormContext.Provider value={options}>
         <Form
           liveValidate={liveValidate}
@@ -201,8 +232,13 @@ export const JSONFormComponent = React.forwardRef(
             });
 
             Object.entries(errorLookup).forEach(([dataPath, message]) => {
-              const errorHandler = pointer.get(errorHandlers, dataPath);
-              if (errorHandler?.addError) errorHandler.addError(message);
+              try {
+                const errorHandler = pointer.get(errorHandlers, dataPath);
+                if (errorHandler?.addError) errorHandler.addError(message);
+              } catch (e) {
+                setSchemaError(true);
+                logger.error(`Invalid JSON Schema ${dataPath} - ${message} - ${e}`);
+              }
             });
 
             // The same ErrorHandlers object must be returned from this function, which should be


### PR DESCRIPTION
Fixes #4239 

## Change summary

- The original error was from `json-pointer` using an invalid reference. So, Catch that and set an error state.
- Wanted to use an error boundary with `componentDidCatch` but 1) event handlers does get caught (can be worked around with `setState`, though) and the nail in the coffin for that idea 2) it's working super funky on react-native. I believe it's not catching in development builds from what I can google.

## Testing

Use this schema:

```
const invalid = {
  type: 'object',
  title: 'Extra information',
  required: ['patientDemographicData', 'island', 'x'],
};
```


- [ ] When editing a patient, the app doesn't crash with an invalid json schema

### Related areas to think about
- Looks like this:
![image](https://user-images.githubusercontent.com/35858975/126919797-a445f72d-0c36-4541-bcd9-549ae12ca158.png)
- Looks like this with the keyboard up.. I thought it was kinda cool looking... but 🤷 
![image](https://user-images.githubusercontent.com/35858975/126919824-61e282c7-9b47-4b93-87ac-bd9c6510feb8.png)
- Had no idea what to put as the error message, so feel free to change/suggest changes..
- At the moment you'll be able to edit a patient that has had a name note filled out previously (Because it hasn't changed, it's fine), but you won't be able to create one. Not sure if this is the right behaviour. Think it'll require a bit more hacking around to make it possible to still create a patient with if there's an invalid schema, but i'm not sure what the desired behaviour should be here, anyway. These invalid schemas shouldn't really be making it into the wild, anyway?
