### PR TITLE
#4592 Fix Response requisition rouge CI problem

### DIFF
--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -249,7 +249,7 @@ export class Requisition extends Realm.Object {
    */
   createCustomerInvoice(database, user) {
     if (this.isRequest || this.isFinalised) {
-      throw new Error('Cannot create invoice from Finalised or Request Requistion ');
+      throw new Error('Cannot create invoice from Finalised or Request Requisition ');
     }
 
     if (

--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -52,6 +52,10 @@ export class Requisition extends Realm.Object {
    */
   destructor(database) {
     database.delete('RequisitionItem', this.items);
+
+    if (this.linkedTransaction) {
+      database.delete('Transaction', this.linkedTransaction);
+    }
   }
 
   /**

--- a/src/pages/CustomerRequisitionsPage.js
+++ b/src/pages/CustomerRequisitionsPage.js
@@ -187,7 +187,7 @@ export const CustomerRequisitions = ({
 };
 
 const mapDispatchToProps = dispatch => ({
-  ...getPageDispatchers(dispatch, 'Transaction', ROUTES.CUSTOMER_REQUISITIONS),
+  ...getPageDispatchers(dispatch, 'Requisition', ROUTES.CUSTOMER_REQUISITIONS),
   onFilterData: value =>
     dispatch(PageActions.filterDataWithFinalisedToggle(value, ROUTES.CUSTOMER_REQUISITIONS)),
   refreshData: () =>


### PR DESCRIPTION
Fixes #4592 

- The deletion sync was not syncing back to sever, resulting in sever still retaining the requisition that was deleted on mobile.

## Change summary

Suggested Customer Requisition deletion should delete its corresponding CI too.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a Customer Requisition on mobile
- [ ] After it syncs delete it
- [ ] Go to Customer invoice tab
- [ ] See a customer invoice corresponding (created by) the deleted Customer Requisition appear. This CI should have been deleted with Customer Requisition. 
- [ ] Check to see if the deleted requisition in mobile is also deleted on server.

## Regression tests

- [ ] Create, update and delete customer and supplier requisitions. They should all work as expected.

### Related areas to think about

None
