### PR TITLE
#4743 Fix broken name note duplicate filter

### DIFF
--- a/src/hooks/useLocalAndRemoteHistory.js
+++ b/src/hooks/useLocalAndRemoteHistory.js
@@ -5,6 +5,7 @@ import {
   getServerURL,
   getPatientHistoryResponseProcessor,
 } from '../sync/lookupApiUtils';
+import { convertVaccinationEntryToISOString } from '../utilities/parsers';
 import { useFetch } from './useFetch';
 import { useThrottled } from './useThrottled';
 
@@ -25,12 +26,13 @@ const reducer = (state, action) => {
       const { data: initialData } = state;
       const localTransactionIds = initialData.map(transactions => transactions.id);
 
-      // Name notes do not have transaction ids, create filter instead based on itemCode/confirmDate
+      // Name notes do not have transaction objects
+      // Create filter instead based on itemCode/confirmDate
       const localNameNoteFilter = initialData
-        .filter(transaction => !transaction.id)
+        .filter(record => !record.transaction)
         .map(nameNotes => ({
           itemCode: nameNotes.itemCode,
-          confirmDate: nameNotes.confirmDate,
+          confirmDate: new Date(convertVaccinationEntryToISOString(nameNotes.vaccineDate)),
           select: '>',
         }));
 


### PR DESCRIPTION
Fixes #4743

## Change summary

- Correct incorrect duplicate detection
  - Previous filter was incorrectly looking for records without ids, name_notes still have ids so this was failing every time
  - Adjusted to account for date discrepancy between the name note and the date returned via the mSupply api

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Dispense a vaccine (requires dispensary mode to be enabled, vaccine stock available, patient event = vaccination and dangerous patient mode on / view history everywhere enabled)
- [ ] Sync with Desktop
- [ ] Go to dispensary and view history, should not see the vaccination duplicated

### Related areas to think about
N/A