### PR TITLE
#4820 Disabled next button during submission enable it afterwards

### DIFF
--- a/src/hooks/useButtonEnabled.js
+++ b/src/hooks/useButtonEnabled.js
@@ -1,0 +1,15 @@
+import { useIsFocused } from '@react-navigation/native';
+import React, { useState } from 'react';
+
+export default function useButtonEnabled(defaultValue = true) {
+  const [enabled, setEnabled] = useState(defaultValue);
+  const isFocused = useIsFocused();
+
+  React.useEffect(() => {
+    if (!isFocused) {
+      setEnabled(true);
+    }
+  }, [isFocused]);
+
+  return { enabled, setEnabled };
+}

--- a/src/widgets/Tabs/PatientEdit.js
+++ b/src/widgets/Tabs/PatientEdit.js
@@ -4,12 +4,12 @@
  * Sustainable Solutions (NZ) Ltd. 2021
  */
 
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { ToastAndroid, View } from 'react-native';
-import { useIsFocused } from '@react-navigation/native';
 import { connect } from 'react-redux';
 import * as Animatable from 'react-native-animatable';
+import useButtonEnabled from '../../hooks/useButtonEnabled';
 import { FormControl } from '../FormControl';
 import { PageButton } from '../PageButton';
 import { FlexRow } from '../FlexRow';
@@ -66,18 +66,8 @@ const PatientEditComponent = ({
 }) => {
   const { pageTopViewContainer } = globalStyles;
   const [isDeceasedModalOpen, toggleIsDeceasedAlert] = useToggle(false);
-  const [nextButtonEnabled, setNextButtonEnabled] = useState(true);
 
-  const isFocused = useIsFocused();
-
-  React.useEffect(() => {
-    // Enable next button when component goes out of focus
-    // This combined with the way nextButtonEnabled is being used below, would ensure
-    // and Next button cannot be clicked multiple times
-    if (!isFocused) {
-      setNextButtonEnabled(true);
-    }
-  }, [isFocused]);
+  const { enabled: nextButtonEnabled, setEnabled: setNextButtonEnabled } = useButtonEnabled();
 
   const formRef = useRef(null);
   const savePatient = useCallback(

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -4,7 +4,7 @@
  * Sustainable Solutions (NZ) Ltd. 2021
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigation } from '@react-navigation/native';
 import { Dimensions, Text, StyleSheet, TextInput, View } from 'react-native';
@@ -46,6 +46,7 @@ import { PaperModalContainer } from '../PaperModal/PaperModalContainer';
 import { PaperConfirmModal } from '../PaperModal/PaperConfirmModal';
 import { useToggle } from '../../hooks/useToggle';
 import { PageButton } from '../PageButton';
+import useButtonEnabled from '../../hooks/useButtonEnabled';
 
 const ListEmptyComponent = () => (
   <FlexView flex={1} justifyContent="center" alignItems="center">
@@ -85,6 +86,10 @@ const VaccineSelectComponent = ({
   wasPatientVaccinatedWithinOneDay,
 }) => {
   const { pageTopViewContainer } = globalStyles;
+  const {
+    enabled: okConfirmButtonEnabled,
+    setEnabled: setOkConfirmButtonEnabled,
+  } = useButtonEnabled(false);
   const [confirmDoubleDoseModalOpen, toggleConfirmDoubleDoseModal] = useToggle();
   const [confirmAndRepeatDoubleDoseModalOpen, toggleConfirmAndRepeatDoubleDoseModal] = useToggle();
   const vaccineColumns = React.useMemo(() => getColumns(TABS.ITEM), []);
@@ -104,6 +109,14 @@ const VaccineSelectComponent = ({
     [vaccines]
   );
   const runWithLoadingIndicator = useLoadingIndicator();
+
+  useEffect(() => {
+    // Wait for two seconds before enabling confirm button
+    // to avoid accidental form submission.
+    setTimeout(() => {
+      setOkConfirmButtonEnabled(true);
+    }, 2000);
+  }, []);
 
   const confirmPrescription = React.useCallback(() => runWithLoadingIndicator(onConfirm), [
     onConfirm,
@@ -200,7 +213,7 @@ const VaccineSelectComponent = ({
           debounceTimer={1000}
           text={buttonStrings.confirm}
           style={{ marginLeft: 'auto' }}
-          isDisabled={!selectedBatches && !hasRefused}
+          isDisabled={(!selectedBatches && !hasRefused) || !okConfirmButtonEnabled}
           onPress={
             wasPatientVaccinatedWithinOneDay ? toggleConfirmDoubleDoseModal : confirmPrescription
           }
@@ -209,7 +222,7 @@ const VaccineSelectComponent = ({
           debounceTimer={1000}
           text={generalStrings.ok_and_next}
           style={{ marginLeft: 5 }}
-          isDisabled={!selectedBatches && !hasRefused}
+          isDisabled={(!selectedBatches && !hasRefused) || !okConfirmButtonEnabled}
           onPress={
             wasPatientVaccinatedWithinOneDay
               ? toggleConfirmAndRepeatDoubleDoseModal


### PR DESCRIPTION
Fixes #4820

## Change summary

Explain and justify your changes

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Vaccinations > New Patient or Select a patient that already exists
- [ ] Fill up the patient details on Step2 page if new or just leave it as it is for existing.
- [ ] Now quickly tap Next button twice, this should not skip step 3 as it has required fields 
- [ ] In the error case when step 3 was skipped, the system would have allowed you to save this form without there required fields and trying to load this form would have crashed the app. Make sure the step 3's required fields are enforced before it allows us to move to step 4.
- [ ] Same for step 3 try filling the form properly and then multi-clicking it. It should not trigger form submission.
- [ ] Since the ok and confirm button of step 4 is just below the next button of step 3 multi-clicking was triggering it. Since step 4's code auto select the top vaccine the form would submit by accident. And since it happens so fast react-native has not time to update the render properly and it errors out. To fix it, I have added a 2 sec deactivation of the ok next button by default for step 4. 
  - [ ] Check this 2 sec delay is taking effect
  - [ ] Try mult clicking step 3 next button trying to trigger step 4 submission, it should not be possible. 


### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
