### PR TITLE
#4838 Fix PatientSelectComponent bugs out when closed

### DIFF
--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -80,8 +80,11 @@ const FormControlComponent = ({
   const isFocused = useIsFocused();
 
   React.useEffect(() => {
-    onInitialiseForm();
-    setRefs({ length: inputConfig.length });
+    // Only update state if component comes in focus
+    if (isFocused) {
+      onInitialiseForm();
+      setRefs({ length: inputConfig.length });
+    }
   }, [isFocused]);
 
   const debouncedUpdateForm = useDebounce(onUpdateForm, 500);

--- a/src/widgets/JSONForm/widgets/Checkbox.js
+++ b/src/widgets/JSONForm/widgets/Checkbox.js
@@ -82,9 +82,13 @@ const styles = StyleSheet.create({
   },
 });
 
+Checkbox.defaultProps = {
+  value: false,
+};
+
 Checkbox.propTypes = {
   options: PropTypes.object.isRequired,
-  value: PropTypes.bool.isRequired,
+  value: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   onBlur: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,

--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -22,7 +22,7 @@ export const DatePicker = ({
   const { focusController } = useJSONFormOptions();
   const ref = focusController.useRegisteredRef();
 
-  const [selectedDate, setSelectedDate] = useState(Date());
+  const [selectedDate, setSelectedDate] = useState('');
 
   const handleChange = dateString => {
     onChange(dateString);


### PR DESCRIPTION
Fixes  #4838

## Change summary

- Stop triggering of redux state update for patient list when the window closes. 
- There are some other checkbox and datepicker error fixes too which is actually not related to the issue linked.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Vaccinations > Patient select window
- [ ] (Optional) Search for a patient, select a patient, go to step 2-3-4 and add some vax data or not, it does not matter, because the error would have triggered once you opened the window and closed it with the < button at top left. You can do some steps for testing purpose.
- [ ] Click the `<` button at the top left to close the window, discarding the vaccination window.
- [ ] You might not see the error message in testing mobile app as it would have shown in console. You may notice the smoothness of the window closing and going back to main page with an animation which was simply not there earlier due to the bug. 
- [ ] In many cases this issue might have crashed the system which would not happen now.
- [ ] This issue fixes a bug in FormControl component, which is one of the most generic components in the application. This effects all FormControls including input boxes, date of birth, date controls, dropdown and sliders. Maybe we should generally test them to see if they work properly.

### Related areas to think about

This issue fixes a bug in FormControl component, which is one of the most generic components in the application. This effects all FormControls including input boxes, date of birth, date controls, dropdown and sliders. Maybe we should generally test them to see if they work properly.
