### PR TITLE
#4844 kiribati Vax: Editing vaccination event, clicking save buttons multiple times quickly is crashing apps and which is corrupting the record

### DIFF
--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -129,6 +129,9 @@ export const VaccinationEventComponent = ({
   };
 
   const trySave = useCallback(() => {
+    setIsDeletedVaccinationEvent({
+      isDeletedVaccinationEvent: true,
+    });
     const vaccineChanged = vaccine.code !== transactionBatch?.itemBatch?.item?.code;
     const vaccinatorChanged =
       JSON.stringify(vaccinator) !== JSON.stringify(transactionBatch.medicineAdministrator);
@@ -143,10 +146,10 @@ export const VaccinationEventComponent = ({
         vaccinationEventNameNote
       );
       toggleEditTransaction();
-      setIsDeletedVaccinationEvent({
-        isDeletedVaccinationEvent: true,
-      });
     } else {
+      setIsDeletedVaccinationEvent({
+        isDeletedVaccinationEvent: false,
+      });
       ToastAndroid.show(vaccineStrings.vaccination_not_updated, ToastAndroid.LONG);
     }
   }, [patient, transactionBatch, vaccine]);


### PR DESCRIPTION
Fixes #4844

## Change summary

Disabled button after clicking

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to any vaccination event that you can edit from the current tablet
- [ ] Click "Save changes" with no changes - alert is shown, the button is back to be enbaled
- [ ] Change vaccination or vaccine, try to click "Save" multiple times - shouldn't be allowed.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
