### PR TITLE
#4801 Kiribati: a pop-up message to contain the name of the store where vaccination was made

### DIFF
--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -8,6 +8,7 @@
     "confirm": "Confirm",
     "confirm_double_dose": "This patient already has a vaccination recorded within the last 24 hours, do you want to proceed?",
     "vaccine_event_not_editable": "Vaccinator and stock details can only be modified on the device it was originally entered on. Please find the tablet used to enter the vaccination.",
+    "vaccine_event_not_editable_store": "Vaccinator and stock details can only be modified on {0} store. Please find the tablet used to enter the vaccination.",
     "create": "Create",
     "delete_these_fridges": "Are you sure you want to delete these fridges?",
     "create_cash_transaction": "Create new cash transaction",

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -70,6 +70,10 @@ export const VaccinationEventComponent = ({
   const vaccinationEventNameNote = UIDatabase.get('NameNote', vaccinationEventId);
   const vaccinationEvent = vaccinationEventNameNote.data;
   const transaction = UIDatabase.get('Transaction', vaccinationEvent?.extra?.prescription?.id);
+  const nameNoteStoreName = vaccinationEvent?.storeName;
+  const alertText = nameNoteStoreName
+    ? modalStrings.formatString(modalStrings.vaccine_event_not_editable_store, nameNoteStoreName)
+    : modalStrings.vaccine_event_not_editable;
   const transactionBatch = UIDatabase.objects('TransactionBatch').filtered(
     'transaction.id == $0',
     transaction?.id
@@ -299,7 +303,7 @@ export const VaccinationEventComponent = ({
       </FlexRow>
       <PaperModalContainer isVisible={isModalOpen} onClose={toggleModal}>
         <PaperConfirmModal
-          questionText={modalStrings.vaccine_event_not_editable}
+          questionText={alertText}
           confirmText={modalStrings.confirm}
           onConfirm={toggleModal}
         />


### PR DESCRIPTION
Fixes #4801

## Change summary

If store name is saved on vaccination event, the alert containing store name is shown.

## Testing

- [ ] Use a data file with the vaccination module set up and some vaccinations already dispensed. You will need two tablets with two different stores set up on them (let's say "Tablet 1" (with "Store 1") and "Tablet 2" (with "Store 2").
- [ ] On "Tablet 1" some vaccination events should be entered for "Patient 1" (before this version upgrade).
- [ ] Log in "Tablet 2" and go to "Vaccination" -> Open "Patient 1" history. Click on any vaccination event.
- [ ] In the last column click "Edit" -> see an alert that says you have to find a tablet where vaccination was made.
- [ ] Using "Tablet 1" add another vaccination event for "Patient 1". 
- [ ] On "Tablet 2" go to "Vaccination" -> Open "Patient 1" history. Click on the latest vaccination event.
- [ ] In the last column click "Edit" -> see an alert that specifies that you have to use "Store 1" tablet to edit this vaccination event.

