### PR TITLE
#4849 Fix save and delete button was still showing for remote patients

### DIFF
--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -35,7 +35,7 @@ export const PatientEditModalComponent = ({
   let canSave = canSaveForm;
   const hasVaccineEvents = hasVaccineEventsForm;
   if (canSave) {
-    canSave = surveySchema && surveyForm ? nameNoteIsValid : !isDisabled;
+    canSave = !isDisabled && surveySchema && surveyForm && nameNoteIsValid;
   }
 
   const canDelete = !isDisabled;
@@ -84,6 +84,7 @@ export const PatientEditModalComponent = ({
               onPress={hasVaccineEvents ? toggleCannotDeleteModal : toggleRemoveModal}
               style={styles.cancelButton}
               textStyle={styles.saveButtonTextStyle}
+              isDisabled={!canDelete}
               text={generalStrings.delete}
             />
           )}


### PR DESCRIPTION
Fixes #4849

## Change summary

- Update canSave conditional logic logic.
- Add button disable option for delete button

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Set CAN_EDIT_PATIENTS_FROM_ANY_STORE pref to false. mSupply desktop has default pref that sets CAN_EDIT_PATIENTS_FROM_ANY_STORE to true. Have to disabled.
- [ ] Go to Dispensing page
- [ ] In edit column you would see the book icon (not the pen icon). This means the record is read only. These patient records are created in other store and should not be editable in this store.
- [ ] Click icon (book) to go inside.
- [ ] See that save and delete button these should be inactive. 

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
