### PR TITLE
#4414 Update ADRInput to look in correct place for vaccinations

### DIFF
--- a/src/pages/DispensingPage.js
+++ b/src/pages/DispensingPage.js
@@ -296,7 +296,7 @@ const Dispensing = ({
         isVisible={isADRModalOpen}
         onClose={cancelCreatingADR}
       >
-        <ADRInput patientHistory={patientHistory} />
+        <ADRInput />
       </ModalContainer>
     </>
   );

--- a/src/selectors/Entities/name.js
+++ b/src/selectors/Entities/name.js
@@ -112,8 +112,9 @@ export const selectVaccinePatientHistory = patient => {
       ({ patientEventID, data }) =>
         patientEventID === vaccinationPatientEventID && validateJsonSchemaData(jsonSchema, data)
     )
-    .map(({ data: vaccinationNameNotes }) => ({
+    .map(({ id, data: vaccinationNameNotes }) => ({
       ...vaccinationNameNotes,
+      id,
       doses: 1, // Currently not possible to dispense more than 1 dose
       totalQuantity: 1,
       confirmDate: new Date(convertMobileDateToISO(vaccinationNameNotes.vaccineDate)),

--- a/src/widgets/modalChildren/ADRInput.js
+++ b/src/widgets/modalChildren/ADRInput.js
@@ -15,6 +15,7 @@ import { PatientActions } from '../../actions/PatientActions';
 import { selectCurrentPatient } from '../../selectors/patient';
 import { useLocalAndRemotePatientHistory } from '../../hooks/useLocalAndRemoteHistory';
 import { dispensingStrings, generalStrings, vaccineStrings } from '../../localization';
+import { selectVaccinePatientHistory } from '../../selectors/Entities/name';
 
 const getSchemaItems = jsonSchema => {
   const { properties = {} } = jsonSchema;
@@ -47,13 +48,12 @@ LoadingIndicator.propTypes = {
   loading: PropTypes.bool.isRequired,
 };
 
-export const ADRInputComponent = ({ onCancel, onSave, patient, patientHistory }) => {
+export const ADRInputComponent = ({ onCancel, onSave, patient, vaccineHistory }) => {
   const [{ formData, isValid }, setForm] = useState({ formData: null, isValid: false });
   const patientId = patient?.id;
   const [ADRSchema, setADRSchema] = useState(UIDatabase.objects('ADRForm')[0]);
   const { jsonSchema, uiSchema, type, version } = UIDatabase.objects('ADRForm')[0];
   const items = getSchemaItems(jsonSchema);
-  const vaccineHistory = patientHistory.filter(h => h.itemBatch?.item?.isVaccine);
   const [{ data, loading, searched }, fetchOnline] = useLocalAndRemotePatientHistory({
     isVaccineDispensingModal: true,
     patientId,
@@ -115,7 +115,7 @@ ADRInputComponent.propTypes = {
   onCancel: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
   patient: PropTypes.object.isRequired,
-  patientHistory: PropTypes.array.isRequired,
+  vaccineHistory: PropTypes.array.isRequired,
 };
 
 const localStyles = StyleSheet.create({
@@ -149,7 +149,8 @@ const localStyles = StyleSheet.create({
 
 const stateToProps = state => {
   const patient = selectCurrentPatient(state);
-  return { patient };
+  const vaccineHistory = selectVaccinePatientHistory(patient);
+  return { patient, vaccineHistory };
 };
 
 const dispatchToProps = dispatch => ({


### PR DESCRIPTION
Fixes #4414

## Change summary

Update ADRInput to pull all local vaccinations (from name_note records) instead of filtering on transactions (as the filter doesn't work anymore).

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Follow repro steps in #4414 - should see local vaccinations

### Related areas to think about
