### PR TITLE
#4644 Update to use selected language rather than previous language

### DIFF
--- a/src/widgets/modals/LoginModal.js
+++ b/src/widgets/modals/LoginModal.js
@@ -126,7 +126,7 @@ class LoginModal extends React.Component {
 
   onSelectLanguage = ({ item }) => {
     const { settings, changeCurrentLanguage } = this.props;
-    changeCurrentLanguage(UIDatabase.getSetting(SETTINGS_KEYS.CURRENT_LANGUAGE));
+    changeCurrentLanguage(item.code);
     settings.set(SETTINGS_KEYS.CURRENT_LANGUAGE, item.code);
     setCurrencyLocalisation(item.code);
     setDateLocale(item.code);


### PR DESCRIPTION
Fixes #4644

## Change summary

- Tiny adjustment to use the selected language rather than the previously saved one (thought I'd just fix while passing through for the Kiribati updates - and was also curious about the recent localisation updates)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Change language on login screen and then login, check the flag 
![image](https://user-images.githubusercontent.com/65875762/162337886-177eaaff-0bbc-405c-a349-19c22f63fb3d.png)

### Related areas to think about

N/A