### PR TITLE
#4484 Add Name linked objects to merge

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -1246,8 +1246,17 @@ const RECORD_TYPE_TO_TABLE = {
     },
   },
   Name: {
+    AdverseDrugReaction: {
+      field: 'name',
+    },
     ItemBatch: {
       field: 'supplier',
+    },
+    NameNote: {
+      field: 'name',
+    },
+    NameTagJoin: {
+      field: 'name',
     },
     Transaction: {
       field: 'otherParty',


### PR DESCRIPTION
Fixes #4484

## Change summary

Adds updates to tables linked to retained `Name` records when merged.
Doesn't fix Realm problem with deleting records that are currently being edited or viewed (going to log as a separate issue).

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Merge two patients in Desktop (both of their home stores need to be the store you are logged into it seems), for Kiribati they will still show up in all mobile stores due to patients syncing everywhere. The vaccination records for both patient records should appear in mobile against the patient that was retained.

### Related areas to think about
- Can't be working with a patient when it is merged or deleted via sync (although if you happen to be and see the crash, when relaunching the app after the initial crash it will be fine)