### PR TITLE
#4691 edit pcd via vaccination event modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "8.5.0-rc1",
+  "version": "8.4.2",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/actions/Entities/NameNoteActions.js
+++ b/src/actions/Entities/NameNoteActions.js
@@ -1,5 +1,6 @@
 import { generateUUID } from 'react-native-database';
 import merge from 'lodash.merge';
+import { ToastAndroid } from 'react-native';
 import { createRecord, UIDatabase } from '../../database/index';
 import {
   selectCreatingNameNote,
@@ -7,6 +8,7 @@ import {
 } from '../../selectors/Entities/nameNote';
 import { selectSurveySchemas } from '../../selectors/formSchema';
 import { validateJsonSchemaData } from '../../utilities/ajvValidator';
+import { vaccineStrings } from '../../localization';
 
 export const NAME_NOTE_ACTIONS = {
   SELECT: 'NAME_NOTE/select',
@@ -79,6 +81,7 @@ const updateLinkedSurveyNameNote = (originalNote, updatedData) => () => {
   };
 
   UIDatabase.write(() => UIDatabase.update('NameNote', updatedNote));
+  ToastAndroid.show(vaccineStrings.vaccination_updated, ToastAndroid.LONG);
 };
 
 const createNotes = (nameNotes = []) => {

--- a/src/actions/Entities/NameNoteActions.js
+++ b/src/actions/Entities/NameNoteActions.js
@@ -67,6 +67,20 @@ const saveEditing = () => (dispatch, getState) => {
   dispatch(reset());
 };
 
+const updateLinkedSurveyNameNote = (originalNote, updatedData) => () => {
+  const { id, patientEvent, name, entryDate } = originalNote;
+
+  const updatedNote = {
+    id,
+    patientEvent,
+    name,
+    entryDate: new Date(entryDate),
+    _data: JSON.stringify(updatedData),
+  };
+
+  UIDatabase.write(() => UIDatabase.update('NameNote', updatedNote));
+};
+
 const createNotes = (nameNotes = []) => {
   UIDatabase.write(() => {
     nameNotes.forEach(nameNote => {
@@ -99,5 +113,6 @@ export const NameNoteActions = {
   reset,
   createSurveyNameNote,
   updateForm,
+  updateLinkedSurveyNameNote,
   saveEditing,
 };

--- a/src/actions/Entities/NameNoteActions.js
+++ b/src/actions/Entities/NameNoteActions.js
@@ -80,7 +80,30 @@ const updateLinkedSurveyNameNote = (originalNote, updatedData) => () => {
     _data: JSON.stringify(updatedData),
   };
 
-  UIDatabase.write(() => UIDatabase.update('NameNote', updatedNote));
+  const [auditEvent] = UIDatabase.objects('PatientEvent').filtered('code == "NameNoteModified"');
+
+  const auditNameNote = {
+    id: generateUUID(),
+    name,
+    auditEvent,
+    entryDate: new Date(),
+    _data: JSON.stringify({
+      patientEvent,
+      old: {
+        entryDate,
+        data: originalNote.data,
+      },
+      new: {
+        entryDate: new Date(),
+        data: updatedData,
+      },
+    }),
+  };
+
+  UIDatabase.write(() => {
+    UIDatabase.update('NameNote', updatedNote);
+    UIDatabase.create('NameNote', auditNameNote);
+  });
   ToastAndroid.show(vaccineStrings.vaccination_updated, ToastAndroid.LONG);
 };
 

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -74,7 +74,8 @@
     "is_paused": "PAUSED",
     "pause": "Pause",
     "resume": "Resume",
-    "refusal_reason": "Reason for refusal"
+    "refusal_reason": "Reason for refusal",
+    "vaccination_updated": "Vaccination details updated"
   },
   "fr": {
     "no_vaccine_stock": "Vous n'avez pas de vaccins en stock!",

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -114,7 +114,7 @@ export const VaccinationEventComponent = ({
       <FlexRow flex={0} justifyContent="center">
         <PageButton
           text={buttonStrings.save_changes}
-          onPress={() => (isPCDValid ? saveForm(surveyForm, updatedPcdForm) : null)}
+          onPress={() => saveForm(surveyForm, updatedPcdForm)}
           style={localStyles.saveButton}
           textStyle={localStyles.saveButtonTextStyle}
           isDisabled={!isPCDValid}

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -11,8 +11,14 @@ import { UIDatabase } from '../../database';
 import { selectMostRecentNameNote } from '../../selectors/Entities/nameNote';
 import { FlexColumn } from '../FlexColumn';
 import { BreachManUnhappy } from '../BreachManUnhappy';
-import { APP_FONT_FAMILY, DARKER_GREY, GREY } from '../../globalStyles';
-import { generalStrings } from '../../localization';
+import globalStyles, {
+  APP_FONT_FAMILY,
+  DARKER_GREY,
+  GREY,
+  SUSSOL_ORANGE,
+} from '../../globalStyles';
+import { buttonStrings, generalStrings } from '../../localization';
+import { PageButton } from '../PageButton';
 
 // It's possible to get into this state if vaccination events were configured but PCD events weren't
 // and someone dispensed a vaccine. Some data cleanup may be required.
@@ -62,7 +68,7 @@ export const VaccinationEventComponent = ({
       <FlexRow flex={1}>
         {!!vaccinationEventSchema && !!vaccinationEvent && (
           <FlexRow flex={1}>
-            <View style={styles.formContainer}>
+            <View style={localStyles.formContainer}>
               <JSONForm
                 ref={vaccinationFormRef}
                 disabled={true}
@@ -75,13 +81,12 @@ export const VaccinationEventComponent = ({
           </FlexRow>
         )}
         <FlexRow flex={1}>
-          <View style={styles.formContainer}>
+          <View style={localStyles.formContainer}>
             {!!surveySchema && !!surveyForm ? (
               <FlexRow flex={1}>
-                <View style={styles.formContainer}>
+                <View style={localStyles.formContainer}>
                   <JSONForm
                     ref={pcdFormRef}
-                    disabled={true}
                     formData={surveyForm.data ?? null}
                     surveySchema={surveySchema}
                   >
@@ -94,6 +99,14 @@ export const VaccinationEventComponent = ({
             )}
           </View>
         </FlexRow>
+      </FlexRow>
+      <FlexRow flex={0} justifyContent="center">
+        <PageButton
+          text={buttonStrings.save_changes}
+          onPress={() => console.log('button pressed')}
+          style={localStyles.saveButton}
+          textStyle={localStyles.saveButtonTextStyle}
+        />
       </FlexRow>
     </FlexView>
   );
@@ -112,12 +125,23 @@ const mapStateToProps = () => {
   };
 };
 
-const styles = StyleSheet.create({
+const localStyles = StyleSheet.create({
   formContainer: {
     flex: 1,
     flexDirection: 'row',
     backgroundColor: 'white',
     alignItems: 'stretch',
+  },
+  saveButton: {
+    ...globalStyles.button,
+    flex: 1,
+    backgroundColor: SUSSOL_ORANGE,
+    alignSelf: 'center',
+  },
+  saveButtonTextStyle: {
+    ...globalStyles.buttonText,
+    color: 'white',
+    fontSize: 14,
   },
 });
 


### PR DESCRIPTION
Fixes #4691

https://user-images.githubusercontent.com/65875762/168718354-494d5a41-d6c9-4405-b5a8-1f583d2c0489.mp4

## Change summary

- Adds the ability to edit the PCD linked to a vaccination event via the vaccination event modal.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Follow steps in this PR to view vaccination event details: #4668 
- [ ] When a detail view is opened, the RHS panel should be editable and allow the linked PCD to be edited

### Related areas to think about
- This just overwrites the historical PCD, it doesn't create a new one, due to the complexity of linking multiple dependent name_notes. This has a few implications:
  - If the same PCD was used for two vaccinations (a new PCD is only created if there were updates to the form during vaccination) - when the PCD is edited, both of the vaccination records will be linked to the updated data.
  - No continuous audit trail within mobile (although speaking with some 4D experts it seems like the changes can (if needed, and with difficulty) be traced back through the journal. 

@adamdewey tagging FYI!

Been thinking a bit on this: if we wanted to keep an audit trail (maybe) we could do something like the following (although its maybe a little bit bloated/convoluted):
- Add soft deletion flag to name_notes (also needs desktop change)
- When _anything_ in the vaccination event modal is edited, soft delete the old vaccination event name note and create a new one, changes only to be applied to the copy
- If the PCD form was edited, create a copy of the PCD note, save the updates into the copy, and link the vaccination event name note to the new PCD copy 
- Don't soft delete the PCD name note (there may be other vaccination events pointing to it)