### PR TITLE
#4562 Customer Requisition with no Supplied quantity creates blank CI when finalised

### DIFF
--- a/src/database/DataTypes/Requisition.js
+++ b/src/database/DataTypes/Requisition.js
@@ -436,6 +436,16 @@ export class Requisition extends Realm.Object {
       return { success: false, message: modalStrings.requisition_invalid_closing_stock };
     }
 
+    // If all of the supplied quantity field has 0 quantity,
+    // then the requisition is not ready to be finalised
+    const suppliedQuantitiesAreValid = this.items.some(
+      ({ hasSuppliedQuantity }) => hasSuppliedQuantity
+    );
+
+    if (!suppliedQuantitiesAreValid) {
+      return { success: false, message: modalStrings.requisition_no_supplied_quantity };
+    }
+
     const daysOutOfStockAreValid = this.items.every(
       ({ daysOutOfStockIsValid }) => daysOutOfStockIsValid
     );

--- a/src/database/DataTypes/RequisitionItem.js
+++ b/src/database/DataTypes/RequisitionItem.js
@@ -278,6 +278,10 @@ export class RequisitionItem extends Realm.Object {
     return this.stockOnHand >= 0;
   }
 
+  get hasSuppliedQuantity() {
+    return this.suppliedQuantity > 0;
+  }
+
   get daysOutOfStockIsValid() {
     return this.daysOutOfStock <= this.numberOfDaysInPeriod;
   }

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -60,6 +60,7 @@
     "location_details": "Location Details",
     "requisition_invalid_closing_stock": "Can't finalise a requisition which has items with a negative closing quantity. Please adjust these quantities before trying to finalise!",
     "requisition_days_out_of_stock": "Can't finalise a requisition with items that have a higher days out of stock value than the length of the requisition's period",
+    "requisition_no_supplied_quantity": "Can't finalise a requisition where no item has supplied quantity. Please give quantity to at least one of the lines before trying to finalise!",
     "permissions": "Permissions",
     "services": "Services",
     "storage_permission": "Storage",


### PR DESCRIPTION
Fixes #4562

## Change summary

- Disable finalisation of Customer requisition with all of the lines with 0 supplied quantity.
- In desktop, this has always been disallowed so replicating desktop behavior.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a Customer requisition, without giving any supplied quantity finalise it
- [ ] You should get a model message saying you are not allowed and instructing you to add some supplied quantity.
- [ ] Upon giving some supplied quantity finalisation should work as expected

### Related areas to think about

None

### Additional tasks
<!-- Remove this checkbox if your PR does not have any new or edited XLIFF strings. -->
- [ ] Request XLIFF translations - `requisition_no_supplied_quantity `
  - [ ] Portuguese (pt)
  - [ ] Spanish (es)
  - [ ] French (fr)
  - [ ] Myanmar (my)
  - [ ] Laos (la)
  - [ ] Kiribati (gil)
  - [ ] Tetum (tl)
