### PR TITLE
#3966 Adjust threshold temperatures to match the step amount

### DIFF
--- a/src/selectors/Entities/temperatureBreachConfig.js
+++ b/src/selectors/Entities/temperatureBreachConfig.js
@@ -33,11 +33,11 @@ export const selectEditingConfigThresholds = state => {
     COLD_CUMULATIVE: coldCumulativeConfig = {},
   } = editingConfigs;
 
-  const coldConsecutiveThreshold = (hotConsecutiveConfig.minimumTemperature ?? 0) - 0.1;
-  const hotConsecutiveThreshold = (coldConsecutiveConfig.maximumTemperature ?? 0) + 0.1;
+  const coldConsecutiveThreshold = (hotConsecutiveConfig.minimumTemperature ?? 0) - 0.5;
+  const hotConsecutiveThreshold = (coldConsecutiveConfig.maximumTemperature ?? 0) + 0.5;
 
-  const coldCumulativeThreshold = (hotCumulativeConfig.minimumTemperature ?? 0) - 0.1;
-  const hotCumulativeThreshold = (coldCumulativeConfig.maximumTemperature ?? 0) + 0.1;
+  const coldCumulativeThreshold = (hotCumulativeConfig.minimumTemperature ?? 0) - 0.5;
+  const hotCumulativeThreshold = (coldCumulativeConfig.maximumTemperature ?? 0) + 0.5;
 
   return {
     coldConsecutiveThreshold,

--- a/src/selectors/Entities/temperatureBreachConfig.js
+++ b/src/selectors/Entities/temperatureBreachConfig.js
@@ -68,11 +68,11 @@ export const selectNewConfigThresholds = state => {
     COLD_CUMULATIVE: coldCumulativeConfig = {},
   } = newConfigs;
 
-  const coldConsecutiveThreshold = (hotConsecutiveConfig.minimumTemperature ?? 0) - 0.1;
-  const hotConsecutiveThreshold = (coldConsecutiveConfig.maximumTemperature ?? 0) + 0.1;
+  const coldConsecutiveThreshold = (hotConsecutiveConfig.minimumTemperature ?? 0) - 0.5;
+  const hotConsecutiveThreshold = (coldConsecutiveConfig.maximumTemperature ?? 0) + 0.5;
 
-  const coldCumulativeThreshold = (hotCumulativeConfig.minimumTemperature ?? 0) - 0.1;
-  const hotCumulativeThreshold = (coldCumulativeConfig.maximumTemperature ?? 0) + 0.1;
+  const coldCumulativeThreshold = (hotCumulativeConfig.minimumTemperature ?? 0) - 0.5;
+  const hotCumulativeThreshold = (coldCumulativeConfig.maximumTemperature ?? 0) + 0.5;
 
   return {
     coldConsecutiveThreshold,


### PR DESCRIPTION
Fixes #3966

## Change summary

- When a temperature approaches a threshold (i.e. cold temperature threshold = hot temperature threshold), make the offset 0.5 degrees celsius, rather than 0.1. This matches the step amount configured in the `TemperatureEditor` component.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Follow steps in #3966

### Related areas to think about

Pretty lazy change (could have tried some fancy rounding maths), but it doesn't really make sense to have or allow the hot and cold temperature thresholds to be within 0.1 degrees of each other, I think (that would be a really fragile vaccine?!? 💉 )
