### PR TITLE
#4785 Update date-picker to properly set initialValue

### DIFF
--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -34,7 +34,7 @@ export const DatePicker = ({
         underlineColorAndroid={DARKER_GREY}
         placeholder={placeholder}
         editable={!(readonly || disabled)}
-        value={moment(value).format(DATE_FORMAT.DD_MM_YYYY)}
+        value={value}
         ref={ref}
         onSubmitEditing={() => focusController.next(ref)}
         onChangeText={handleChange}
@@ -45,7 +45,7 @@ export const DatePicker = ({
       />
       <DatePickerButton
         isDisabled={readonly || disabled}
-        initialValue={new Date(moment(value).format(DATE_FORMAT.DD_MM_YYYY))}
+        initialValue={moment(value, DATE_FORMAT.DD_MM_YYYY).toDate()}
         minimumDate={options.dateRange === 'future' ? new Date() : null}
         maximumDate={options.dateRange === 'past' ? new Date() : null}
         onDateChanged={date => handleChange(moment(date).format(DATE_FORMAT.DD_MM_YYYY))}

--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -31,11 +31,11 @@ export const DatePicker = ({
 
   React.useEffect(() => {
     const alternateFormatDate = moment(value, 'YYYY-MM-DD', true);
-    const expectedFormateDate = alternateFormatDate.isValid()
+    const expectedFormatDate = alternateFormatDate.isValid()
       ? alternateFormatDate
       : moment(value, DATE_FORMAT.DD_MM_YYYY, true);
 
-    setSelectedDate(expectedFormateDate.isValid() ? expectedFormateDate.toDate() : value);
+    setSelectedDate(expectedFormatDate.isValid() ? expectedFormatDate.toDate() : value);
   }, [value]);
 
   return (

--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -22,7 +22,7 @@ export const DatePicker = ({
   const { focusController } = useJSONFormOptions();
   const ref = focusController.useRegisteredRef();
 
-  const [selectedDate, setSelectedDate] = useState(null);
+  const [selectedDate, setSelectedDate] = useState('');
 
   const handleChange = dateString => {
     onChange(dateString);
@@ -35,7 +35,7 @@ export const DatePicker = ({
       ? alternateFormatDate
       : moment(value, DATE_FORMAT.DD_MM_YYYY, true);
 
-    setSelectedDate(expectedFormateDate.isValid() ? expectedFormateDate.toDate() : null);
+    setSelectedDate(expectedFormateDate.isValid() ? expectedFormateDate.toDate() : value);
   }, [value]);
 
   return (
@@ -46,7 +46,11 @@ export const DatePicker = ({
         underlineColorAndroid={DARKER_GREY}
         placeholder={placeholder}
         editable={!(readonly || disabled)}
-        value={selectedDate ? moment(selectedDate).format(DATE_FORMAT.DD_MM_YYYY) : ''}
+        value={
+          moment(selectedDate, DATE_FORMAT.DD_MM_YYYY, true).isValid()
+            ? moment(selectedDate).format(DATE_FORMAT.DD_MM_YYYY)
+            : selectedDate
+        }
         ref={ref}
         onSubmitEditing={() => focusController.next(ref)}
         onChangeText={handleChange}

--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -22,7 +22,7 @@ export const DatePicker = ({
   const { focusController } = useJSONFormOptions();
   const ref = focusController.useRegisteredRef();
 
-  const [selectedDate, setSelectedDate] = useState('');
+  const [selectedDate, setSelectedDate] = useState(Date());
 
   const handleChange = dateString => {
     onChange(dateString);

--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { TextInput } from 'react-native';
 import moment from 'moment';
 import PropTypes from 'prop-types';
@@ -21,10 +21,22 @@ export const DatePicker = ({
 }) => {
   const { focusController } = useJSONFormOptions();
   const ref = focusController.useRegisteredRef();
+
+  const [selectedDate, setSelectedDate] = useState(null);
+
   const handleChange = dateString => {
     onChange(dateString);
     onBlur(id, dateString);
   };
+
+  React.useEffect(() => {
+    const alternateFormatDate = moment(value, 'YYYY-MM-DD', true);
+    const expectedFormateDate = alternateFormatDate.isValid()
+      ? alternateFormatDate
+      : moment(value, DATE_FORMAT.DD_MM_YYYY, true);
+
+    setSelectedDate(expectedFormateDate.isValid() ? expectedFormateDate.toDate() : null);
+  }, [value]);
 
   return (
     <FlexRow>
@@ -34,7 +46,7 @@ export const DatePicker = ({
         underlineColorAndroid={DARKER_GREY}
         placeholder={placeholder}
         editable={!(readonly || disabled)}
-        value={value}
+        value={selectedDate ? moment(selectedDate).format(DATE_FORMAT.DD_MM_YYYY) : ''}
         ref={ref}
         onSubmitEditing={() => focusController.next(ref)}
         onChangeText={handleChange}
@@ -45,7 +57,7 @@ export const DatePicker = ({
       />
       <DatePickerButton
         isDisabled={readonly || disabled}
-        initialValue={moment(value, DATE_FORMAT.DD_MM_YYYY).toDate()}
+        initialValue={selectedDate || moment().toDate()}
         minimumDate={options.dateRange === 'future' ? new Date() : null}
         maximumDate={options.dateRange === 'past' ? new Date() : null}
         onDateChanged={date => handleChange(moment(date).format(DATE_FORMAT.DD_MM_YYYY))}

--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -34,7 +34,7 @@ export const DatePicker = ({
         underlineColorAndroid={DARKER_GREY}
         placeholder={placeholder}
         editable={!(readonly || disabled)}
-        value={value}
+        value={moment(value).format(DATE_FORMAT.DD_MM_YYYY)}
         ref={ref}
         onSubmitEditing={() => focusController.next(ref)}
         onChangeText={handleChange}
@@ -45,7 +45,7 @@ export const DatePicker = ({
       />
       <DatePickerButton
         isDisabled={readonly || disabled}
-        initialValue={new Date()}
+        initialValue={new Date(moment(value).format(DATE_FORMAT.DD_MM_YYYY))}
         minimumDate={options.dateRange === 'future' ? new Date() : null}
         maximumDate={options.dateRange === 'past' ? new Date() : null}
         onDateChanged={date => handleChange(moment(date).format(DATE_FORMAT.DD_MM_YYYY))}


### PR DESCRIPTION
Fixes #4785

## Change summary

- Previously the datepicker, when pulling date from sever, was getting the date in wrong format, saving this date, if the date was converted to dd/mm/yyyy format would show wrong date.
- if you click the datepicker button, the date selected would be today's date not the date in input box.
- If you try to edit the date in input box mid-way or make it blank, and open datepicker button the app would error out.
- if you add date in correct format and save, the saved date would be in wrong format, that is day and month swaped.


## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to `Vaccinations` page
- [ ] Select vaccination history of one of the patient from online search
- [ ] see the date of vaccination
- [ ] Select to edit details
- [ ] In pages additional details see that the date is in dd/mm/yyyy format. 
- [ ] click the datepicker button, the date should show properly in datepicker.
- [ ] now in the date input box, press backspace to delete the date, it should not error out or say invalid date
- [ ] click the datepicker button again, and the picker now should show today's date and let you select other dates

### Related areas to think about

This datepicker is not limited to vaccination event details page so we have to look at other pages where this datepicker is used too.
Save or edit might bug out by taking invalid date if this code has bugs so maybe test edit and save too.
