### PR TITLE
sync patient female field

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -601,6 +601,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         occupation: database.getOrCreate('Occupation', record.occupation_ID),
         ethnicity: database.getOrCreate('Ethnicity', record.ethnicity_ID),
         createdDate: parseDate(record.created_date),
+        female: parseBoolean(record.female),
       };
 
       if (isPatient) internalRecord.isVisible = true;


### PR DESCRIPTION
Fixes #4328 

## Change summary

`[name]female` was not being set for incoming sync requests

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Turn off the pref `new_patients_visible_in_this_store_only` for your mobile store. create a female patient in another store and sync on the tablet. Check the gender of the patient on the tablet

