### PR TITLE
#4385 Tabbed view for patient history

### DIFF
--- a/src/localization/dispensingStrings.json
+++ b/src/localization/dispensingStrings.json
@@ -19,6 +19,7 @@
     "decimal_point": ".",
     "details": "Details",
     "directions": "Directions",
+    "dispensing": "Dispensing",
     "enter_a_description": "Enter a description",
     "enter_the_amount": "Enter the amount",
     "facility": "Facility",
@@ -70,6 +71,7 @@
     "edit_the_patient": "Edit patient details",
     "edit_supplemental_data": "Edit additional details",
     "refused_vaccine": "Refused vaccine",
+    "vaccinations": "Vaccinations",
     "validation_failed": "Some required fields are not completed."
   },
   "fr": {

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -246,6 +246,7 @@ export const getPatientHistoryResponseProcessor = ({
           totalQuantity: item.is_vaccine ? totalQuantity * doses : totalQuantity,
           vaccinator,
           prescriberOrVaccinator: medicineAdministrator ? vaccinator : prescriber,
+          isVaccine: item.is_vaccine,
         });
       }
     )

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -330,7 +330,7 @@ const PatientSelectComponent = ({
           patientHistory={history}
           patientId={patient?.id || ''}
           sortKey="itemName"
-          isVaccine={true}
+          isVaccineDispensingModal={true}
         />
       </ModalContainer>
     </FlexView>

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -58,8 +58,8 @@ import {
 } from '../../sync/lookupApiUtils';
 import { SETTINGS_KEYS } from '../../settings/index';
 import { DataTable, DataTableRow, DataTableHeaderRow } from '../DataTable';
-import { selectVaccinePatientHistory } from '../../selectors/Entities/name';
 import { PatientHistoryModal } from '../modals/PatientHistory';
+import { selectVaccinePatientHistory } from '../../selectors/patient';
 
 const getMessage = (noResults, error) => {
   if (noResults) return generalStrings.could_not_find_patient;

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -41,11 +41,11 @@ import { AfterInteractions } from '../AfterInteractions';
 import { Paper } from '../Paper';
 import { VaccinePrescriptionInfo } from '../VaccinePrescriptionInfo';
 import { useNavigationFocus } from '../../hooks/useNavigationFocus';
-import { selectWasPatientVaccinatedWithinOneDay } from '../../selectors/Entities/name';
 import { PaperModalContainer } from '../PaperModal/PaperModalContainer';
 import { PaperConfirmModal } from '../PaperModal/PaperConfirmModal';
 import { useToggle } from '../../hooks/useToggle';
 import { PageButton } from '../PageButton';
+import { selectWasPatientVaccinatedWithinOneDay } from '../../selectors/patient';
 
 const ListEmptyComponent = () => (
   <FlexView flex={1} justifyContent="center" alignItems="center">

--- a/src/widgets/modalChildren/ADRInput.js
+++ b/src/widgets/modalChildren/ADRInput.js
@@ -12,10 +12,9 @@ import { PageButton } from '../PageButton';
 import { SUSSOL_ORANGE, WHITE } from '../../globalStyles/colors';
 import globalStyles from '../../globalStyles/index';
 import { PatientActions } from '../../actions/PatientActions';
-import { selectCurrentPatient } from '../../selectors/patient';
+import { selectCurrentPatient, selectVaccinePatientHistory } from '../../selectors/patient';
 import { useLocalAndRemotePatientHistory } from '../../hooks/useLocalAndRemoteHistory';
 import { dispensingStrings, generalStrings, vaccineStrings } from '../../localization';
-import { selectVaccinePatientHistory } from '../../selectors/Entities/name';
 
 const getSchemaItems = jsonSchema => {
   const { properties = {} } = jsonSchema;

--- a/src/widgets/modals/PatientHistory.js
+++ b/src/widgets/modals/PatientHistory.js
@@ -41,9 +41,9 @@ LoadingIndicator.propTypes = {
   loading: PropTypes.bool.isRequired,
 };
 
-const getColumnKey = (isVaccine, canViewHistory) => {
+const getColumnKey = (isVaccineDispensingModal, canViewHistory) => {
   // Vaccine Dispensing History
-  if (isVaccine) {
+  if (isVaccineDispensingModal) {
     return canViewHistory ? MODALS.VACCINE_HISTORY_LOOKUP : MODALS.VACCINE_HISTORY;
   }
 
@@ -55,27 +55,36 @@ const getColumnKey = (isVaccine, canViewHistory) => {
   return MODALS.PATIENT_HISTORY_LOOKUP_WITH_VACCINES;
 };
 
-export const PatientHistoryModal = ({ isVaccine, patientId, patientHistory, sortKey }) => {
+export const PatientHistoryModal = ({
+  isVaccineDispensingModal,
+  patientId,
+  patientHistory,
+  sortKey,
+}) => {
   const canViewHistory = UIDatabase.getPreference(PREFERENCE_KEYS.CAN_VIEW_ALL_PATIENTS_HISTORY);
   const patientsSyncEverywhere = !UIDatabase.getPreference(
     PREFERENCE_KEYS.NEW_PATIENTS_VISIBLE_THIS_STORE_ONLY
   );
-  const filteredHistory = isVaccine
+  const filteredHistory = isVaccineDispensingModal
     ? patientHistory.filter(record => record.isVaccine)
     : patientHistory.filter(record => !record.isVaccine);
 
   // Remote fetch not required if patients sync everywhere is enabled and only fetching vaccines
   const isRemoteFetchRequired =
-    (canViewHistory && !isVaccine) || (canViewHistory && !patientsSyncEverywhere && isVaccine);
+    (canViewHistory && !isVaccineDispensingModal) ||
+    (canViewHistory && !patientsSyncEverywhere && isVaccineDispensingModal);
 
-  const columns = React.useMemo(() => getColumns(getColumnKey(isVaccine, canViewHistory)), []);
+  const columns = React.useMemo(
+    () => getColumns(getColumnKey(isVaccineDispensingModal, canViewHistory)),
+    []
+  );
 
   const [
     { data, loading, error, historyType },
     toggleHistoryType,
     fetchOnline,
   ] = useLocalAndRemotePatientHistory({
-    isVaccineDispensingModal: isVaccine,
+    isVaccineDispensingModal,
     patientId,
     initialValue: filteredHistory,
     sortKey,
@@ -117,7 +126,7 @@ export const PatientHistoryModal = ({ isVaccine, patientId, patientHistory, sort
 
   return (
     <View style={localStyles.mainContainer}>
-      {!isVaccine ? (
+      {!isVaccineDispensingModal ? (
         <View style={localStyles.topSectionContainer}>
           <ToggleBar toggles={toggles} />
         </View>
@@ -142,12 +151,12 @@ const localStyles = {
 };
 
 PatientHistoryModal.defaultProps = {
-  isVaccine: false,
+  isVaccineDispensingModal: false,
   patientHistory: [],
 };
 
 PatientHistoryModal.propTypes = {
-  isVaccine: PropTypes.bool,
+  isVaccineDispensingModal: PropTypes.bool,
   patientId: PropTypes.string.isRequired,
   patientHistory: PropTypes.array,
   sortKey: PropTypes.string.isRequired,


### PR DESCRIPTION
Fixes #4385

## Change summary

- Hacked in a toggle to the patient history page:
![image](https://user-images.githubusercontent.com/65875762/134114966-b8d48e84-6b93-4dcd-b727-7bd670f387c2.png)
![image](https://user-images.githubusercontent.com/65875762/134115023-deb434aa-b362-4181-bd36-ec2459b6552b.png)
- Moved a bunch of selectors from name.js to patient.js (just so the history bits were in the same place...)
- Looking at it now I think it's maybe a bit inefficient because of the extra potential remote fetching 😢  (maybe should have kept all the results in state somewhere?). This PR probably isn't even necessary, happy to close, just wanted to fiddle around a bit with the UI 😆 .

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] View patient history. The dispensing and vaccination transactions should be separated

### Related areas to think about
N/A
