### PR TITLE
#4665 Remove last digit from temperature breach config

### DIFF
--- a/src/widgets/StepperInputs/DurationEditor.js
+++ b/src/widgets/StepperInputs/DurationEditor.js
@@ -48,7 +48,11 @@ export const DurationEditor = ({
           <TextInputWithAffix
             ref={textInputRef}
             editable={false}
-            SuffixComponent={<Text style={suffixTextStyle}>{generalStrings.minutes}</Text>}
+            SuffixComponent={
+              <Text allowFontScaling={false} style={suffixTextStyle}>
+                {generalStrings.minutes}
+              </Text>
+            }
             style={textInputStyle}
             value={newValue}
           />

--- a/src/widgets/StepperInputs/TemperatureEditor.js
+++ b/src/widgets/StepperInputs/TemperatureEditor.js
@@ -36,7 +36,7 @@ export const TemperatureEditor = ({
 
   const getAdjustedValue = (toUpdate, addend) =>
     keepInRange(temperature(toUpdate + addend).temperature(), minimum, maximum);
-  const formatter = updated => keepInRange(updated, minimum, maximum).toFixed(2);
+  const formatter = updated => keepInRange(updated, minimum, maximum).toFixed(1);
 
   const [textInputRef, newValue, newOnChange] = useOptimisticUpdating(
     value,

--- a/src/widgets/StepperInputs/TemperatureEditor.js
+++ b/src/widgets/StepperInputs/TemperatureEditor.js
@@ -57,7 +57,7 @@ export const TemperatureEditor = ({
             editable={false}
             SuffixComponent={
               <FlexColumn style={{ marginTop: 12 }}>
-                <Text style={suffixTextStyle}>{`${'\u00B0'}Celsius`}</Text>
+                <Text allowFontScaling={false} style={suffixTextStyle}>{`${'\u00B0'}Celsius`}</Text>
                 <Text style={{ fontSize: 10 }}>
                   {above ? vaccineStrings.and_above : vaccineStrings.and_below}
                 </Text>


### PR DESCRIPTION
Fixes #4665

## Change summary

A super tiny change to format the temperature breach configs to 1dp instead of 2dp (temperature readings are 1dp only, and configs can only be incremented/decremented in steps of 0.5). 

![image](https://user-images.githubusercontent.com/65875762/164118606-af8621d6-3bfa-45e7-bf70-89f5d292f9d1.png)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Get a Samsung tablet (SM-T500 or SM-T505 are known ones used by our users) and set the breach temperature thresholds to anything lower than -10  degrees celsius. 
- [ ] Try to view the settings page afterwards (there are two entry points to this page -> one from sensor list page and one from sensor details page), check that you can see all the digits.

### Related areas to think about
Problem will still probably occur if anyone tries to configure a breach threshold of -100 degrees celsius or lower.