### PR TITLE
#4416 Customer requisition row not updating immediately on edit

### DIFF
--- a/src/pages/CustomerRequisitionPage.js
+++ b/src/pages/CustomerRequisitionPage.js
@@ -198,6 +198,7 @@ export const CustomerRequisition = ({
         <DataTableRow
           rowData={data[index]}
           rowKey={rowKey}
+          rowState={dataState.get(rowKey)}
           columns={currentColumns}
           isFinalised={isFinalised}
           getCallback={getCallback}


### PR DESCRIPTION
Fixes #4416

## Change summary

- One line update to pass in a rowState

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Follow the steps in the original issue reported (#4416) - row values should update immediately on edit and not require the user to unfocus the row

### Related areas to think about
Probably none - took me longer than I think it should have to spot, lol.
