### PR TITLE
#4047 Remove dispensary from usingModules check

### DIFF
--- a/src/reducers/ModulesReducer.js
+++ b/src/reducers/ModulesReducer.js
@@ -36,7 +36,7 @@ const initialState = () => {
     UIDatabase.getPreference(PREFERENCE_KEYS.CAN_EDIT_PATIENTS_FROM_ANY_STORE)
   );
 
-  const usingModules = usingDashboard || usingDispensary || usingVaccines || usingCashRegister;
+  const usingModules = usingDashboard || usingVaccines || usingCashRegister;
 
   return {
     usingAdverseDrugReactions,


### PR DESCRIPTION
Fixes #4047

## Change summary

- Removes the presence of dispensary menu item from triggering module section to appear (as the Dispensary was moved into the same menu section as Customer Invoices / Customer Requisitions).

![image](https://user-images.githubusercontent.com/65875762/130716169-37f337b3-c874-4f3f-ab73-a14b920dac68.png)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Have no modules enabled and no visibility of any vaccine items in a mobile store, but have the dispensary enabled. Module section should not show.

### Related areas to think about

Is the dispensary actually a module? 🤔 
