### PR TITLE
#4625 fix language effect on menu app

### DIFF
--- a/src/actions/UserActions.js
+++ b/src/actions/UserActions.js
@@ -11,12 +11,14 @@ export const USER_ACTION_TYPES = {
   LOG_IN: 'USER/LOG_IN',
   LOG_OUT: 'USER/LOG_OUT',
   SET_TIME: 'USER/SET_TIME',
+  SET_LANGUAGE: 'USER/SET_LANGUAGE',
   ACTIVE: 'USER/ACTIVE',
 };
 
 const login = user => ({ type: USER_ACTION_TYPES.LOG_IN, payload: { user } });
 const logout = () => ({ type: USER_ACTION_TYPES.LOG_OUT });
 const setTime = () => ({ type: USER_ACTION_TYPES.SET_TIME });
+const setLanguage = code => ({ type: USER_ACTION_TYPES.SET_LANGUAGE, payload: { code } });
 
 const active = () => (dispatch, getState) => {
   const { user } = getState();
@@ -34,5 +36,6 @@ export const UserActions = {
   login,
   logout,
   setTime,
+  setLanguage,
   active,
 };

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -153,8 +153,6 @@ class MSupplyMobileAppContainer extends React.Component {
   onAuthentication = user => {
     const { dispatch } = this.props;
     dispatch(UserActions.login(user));
-    // Required to refresh menuApp after language is updated (which is only on login page)
-    dispatch(UserActions.setLanguage(UIDatabase.getSetting(SETTINGS_KEYS.CURRENT_LANGUAGE)));
     this.postSyncProcessor.setUser(user);
   };
 

--- a/src/mSupplyMobileApp.js
+++ b/src/mSupplyMobileApp.js
@@ -153,6 +153,8 @@ class MSupplyMobileAppContainer extends React.Component {
   onAuthentication = user => {
     const { dispatch } = this.props;
     dispatch(UserActions.login(user));
+    // Required to refresh menuApp after language is updated (which is only on login page)
+    dispatch(UserActions.setLanguage(UIDatabase.getSetting(SETTINGS_KEYS.CURRENT_LANGUAGE)));
     this.postSyncProcessor.setUser(user);
   };
 

--- a/src/pages/MenuPage.js
+++ b/src/pages/MenuPage.js
@@ -14,9 +14,10 @@ import {
   ModulesImage,
   CustomerImage,
   IconButton,
+  InfoBadge,
+  Flag,
   SupplierImage,
   StockImage,
-  InfoBadge,
 } from '../widgets';
 
 import {
@@ -87,6 +88,7 @@ const Menu = ({
   usingCashRegister,
   usingModules,
   usingVaccines,
+  currentLanguage,
   isAdmin,
   hasVaccines,
   toVaccineDispensingPage,
@@ -224,6 +226,7 @@ const Menu = ({
     () => (
       <View style={styles.bottomRow}>
         <IconButton Icon={<PowerIcon />} label={navStrings.log_out} onPress={logout} />
+        <Flag countryCode={currentLanguage} />
         {!!isInAdminMode && <MenuButton text="Realm Explorer" onPress={toRealmExplorer} />}
         {!!isInAdminMode && <MenuButton text="Export Data" onPress={exportData} />}
         {!!isAdmin && (
@@ -231,7 +234,7 @@ const Menu = ({
         )}
       </View>
     ),
-    [isInAdminMode, isAdmin]
+    [isInAdminMode, isAdmin, currentLanguage]
   );
 
   const ModuleLayout = useCallback(
@@ -321,7 +324,10 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const mapStateToProps = state => {
-  const { modules } = state;
+  const {
+    modules,
+    user: { currentLanguage },
+  } = state;
 
   const {
     usingDashboard,
@@ -342,6 +348,7 @@ const mapStateToProps = state => {
     usingModules,
     hasVaccines,
     isAdmin,
+    currentLanguage,
   };
 };
 
@@ -370,6 +377,7 @@ Menu.propTypes = {
   toDashboard: PropTypes.func.isRequired,
   toCashRegister: PropTypes.func.isRequired,
   isAdmin: PropTypes.bool,
+  currentLanguage: PropTypes.string.isRequired,
   usingDispensary: PropTypes.bool.isRequired,
   usingDashboard: PropTypes.bool.isRequired,
   usingCashRegister: PropTypes.bool.isRequired,

--- a/src/reducers/UserReducer.js
+++ b/src/reducers/UserReducer.js
@@ -9,6 +9,7 @@ import { USER_ACTION_TYPES } from '../actions/UserActions';
 
 const initialState = () => ({
   currentUser: null,
+  currentLanguage: 'gb',
   time: null,
 });
 
@@ -27,6 +28,11 @@ export const UserReducer = (state = initialState(), action) => {
 
     case USER_ACTION_TYPES.SET_TIME: {
       return { ...state, time: moment() };
+    }
+
+    case USER_ACTION_TYPES.SET_LANGUAGE: {
+      const { payload } = action;
+      return { ...state, currentLanguage: payload.code };
     }
 
     default:

--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -7,9 +7,11 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { Image, Text, TextInput, View } from 'react-native';
 import { Button } from 'react-native-ui-components';
 
+import { UserActions } from '../../actions';
 import { SETTINGS_KEYS } from '../../settings';
 
 import globalStyles, { WHITE, SUSSOL_ORANGE, WARM_GREY } from '../../globalStyles';
@@ -34,7 +36,7 @@ const AUTH_STATUSES = {
   ERROR: 'error',
 };
 
-export class LoginModal extends React.Component {
+class LoginModal extends React.Component {
   constructor(props) {
     super(props);
     const username = props.settings.get(SETTINGS_KEYS.MOST_RECENT_USERNAME);
@@ -123,7 +125,8 @@ export class LoginModal extends React.Component {
   };
 
   onSelectLanguage = ({ item }) => {
-    const { settings } = this.props;
+    const { settings, changeCurrentLanguage } = this.props;
+    changeCurrentLanguage(UIDatabase.getSetting(SETTINGS_KEYS.CURRENT_LANGUAGE));
     settings.set(SETTINGS_KEYS.CURRENT_LANGUAGE, item.code);
     setCurrencyLocalisation(item.code);
     setDateLocale(item.code);
@@ -244,11 +247,16 @@ export class LoginModal extends React.Component {
   }
 }
 
-export default LoginModal;
-
 LoginModal.propTypes = {
   authenticator: PropTypes.object.isRequired,
+  changeCurrentLanguage: PropTypes.func.isRequired,
   isAuthenticated: PropTypes.bool.isRequired,
   onAuthentication: PropTypes.func.isRequired,
   settings: PropTypes.object.isRequired,
 };
+
+const mapDispatchToProps = dispatch => ({
+  changeCurrentLanguage: code => dispatch(UserActions.setLanguage(code)),
+});
+
+export default connect(null, mapDispatchToProps)(LoginModal);

--- a/src/widgets/modals/index.js
+++ b/src/widgets/modals/index.js
@@ -8,5 +8,5 @@ export { ConfirmForm } from '../modalChildren';
 export { DataTablePageModal } from './DataTablePageModal';
 export { DemoUserModal } from './DemoUserModal';
 export { FinaliseModal } from './FinaliseModal';
-export { LoginModal } from './LoginModal';
+export { default as LoginModal } from './LoginModal';
 export { ModalContainer } from './ModalContainer';


### PR DESCRIPTION
Fixes #4625

## Change summary

new `currentLanguage` added to user state which gets set with the language store in settings. Also needed to add to the MenuPage mapPropsToState so it get triggered by a change on this state = reason why I added the flag showing on the bottom of the main Menupage. Hope you will like it : 9

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Select a language on the login screen
- [ ] Login and see the language took effect (also new Flag on the bottom area)
- [ ] Try again by Logging out and selecting another language. Then login

The second time wasn't taking effect. Should be sorted now.

### Related areas to think about

Sync modal, settings, other pages and Menu.
