### PR TITLE
DOB Defaults

### DIFF
--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -121,7 +121,7 @@ const FORM_INPUT_CONFIGS = seedObject => ({
   },
   [FORM_INPUT_KEYS.DATE_OF_BIRTH]: {
     type: FORM_INPUT_TYPES.DATE_OF_BIRTH,
-    initialValue: new Date(),
+    initialValue: '',
     key: 'dateOfBirth',
     invalidMessage: formInputStrings.must_be_a_date,
     isRequired: true,

--- a/src/widgets/FormInputs/FormDOBInput.js
+++ b/src/widgets/FormInputs/FormDOBInput.js
@@ -16,7 +16,7 @@ import { FormLabel } from './FormLabel';
 import { FormInvalidMessage } from './FormInvalidMessage';
 import { DATE_FORMAT } from '../../utilities/constants';
 
-const calculateAge = dob => `${Math.floor(moment().diff(dob, 'years', true))}`;
+const calculateAge = dob => (!dob ? '' : `${Math.floor(moment().diff(dob, 'years', true))}`);
 
 const Action = {
   toggleDatePicker: 'toggleDatePicker',
@@ -31,9 +31,9 @@ const Action = {
 const initialState = (seedDate, isValid) => ({
   isValid, // If the date is a valid date
   datePickerOpen: false,
-  pickerValue: seedDate.toDate(),
+  pickerValue: seedDate?.toDate() || new Date(),
   ageValue: calculateAge(seedDate),
-  textInputValue: seedDate.format(DATE_FORMAT.DD_MM_YYYY),
+  textInputValue: seedDate ? seedDate.format(DATE_FORMAT.DD_MM_YYYY) : '',
 });
 
 const reducer = (state, action) => {
@@ -161,7 +161,7 @@ export const FormDOBInput = React.forwardRef(
     const [
       { datePickerOpen, isValid, pickerValue, ageValue, textInputValue },
       { toggleDatePicker, onPickDate, onTypeDate, onTypeAge },
-    ] = useDobInput(moment(value ?? new Date()), onChangeDate, onValidate);
+    ] = useDobInput(value ? moment(value) : undefined, onChangeDate, onValidate);
 
     return (
       <>


### PR DESCRIPTION
Fixes #4350 ?

The date of birth is defaulting to the current date and that was causing issues with the validation for me - strangely, it was validation in the wrong direction: the `FormDOBInput` was valid, though the data in it was out of sync internally.

It did result in the observed effect though, that the form was invalid even though there was something in the age field and therefore a calculated value in the dob text field.

## Change summary

Default the DOB value to blank - if this field is required the validation is handled correctly now, with the validation error shown on form load.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a patient, enter all required values, except DOB. Enter a value for 'age' : expected result - the OK button should be enabled.
