### PR TITLE
#4759 Allow length of > 3 for email TLD when requesting demo store

### DIFF
--- a/src/authentication/DemoSiteRequest.js
+++ b/src/authentication/DemoSiteRequest.js
@@ -52,7 +52,7 @@ export class DemoSiteRequest {
   // TODO: Could be extracted to a helper file to be used elsewhere.
   // eslint-disable-next-line class-methods-use-this
   validateEmail(text) {
-    const reg = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w+)+$/;
+    const reg = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/;
     return reg.test(text);
   }
 

--- a/src/authentication/DemoSiteRequest.js
+++ b/src/authentication/DemoSiteRequest.js
@@ -52,7 +52,7 @@ export class DemoSiteRequest {
   // TODO: Could be extracted to a helper file to be used elsewhere.
   // eslint-disable-next-line class-methods-use-this
   validateEmail(text) {
-    const reg = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
+    const reg = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w+)+$/;
     return reg.test(text);
   }
 


### PR DESCRIPTION
Fixes #4759

## Change summary

- Allow email TLD to have more than 3 chars

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Test emails with some of these domains out: https://data.iana.org/TLD/tlds-alpha-by-domain.txt

### Related areas to think about
N/A