### PR TITLE
#4714 Add ability to edit supplemental data form

### DIFF
--- a/src/actions/Entities/NameNoteActions.js
+++ b/src/actions/Entities/NameNoteActions.js
@@ -69,17 +69,33 @@ const saveEditing = () => (dispatch, getState) => {
   dispatch(reset());
 };
 
-const updateLinkedSurveyNameNote = (originalNote, updatedData) => () => {
-  const { id, patientEvent, name, entryDate } = originalNote;
+const updateNameNote = (originalNote, updatedData) => () => {
+  const { id, patientEvent, name, entryDate, _data } = originalNote;
 
-  const updatedNote = {
-    id,
-    patientEvent,
-    name,
-    entryDate: new Date(entryDate),
-    _data: JSON.stringify(updatedData),
-  };
+  // Quick & dirty check if the object was updated, trims out some un-needed updates
+  const isDirty = _data !== JSON.stringify(updatedData);
 
+  if (isDirty) {
+    const updatedNote = {
+      id,
+      patientEvent,
+      name,
+      entryDate: new Date(entryDate),
+      _data: JSON.stringify(updatedData),
+    };
+
+    UIDatabase.write(() => {
+      UIDatabase.update('NameNote', updatedNote);
+      UIDatabase.create('NameNote', createNameNoteAudit(originalNote, updatedData));
+    });
+    ToastAndroid.show(vaccineStrings.vaccination_updated, ToastAndroid.LONG);
+  } else {
+    ToastAndroid.show('No updates were made', ToastAndroid.LONG);
+  }
+};
+
+const createNameNoteAudit = (originalNote, updatedData) => {
+  const { patientEvent, name, entryDate } = originalNote;
   const [auditEvent] = UIDatabase.objects('PatientEvent').filtered('code == "NameNoteModified"');
 
   const auditNameNote = {
@@ -100,11 +116,7 @@ const updateLinkedSurveyNameNote = (originalNote, updatedData) => () => {
     }),
   };
 
-  UIDatabase.write(() => {
-    UIDatabase.update('NameNote', updatedNote);
-    UIDatabase.create('NameNote', auditNameNote);
-  });
-  ToastAndroid.show(vaccineStrings.vaccination_updated, ToastAndroid.LONG);
+  return auditNameNote;
 };
 
 const createNotes = (nameNotes = []) => {
@@ -139,6 +151,6 @@ export const NameNoteActions = {
   reset,
   createSurveyNameNote,
   updateForm,
-  updateLinkedSurveyNameNote,
+  updateNameNote,
   saveEditing,
 };

--- a/src/actions/Entities/NameNoteActions.js
+++ b/src/actions/Entities/NameNoteActions.js
@@ -90,7 +90,7 @@ const updateNameNote = (originalNote, updatedData) => () => {
     });
     ToastAndroid.show(vaccineStrings.vaccination_updated, ToastAndroid.LONG);
   } else {
-    ToastAndroid.show('No updates were made', ToastAndroid.LONG);
+    ToastAndroid.show(vaccineStrings.vaccination_not_updated, ToastAndroid.LONG);
   }
 };
 

--- a/src/localization/buttonStrings.json
+++ b/src/localization/buttonStrings.json
@@ -13,6 +13,7 @@
     "create_automatic_order": "Create Automatic Order",
     "current": "Current",
     "done": "Done",
+    "edit": "Edit",
     "export_data": "Export Data",
     "import_data": "Import Data",
     "hide_stockouts": "Hide Stockouts",

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -7,6 +7,7 @@
     "vaccine_dispense_step_two_title": "Step: 2 Edit the patients details",
     "vaccine_dispense_vaccine_select_title": "Select the vaccine",
     "vaccine_dispense_supplemental_data_title": "Step: 3 Enter additional vaccination details",
+    "vaccine_event_supplemental_data_title": "Page 2: Additional Details",
     "vaccinator": "Vaccinator",
     "logging_delayed_until": "Logging delayed until",
     "hot_consecutive": "Hot consecutive",

--- a/src/localization/vaccineStrings.json
+++ b/src/localization/vaccineStrings.json
@@ -8,6 +8,7 @@
     "vaccine_dispense_vaccine_select_title": "Select the vaccine",
     "vaccine_dispense_supplemental_data_title": "Step: 3 Enter additional vaccination details",
     "vaccine_event_supplemental_data_title": "Page 2: Additional Details",
+    "vaccine_event_transact_data_title": "Page 3: Vaccination Event",
     "vaccinator": "Vaccinator",
     "logging_delayed_until": "Logging delayed until",
     "hot_consecutive": "Hot consecutive",
@@ -76,7 +77,8 @@
     "pause": "Pause",
     "resume": "Resume",
     "refusal_reason": "Reason for refusal",
-    "vaccination_updated": "Vaccination details updated"
+    "vaccination_updated": "Vaccination details updated",
+    "vaccination_not_updated": "No updates were made to the vaccination record"
   },
   "fr": {
     "no_vaccine_stock": "Vous n'avez pas de vaccins en stock!",

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -342,7 +342,7 @@ const PatientSelectComponent = ({
         onClose={() => setVaccinationEvent(null)}
         title={`${dispensingStrings.vaccination_details}`}
       >
-        <VaccinationEvent vaccinationEvent={vaccinationEvent} patient={patient} />
+        <VaccinationEvent vaccinationEventId={vaccinationEvent?.id} patient={patient} />
       </ModalContainer>
     </FlexView>
   );

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-curly-newline */
 /* eslint-disable react/forbid-prop-types */
 import React, { useRef, useState } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
@@ -5,7 +6,11 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { FlexRow } from '../FlexRow';
 import { JSONForm } from '../JSONForm/JSONForm';
-import { selectSurveySchemas, selectVaccinationEventSchemas } from '../../selectors/formSchema';
+import {
+  selectSupplementalDataSchemas,
+  selectSurveySchemas,
+  selectVaccinationEventSchemas,
+} from '../../selectors/formSchema';
 import { FlexView } from '../FlexView';
 import { UIDatabase } from '../../database';
 import { selectMostRecentNameNote } from '../../selectors/Entities/nameNote';
@@ -17,9 +22,11 @@ import globalStyles, {
   GREY,
   SUSSOL_ORANGE,
 } from '../../globalStyles';
-import { buttonStrings, generalStrings } from '../../localization';
+import { buttonStrings, generalStrings, vaccineStrings } from '../../localization';
 import { PageButton } from '../PageButton';
 import { NameNoteActions } from '../../actions';
+import { Paper } from '../Paper';
+import { Title } from '../JSONForm/fields';
 
 // It's possible to get into this state if vaccination events were configured but PCD events weren't
 // and someone dispensed a vaccine. Some data cleanup may be required.
@@ -40,17 +47,27 @@ export const NoPCDForm = () => (
 
 export const VaccinationEventComponent = ({
   patient,
-  vaccinationEvent,
+  supplementalDataSchema,
+  vaccinationEventId,
   vaccinationEventSchema,
-  saveForm,
+  savePCDForm,
+  saveSupplementalData,
   surveySchema,
 }) => {
   const pcdFormRef = useRef(null);
+  const supplementalFormRef = useRef(null);
   const vaccinationFormRef = useRef(null);
+
   const [{ updatedPcdForm, isPCDValid }, setPCDForm] = useState({
     updatedPcdForm: null,
     isPCDValid: false,
   });
+  const [{ updatedSupplementalDataForm, isSupplementalDataValid }, setSupplementalData] = useState({
+    updatedSupplementalDataForm: null,
+    isSupplementalDataValid: false,
+  });
+  const vaccinationEventNameNote = UIDatabase.get('NameNote', vaccinationEventId);
+  const vaccinationEvent = vaccinationEventNameNote.data;
 
   const { pcdNameNoteId } = vaccinationEvent;
   const surveyForm = pcdNameNoteId
@@ -64,27 +81,13 @@ export const VaccinationEventComponent = ({
   const parsedVaccinationEvent = {
     ...vaccinationEvent,
     extra: {
-      prescription: { ...vaccinationEvent.prescription, customData: customDataObject },
+      prescription: { ...vaccinationEvent.extra.prescription, customData: customDataObject },
     },
   };
 
   return (
     <FlexView>
-      <FlexRow flex={1}>
-        {!!vaccinationEventSchema && !!vaccinationEvent && (
-          <FlexRow flex={1}>
-            <View style={localStyles.formContainer}>
-              <JSONForm
-                ref={vaccinationFormRef}
-                disabled={true}
-                formData={parsedVaccinationEvent ?? null}
-                surveySchema={vaccinationEventSchema}
-              >
-                <></>
-              </JSONForm>
-            </View>
-          </FlexRow>
-        )}
+      <FlexRow flex={1} style={localStyles.formContainer}>
         <FlexRow flex={1}>
           <View style={localStyles.formContainer}>
             {!!surveySchema && !!surveyForm ? (
@@ -110,14 +113,69 @@ export const VaccinationEventComponent = ({
             )}
           </View>
         </FlexRow>
+        <FlexRow flex={1}>
+          <View style={localStyles.formContainer}>
+            <Paper
+              Header={
+                <Title title={vaccineStrings.vaccine_event_supplemental_data_title} size="large" />
+              }
+              contentContainerStyle={{ flex: 1 }}
+              style={{ flex: 1 }}
+              headerContainerStyle={localStyles.title}
+            >
+              <JSONForm
+                ref={supplementalFormRef}
+                formData={customDataObject ?? null}
+                surveySchema={supplementalDataSchema}
+                onChange={(changed, validator) => {
+                  setSupplementalData({
+                    updatedSupplementalDataForm: changed.formData,
+                    isSupplementalDataValid: validator(changed.formData),
+                  });
+                }}
+              >
+                <></>
+              </JSONForm>
+            </Paper>
+          </View>
+        </FlexRow>
+        {!!vaccinationEventSchema && !!vaccinationEvent && (
+          <FlexRow flex={1}>
+            <View style={localStyles.formContainer}>
+              <JSONForm
+                ref={vaccinationFormRef}
+                disabled={true}
+                formData={parsedVaccinationEvent ?? null}
+                surveySchema={vaccinationEventSchema}
+              >
+                <></>
+              </JSONForm>
+            </View>
+          </FlexRow>
+        )}
       </FlexRow>
       <FlexRow flex={0} justifyContent="center">
         <PageButton
           text={buttonStrings.save_changes}
-          onPress={() => saveForm(surveyForm, updatedPcdForm)}
+          onPress={() => savePCDForm(surveyForm, updatedPcdForm)}
           style={localStyles.saveButton}
           textStyle={localStyles.saveButtonTextStyle}
           isDisabled={!isPCDValid}
+        />
+        <PageButton
+          text={buttonStrings.save_changes}
+          onPress={() =>
+            saveSupplementalData(vaccinationEventNameNote, updatedSupplementalDataForm)
+          }
+          style={localStyles.saveButton}
+          textStyle={localStyles.saveButtonTextStyle}
+          isDisabled={!isSupplementalDataValid}
+        />
+        <PageButton
+          text={buttonStrings.edit}
+          style={localStyles.saveButton}
+          textStyle={localStyles.saveButtonTextStyle}
+          isDisabled={true}
         />
       </FlexRow>
     </FlexView>
@@ -131,16 +189,39 @@ const mapStateToProps = () => {
   const vaccinationEventSchemas = selectVaccinationEventSchemas();
   const [vaccinationEventSchema] = vaccinationEventSchemas;
 
+  const supplementalDataSchemas = selectSupplementalDataSchemas();
+  const [supplementalDataSchema] = supplementalDataSchemas;
+
   return {
     surveySchema,
     vaccinationEventSchema,
+    supplementalDataSchema,
   };
 };
 
-const mapDispatchToProps = dispatch => ({
-  saveForm: (oldSurveyNote, updatedSurveyData) =>
-    dispatch(NameNoteActions.updateLinkedSurveyNameNote(oldSurveyNote, updatedSurveyData)),
-});
+const mapDispatchToProps = dispatch => {
+  const savePCDForm = (oldSurveyNote, updatedSurveyData) => {
+    dispatch(NameNoteActions.updateNameNote(oldSurveyNote, updatedSurveyData));
+  };
+
+  const saveSupplementalData = (vaccinationEventNameNote, updatedSupplementalData) => {
+    const vaccinationEvent = vaccinationEventNameNote.data;
+
+    const updatedData = {
+      ...vaccinationEvent,
+      extra: {
+        ...vaccinationEvent.extra,
+        prescription: {
+          ...vaccinationEvent.extra.prescription,
+          customData: JSON.stringify(updatedSupplementalData),
+        },
+      },
+    };
+    dispatch(NameNoteActions.updateNameNote(vaccinationEventNameNote, updatedData));
+  };
+
+  return { savePCDForm, saveSupplementalData };
+};
 
 const localStyles = StyleSheet.create({
   formContainer: {
@@ -160,18 +241,27 @@ const localStyles = StyleSheet.create({
     color: 'white',
     fontSize: 14,
   },
+  title: {
+    textAlignVertical: 'center',
+    fontWeight: 'bold',
+    fontSize: 22,
+    fontFamily: APP_FONT_FAMILY,
+    color: DARKER_GREY,
+  },
 });
 
 VaccinationEventComponent.defaultProps = {
   patient: {},
-  vaccinationEvent: {},
+  vaccinationEventId: '',
 };
 
 VaccinationEventComponent.propTypes = {
   patient: PropTypes.object,
-  saveForm: PropTypes.func.isRequired,
+  savePCDForm: PropTypes.func.isRequired,
+  saveSupplementalData: PropTypes.func.isRequired,
+  supplementalDataSchema: PropTypes.object.isRequired,
   surveySchema: PropTypes.object.isRequired,
-  vaccinationEvent: PropTypes.object,
+  vaccinationEventId: PropTypes.string,
   vaccinationEventSchema: PropTypes.object.isRequired,
 };
 

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -172,7 +172,7 @@ export const VaccinationEventComponent = ({
           isDisabled={!isSupplementalDataValid}
         />
         <PageButton
-          text={buttonStrings.edit}
+          text={buttonStrings.save_changes}
           style={localStyles.saveButton}
           textStyle={localStyles.saveButtonTextStyle}
           isDisabled={true}


### PR DESCRIPTION
Fixes #4714

## Change summary

- Butchered the UI in an attempt to allow easier data editing:
  - ![image](https://user-images.githubusercontent.com/65875762/173726328-5633bb7b-75bd-490e-ae44-01b38fca5b48.png)
- Updated modal to grab the actual name note - it was previously working with data mapped for the history view 
- Added 'isDirty' check to not update if the contents are the same

## Testing

Steps to reproduce or otherwise test the changes of this PR:

Prerequisites:
- Update VaccinationEvent JSON schema:
  - [VaccinationEvent.txt](https://github.com/openmsupply/mobile/files/8905265/VaccinationEvent.txt)
  - [VaccinationEvent-UI.txt](https://github.com/openmsupply/mobile/files/8905267/VaccinationEvent-UI.txt)
- [ ] View the vaccination history for a patient and edit the supplemental data form

### Related areas to think about
- Too many buttons? 🤔 Bit awkward because the data is stored in 3 different places though conceptually to users it's all supposed to be part of one event (Maybe a tabbed view would be better?)
- Maybe 'editing' should be disallowed until the user tries to press an 'edit' button of some sort?