### PR TITLE
#3984 Replace min/max domain lines with hot/cold consecutive breach lines

### DIFF
--- a/src/widgets/VaccineBarChart.js
+++ b/src/widgets/VaccineBarChart.js
@@ -40,8 +40,14 @@ export const VaccineBarChart = ({
     maxDomain,
   ]);
 
-  const upperBoundData = maxLine.map(point => ({ x: point.timestamp, y: breachBoundaries.upper }));
-  const lowerBoundData = minLine.map(point => ({ x: point.timestamp, y: breachBoundaries.lower }));
+  const upperBreachLimit = maxLine.map(point => ({
+    x: point.timestamp,
+    y: breachBoundaries.upper,
+  }));
+  const lowerBreachLimit = minLine.map(point => ({
+    x: point.timestamp,
+    y: breachBoundaries.lower,
+  }));
   const barData = minLine.map(minPoint => {
     const maxPoint = maxLine.find(max => max.timestamp === minPoint.timestamp);
 
@@ -121,8 +127,8 @@ export const VaccineBarChart = ({
               tickCount={CHART_CONSTANTS.MAX_TICK_COUNTS}
             />
 
-            <VictoryLine data={upperBoundData} style={chartStyles.maxBoundaryLine} />
-            <VictoryLine data={lowerBoundData} style={chartStyles.minBoundaryLine} />
+            <VictoryLine data={upperBreachLimit} style={chartStyles.maxBoundaryLine} />
+            <VictoryLine data={lowerBreachLimit} style={chartStyles.minBoundaryLine} />
             <VictoryBar
               data={barData}
               y="hotY"

--- a/src/widgets/VaccineLineChart.js
+++ b/src/widgets/VaccineLineChart.js
@@ -26,12 +26,10 @@ export const VaccineLineChart = ({
   x,
   y,
   breaches,
+  breachBoundaries,
   onPressBreach,
 }) => {
   const [width, height, setDimensions] = useLayoutDimensions();
-
-  const maxBoundary = React.useCallback(() => maxDomain, []);
-  const minBoundary = React.useCallback(() => minDomain, []);
 
   const chartMinDomain = React.useMemo(() => ({ y: minDomain - CHART_CONSTANTS.DOMAIN_OFFSET }), [
     minDomain,
@@ -39,6 +37,15 @@ export const VaccineLineChart = ({
   const chartMaxDomain = React.useMemo(() => ({ y: maxDomain + CHART_CONSTANTS.DOMAIN_OFFSET }), [
     maxDomain,
   ]);
+
+  const upperBreachLimit = maxLine.map(point => ({
+    x: point.timestamp,
+    y: breachBoundaries.upper,
+  }));
+  const lowerBreachLimit = minLine.map(point => ({
+    x: point.timestamp,
+    y: breachBoundaries.lower,
+  }));
 
   return (
     <FlexView
@@ -85,8 +92,8 @@ export const VaccineLineChart = ({
               x={x}
               style={chartStyles.maxLine}
             />
-            <VictoryLine data={maxLine} y={maxBoundary} x={x} style={chartStyles.maxBoundaryLine} />
-            <VictoryLine data={minLine} y={minBoundary} x={x} style={chartStyles.minBoundaryLine} />
+            <VictoryLine data={upperBreachLimit} style={chartStyles.maxBoundaryLine} />
+            <VictoryLine data={lowerBreachLimit} style={chartStyles.minBoundaryLine} />
 
             <VictoryScatter data={maxLine} y={y} x={x} style={chartStyles.maxScatterPlot} />
             <VictoryScatter data={minLine} y={y} x={x} style={chartStyles.minScatterPlot} />
@@ -119,6 +126,7 @@ VaccineLineChart.propTypes = {
   maxLine: PropTypes.array.isRequired,
   onPressBreach: PropTypes.func,
   breaches: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  breachBoundaries: PropTypes.object.isRequired,
 };
 
 const chartStyles = {


### PR DESCRIPTION
Fixes #3984

## Change summary

As per the title (see below with dodgy test data):

![image](https://user-images.githubusercontent.com/65875762/128436350-17073668-a04b-4011-9cad-282413b634bd.png)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Have a sensor connected with logs, and navigate to the Vaccine Line Chart (Under Cold Chain menu option), confirm that the hot and cold consecutive breach lines are showing instead of the min/max temperature averages.

### Related areas to think about
Didn't do anything about cumulative breaches (though it was mentioned in the original issue) as I think it could get quite cluttered with 4 similar looking lines on the chart - esp if the cumulative/consecutive limits are very close to each other ... 
Maybe could use different colours/line styles (e.g. a broken line?). Would probably need some kind of legend 🤔 
