### PR TITLE
Add closing of modal before spinning

### DIFF
--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -117,9 +117,15 @@ const VaccineSelectComponent = ({
     ? toggleConfirmDoubleDoseModal
     : toggleConfirmAndRepeatDoubleDoseModal;
 
-  const onModalConfirm = confirmDoubleDoseModalOpen
-    ? confirmPrescription
-    : confirmAndRepeatPrescription;
+  const onModalConfirm = () => {
+    onModalClose();
+
+    if (confirmDoubleDoseModalOpen) {
+      confirmPrescription();
+    } else {
+      confirmAndRepeatPrescription();
+    }
+  };
 
   const isModalOpen = confirmDoubleDoseModalOpen || confirmAndRepeatDoubleDoseModalOpen;
 


### PR DESCRIPTION
Fixes #4302 

## Change summary

- closes the modal before confirm
- Didn't end up debouncing- I can't trigger multiple invocations so didn't bother 

## Testing

- [ ] Issue a vaccine to a patient the second time. When confirming on the modal, the modal doesn't block the spinner

### Related areas to think about

N/A
