### PR TITLE
#4334 Update dates for nameRecords

### DIFF
--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -86,7 +86,7 @@ const generateSyncData = (settings, recordType, record) => {
         middle: record.middleName,
         last: record.lastName,
         name: record.name,
-        date_of_birth: moment(record.dateOfBirth).format(),
+        date_of_birth: getDateString(record.dateOfBirth),
         code: record.code,
         email: record.emailAddress,
         supplying_store_id: record.supplyingStoreId || settings.get(THIS_STORE_ID),
@@ -104,7 +104,7 @@ const generateSyncData = (settings, recordType, record) => {
         ethnicity_ID: record.ethnicity?.id ?? '',
       };
       if (record.createdDate) {
-        nameRecord.created_date = moment(record.createdDate).format();
+        nameRecord.created_date = getDateString(record.createdDate);
       }
 
       return nameRecord;


### PR DESCRIPTION
Fixes #4334

## Change summary

- Adjust the date format to not include offset when syncing to server
- e.g.
Send `1991-12-24T11:00:00.000Z` instead of `1991-12-25T00:00:00+13:00`

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Edit a patient's DOB (or create a new patient), sync to the server and check the patient's DOB on the server. The date should be the same as what was entered in the mobile UI

### Related areas to think about
I'm kind of undoing a change in https://github.com/openmsupply/mobile/pull/2101 ... not sure if something else has changed since then, but testing locally (where both mobile and mSupply Desktop are running in NZT) this change stops the days from appearing a day in the past on the server.