### PR TITLE
#4618 fix translation script export non existing lang

### DIFF
--- a/dev_scripts/translation.js
+++ b/dev_scripts/translation.js
@@ -50,10 +50,14 @@ fs.readdirSync(`./${filesFolder}`).forEach(file => {
 const exportTranslation = () => {
   let csvData = '';
   localizationFiles.forEach(({ fileName, fileContent }) => {
-    const {
-      [mainLanguage]: mainLanguageContent,
-      [selectedLanguage]: selectedLanguageContent,
-    } = fileContent;
+    const { [mainLanguage]: mainLanguageContent } = fileContent;
+    let { [selectedLanguage]: selectedLanguageContent } = fileContent;
+    if (selectedLanguageContent === undefined) {
+      selectedLanguageContent = Object.keys(mainLanguageContent).reduce(
+        (selectedLanguageKeys, key) => ({ ...selectedLanguageKeys, [key]: '' }),
+        {}
+      );
+    }
     Object.entries(mainLanguageContent).forEach(([key, value]) => {
       value = value.replace(/\n/gi, '{nextLine}');
       if (selectedLanguageContent[key]) {

--- a/dev_scripts/translation.js
+++ b/dev_scripts/translation.js
@@ -84,9 +84,13 @@ const importTranslation = () => {
     const [fileName, translationField, generalValue, selectedValue] = csvRow.split('\t');
     const trimmedFileName = fileName.trim();
     if (!csvObject[trimmedFileName]) csvObject[trimmedFileName] = {};
-    if (!selectedValue) return;
-    const trimmedSelectedValue = selectedValue.replace(nextLine, '\n').trim();
-    if (trimmedSelectedValue) csvObject[trimmedFileName][translationField] = trimmedSelectedValue;
+    if (!selectedValue) {
+      const trimmedGeneraldValue = generalValue.replace(nextLine, '\n').trim();
+      if (trimmedGeneraldValue) csvObject[trimmedFileName][translationField] = trimmedGeneraldValue;
+    } else {
+      const trimmedSelectedValue = selectedValue.replace(nextLine, '\n').trim();
+      if (trimmedSelectedValue) csvObject[trimmedFileName][translationField] = trimmedSelectedValue;
+    }
   });
 
   localizationFiles.forEach(({ fileName, fileContent }) => {


### PR DESCRIPTION
Fixes #4618

## Change summary

Noticed while translating Pt strings for issue #4613. When one of the localization files is missing the language. i.e: `pt: {...}` the script `yarn translations export pt` was failing. Not it would simply add all strings mentioned on the main language with empty values to be added on the language exported. 

Also when importing checks for empty string and add the main language instead. To prevent from no string presented in the UI.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Remove the language keys & values on one of the localized file i.e `mobile/src/localization/authStrings.json`
- [ ] Try running the export script for that one. It should run correctly and the generated file i.e `pt.csv` should include the strings from `authString` as well.

### Related areas to think about

N/A
