### PR TITLE
#4724 Try a wider variety of formats when parsing vaccination dates

### DIFF
--- a/src/selectors/Entities/name.js
+++ b/src/selectors/Entities/name.js
@@ -88,7 +88,7 @@ export const selectVaccinePatientHistory = patient => {
   const [supplementalDataSchema = {}] = selectSupplementalDataSchemas();
 
   const hasDateOfVaccinationInSchema =
-    supplementalDataSchema?.jsonSchema?.properties?.dateOfVaccination;
+    !!supplementalDataSchema?.jsonSchema?.properties?.dateOfVaccination;
 
   const nameNotes = patient?.nameNotes
     ?.filter(

--- a/src/selectors/Entities/name.js
+++ b/src/selectors/Entities/name.js
@@ -120,7 +120,7 @@ export const selectVaccinePatientHistory = patient => {
       select: '>',
     }));
 
-  return nameNotes ?? [];
+  return nameNotes ? nameNotes.sort((a, b) => a.confirmDate - b.confirmDate) : [];
 };
 
 export const selectWasPatientVaccinatedWithinOneDay = state => {

--- a/src/selectors/Entities/name.js
+++ b/src/selectors/Entities/name.js
@@ -6,8 +6,8 @@ import { DATE_FORMAT } from '../../utilities/constants';
 import { PREFERENCE_KEYS } from '../../database/utilities/preferenceConstants';
 import { MILLISECONDS_PER_DAY } from '../../database/utilities/constants';
 import { validateJsonSchemaData } from '../../utilities';
-import { convertMobileDateToISO } from '../../utilities/formatters';
 import { selectVaccinationEventSchemas } from '../formSchema';
+import { convertVaccinationEntryToISOString } from '../../utilities/parsers';
 
 export const selectEditingNameId = state => {
   const NameState = selectSpecificEntityState(state, 'name');
@@ -105,7 +105,7 @@ export const selectVaccinePatientHistory = patient => {
         (vaccinationData.extra?.prescription?.customData &&
           JSON.parse(vaccinationData.extra?.prescription?.customData).dateOfVaccination &&
           new Date(
-            convertMobileDateToISO(
+            convertVaccinationEntryToISOString(
               JSON.parse(vaccinationData.extra?.prescription?.customData).dateOfVaccination
             )
           )) ??

--- a/src/utilities/formatters.js
+++ b/src/utilities/formatters.js
@@ -67,23 +67,6 @@ export const temperatureTickFormatter = tick => `${tick} \u2103`;
 
 export const formatDate = date => (date ? moment(date).fromNow() : generalStrings.not_available);
 
-/**
- * Converts date from mobile input format string to ISO format string
- *
- * @param   {string}  dateString  The date in mobile's standard format (DD/MM/YYYY or dd-mm-yyyy)
- * @return  {string}              A string representing the date in 'yyyy-mm-dd' format
- */
-export const convertMobileDateToISO = dateString => {
-  if (!dateString) return undefined; // show undefined if no date
-  const separators = ['/', '-'];
-  const splitDate = dateString.split(new RegExp(separators.join('|'), 'g'));
-  if (splitDate.length !== 3) return undefined; // date needs to have month, date and year
-  const dayOfMonth = splitDate[0].padStart(2, '0');
-  const month = splitDate[1].padStart(2, '0');
-  const year = splitDate[2].padStart(4, '0');
-  return `${year}-${month}-${dayOfMonth}`;
-};
-
 export const formatTime = sum => {
   const asMoment = moment.duration(sum);
 

--- a/src/utilities/parsers/index.js
+++ b/src/utilities/parsers/index.js
@@ -4,3 +4,4 @@
  */
 
 export { parsePositiveIntegerInterfaceInput } from './interfaceParsers';
+export { convertVaccinationEntryToISOString } from './vaccinationDateParser';

--- a/src/utilities/parsers/vaccinationDateParser.js
+++ b/src/utilities/parsers/vaccinationDateParser.js
@@ -10,11 +10,12 @@ import moment from 'moment';
  * @return  {string}              ISO formatted date string
  */
 export const convertVaccinationEntryToISOString = dateString => {
-  if (!dateString) return undefined; // show undefined if no date
+  const invalidDateString = 'Invalid date';
+  if (!dateString) return invalidDateString; // show 'Invalid date' if no date
   const separators = ['/', '-'];
   const splitDate = dateString.split(new RegExp(separators.join('|'), 'g'));
 
-  if (splitDate.length !== 3) return undefined; // date needs to have month, date and year
+  if (splitDate.length !== 3) return invalidDateString; // date needs to have month, date and year
 
   let convertedDate;
   // Some variant of xx-xx-yyyy format

--- a/src/utilities/parsers/vaccinationDateParser.js
+++ b/src/utilities/parsers/vaccinationDateParser.js
@@ -1,0 +1,32 @@
+import moment from 'moment';
+
+/**
+ * Converts the vaccinationDate (stored as a string and potentially in a variable format) to a
+ * JavaScript date object.
+ * The 'expected' mobile format is DD/MM/YYYY but some users have inserted/scripted data
+ * in all sorts of weird formats - this is a hack to make a best attempt to read it.
+ *
+ * @param   {string}  dateString  The date of vaccination (as entered by the user / script)
+ * @return  {Date}              A JavaScript date object representing the date of vaccination
+ */
+export const convertVaccinationEntryToISOString = dateString => {
+  if (!dateString) return undefined; // show undefined if no date
+  const separators = ['/', '-'];
+  const splitDate = dateString.split(new RegExp(separators.join('|'), 'g'));
+
+  if (splitDate.length !== 3) return undefined; // date needs to have month, date and year
+
+  let convertedDate;
+  // Some variant of xx-xx-yyyy format
+  if (splitDate[2].length === 4) {
+    convertedDate = moment(dateString, 'DD/MM/YYYY').isValid()
+      ? moment(dateString, 'DD/MM/YYYY')
+      : moment(dateString, 'MM/DD/YYYY'); // Try swap - likely month was entered the wrong way
+  } else {
+    // Some variant of yyyy-xx-xx format
+    convertedDate = moment(dateString, 'YYYY/MM/DD').isValid()
+      ? moment(dateString, 'YYYY/MM/DD')
+      : moment(dateString, 'YYYY/DD/MM'); // Try swap - likely month was entered the wrong way
+  }
+  return convertedDate.format('YYYY-MM-DD');
+};

--- a/src/utilities/parsers/vaccinationDateParser.js
+++ b/src/utilities/parsers/vaccinationDateParser.js
@@ -1,7 +1,7 @@
 import moment from 'moment';
 
 /**
- * Converts the vaccinationDate (stored as a string and potentially in a variable format) to a
+ * Converts the vaccinationDate (stored as a string and potentially in a variable format) to
  * an ISO formatted date string
  * The 'expected' mobile format is DD/MM/YYYY but some users have inserted/scripted data
  * in all sorts of weird formats - this is a hack to make a best attempt to read it.

--- a/src/utilities/parsers/vaccinationDateParser.js
+++ b/src/utilities/parsers/vaccinationDateParser.js
@@ -2,12 +2,12 @@ import moment from 'moment';
 
 /**
  * Converts the vaccinationDate (stored as a string and potentially in a variable format) to a
- * JavaScript date object.
+ * an ISO formatted date string
  * The 'expected' mobile format is DD/MM/YYYY but some users have inserted/scripted data
  * in all sorts of weird formats - this is a hack to make a best attempt to read it.
  *
  * @param   {string}  dateString  The date of vaccination (as entered by the user / script)
- * @return  {Date}              A JavaScript date object representing the date of vaccination
+ * @return  {string}              ISO formatted date string
  */
 export const convertVaccinationEntryToISOString = dateString => {
   if (!dateString) return undefined; // show undefined if no date

--- a/src/utilities/parsers/vaccinationDateParser.test.js
+++ b/src/utilities/parsers/vaccinationDateParser.test.js
@@ -68,6 +68,13 @@ describe('vaccinationDateParser: convertVaccinationEntryToISOString', () => {
     expect(result).toEqual(invalidDateString);
   });
 
+  it('Month > 12 is invalid date', () => {
+    const testDate = '13-13-2022';
+    const result = convertVaccinationEntryToISOString(testDate);
+
+    expect(result).toEqual(invalidDateString);
+  });
+
   it('Date without 3 parts is invalid date', () => {
     const testDate = '18/01';
     const result = convertVaccinationEntryToISOString(testDate);

--- a/src/utilities/parsers/vaccinationDateParser.test.js
+++ b/src/utilities/parsers/vaccinationDateParser.test.js
@@ -1,5 +1,6 @@
 import { convertVaccinationEntryToISOString } from './vaccinationDateParser';
 
+const invalidDateString = 'Invalid date';
 // Test cases from https://github.com/openmsupply/mobile/issues/4724
 describe('vaccinationDateParser: convertVaccinationEntryToISOString', () => {
   it('Correctly formats a date provided in DD-MM-YYYY format', () => {
@@ -37,14 +38,6 @@ describe('vaccinationDateParser: convertVaccinationEntryToISOString', () => {
     expect(result).toEqual('2022-03-28');
   });
 
-  // This format is invalid and also does not have enough granularity to correctly parse this date
-  // it('Correctly formats a date provided in M/D/YYYY format', () => {
-  //   const testDate = '3/4/2022';
-  //   const result = convertVaccinationEntryToISOString(testDate);
-
-  //   expect(result).toEqual('2022-03-04');
-  // });
-
   it('Correctly formats a date provided in YYYY/DD/MM format', () => {
     const testDate = '2022/03/28';
     const result = convertVaccinationEntryToISOString(testDate);
@@ -52,14 +45,8 @@ describe('vaccinationDateParser: convertVaccinationEntryToISOString', () => {
     expect(result).toEqual('2022-03-28');
   });
 
-  // This format is invalid and also does not have enough granularity to correctly parse this date
-  // it('Correctly formats a date provided in YYYY/D/M format', () => {
-  //   const testDate = '2022/4/3';
-  //   const result = convertVaccinationEntryToISOString(testDate);
-
-  //   expect(result).toEqual('2022-03-04');
-  // });
-
+  // NB: D/M/YYYY is the default if there is not enough granularity
+  // (e.g 3/4/2022 vs 4/3/2022 will both be treated as D/M/YYYY)
   it('Correctly formats a date provided in D/M/YYYY format', () => {
     const testDate = '4/3/2022';
     const result = convertVaccinationEntryToISOString(testDate);
@@ -72,5 +59,26 @@ describe('vaccinationDateParser: convertVaccinationEntryToISOString', () => {
     const result = convertVaccinationEntryToISOString(testDate);
 
     expect(result).toEqual('2022-03-04');
+  });
+
+  it('Alphabetical input is invalid date', () => {
+    const testDate = 'AA-BB-CCCC';
+    const result = convertVaccinationEntryToISOString(testDate);
+
+    expect(result).toEqual(invalidDateString);
+  });
+
+  it('Date without 3 parts is invalid date', () => {
+    const testDate = '18/01';
+    const result = convertVaccinationEntryToISOString(testDate);
+
+    expect(result).toEqual(invalidDateString);
+  });
+
+  it('undefined dateString is invalid date', () => {
+    const testDate = undefined;
+    const result = convertVaccinationEntryToISOString(testDate);
+
+    expect(result).toEqual(invalidDateString);
   });
 });

--- a/src/utilities/parsers/vaccinationDateParser.test.js
+++ b/src/utilities/parsers/vaccinationDateParser.test.js
@@ -1,0 +1,76 @@
+import { convertVaccinationEntryToISOString } from './vaccinationDateParser';
+
+// Test cases from https://github.com/openmsupply/mobile/issues/4724
+describe('vaccinationDateParser: convertVaccinationEntryToISOString', () => {
+  it('Correctly formats a date provided in DD-MM-YYYY format', () => {
+    const testDate = '28-03-2022';
+    const result = convertVaccinationEntryToISOString(testDate);
+
+    expect(result).toEqual('2022-03-28');
+  });
+
+  it('Correctly formats a date provided in DD/MM/YYYY format', () => {
+    const testDate = '28/03/2022';
+    const result = convertVaccinationEntryToISOString(testDate);
+
+    expect(result).toEqual('2022-03-28');
+  });
+
+  it('Correctly formats a date provided in YYYY-MM-DD format', () => {
+    const testDate = '2022-03-28';
+    const result = convertVaccinationEntryToISOString(testDate);
+
+    expect(result).toEqual('2022-03-28');
+  });
+
+  it('Correctly formats a date provided in YYYY/MM/DD format', () => {
+    const testDate = '2022/03/28';
+    const result = convertVaccinationEntryToISOString(testDate);
+
+    expect(result).toEqual('2022-03-28');
+  });
+
+  it('Correctly formats a date provided in MM/DD/YYYY format', () => {
+    const testDate = '03/28/2022';
+    const result = convertVaccinationEntryToISOString(testDate);
+
+    expect(result).toEqual('2022-03-28');
+  });
+
+  // This format is invalid and also does not have enough granularity to correctly parse this date
+  // it('Correctly formats a date provided in M/D/YYYY format', () => {
+  //   const testDate = '3/4/2022';
+  //   const result = convertVaccinationEntryToISOString(testDate);
+
+  //   expect(result).toEqual('2022-03-04');
+  // });
+
+  it('Correctly formats a date provided in YYYY/DD/MM format', () => {
+    const testDate = '2022/03/28';
+    const result = convertVaccinationEntryToISOString(testDate);
+
+    expect(result).toEqual('2022-03-28');
+  });
+
+  // This format is invalid and also does not have enough granularity to correctly parse this date
+  // it('Correctly formats a date provided in YYYY/D/M format', () => {
+  //   const testDate = '2022/4/3';
+  //   const result = convertVaccinationEntryToISOString(testDate);
+
+  //   expect(result).toEqual('2022-03-04');
+  // });
+
+  it('Correctly formats a date provided in D/M/YYYY format', () => {
+    const testDate = '4/3/2022';
+    const result = convertVaccinationEntryToISOString(testDate);
+
+    expect(result).toEqual('2022-03-04');
+  });
+
+  it('Correctly formats a date provided in D-M-YYYY format', () => {
+    const testDate = '4-3-2022';
+    const result = convertVaccinationEntryToISOString(testDate);
+
+    expect(result).toEqual('2022-03-04');
+  });
+});


### PR DESCRIPTION
Fixes #4724

## Change summary

- Best effort attempt to read dodgily entered vaccination dates based on what Kiribati have in their database (🙀 )
- In cases where it's impossible to determine (e.g. 04/03/2022 could be read either as 4th of March, or 3rd of April), we use these defaults:
  - D/M/YYYY (if the year is at the end - we assume they are using the standard mobile format)
  - YYYY-MM-DD (if the year is at the beginning - we assume they were using the ISO format)

Some users may get strange results - but there's realistically no real way to completely fix this properly without a manual review of a lot of the dates.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Have included some unit tests to cover basic cases from the Kiribati datafile (can run with source code using `yarn test`)
- [ ] Otherwise test against the Kiribati data file or manually edit vaccination dates to be like the ones reported in the issue and see if you can view them in mobile.

### Related areas to think about
I'm really sorry to anyone who has to read this, and if there is a better solution, all 👂 !