### PR TITLE
#4640 Showing invalid date

### DIFF
--- a/src/utilities/formatters.js
+++ b/src/utilities/formatters.js
@@ -74,6 +74,7 @@ export const formatDate = date => (date ? moment(date).fromNow() : generalString
  * @return  {string}              A string representing the date in 'yyyy-mm-dd' format
  */
 export const convertMobileDateToISO = dateString => {
+  dateString = moment(dateString).format('MM/DD/YYYY');
   const dayOfMonth = dateString.substring(0, 2);
   const month = dateString.substring(3, 5);
   const year = dateString.substring(6, 10);

--- a/src/utilities/formatters.js
+++ b/src/utilities/formatters.js
@@ -74,11 +74,13 @@ export const formatDate = date => (date ? moment(date).fromNow() : generalString
  * @return  {string}              A string representing the date in 'yyyy-mm-dd' format
  */
 export const convertMobileDateToISO = dateString => {
-  dateString = moment(dateString).format('MM/DD/YYYY');
-  const dayOfMonth = dateString.substring(0, 2);
-  const month = dateString.substring(3, 5);
-  const year = dateString.substring(6, 10);
-
+  if (!dateString) return undefined; // show undefined if no date
+  const separators = ['/', '-'];
+  const splitDate = dateString.split(new RegExp(separators.join('|'), 'g'));
+  if (splitDate.length !== 3) return undefined; // date needs to have month, date and year
+  const dayOfMonth = splitDate[0].padStart(2, '0');
+  const month = splitDate[1].padStart(2, '0');
+  const year = splitDate[2].padStart(4, '0');
   return `${year}-${month}-${dayOfMonth}`;
 };
 


### PR DESCRIPTION
By default take date format to 'MM/DD/YYYY'

Fixes #4640 

## Change summary

Change date format to 'MM/DD/YYYY'

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Add any name notes in msupply and change date to 'm/d/yyyy'.
- [ ] Once it synced to mobile check vaccincation>history for that patient.
- [ ] Check Date it shouldn't show 'Invalid date'.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
