### PR TITLE
#4380 Re-throw error if error occurred during authentication

### DIFF
--- a/src/authentication/SyncAuthenticator.js
+++ b/src/authentication/SyncAuthenticator.js
@@ -58,6 +58,10 @@ export class SyncAuthenticator {
       ...this.extraHeaders,
     });
 
+    if (responseJson.error) {
+      throw new Error(responseJson.error);
+    }
+
     const { version: appVersion } = packageJson;
     const [majorAppVersion] = appVersion.split('.');
     const { ServerVersion: serverVersion } = responseJson;


### PR DESCRIPTION
Fixes #4380

## Change summary

As per PR title

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Follow steps in #4380, should see correct error messages (e.g 'Account is blocked until the lockout period has expired.' or 'Invalid username or password.')

### Related areas to think about
N/A
