### PR TITLE
#4631 update lookup patients with hl7 integration

### DIFF
--- a/src/hooks/useLocalAndRemotePatients.js
+++ b/src/hooks/useLocalAndRemotePatients.js
@@ -24,6 +24,7 @@ const initialState = (initialValue = []) => ({
   noMore: true,
   limit: BATCH_SIZE,
   offset: 0,
+  useHL7: 1,
 });
 
 const reducer = (state, action) => {
@@ -98,7 +99,7 @@ const reducer = (state, action) => {
  */
 export const useLocalAndRemotePatients = (initialValue = []) => {
   const [
-    { data, loading, searchedWithNoResults, error, limit, offset, gettingMore, noMore },
+    { data, loading, searchedWithNoResults, error, limit, offset, gettingMore, noMore, useHL7 },
     dispatch,
   ] = useReducer(reducer, initialValue, initialState);
 
@@ -133,7 +134,7 @@ export const useLocalAndRemotePatients = (initialValue = []) => {
   }, [fetchError]);
 
   const onPressSearchOnline = searchParams => {
-    const paramsWithLimits = { ...searchParams, limit: BATCH_SIZE, offset: 0 };
+    const paramsWithLimits = { ...searchParams, limit: BATCH_SIZE, offset: 0, useHL7: 1 };
 
     dispatch({ type: 'clear' });
     refresh();
@@ -151,7 +152,7 @@ export const useLocalAndRemotePatients = (initialValue = []) => {
     if (!response || noMore) return;
 
     dispatch({ type: 'getting_more_patients' });
-    const paramsWithLimits = { ...searchParams, limit, offset };
+    const paramsWithLimits = { ...searchParams, limit, offset, useHL7 };
 
     // Use RNFetch as the fetch returned from `useFetch` is coupled with it's state in a specific
     // implementation, which we want to change by appending to the result, rather than replacing.

--- a/src/localization/tableStrings.json
+++ b/src/localization/tableStrings.json
@@ -40,6 +40,7 @@
     "first_name": "FIRST NAME",
     "history": "HISTORY",
     "id": "ID",
+    "in_msupply": "In mSupply",
     "in_progress": "In Progress",
     "invoice_number": "INVOICE\nNUMBER",
     "invoices": "INVOICES",

--- a/src/pages/dataTableUtilities/constants.js
+++ b/src/pages/dataTableUtilities/constants.js
@@ -147,6 +147,7 @@ export const COLUMN_NAMES = {
   ENTRY_DATE: 'entryDate',
   EXPIRY_DATE: 'expiryDate',
   FIRST_NAME: 'firstName',
+  IN_MSUPPLY: 'inmSupply',
   INVOICE_TYPE: 'invoiceType',
   INVOICE_NUMBER: 'invoiceNumber',
   IS_REMOTE: 'isRemote',

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -178,6 +178,7 @@ const PAGE_COLUMNS = {
     COLUMN_NAMES.IS_REMOTE,
   ],
   [MODALS.PATIENT_LOOKUP]: [
+    COLUMN_NAMES.IN_MSUPPLY,
     COLUMN_NAMES.FIRST_NAME,
     COLUMN_NAMES.LAST_NAME,
     COLUMN_NAMES.DATE_OF_BIRTH,
@@ -596,6 +597,14 @@ const COLUMNS = () => ({
     key: COLUMN_KEYS.PAYMENT_TYPE_TITLE,
     title: tableStrings.payment_type,
     sortable: false,
+    editable: false,
+  },
+  [COLUMN_NAMES.IN_MSUPPLY]: {
+    type: COLUMN_TYPES.STRING,
+    key: COLUMN_KEYS.IN_MSUPPLY,
+    title: tableStrings.in_msupply,
+    alignText: 'left',
+    sortable: true,
     editable: false,
   },
   [COLUMN_NAMES.FIRST_NAME]: {

--- a/src/pages/dataTableUtilities/getColumns.js
+++ b/src/pages/dataTableUtilities/getColumns.js
@@ -18,7 +18,7 @@ const PAGE_COLUMN_WIDTHS = {
   [MODALS.PATIENT_HISTORY_LOOKUP]: [1, 4, 1, 1, 2, 1],
   [MODALS.PATIENT_HISTORY_LOOKUP_WITH_VACCINES]: [1, 4, 1, 1, 2, 1],
   [MODALS.VACCINE_HISTORY_LOOKUP]: [1, 4, 1, 1, 2, 1],
-  [MODALS.PATIENT_LOOKUP]: [2, 2, 2],
+  [MODALS.PATIENT_LOOKUP]: [2, 2, 2, 1],
   [MODALS.VACCINE_PATIENT_LOOKUP]: [2, 2, 2, 1],
   [MODALS.PRESCRIBER_LOOKUP]: [2, 2, 2],
   [MODALS.REGIMEN_DATA]: [4, 1, 5],
@@ -178,10 +178,10 @@ const PAGE_COLUMNS = {
     COLUMN_NAMES.IS_REMOTE,
   ],
   [MODALS.PATIENT_LOOKUP]: [
-    COLUMN_NAMES.IN_MSUPPLY,
     COLUMN_NAMES.FIRST_NAME,
     COLUMN_NAMES.LAST_NAME,
     COLUMN_NAMES.DATE_OF_BIRTH,
+    COLUMN_NAMES.IN_MSUPPLY,
   ],
   [MODALS.VACCINE_PATIENT_LOOKUP]: [
     COLUMN_NAMES.FIRST_NAME,
@@ -597,14 +597,6 @@ const COLUMNS = () => ({
     key: COLUMN_KEYS.PAYMENT_TYPE_TITLE,
     title: tableStrings.payment_type,
     sortable: false,
-    editable: false,
-  },
-  [COLUMN_NAMES.IN_MSUPPLY]: {
-    type: COLUMN_TYPES.STRING,
-    key: COLUMN_KEYS.IN_MSUPPLY,
-    title: tableStrings.in_msupply,
-    alignText: 'left',
-    sortable: true,
     editable: false,
   },
   [COLUMN_NAMES.FIRST_NAME]: {
@@ -1193,6 +1185,15 @@ const COLUMNS = () => ({
     title: tableStrings.selected,
     alignText: 'center',
     sortable: false,
+    editable: false,
+  },
+
+  [COLUMN_NAMES.IN_MSUPPLY]: {
+    type: COLUMN_TYPES.CHECKABLE,
+    key: COLUMN_KEYS.IN_MSUPPLY,
+    title: tableStrings.in_msupply,
+    alignText: 'center',
+    sortable: true,
     editable: false,
   },
 

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -86,7 +86,7 @@ const getQueryString = params => {
     if (!value) return queryObject;
 
     const formatter = {
-      [TYPES.STRING]: string => `@${string}@`,
+      [TYPES.STRING]: string => `${string}@`,
       [TYPES.DATE]: date => moment(date).format('DDMMYYYY'),
       [TYPES.NUMBER]: number => Number(number),
     };
@@ -127,8 +127,10 @@ const getPatientQueryString = ({
 };
 
 export const getPatientRequestUrl = params => {
+  console.log('params', params);
   const endpoint = RESOURCES.PATIENT;
   const queryString = getPatientQueryString(params);
+  console.log('queryString', queryString);
   return endpoint + queryString;
 };
 

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -46,6 +46,7 @@ const PARAMETERS = {
   registrationCode: { key: 'code', type: TYPES.STRING },
   limit: { key: 'limit', type: TYPES.NUMBER },
   offset: { key: 'offset', type: TYPES.NUMBER },
+  useHL7: { key: 'useHL7', type: TYPES.NUMBER },
 };
 
 class BugsnagError extends Error {
@@ -114,6 +115,7 @@ const getPatientQueryString = ({
   policyNumber = '',
   limit = null,
   offset = null,
+  useHL7 = null,
 } = {}) => {
   const queryParams = [
     { [PARAMETERS.firstName.key]: firstName, type: PARAMETERS.firstName.type },
@@ -123,8 +125,9 @@ const getPatientQueryString = ({
     { [PARAMETERS.policyNumber.key]: policyNumber, type: PARAMETERS.policyNumber.type },
     { [PARAMETERS.offset.key]: offset, type: PARAMETERS.offset.type },
     { [PARAMETERS.limit.key]: limit, type: PARAMETERS.limit.type },
+    { [PARAMETERS.useHL7.key]: useHL7, type: PARAMETERS.useHL7.type },
   ];
-  return getQueryString(queryParams);
+  return `${getQueryString(queryParams)}&useHL7=1`;
 };
 
 export const getPatientRequestUrl = params => {

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -256,8 +256,8 @@ export const getPatientHistoryResponseProcessor = ({
 
 export const processPatientResponse = response => {
   const result = processResponse(response);
-  return result.map(
-    ({
+  return result.map(patient => {
+    const {
       ID: id,
       name,
       code,
@@ -277,7 +277,9 @@ export const processPatientResponse = response => {
       female,
       nationality_ID,
       ethnicity_ID,
-    }) => ({
+    } = patient;
+
+    return {
       id,
       name,
       barcode,
@@ -291,14 +293,14 @@ export const processPatientResponse = response => {
       firstName,
       middleName,
       lastName,
-      nationality: UIDatabase.get('Nationality', nationality_ID),
-      ethnicity: UIDatabase.get('Ethnicity', ethnicity_ID),
-      dateOfBirth: parseDate(date_of_birth),
-      policies: processInsuranceResponse(nameInsuranceJoin),
-      nameNotes: processNameNoteResponse(nameNotes),
+      nationality: nationality_ID ? UIDatabase.get('Nationality', nationality_ID) : undefined,
+      ethnicity: ethnicity_ID ? UIDatabase.get('Ethnicity', ethnicity_ID) : undefined,
+      dateOfBirth: date_of_birth ? parseDate(date_of_birth) : undefined,
+      policies: nameInsuranceJoin ? processInsuranceResponse(nameInsuranceJoin) : undefined,
+      nameNotes: nameNotes ? processNameNoteResponse(nameNotes) : undefined,
       female,
-    })
-  );
+    };
+  });
 };
 
 export const processPrescriberResponse = response =>

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -127,7 +127,7 @@ const getPatientQueryString = ({
     { [PARAMETERS.limit.key]: limit, type: PARAMETERS.limit.type },
     { [PARAMETERS.useHL7.key]: useHL7, type: PARAMETERS.useHL7.type },
   ];
-  return `${getQueryString(queryParams)}&useHL7=1`;
+  return getQueryString(queryParams);
 };
 
 export const getPatientRequestUrl = params => {

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -73,7 +73,7 @@ export const SearchFormComponent = ({
     if (isPatient) {
       return async params => {
         fetch(
-          getPatientRequestUrl(params),
+          getPatientRequestUrl({ ...params, useHL7: 1 }),
           { headers: { authorization: getAuthorizationHeader() } },
           { responseHandler: processPatientResponse }
         );

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -174,8 +174,8 @@ const mapDispatchToProps = dispatch => ({
     if (result) {
       await dispatch(PatientActions.patientUpdate(patient));
       batch(() => {
-        patient.policies.forEach(policy => dispatch(InsuranceActions.update(policy)));
-        dispatch(NameNoteActions.createNotes(patient?.nameNotes));
+        (patient?.policies || []).forEach(policy => dispatch(InsuranceActions.update(policy)));
+        if (patient?.nameNotes) dispatch(NameNoteActions.createNotes(patient?.nameNotes));
       });
     } else {
       ToastAndroid.show(generalStrings.problem_connecting_please_try_again, ToastAndroid.LONG);


### PR DESCRIPTION
Fixes #4631 

## Change summary

Work required to get HL7 patitne also received on query and imported on the **Lookup patient** search on Dispensary mode. This new feature will be included in a patch on release version of mSupply desktop 5.07.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Have a server configured to use HL7 integration
- [ ] Sync a mobile using Dispensing mode
- [ ] Open Dispensary -> Lookup patients
- [ ] Type the last, first of d.o.b on the search and check the results:

i.e searching for last name starting with "a":
![Screen Shot 2022-03-22 at 3 17 05 PM](https://user-images.githubusercontent.com/16461988/159394758-c5112569-c3cd-4a50-bb7b-545eff5a0497.png)

i.e searching for DOB "29/08/1972":
![Screen Shot 2022-03-22 at 3 17 30 PM](https://user-images.githubusercontent.com/16461988/159394755-fff108a6-7cbe-4fed-bb31-da4bdcd5434f.png)

### Related areas to think about

mSupply Desktop [PR](https://github.com/sussol/msupply/pull/10416)
