### PR TITLE
#4792 Kiribati: Prevent giving vaccine to deceased patient

### DIFF
--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -9,6 +9,7 @@
     "confirm_double_dose": "This patient already has a vaccination recorded within the last 24 hours, do you want to proceed?",
     "vaccine_event_not_editable": "Vaccinator and stock details can only be modified on the device it was originally entered on. Please find the tablet used to enter the vaccination.",
     "create": "Create",
+    "deceased_patient_vaccination": "You cannot dispense vaccines to a deceased patient!",
     "delete_these_fridges": "Are you sure you want to delete these fridges?",
     "create_cash_transaction": "Create new cash transaction",
     "delete_these_invoices": "Are you sure you want to delete these invoices?",

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -9,7 +9,7 @@
     "confirm_double_dose": "This patient already has a vaccination recorded within the last 24 hours, do you want to proceed?",
     "vaccine_event_not_editable": "Vaccinator and stock details can only be modified on the device it was originally entered on. Please find the tablet used to enter the vaccination.",
     "create": "Create",
-    "deceased_patient_vaccination": "You cannot dispense vaccines to a deceased patient!",
+    "deceased_patient_vaccination": "Can not administer vaccination - this patient is deceased.",
     "delete_these_fridges": "Are you sure you want to delete these fridges?",
     "create_cash_transaction": "Create new cash transaction",
     "delete_these_invoices": "Are you sure you want to delete these invoices?",

--- a/src/widgets/CircleButton.js
+++ b/src/widgets/CircleButton.js
@@ -18,9 +18,9 @@ const SIZE_VALUES = {
 };
 
 const ICON_SIZE_VALUES = {
-  small: 10,
-  medium: 15,
-  large: 20,
+  small: 8,
+  medium: 13,
+  large: 17,
 };
 
 /**

--- a/src/widgets/FormInputs/FormToggle.js
+++ b/src/widgets/FormInputs/FormToggle.js
@@ -54,6 +54,7 @@ export const FormToggle = ({
         toggleOnStyle={localStyles.toggleOnStyle}
         toggleOffStyle={localStyles.toggleOffStyle}
         toggleOnDisabledStyle={localStyles.toggleOnDisabledStyle}
+        toggleOffDisabledStyle={localStyles.toggleOffDisabledStyle}
       />
     </FlexView>
   );
@@ -83,6 +84,14 @@ const localStyles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: WARMER_GREY,
+    borderRadius: 20,
+    margin: 5,
+  },
+  toggleOffDisabledStyle: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderColor: WARMER_GREY,
     borderRadius: 20,
     margin: 5,
   },

--- a/src/widgets/Tabs/PatientEdit.js
+++ b/src/widgets/Tabs/PatientEdit.js
@@ -69,16 +69,16 @@ const PatientEditComponent = ({
   const savePatient = useCallback(
     e => {
       updatePatientDetails(completedForm);
-      if (!completedForm.isDeceased) {
-        formRef?.current?.submit(e);
-
-        if (canSaveForm) {
-          onCompleted();
-        } else {
-          ToastAndroid.show(dispensingStrings.validation_failed, ToastAndroid.LONG);
-        }
-      } else {
+      if (completedForm.isDeceased) {
         toggleIsDeceasedAlert();
+        return;
+      }
+
+      formRef?.current?.submit(e);
+      if (canSaveForm) {
+        onCompleted();
+      } else {
+        ToastAndroid.show(dispensingStrings.validation_failed, ToastAndroid.LONG);
       }
     },
     [completedForm, canSaveForm]

--- a/src/widgets/Tabs/PatientEdit.js
+++ b/src/widgets/Tabs/PatientEdit.js
@@ -14,6 +14,8 @@ import { PageButton } from '../PageButton';
 import { FlexRow } from '../FlexRow';
 import { FlexView } from '../FlexView';
 import { PageButtonWithOnePress } from '../PageButtonWithOnePress';
+import { PaperModalContainer } from '../PaperModal/PaperModalContainer';
+import { PaperConfirmModal } from '../PaperModal/PaperConfirmModal';
 
 import { selectCanEditPatient, selectEditingName } from '../../selectors/Entities/name';
 import { selectSurveySchemas } from '../../selectors/formSchema';
@@ -22,8 +24,15 @@ import { WizardActions } from '../../actions/WizardActions';
 import { VaccinePrescriptionActions } from '../../actions/Entities/VaccinePrescriptionActions';
 import { selectCanSaveForm, selectCompletedForm } from '../../selectors/form';
 import { getFormInputConfig } from '../../utilities/formInputConfigs';
+import { useToggle } from '../../hooks/useToggle';
 
-import { buttonStrings, vaccineStrings, dispensingStrings } from '../../localization';
+import {
+  buttonStrings,
+  vaccineStrings,
+  dispensingStrings,
+  modalStrings,
+  generalStrings,
+} from '../../localization';
 import globalStyles from '../../globalStyles';
 import { JSONForm } from '../JSONForm/JSONForm';
 import { NameNoteActions } from '../../actions/Entities/NameNoteActions';
@@ -55,17 +64,21 @@ const PatientEditComponent = ({
   canEditPatient,
 }) => {
   const { pageTopViewContainer } = globalStyles;
+  const [isDeceasedModalOpen, toggleIsDeceasedAlert] = useToggle(false);
   const formRef = useRef(null);
-
   const savePatient = useCallback(
     e => {
       updatePatientDetails(completedForm);
-      formRef?.current?.submit(e);
+      if (!completedForm.isDeceased) {
+        formRef?.current?.submit(e);
 
-      if (canSaveForm) {
-        onCompleted();
+        if (canSaveForm) {
+          onCompleted();
+        } else {
+          ToastAndroid.show(dispensingStrings.validation_failed, ToastAndroid.LONG);
+        }
       } else {
-        ToastAndroid.show(dispensingStrings.validation_failed, ToastAndroid.LONG);
+        toggleIsDeceasedAlert();
       }
     },
     [completedForm, canSaveForm]
@@ -118,6 +131,13 @@ const PatientEditComponent = ({
           style={{ marginLeft: 'auto' }}
         />
       </FlexRow>
+      <PaperModalContainer isVisible={isDeceasedModalOpen} onClose={toggleIsDeceasedAlert}>
+        <PaperConfirmModal
+          questionText={modalStrings.deceased_patient_vaccination}
+          confirmText={generalStrings.ok}
+          onConfirm={toggleIsDeceasedAlert}
+        />
+      </PaperModalContainer>
     </FlexView>
   );
 };

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -371,11 +371,9 @@ const mapDispatchToProps = dispatch => {
       Keyboard.dismiss();
       const selectedPatient = await dispatch(NameActions.select(patient));
 
-      if (selectedPatient) {
-        if (!selectedPatient.isDeceased) {
-          dispatch(NameNoteActions.createSurveyNameNote(selectedPatient));
-          dispatch(WizardActions.nextTab());
-        }
+      if (selectedPatient && !selectedPatient.isDeceased) {
+        dispatch(NameNoteActions.createSurveyNameNote(selectedPatient));
+        dispatch(WizardActions.nextTab());
       }
     });
 

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -147,7 +147,7 @@ const PatientSelectComponent = ({
 }) => {
   const withLoadingIndicator = useLoadingIndicator();
   const [isQrModalOpen, toggleQrModal] = useToggle();
-  const [isModalOpen, toggleIsDeceasedAlert] = useToggle(false);
+  const [isDeceasedModalOpen, toggleIsDeceasedAlert] = useToggle(false);
   const [{ history, patient } = {}, setPatientHistory] = useState({});
   const [vaccinationEvent, setVaccinationEvent] = useState(null);
 
@@ -351,7 +351,7 @@ const PatientSelectComponent = ({
       >
         <VaccinationEvent vaccinationEventId={vaccinationEvent?.id} patient={patient} />
       </ModalContainer>
-      <PaperModalContainer isVisible={isModalOpen} onClose={toggleIsDeceasedAlert}>
+      <PaperModalContainer isVisible={isDeceasedModalOpen} onClose={toggleIsDeceasedAlert}>
         <PaperConfirmModal
           questionText={modalStrings.deceased_patient_vaccination}
           confirmText={generalStrings.ok}

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -257,15 +257,16 @@ const PatientSelectComponent = ({
           columns={columns}
           onPress={name => {
             if (!name?.isDeceased) {
-              // Only show a spinner when the name doesn't exist in the database, as we need to
-              // send a request to the server to add a name store join.
-              if (UIDatabase.get('Name', name?.id)) {
-                selectPatient(name);
-              } else {
-                withLoadingIndicator(() => selectPatient(name));
-              }
-            } else {
               toggleIsDeceasedAlert();
+              return;
+            }
+
+            // Only show a spinner when the name doesn't exist in the database, as we need to
+            // send a request to the server to add a name store join.
+            if (UIDatabase.get('Name', name?.id)) {
+              selectPatient(name);
+            } else {
+              withLoadingIndicator(() => selectPatient(name));
             }
           }}
           rowIndex={index}

--- a/src/widgets/ToggleBar/ToggleBar.js
+++ b/src/widgets/ToggleBar/ToggleBar.js
@@ -56,9 +56,7 @@ export const ToggleBarComponent = props => {
     const defaultOffTextStyle = isDisabled ? textOffDisabledStyle : textOffStyle;
 
     buttons.forEach((button, i) => {
-      const currentTextStyle = button.isOn
-        ? [localStyles.textOnStyle, textOnStyle]
-        : [localStyles.textOffStyle, defaultOffTextStyle];
+      const currentTextStyle = button.isOn ? textOnStyle : defaultOffTextStyle;
       const currentToggleStyle = button.isOn ? defaultOnStyle : defaultOffStyle;
       const Container = isDisabled ? View : TouchableOpacity;
 
@@ -123,7 +121,7 @@ const localStyles = StyleSheet.create({
     borderColor: WARMER_GREY,
     width: 142,
   },
-  toggleTextDisabledSelected: {
+  textOffDisabledStyle: {
     fontFamily: APP_FONT_FAMILY,
     fontSize: 12,
     color: WARMER_GREY,
@@ -137,9 +135,9 @@ ToggleBarComponent.propTypes = {
   toggleOffStyle: ViewPropTypes.style,
   toggleOnStyle: ViewPropTypes.style,
   textOffStyle: Text.propTypes.style,
-  textOffDisabledStyle: Text.propTypes.style,
   textOnStyle: Text.propTypes.style,
   isDisabled: PropTypes.bool,
+  textOffDisabledStyle: Text.propTypes.style,
   toggleOnDisabledStyle: PropTypes.object,
   toggleOffDisabledStyle: PropTypes.object,
 };
@@ -149,9 +147,9 @@ ToggleBarComponent.defaultProps = {
   toggleOffStyle: localStyles.toggleOffStyle,
   toggleOnStyle: localStyles.toggleOnStyle,
   textOffStyle: globalStyles.toggleText,
-  textOffDisabledStyle: globalStyles.toggleTextDisabledSelected,
   textOnStyle: globalStyles.toggleTextSelected,
+  isDisabled: false,
+  textOffDisabledStyle: localStyles.textOffDisabledStyle,
   toggleOnDisabledStyle: localStyles.toggleOnDisabledStyle,
   toggleOffDisabledStyle: localStyles.toggleOffDisabledStyle,
-  isDisabled: false,
 };


### PR DESCRIPTION
Fixes #4792 (and small bug fixed #4783)
My first PR here YAY

## Change summary

Added an alert to the patient select and patient edit tabs to prevent vaccine dispensing if a patient is deceased.
Also, fixed a bug in the toggle styling so now "Gender" and "Is deceased" are shown correctly. Did it here as currently it is very broken and would be quite confusing for the clients.

## Testing

1.
- [ ] Go "Vaccination" -> Search for patients
- [ ] Select a patient who you know is deceased -> see an alert.
- [ ] Clicking "OK" closes an alert, you stay on the same page.

2. 
- [ ] Go "Vaccination" -> Search for patients
- [ ] Select a patient who you know is editable on the current site. Edit patient window opens.
- [ ] Change "Is deceased" to "Yes", click "Next" -> see an alert.
- [ ] Clicking "OK" closes an alert, you stay on the same page.

3. 
- [ ] Go "Vaccination" -> Search for patients
- [ ] Click "New patient". Edit patient window opens.
- [ ] Change "Is deceased" to "Yes", click "Next" -> see an alert.
- [ ] Clicking "OK" closes an alert, you stay on the same page.

4.
- [ ] Go to "Vaccination" or "Dispensing". Select any patient to edit.
- [ ] Toggles for "Gender" and "Is Deceased" must be displayed correctly in both of the cases:
  - [ ] If patient is editable on the current site
  - [ ] If patient is not editable on the current site

### Related areas to think about

- I'm not sure why we are able to change patient status to "Deceased" during the vaccination -> probably we should disable it in the future