### PR TITLE
#4549 missing consecutive breaches

### DIFF
--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -137,9 +137,8 @@ const downloadLogsFromSensor = sensor => async dispatch => {
               false /* don't clear logs */
             );
 
-            await BleService().clearLogs(macAddress);
-
             await dispatch(BreachActions.createConsecutiveBreaches(sensor));
+            await BleService().clearLogs(macAddress);
           } catch (e) {
             dispatch(sensorDownloadError(sensor, DOWNLOADING_ERROR_CODES.E_CANT_CONNECT));
           }

--- a/src/actions/BreachActions.js
+++ b/src/actions/BreachActions.js
@@ -32,7 +32,8 @@ const createConsecutiveBreaches = sensor => async dispatch => {
       temperature,
       timestamp: moment(timestamp).unix(),
     }));
-    const configs = sensor.breachConfigs;
+
+    const configs = sensor.breachConfigs.filter(config => config.type.includes('CONSECUTIVE'));
     const mostRecentBreach = await BreachManager().getMostRecentBreach(sensorID);
     const [breaches, temperatureLogs] = await BreachManager().createBreaches(
       sensor,


### PR DESCRIPTION
Fixes #4549 (I think!?)

## Change summary

- Filters breach configs so that only consecutive configs are used when calculating consecutive breaches
- Have reordered operations so that the app will attempt to record consecutive breaches before trying to clear logs (I think I saw log clearing fail causing consec breach creation to be skipped, although now I can't replicate so I'm not 100% sure I saw what I thought I saw - think the change is safe enough anyway).

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Attempt to replicate issue #4549

### Related areas to think about
Have created this issue to try to clear logs more times before giving up: https://github.com/openmsupply/msupply-ble-service/issues/4
