### PR TITLE
#4525 Make the menu button a tiny bit wider

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "8.4.2-rc1",
+  "version": "8.4.2-rc2",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/globalStyles/buttonStyles.js
+++ b/src/globalStyles/buttonStyles.js
@@ -69,7 +69,7 @@ export const buttonStyles = {
     padding: 15,
     marginVertical: 12,
     marginHorizontal: 30,
-    width: 240,
+    width: 250,
     height: 60,
     borderWidth: 1,
     borderRadius: 4,


### PR DESCRIPTION
Fixes #4525

## Change summary

- Widens the menu button by the minimum amount possible to make the text appear on a Samsung T500 device.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Get a Samsung T500 or Samsung T505 (not sure what other devices this issue occurs on but try a manufacturer who sets their default font size to something large 🤷 ), navigate to the main menu page
- [ ] Get all the devices mSupply mobile supports and try it on them too (maybe this will take too long - I tried on a few different emulator settings... the min specs here seem super small? https://docs.msupply.foundation/en%3Amobile%3Auser_guide%3Agetting_started#recommended_specification)

### Related areas to think about
- Tried shrinking the fontSize down by 1 unit which also fixes the problem, but then the text looks a bit small on other devices.
- Had another super hacky idea to check if DeviceInfo.getModel() returned 'SM-T500' or 'SM-T505' to shrink the font. But that's super ick. Am open to other/better suggestions
