### PR TITLE
#4296 name note for all vaccinations

### DIFF
--- a/src/database/DataTypes/MedicineAdministrator.js
+++ b/src/database/DataTypes/MedicineAdministrator.js
@@ -9,6 +9,15 @@ export class MedicineAdministrator extends Realm.Object {
   get displayString() {
     return `${this.code ?? ''} ${this.firstName ?? ''} ${this.lastName ?? ''}`.trim();
   }
+
+  toJSON() {
+    return {
+      firstName: this.firstName,
+      lastName: this.lastName,
+      code: this.code,
+      isActive: this.isActive,
+    };
+  }
 }
 
 MedicineAdministrator.schema = {


### PR DESCRIPTION
Fixes #4296 

Note: I haven't tested sync yet, sorry- will do soon. I am in the middle of creating 9million sync out records for testing and it's taking awhile.

## Change summary

- Just changes from creating a refusal name note when refused to creating a vaccination name note, everytime.

## Testing

- [ ] Create a vaccine prescription where everything is standard. Sync and view the name note on desktop (Through record browser :))
- [ ] Create a vaccine prescription where you refuse the vaccine. Sync and view the name note on desktop (Through record browser :))
- [ ] Create a vaccine prescription where you use a bonus dose. Sync and view the name note on desktop (Through record browser :))

### Related areas to think about

- Too much info? :)
