### PR TITLE
#4424 trim trailing '/' chars from sync url

### DIFF
--- a/src/localization/authStrings.json
+++ b/src/localization/authStrings.json
@@ -9,7 +9,7 @@
     "site": "Site",
     "store": "Store",
     "invalid_username_or_password": "Invalid username or password",
-    "warning_sync_edit": "WARNING:\nThis will effect syncing for this store.\nMake sure you know what you doing!",
+    "warning_sync_edit": "WARNING:\nThis will affect syncing for this store.\nMake sure you know what you are doing!",
     "incompatible_server": "The mSupply Server you're trying to sync with is not compatible with your current version. Please contact your administrator."
   },
   "fr": {

--- a/src/pages/FirstUsePage.js
+++ b/src/pages/FirstUsePage.js
@@ -52,9 +52,12 @@ export class FirstUsePageComponent extends React.Component {
     const { onInitialised, synchroniser } = this.props;
     const { serverURL, syncSiteName, syncSitePassword } = this.state;
 
+    // Quietly snip off trailing '/' characters before persisting as this causes invalid urls
+    const trimmedSyncUrl = serverURL.replace(/\/$/, '');
+
     try {
       this.setState({ status: STATUSES.INITIALISING });
-      await synchroniser.initialise(serverURL, syncSiteName, syncSitePassword);
+      await synchroniser.initialise(trimmedSyncUrl, syncSiteName, syncSitePassword);
       this.setState({ status: STATUSES.INITIALISED });
 
       onInitialised();

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -116,9 +116,9 @@ const Settings = ({
       UIDatabase.write(() => {
         UIDatabase.update('Setting', {
           key: SETTINGS_KEYS.SYNC_URL,
-          value: syncURL,
+          // Quietly snip off trailing '/' characters before persisting as this causes invalid urls
+          value: syncURL.replace(/\/$/, ''),
         });
-
         UIDatabase.update('Setting', {
           key: SETTINGS_KEYS.SYNC_SITE_PASSWORD_HASH,
           value: syncPassword ? hashPassword(syncPassword) : currentUserPasswordHash,


### PR DESCRIPTION
Fixes #4424

## Change summary

- Super minor change to trim extraneous '/' characters at the end of an otherwise valid url. See issue for history. 
- Minor offroad for grammar (side note: the 'Make sure you know what you are doing' prompt always makes me hesitate, feels like such a bold claim).

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Set up (on the initialise or settings page) a URL ending with '/', e.g. `http://192.168.1.158:5000/` when saved, sync/login should still work

### Related areas to think about
- FirstUsePage does whitespace trimming `onBlur()`, didn't put this there because that might be weird for users to see it being edited for them. Thought it was better to let them think it was fine and just clean it up in the background.
