### PR TITLE
Add restarting scheduler on mount

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "8.4.1",
+  "version": "8.4.1-rc1",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/Store.js
+++ b/src/Store.js
@@ -27,10 +27,16 @@ const bugsnagMiddleware = () => next => action => {
   next(action);
 };
 
+const logMiddleware = () => next => action => {
+  console.log(action.type);
+
+  next(action);
+};
+
 const store = createStore(
   persistedReducer,
   {},
-  applyMiddleware(thunk, navigationMiddleware, bugsnagMiddleware)
+  applyMiddleware(thunk, navigationMiddleware, bugsnagMiddleware, logMiddleware)
 );
 
 const persistedStore = persistStore(store);

--- a/src/Store.js
+++ b/src/Store.js
@@ -27,16 +27,10 @@ const bugsnagMiddleware = () => next => action => {
   next(action);
 };
 
-const logMiddleware = () => next => action => {
-  console.log(action.type);
-
-  next(action);
-};
-
 const store = createStore(
   persistedReducer,
   {},
-  applyMiddleware(thunk, navigationMiddleware, bugsnagMiddleware, logMiddleware)
+  applyMiddleware(thunk, navigationMiddleware, bugsnagMiddleware)
 );
 
 const persistedStore = persistStore(store);

--- a/src/actions/Bluetooth/SensorDownloadActions.js
+++ b/src/actions/Bluetooth/SensorDownloadActions.js
@@ -20,12 +20,14 @@ export const DOWNLOAD_ACTIONS = {
   DOWNLOAD_LOGS_ERROR: 'Bluetooth/downloadLogsError',
   DOWNLOAD_LOGS_COMPLETE: 'Bluetooth/downloadLogsComplete',
   PASSIVE_DOWNLOAD_START: 'Bluetooth/passiveDownloadStart',
+  PASSIVE_DOWNLOAD_STOP: 'Bluetooth/passiveDownloadStop',
   SENSOR_DOWNLOAD_START: 'Bluetooth/sensorDownloadStart',
   SENSOR_DOWNLOAD_SUCCESS: 'Bluetooth/sensorDownloadSuccess',
   SENSOR_DOWNLOAD_ERROR: 'Bluetooth/sensorDownloadError',
 };
 
 const startPassiveDownloadJob = () => ({ type: DOWNLOAD_ACTIONS.PASSIVE_DOWNLOAD_START });
+const stopPassiveDownloadJob = () => ({ type: DOWNLOAD_ACTIONS.PASSIVE_DOWNLOAD_STOP });
 const downloadLogsStart = () => ({ type: DOWNLOAD_ACTIONS.DOWNLOAD_LOGS_START });
 const downloadLogsComplete = () => ({ type: DOWNLOAD_ACTIONS.DOWNLOAD_LOGS_COMPLETE });
 const downloadLogsError = error => ({
@@ -187,4 +189,5 @@ const startDownloadAll = () => async (dispatch, getState) => {
 export const SensorDownloadActions = {
   startDownloadAll,
   startPassiveDownloadJob,
+  stopPassiveDownloadJob,
 };

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -57,7 +57,7 @@ import BreachManager from './bluetooth/BreachManager';
 import { selectIsPassivelyDownloadingTemps } from './selectors/Bluetooth/sensorDownload';
 import LoggerService from './utilities/logging';
 
-const BLUETOOTH_SYNC_INTERVAL = 60 * 1000; // 1 minute in milliseconds.
+const BLUETOOTH_SYNC_INTERVAL = 10 * 1000; // 1 minute in milliseconds.
 const AUTHENTICATION_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 
 SensorManager(new VaccineDataAccess(UIDatabase), new UtilService());
@@ -110,30 +110,26 @@ class MSupplyMobileAppContainer extends React.Component {
   }
 
   componentDidUpdate() {
-    const { dispatch, usingVaccines, syncTemperatures, requestBluetooth } = this.props;
+    const { dispatch, requestBluetooth } = this.props;
 
-    if (usingVaccines) {
-      const { isPassivelyDownloadingTemps } = this.props;
+    this.startTemperatureDownload();
 
-      if (!isPassivelyDownloadingTemps) {
-        this.scheduler.schedule(syncTemperatures, BLUETOOTH_SYNC_INTERVAL);
-        dispatch(SensorDownloadActions.startPassiveDownloadJob());
-      }
-
-      BluetoothStatus.addListener(requestBluetooth);
-      dispatch(PermissionActions.checkPermissions());
-    }
+    BluetoothStatus.addListener(requestBluetooth);
+    dispatch(PermissionActions.checkPermissions());
   }
 
   componentDidMount = () => {
-    if (!__DEV__) AppState.addEventListener('change', this.onAppStateChange);
+    this.startTemperatureDownload();
+    AppState.addEventListener('change', this.onAppStateChange);
   };
 
   componentWillUnmount = () => {
-    const { usingVaccines } = this.props;
+    const { usingVaccines, dispatch } = this.props;
+
+    dispatch(SensorDownloadActions.stopPassiveDownloadJob());
 
     if (usingVaccines) BluetoothStatus.removeListener();
-    if (!__DEV__) AppState.removeEventListener('change', this.onAppStateChange);
+    AppState.removeEventListener('change', this.onAppStateChange);
 
     this.scheduler.clearAll();
   };
@@ -206,6 +202,19 @@ class MSupplyMobileAppContainer extends React.Component {
       dispatch(setSyncError(error.message));
     }
   };
+
+  startTemperatureDownload() {
+    const { dispatch, usingVaccines, syncTemperatures } = this.props;
+
+    if (usingVaccines) {
+      const { isPassivelyDownloadingTemps } = this.props;
+
+      if (!isPassivelyDownloadingTemps) {
+        this.scheduler.schedule(syncTemperatures, BLUETOOTH_SYNC_INTERVAL);
+        dispatch(SensorDownloadActions.startPassiveDownloadJob());
+      }
+    }
+  }
 
   renderLoadingIndicator = () => {
     const { isLoading } = this.state;

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -57,7 +57,7 @@ import BreachManager from './bluetooth/BreachManager';
 import { selectIsPassivelyDownloadingTemps } from './selectors/Bluetooth/sensorDownload';
 import LoggerService from './utilities/logging';
 
-const BLUETOOTH_SYNC_INTERVAL = 10 * 1000; // 1 minute in milliseconds.
+const BLUETOOTH_SYNC_INTERVAL = 60 * 1000; // 1 minute in milliseconds.
 const AUTHENTICATION_INTERVAL = 10 * 60 * 1000; // 10 minutes in milliseconds.
 
 SensorManager(new VaccineDataAccess(UIDatabase), new UtilService());

--- a/src/reducers/Bluetooth/SensorDownloadReducer.js
+++ b/src/reducers/Bluetooth/SensorDownloadReducer.js
@@ -87,6 +87,10 @@ export const SensorDownloadReducer = (state = initialState(), action) => {
       return { ...state, isPassivelyDownloadingTemps: true };
     }
 
+    case DOWNLOAD_ACTIONS.PASSIVE_DOWNLOAD_STOP: {
+      return { ...state, isPassivelyDownloadingTemps: false };
+    }
+
     case DOWNLOAD_ACTIONS.DOWNLOAD_LOGS_START: {
       return { ...state, isSyncingTemps: true, error: null };
     }


### PR DESCRIPTION
Fixes #4568 ???

- The flow which causes *an* issue is that 'minimising' or sending to the app to the background 'regularly', doesn't trigger an unmount. But using the `back` button does (on the menu page), so the scheduler get's removed. When entering the foreground again, `onUpdate` isn't called, so the scheduler is not started again.

## Change summary

- Added a call to start the download scheduler on mount and left it also in the on update lifecycle method. This is because the passive download needs to potentially start after having synced from the server, also.


## Testing

- [ ] Pressing the back button on the menu page and returning to the app: Sensor temperatures are still being downloaded.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
