### PR TITLE
round down age value

### DIFF
--- a/src/widgets/FormInputs/FormDOBInput.js
+++ b/src/widgets/FormInputs/FormDOBInput.js
@@ -16,7 +16,7 @@ import { FormLabel } from './FormLabel';
 import { FormInvalidMessage } from './FormInvalidMessage';
 import { DATE_FORMAT } from '../../utilities/constants';
 
-const calculateAge = dob => moment().diff(dob, 'years', true).toFixed(0);
+const calculateAge = dob => `${Math.floor(moment().diff(dob, 'years', true))}`;
 
 const Action = {
   toggleDatePicker: 'toggleDatePicker',


### PR DESCRIPTION
Fixes #4327 

## Change summary

As per the issue - rounding down the age value rather than a numerical rounding. So patients who are `23.9` years old show as `23`

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Set the date of birth to `25/08/1997` for a patient and check the age. Should be `23`

