### PR TITLE
#4387 Set requistion.isRemoteOrder to false by default

### DIFF
--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -500,7 +500,7 @@ Requisition.schema = {
     otherStoreName: { type: 'Name', optional: true },
     customData: { type: 'string', optional: true },
     createdDate: { type: 'date', default: new Date() },
-    isRemoteOrder: { type: 'bool', default: true },
+    isRemoteOrder: { type: 'bool', default: false },
   },
 };
 

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -451,6 +451,15 @@ export class Requisition extends Realm.Object {
     return finaliseStatus;
   }
 
+  /**
+   * Get if this requisition is linked to a requisition.
+   *
+   * @return  {boolean}
+   */
+  get isLinkedToRequisition() {
+    return !!this.linkedRequisition;
+  }
+
   get canFinalise() {
     return this.isRequest ? this.canFinaliseRequest : this.canFinaliseResponse;
   }
@@ -497,6 +506,7 @@ Requisition.schema = {
     linkedTransaction: { type: 'Transaction', optional: true },
     program: { type: 'MasterList', optional: true },
     period: { type: 'Period', optional: true },
+    linkedRequisition: { type: 'string', optional: true },
     otherStoreName: { type: 'Name', optional: true },
     customData: { type: 'string', optional: true },
     createdDate: { type: 'date', default: new Date() },

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -719,6 +719,8 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         period = database.getOrCreate('Period', record.periodID);
       }
 
+      const linkedRequisition = record.linked_requisition_id || null;
+
       internalRecord = {
         id: record.ID,
         status: REQUISITION_STATUSES.translate(record.status, EXTERNAL_TO_INTERNAL),
@@ -733,6 +735,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         thresholdMOS: parseNumber(record.thresholdMOS),
         program: database.getOrCreate('MasterList', record.programID),
         period,
+        linkedRequisition,
         orderType: record.orderType,
         customData: parseJsonString(record.custom_data),
         isRemoteOrder: parseBoolean(record.isRemoteOrder),

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -107,15 +107,25 @@ const DataTableRow = React.memo(
           // Indicator if the right hand border should be removed from styles for this cell.
           const isLastCell = index === columns.length - 1;
 
-          const { isLinkedToTransaction, isFinalised: rowIsFinalised } = rowData;
+          const {
+            isLinkedToTransaction,
+            isFinalised: rowIsFinalised,
+            isLinkedToRequisition,
+            isResponse,
+          } = rowData;
           // This cell is disabled if:
           // - the page is finalised.
           // - the row has been explicitly set as disabled.
           // - The row itself is finalised.
           // - The row was created on the primary
           const rowIsDisabled = rowState?.isDisabled ?? false;
+
           const isDisabled =
-            isFinalised || rowIsDisabled || rowIsFinalised || isLinkedToTransaction;
+            isFinalised ||
+            rowIsDisabled ||
+            rowIsFinalised ||
+            isLinkedToTransaction ||
+            (isResponse && isLinkedToRequisition);
 
           // Alignment of this particular column. Default to left hand ide.
           const cellAlignment = alignText || 'left';

--- a/src/widgets/DataTable/DataTableRow.js
+++ b/src/widgets/DataTable/DataTableRow.js
@@ -107,7 +107,7 @@ const DataTableRow = React.memo(
           // Indicator if the right hand border should be removed from styles for this cell.
           const isLastCell = index === columns.length - 1;
 
-          const { isLinkedToTransaction, isFinalised: rowIsFinalised, isRemoteOrder } = rowData;
+          const { isLinkedToTransaction, isFinalised: rowIsFinalised } = rowData;
           // This cell is disabled if:
           // - the page is finalised.
           // - the row has been explicitly set as disabled.
@@ -115,14 +115,7 @@ const DataTableRow = React.memo(
           // - The row was created on the primary
           const rowIsDisabled = rowState?.isDisabled ?? false;
           const isDisabled =
-            isFinalised ||
-            rowIsDisabled ||
-            rowIsFinalised ||
-            isLinkedToTransaction ||
-            // If the field `isRemoteOrder is a part of the model for the row
-            // (Transaction/Requisition) then disable all rows which are not
-            // remote orders.
-            (isRemoteOrder != null && !isRemoteOrder);
+            isFinalised || rowIsDisabled || rowIsFinalised || isLinkedToTransaction;
 
           // Alignment of this particular column. Default to left hand ide.
           const cellAlignment = alignText || 'left';


### PR DESCRIPTION
## Description

- Fixes #4387
- Set requisition.isRemoteOrder to false by default
- Also remove isRemoteOrder check disabling deletion of requisition if isRemoteOrder is false. Setting isRemoteOrder to false by default would have - otherwise disabled deletion of these newly created requisitions

## Change summary

- **Code change:** We are not handling the `isRemoteOrder` field of the `requisition` table, in mobile, at all. 
  - The idea is `isRemoteOrder` is used on the desktop for a purpose that is completely different from our mobile legacy code's interpretation of that field.
  - _FYI: In desktop `isRemoteOrder` is set to true to allow these requstion to be edited on the server side in case of remote devices getting lost._
  - The setting of isRemoteOrder to true is causing desktop requisition view to show extra columns that are not supposed to show for mobile created requisitions.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Open requisition list, none of the requisitions in the list should have deletion disabled now that we are disabling `isRemoteOrder` check.
- [ ] Create a requisition from mobile
  - [ ] Go to desktop to check, it should not have extra columns.

### Related areas to think about

- Old requisitions may still show extra columns on the desktop until the foot-runner is run to set those requisitions (from mobile) with isRemoteOrder false.
