### PR TITLE
#4367 Add dateRange option to JSONForm DatePicker

### DIFF
--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -10,7 +10,16 @@ import { useJSONFormOptions } from '../JSONFormContext';
 import { DARKER_GREY, LIGHT_GREY } from '../../../globalStyles/colors';
 import { DATE_FORMAT } from '../../../utilities/constants';
 
-export const DatePicker = ({ disabled, value, onChange, placeholder, readonly, onBlur, id }) => {
+export const DatePicker = ({
+  disabled,
+  value,
+  onChange,
+  placeholder,
+  readonly,
+  onBlur,
+  id,
+  options,
+}) => {
   const { focusController } = useJSONFormOptions();
   const ref = focusController.useRegisteredRef();
   const handleChange = dateString => {
@@ -38,6 +47,8 @@ export const DatePicker = ({ disabled, value, onChange, placeholder, readonly, o
       <DatePickerButton
         isDisabled={readonly || disabled}
         initialValue={new Date()}
+        minimumDate={options.dateRange === 'future' ? new Date() : null}
+        maximumDate={options.dateRange === 'past' ? new Date() : null}
         onDateChanged={date => handleChange(moment(date).format(DATE_FORMAT.DD_MM_YYYY))}
       />
     </FlexRow>
@@ -52,6 +63,9 @@ DatePicker.propTypes = {
   disabled: PropTypes.bool.isRequired,
   value: PropTypes.string,
   onChange: PropTypes.func.isRequired,
+  options: PropTypes.shape({
+    dateRange: PropTypes.string,
+  }).isRequired,
   placeholder: PropTypes.string.isRequired,
   readonly: PropTypes.bool.isRequired,
   onBlur: PropTypes.func.isRequired,

--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React from 'react';
 import { TextInput } from 'react-native';
 import moment from 'moment';


### PR DESCRIPTION
Fixes #4367

## Change summary

- Adds the ability in mobile to disable past/future dates via uiSchema config

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] This uiSchema config should only allow past dates (and today's date):
 `"date": { "ui:widget": "DateWidget", "ui:options": { "dateRange": "past" } },`
- [ ] This uiSchema config should only allow future dates (and today's date):
`"date": { "ui:widget": "DateWidget", "ui:options": { "dateRange": "future" } },`
- [ ] This uiSchema config should allow any dates:
`"date": { "ui:widget": "DateWidget" },`

### Related areas to think about
- The patient hub requires a separate update/PR
- Lots of ways to do this change, alternative suggestion: https://github.com/openmsupply/mobile/issues/4367#issuecomment-901670153 - went with UISchema update as I thought of it as more of a UI/widget specific concern rather than an underlying data thing (although could work either way)