### PR TITLE
#4823 mSupply crashes when changing the vaccine to the one that is not in stock currently

### DIFF
--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -86,7 +86,9 @@ export const VaccinationEventComponent = ({
   const [vaccine, setVaccine] = useState(
     vaccines.filter(item => item.id === transactionBatch?.itemId)[0]
   );
-  const vaccineDropDownValues = vaccines.map(({ code, name }) => `${code}: ${name}`);
+  const vaccineDropDownValues = vaccines
+    .filter(v => v.totalQuantity !== 0)
+    .map(({ code, name }) => `${code}: ${name}`);
 
   const [{ updatedPcdForm, isPCDValid }, setPCDForm] = useState({
     updatedPcdForm: null,


### PR DESCRIPTION
Fixes #4823

## Change summary

Removed vaccines out of stock from the dropdown list

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Use a file with some vaccines out of stock
- [ ] Go to vaccination -> see history for any patient -> select any vaccination event -> edit it. See in vaccine dropdown list that there are no vaccines out of stock

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
