### PR TITLE
#4678 - Stopping app to crash

### DIFF
--- a/src/pages/dataTableUtilities/actions/rowActions.js
+++ b/src/pages/dataTableUtilities/actions/rowActions.js
@@ -132,7 +132,7 @@ export const deleteSelectedRecords = (recordType, route) => (dispatch, getState)
   const transactionsToDelete = recordIds.reduce((acc, recordId) => {
     const record = backingData.filtered('id == $0', recordId)[0];
     const shouldDelete = record && record.isValid() && !record.isFinalised;
-    if (shouldDelete) return [...acc, record];
+    if (shouldDelete && record.serialNumber > 0) return [...acc, record];
     return acc;
   }, []);
 


### PR DESCRIPTION
Fixes #4678 

## Change summary

Aiming to stop crashing the App upon deletion like this:

![photo_2022-07-05_10-23-31](https://user-images.githubusercontent.com/13144882/177254738-22ac79bf-c10a-4d1a-ab58-296d5fa1e2e7.jpg)

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Empty Blank supplier requisition
- [ ] Select that and delete it
   - [ ] App should nor crashed
   - [ ] It does not do anything for now, a simple fix to stop the app from Crashing  

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
