### PR TITLE
#4348 Update JSONForm DatePicker format to align with rest of mobile

### DIFF
--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -8,6 +8,7 @@ import { DatePickerButton } from '../../DatePickerButton';
 import { FlexRow } from '../../FlexRow';
 import { useJSONFormOptions } from '../JSONFormContext';
 import { DARKER_GREY, LIGHT_GREY } from '../../../globalStyles/colors';
+import { DATE_FORMAT } from '../../../utilities/constants';
 
 export const DatePicker = ({ disabled, value, onChange, placeholder, readonly, onBlur, id }) => {
   const { focusController } = useJSONFormOptions();
@@ -37,7 +38,7 @@ export const DatePicker = ({ disabled, value, onChange, placeholder, readonly, o
       <DatePickerButton
         isDisabled={readonly || disabled}
         initialValue={new Date()}
-        onDateChanged={date => handleChange(moment(date).format('YYYY-MM-DD'))}
+        onDateChanged={date => handleChange(moment(date).format(DATE_FORMAT.DD_MM_YYYY))}
       />
     </FlexRow>
   );


### PR DESCRIPTION
Fixes #4348

## Change summary

- Update JSON Form DatePicker format to align with other areas of mobile

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Repro #4348, date formats should be consistent across all areas of mobile (and ideally also with patient-hub) 

### Related areas to think about

Not sure if this impacts any reporting/dashboards...etc 
