### PR TITLE
#4775 Flags to allow soft deletion of name notes and patients

### DIFF
--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -197,6 +197,7 @@ Name.schema = {
     lastName: { type: 'string', optional: true },
     isActive: { type: 'bool', optional: true },
     isDeceased: { type: 'bool', optional: true },
+    isDeleted: { type: 'bool', optional: true },
     isCustomer: { type: 'bool', default: false },
     isSupplier: { type: 'bool', default: false },
     isManufacturer: { type: 'bool', default: false },

--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -198,7 +198,7 @@ Name.schema = {
     lastName: { type: 'string', optional: true },
     isActive: { type: 'bool', optional: true },
     isDeceased: { type: 'bool', optional: true },
-    isDeleted: { type: 'bool', optional: true },
+    isDeleted: { type: 'bool', default: false, optional: true },
     isCustomer: { type: 'bool', default: false },
     isSupplier: { type: 'bool', default: false },
     isManufacturer: { type: 'bool', default: false },

--- a/src/database/DataTypes/Name.js
+++ b/src/database/DataTypes/Name.js
@@ -159,6 +159,7 @@ export class Name extends Realm.Object {
       lastName: this.lastName,
       isActive: this.isActive,
       isDeceased: this.isDeceased,
+      isDeleted: this.isDeleted,
       isCustomer: this.isCustomer,
       isSupplier: this.isSupplier,
       isManufacturer: this.isManufacturer,

--- a/src/database/DataTypes/NameNote.js
+++ b/src/database/DataTypes/NameNote.js
@@ -38,6 +38,7 @@ NameNote.schema = {
     id: 'string',
     entryDate: { type: 'date', default: new Date() },
     _data: { type: 'string', optional: true },
+    isDeleted: { type: 'bool', optional: true },
     name: 'Name',
     note: { type: 'string', optional: true },
     patientEvent: 'PatientEvent',

--- a/src/database/DataTypes/NameNote.js
+++ b/src/database/DataTypes/NameNote.js
@@ -38,7 +38,7 @@ NameNote.schema = {
     id: 'string',
     entryDate: { type: 'date', default: new Date() },
     _data: { type: 'string', optional: true },
-    isDeleted: { type: 'bool', optional: true },
+    isDeleted: { type: 'bool', default: false, optional: true },
     name: 'Name',
     note: { type: 'string', optional: true },
     patientEvent: 'PatientEvent',

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -257,7 +257,7 @@ export const schema = {
     VaccineVialMonitorStatus,
     VaccineVialMonitorStatusLog,
   ],
-  schemaVersion: 28,
+  schemaVersion: 29,
 };
 
 export default schema;

--- a/src/hooks/useLocalAndRemotePatients.js
+++ b/src/hooks/useLocalAndRemotePatients.js
@@ -187,7 +187,7 @@ export const useLocalAndRemotePatients = (initialValue = []) => {
     }
     dispatch({ type: 'fetch_start' });
 
-    const query = 'lastName BEGINSWITH[c] $0 AND firstName BEGINSWITH[c] $1';
+    const query = 'isDeleted == false AND lastName BEGINSWITH[c] $0 AND firstName BEGINSWITH[c] $1';
     let patients = UIDatabase.objects('Patient').filtered(query, lastName, firstName);
 
     if (dateOfBirth) {

--- a/src/selectors/Entities/name.js
+++ b/src/selectors/Entities/name.js
@@ -102,7 +102,8 @@ export const selectVaccinePatientHistory = patient => {
 
   const nameNotes = patient?.nameNotes
     ?.filter(
-      ({ patientEventID, data }) =>
+      ({ patientEventID, data, isDeleted }) =>
+        !isDeleted &&
         patientEventID === vaccinationPatientEventID &&
         validateJsonSchemaData(selectVaccinationEventSchemas()[0].jsonSchema, data)
     )

--- a/src/selectors/dispensary.js
+++ b/src/selectors/dispensary.js
@@ -44,8 +44,10 @@ export const selectDataSet = ({ dispensary }) => {
 };
 
 export const selectData = ({ dispensary }) => {
+  const dataSet = selectDataSet({ dispensary });
   const { data } = dispensary;
-  return data.filtered('isDeleted == false');
+
+  return dataSet === 'patient' ? data.filtered('isDeleted == false') : data;
 };
 
 export const selectDataSetInUse = ({ dispensary }) => {

--- a/src/selectors/dispensary.js
+++ b/src/selectors/dispensary.js
@@ -45,7 +45,7 @@ export const selectDataSet = ({ dispensary }) => {
 
 export const selectData = ({ dispensary }) => {
   const { data } = dispensary;
-  return data;
+  return data.filtered('isDeleted == false');
 };
 
 export const selectDataSetInUse = ({ dispensary }) => {

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -589,6 +589,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         type: NAME_TYPES.translate(record.type, EXTERNAL_TO_INTERNAL),
         isCustomer: parseBoolean(record.customer),
         isDeceased: parseBoolean(record.isDeceased),
+        isDeleted: parseBoolean(record.isDeleted),
         isSupplier: parseBoolean(record.supplier),
         isManufacturer: parseBoolean(record.manufacturer),
         supplyingStoreId: record.supplying_store_id,
@@ -1155,6 +1156,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         patientEvent: database.getOrCreate('PatientEvent', record.patient_event_ID),
         entryDate: parseDate(record.entry_date),
         _data: record.data,
+        isDeleted: parseBoolean(record.isDeleted),
         name: database.getOrCreate('Name', record.name_ID),
         note: record.note,
       });

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -589,7 +589,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         type: NAME_TYPES.translate(record.type, EXTERNAL_TO_INTERNAL),
         isCustomer: parseBoolean(record.customer),
         isDeceased: parseBoolean(record.isDeceased),
-        isDeleted: parseBoolean(record.isDeleted),
+        isDeleted: parseBoolean(record.is_deleted),
         isSupplier: parseBoolean(record.supplier),
         isManufacturer: parseBoolean(record.manufacturer),
         supplyingStoreId: record.supplying_store_id,
@@ -1156,7 +1156,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         patientEvent: database.getOrCreate('PatientEvent', record.patient_event_ID),
         entryDate: parseDate(record.entry_date),
         _data: record.data,
-        isDeleted: parseBoolean(record.isDeleted),
+        isDeleted: parseBoolean(record.is_deleted),
         name: database.getOrCreate('Name', record.name_ID),
         note: record.note,
       });

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -99,7 +99,7 @@ const generateSyncData = (settings, recordType, record) => {
         'charge code': record.code,
         currency_id: defaultCurrency?.id ?? '',
         isDeceased: String(record.isDeceased),
-        isDeleted: String(record.isDeleted),
+        is_deleted: String(record.isDeleted),
         female: String(record.female),
         nationality_ID: record.nationality?.id ?? '',
         occupation_ID: record.occupation?.id ?? '',
@@ -424,7 +424,7 @@ const generateSyncData = (settings, recordType, record) => {
         data: record.data,
         store_ID: settings.get(THIS_STORE_ID),
         note: record.note,
-        isDeleted: String(record.isDeleted),
+        is_deleted: String(record.isDeleted),
         // The NameNote table is in the middle of a migration away from the current impl
         // where there are fields boolean_value, value, note etc. To avoid having to also
         // migrate data within mobile, just send the boolean_value field when the name_note

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -99,6 +99,7 @@ const generateSyncData = (settings, recordType, record) => {
         'charge code': record.code,
         currency_id: defaultCurrency?.id ?? '',
         isDeceased: String(record.isDeceased),
+        isDeleted: String(record.isDeleted),
         female: String(record.female),
         nationality_ID: record.nationality?.id ?? '',
         occupation_ID: record.occupation?.id ?? '',
@@ -423,6 +424,7 @@ const generateSyncData = (settings, recordType, record) => {
         data: record.data,
         store_ID: settings.get(THIS_STORE_ID),
         note: record.note,
+        isDeleted: String(record.isDeleted),
         // The NameNote table is in the middle of a migration away from the current impl
         // where there are fields boolean_value, value, note etc. To avoid having to also
         // migrate data within mobile, just send the boolean_value field when the name_note


### PR DESCRIPTION
Fixes #4775

## Change summary

- Changes to include the soft delete flag on `name` and `name_note` objects
- Check flags when rendering patient lists and vaccination history lists on Kiribati datafile and hide `is_deleted` ones.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Check that realm has an `isDeleted` field against `name` records and `name_note` records. Have not been able to test soft deleting name_notes and syncing from desktop (maybe they're not being synced on update??)

### Related areas to think about

N/A
