### PR TITLE
#4796 Kiribati: soft delete of vaccinations 

### DIFF
--- a/src/actions/Entities/NameNoteActions.js
+++ b/src/actions/Entities/NameNoteActions.js
@@ -134,7 +134,6 @@ const createNotes = (nameNotes = []) => {
       const { patientEventID, nameID } = nameNote;
       const name = UIDatabase.get('Name', nameID);
       const patientEvent = UIDatabase.get('PatientEvent', patientEventID);
-      console.log('createNotes(pleeeease): ', nameNote);
       if (name && patientEvent) {
         const toSave = {
           id: nameNote.id,

--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -219,6 +219,7 @@ const createVaccinationNameNote = (
     patientEvent,
     entryDate: new Date(),
     _data: JSON.stringify(data),
+    isDeleted: false,
   };
   UIDatabase.write(() => UIDatabase.create('NameNote', newNameNote));
 };

--- a/src/database/DataTypes/NameNote.js
+++ b/src/database/DataTypes/NameNote.js
@@ -24,6 +24,7 @@ export class NameNote extends Realm.Object {
       id: this.id,
       entryDate: this.entryDate?.getTime(),
       data: this.data,
+      isDeleted: this.isDeleted,
       nameID: this.name?.id,
       note: this.note,
       patientEventID: this.patientEvent?.id,

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -220,7 +220,10 @@ const getPatientUniqueCode = database => {
   return isPatientCodeUnique(code, database) ? code : getPatientUniqueCode(id, database);
 };
 
-const createNameNote = (database, { id, data, patientEventID, nameID, entryDate = new Date() }) => {
+const createNameNote = (
+  database,
+  { id, data, patientEventID, nameID, entryDate = new Date(), isDeleted = false }
+) => {
   const patientEvent = database.get('PatientEvent', patientEventID);
   const name = database.get('Name', nameID);
 
@@ -230,6 +233,7 @@ const createNameNote = (database, { id, data, patientEventID, nameID, entryDate 
       name,
       patientEvent,
       entryDate: new Date(entryDate),
+      isDeleted,
     });
     newNameNote.data = data;
   }

--- a/src/localization/buttonStrings.json
+++ b/src/localization/buttonStrings.json
@@ -13,6 +13,7 @@
     "create_automatic_order": "Create Automatic Order",
     "current": "Current",
     "done": "Done",
+    "delete_vaccination_event": "Delete vaccination event",
     "edit": "Edit",
     "export_data": "Export Data",
     "import_data": "Import Data",

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -14,6 +14,7 @@
     "delete_these_invoices": "Are you sure you want to delete these invoices?",
     "delete_these_requisitions": "Are you sure you want to delete these requisitions?",
     "delete_these_stocktakes": "Are you sure you want to delete these stocktakes?",
+    "delete_vaccination_event": "Are you sure you want to delete this vaccination event?",
     "delete": "Delete",
     "edit_the_invoice_comment": "Edit the invoice comment",
     "edit_the_requisition_comment": "Edit the requisition comment",

--- a/src/reducers/Entities/NameNoteReducer.js
+++ b/src/reducers/Entities/NameNoteReducer.js
@@ -7,6 +7,7 @@ const initialState = () => ({
     patientEventID: '',
     nameID: '',
     entryDate: 0,
+    isDeleted: false,
   },
   isValid: false,
 });

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -93,6 +93,10 @@ export const VaccinationEventComponent = ({
     isSupplementalDataValid: false,
   });
 
+  const [{ isDeletedVaccinationEvent }, setIsDeletedVaccinationEvent] = useState({
+    isDeletedVaccinationEvent: vaccinationEventNameNote.isDeleted,
+  });
+
   // User cannot edit 'Vaccination Event' panel if vaccination was done on a different tablet/store
   const tryEdit = useCallback(() => {
     if (!transaction) {
@@ -132,6 +136,10 @@ export const VaccinationEventComponent = ({
         customDataObject,
         vaccinationEventNameNote
       );
+      toggleEditTransaction();
+      setIsDeletedVaccinationEvent({
+        isDeletedVaccinationEvent: true,
+      });
     } else {
       ToastAndroid.show(vaccineStrings.vaccination_not_updated, ToastAndroid.LONG);
     }
@@ -140,7 +148,12 @@ export const VaccinationEventComponent = ({
   const tryDelete = useCallback(() => {
     deleteVaccinationEvent(patient, transactionBatch, vaccinationEventNameNote);
     toggleDeleteModal();
+    setIsDeletedVaccinationEvent({
+      isDeletedVaccinationEvent: true,
+    });
   }, [patient]);
+  console.log('isDeletedVaccinationEvent: ', isDeletedVaccinationEvent);
+  console.log('isPCDValid: ', isSupplementalDataValid);
 
   return (
     <FlexView>
@@ -160,6 +173,7 @@ export const VaccinationEventComponent = ({
                         isPCDValid: validator(changed.formData),
                       });
                     }}
+                    disabled={isDeletedVaccinationEvent}
                   >
                     <></>
                   </JSONForm>
@@ -190,6 +204,7 @@ export const VaccinationEventComponent = ({
                     isSupplementalDataValid: validator(changed.formData),
                   });
                 }}
+                disabled={isDeletedVaccinationEvent}
               >
                 <></>
               </JSONForm>
@@ -264,7 +279,7 @@ export const VaccinationEventComponent = ({
           onPress={() => savePCDForm(surveyForm, updatedPcdForm)}
           style={localStyles.saveButton}
           textStyle={localStyles.saveButtonTextStyle}
-          isDisabled={!isPCDValid}
+          isDisabled={!isPCDValid || isDeletedVaccinationEvent}
         />
         <PageButton
           text={buttonStrings.save_changes}
@@ -273,13 +288,14 @@ export const VaccinationEventComponent = ({
           }
           style={localStyles.saveButton}
           textStyle={localStyles.saveButtonTextStyle}
-          isDisabled={!isSupplementalDataValid}
+          isDisabled={!isSupplementalDataValid || isDeletedVaccinationEvent}
         />
         <PageButton
           text={isEditingTransaction ? buttonStrings.save_changes : buttonStrings.edit}
           style={localStyles.saveButton}
           textStyle={localStyles.saveButtonTextStyle}
           onPress={isEditingTransaction ? trySave : tryEdit}
+          isDisabled={isDeletedVaccinationEvent}
         />
       </FlexRow>
       <PaperModalContainer isVisible={isModalOpen} onClose={toggleModal}>

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -353,7 +353,6 @@ const mapDispatchToProps = dispatch => {
   ) => {
     batch(() => {
       dispatch(VaccinePrescriptionActions.returnVaccineToStock(patient.id, transactionBatch));
-      dispatch(VaccinePrescriptionActions.softDelete(vaccinationEventNameNote));
       dispatch(NameActions.select(patient));
       dispatch(VaccinePrescriptionActions.selectVaccinator(vaccinator));
       dispatch(VaccinePrescriptionActions.selectVaccine(UIDatabase.get('Item', vaccine.id)));

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -148,6 +148,7 @@ export const VaccinationEventComponent = ({
   const tryDelete = useCallback(() => {
     deleteVaccinationEvent(patient, transactionBatch, vaccinationEventNameNote);
     toggleDeleteModal();
+    toggleEditTransaction();
     setIsDeletedVaccinationEvent({
       isDeletedVaccinationEvent: true,
     });

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -152,8 +152,6 @@ export const VaccinationEventComponent = ({
       isDeletedVaccinationEvent: true,
     });
   }, [patient]);
-  console.log('isDeletedVaccinationEvent: ', isDeletedVaccinationEvent);
-  console.log('isPCDValid: ', isSupplementalDataValid);
 
   return (
     <FlexView>


### PR DESCRIPTION
Fixes #4796 

## Change summary

- Added "Delete button":
![Screen Shot 2022-07-13 at 4 45 47 PM](https://user-images.githubusercontent.com/41636693/178652623-28f1eaf3-81d3-4e94-9e25-2dadef47b8bf.png)
Before anyone asks - the color of this button is DANGER_RED. Yes, it looks orange but I guess this is a part of the design code (I don't know honestly)
- Clicking "Delete button" makes it impossible to implement further changes to the form.
- The vaccination associated with the deleted NameNote will not be visible in the UI anymore. The only way to get the information about the deleted Name Notes is to look into the data base.

## Testing

- [ ] Go to "Vaccination" -> search for a patient. 
- [ ] Select "History" for a patient with the vaccination events entered on the current site.
- [ ] Select one of the vaccination events. Click "Edit" in the last column, click "Delete ...".
- [ ] See confirmation window. Click "Cancel" -> confirmation window closes.
- [ ] click "Delete ...". again, but this time click "Confirm" -> You see all three forms again, all the buttons are disabled, you cannot do any changes anymore.
- [ ] Close it. Sync. Go to "Vaccination" -> Select "History" for this patient again -> see that the deleted vaccination event is not there anymore.
- [ ] Select another vaccination event. Click "Edit". Do some changes, click "Save" -> buttons will become disabled, you cannot change it anymore. 
- [ ] Close it. Sync. Go to "Vaccination" -> Select "History" for this patient again -> see the edited vaccination event (in fact it is a completely new one, the old one is hidden but 🤫)

### Related areas to think about

- [ ] After editing/deleting PCD form and Extra info form do not get disabled. It doesn't really matter as the Save buttons are disabled, but would be nice to fix it (don't know how to do that yet)