### PR TITLE
#4516 Update name.name on patient edit (in vaccine module)

### DIFF
--- a/src/actions/Entities/NameActions.js
+++ b/src/actions/Entities/NameActions.js
@@ -100,7 +100,9 @@ const saveEditing = () => (dispatch, getState) => {
   const currentPatient = selectEditingName(getState());
   const createdDate = currentPatient?.createdDate ? new Date(currentPatient.createdDate) : null;
   const dateOfBirth = new Date(currentPatient.dateOfBirth);
-  const patientRecord = { ...currentPatient, dateOfBirth, createdDate };
+  const name = `${currentPatient.lastName}, ${currentPatient.firstName}`;
+
+  const patientRecord = { ...currentPatient, dateOfBirth, createdDate, name };
 
   UIDatabase.write(() => createRecord(UIDatabase, 'Patient', patientRecord));
   dispatch(reset());


### PR DESCRIPTION
Fixes #4516

## Change summary

- When saving a patient after a vaccination - refresh `name.name` (as `firstName` and/or `lastName` may have been modified)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Try to replicate #4516 (hopefully you can't after this PR 🤞 )

### Related areas to think about
Patients edited in the Dispensing module appear to be fine (name editing code is different depending on which module you are in...)