### PR TITLE
Release/6.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -72,7 +72,6 @@ const generateSyncData = (settings, recordType, record) => {
         total_cost: String(record.costPrice * record.numberOfPacks),
         name_ID: record.supplier?.id ?? '',
         donor_id: record.donor?.id ?? '',
-        doses: String(record.doses),
         location_ID: record.location?.id,
       };
     }
@@ -195,7 +194,6 @@ const generateSyncData = (settings, recordType, record) => {
         item_ID: record.itemId,
         optionID: record.option?.id ?? '',
         is_edited: record.hasBeenCounted,
-        doses: String(record.doses),
         location_ID: record.location?.id,
         vaccine_vial_monitor_status_ID: record.vaccineVialMonitorStatus?.id,
       };
@@ -265,7 +263,6 @@ const generateSyncData = (settings, recordType, record) => {
         donor_id: record.donor?.id ?? '',
         type: record.type,
         linked_transact_id: record.linkedTransaction?.id,
-        doses: String(record.doses),
         location_ID: record.location?.id,
         vaccine_vial_monitor_status_ID: record.vaccineVialMonitorStatus?.id,
         sent_pack_size: String(record.sentPackSize),


### PR DESCRIPTION
Fixes #4556

## Change summary

- Removes doses from outgoingSyncUtils

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Find a version of mSupply without `[item_lines]doses` or `[trans_line]doses` (I used v5.05.00 - presumably anything after will work) and try to sync something to that version of mSupply

### Related areas to think about
- I don't actually want to merge this to master. Thinking of just releasing off this Release/6.0.4 branch? 🤔 
