### PR TITLE
#4647 current stock add toggle to hide zero stock

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "mSupplyMobile",
   "//": "version must be in the format ${majorNumber}.${minorNumber}.${patchNumber}-rc${releaseCandidateNumber}",
-  "version": "8.4.2",
+  "version": "8.5.0",
   "private": false,
   "license": "MIT",
   "description": "Mobile app for use with the mSupply medical inventory control software",

--- a/src/actions/PatientActions.js
+++ b/src/actions/PatientActions.js
@@ -46,7 +46,7 @@ const patientDelete = () => (dispatch, getState) => {
 
   ToastAndroid.show(dispensingStrings.patient_deleted, ToastAndroid.LONG);
   dispatch(closeModal());
-  return { type: PATIENT_ACTIONS.PATIENT_DELETE };
+  return { type: PATIENT_ACTIONS.PATIENT_DELETE, payload: { patient } };
 };
 
 const patientUpdate = patientDetails => async (dispatch, getState) => {

--- a/src/globalStyles/dataTableStyles.js
+++ b/src/globalStyles/dataTableStyles.js
@@ -188,6 +188,13 @@ export const dataTableStyles = {
     backgroundColor: 'white',
     flexDirection: 'row',
   },
+  emptyRow: {
+    backgroundColor: 'white',
+    height: 250,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   headerCells: {
     left: {
       height: 40,

--- a/src/hooks/useLocalAndRemotePatients.js
+++ b/src/hooks/useLocalAndRemotePatients.js
@@ -151,7 +151,7 @@ export const useLocalAndRemotePatients = (initialValue = []) => {
     if (!response || noMore) return;
 
     dispatch({ type: 'getting_more_patients' });
-    const paramsWithLimits = { ...searchParams, limit, offset };
+    const paramsWithLimits = { ...searchParams, limit, offset, isDeleted: false };
 
     // Use RNFetch as the fetch returned from `useFetch` is coupled with it's state in a specific
     // implementation, which we want to change by appending to the result, rather than replacing.

--- a/src/localization/buttonStrings.json
+++ b/src/localization/buttonStrings.json
@@ -78,8 +78,7 @@
     "customer_data": "Données Clients",
     "factory_reset": "Réinitialiser",
     "check_connection": "Vérifiez la connexion",
-    "connection_status": "Connexion réussie",
-    "hide_zero_stocks": "Masquer les stocks zéro"
+    "connection_status": "Connexion réussie"
   },
   "gil": {
     "add_master_list_items": "Rinea am list",
@@ -98,8 +97,7 @@
     "new_supplier_invoice": "Bebwan am oota\nman pharmacy",
     "past": "Are I mwaina",
     "use_requested_quantities": "Kabongana maitina\nae kainnanoaki",
-    "use_suggested_quantities": "Kabongana te\nmwaiti are e katauaki",
-    "hide_zero_stocks": "Hide zero stocks"
+    "use_suggested_quantities": "Kabongana te\nmwaiti are e katauaki"
   },
   "tl": {
     "add_master_list_items": "Utiliza Lista Master",
@@ -118,8 +116,7 @@
     "new_supplier_invoice": "Distribuidor nia Invoice Foun",
     "past": "Pasadu",
     "use_suggested_quantities": "Kuantidade Sujere",
-    "use_requested_quantities": "Kuantidade Ezije",
-    "hide_zero_stocks": "Hide zero stocks"
+    "use_requested_quantities": "Kuantidade Ezije"
   },
   "la": {
     "add_batch": "​ໃສ​່​ເລກ​ຊຸດ​ຜະ​ລິດ",
@@ -139,8 +136,7 @@
     "new_supplier_invoice": "ໃບ​ຮັບ​ສິນ​ຄ້າໃໝ່",
     "past": "ໃນທີ່​ຜ່ານ​ມາ",
     "use_suggested_quantities": "ນຳໃຊ້ຈຳ​ນວນທີ່​ຖືກແນະ​ນຳ",
-    "use_requested_quantities": "ນຳໃຊ້ຈຳ​ນວນທີ່​ສະ​ເໜີ​ຂໍ",
-    "hide_zero_stocks": "Hide zero stocks"
+    "use_requested_quantities": "ນຳໃຊ້ຈຳ​ນວນທີ່​ສະ​ເໜີ​ຂໍ"
   },
   "my": {
     "add_fridge": "အအေးပေးစက်အတွင်း သိမ်းဆည်းသည်",
@@ -168,8 +164,7 @@
     "past": "ယခင်",
     "save_changes": "ပြောင်းလဲမှုအားသိမ်းဆည်းသည်",
     "use_requested_quantities": "တောင်းခံထားသော အ‌ရေအတွက်ကို သုံးသည်",
-    "use_suggested_quantities": "အကြံပြုထားသော အရေအတွက်ကို သုံးသည်",
-    "hide_zero_stocks": "Hide zero stocks"
+    "use_suggested_quantities": "အကြံပြုထားသော အရေအတွက်ကို သုံးသည်"
   },
   "pt": {
     "back": "Voltar",
@@ -208,8 +203,7 @@
     "customer_data": "Dados do cliente",
     "factory_reset": "Configuração inicial",
     "check_connection": "Check connection",
-    "connection_status": "Conexão ativa",
-    "hide_zero_stocks": "Hide zero stocks"
+    "connection_status": "Conexão ativa"
   },
   "es": {
     "next": "Siguiente",
@@ -238,7 +232,6 @@
     "use_requested_quantities": "Usar Cantidades Solicitadas",
     "use_suggested_quantities": "Usar Cantidades Sugeridas",
     "view_regimen_data": "Ver Datos del Régimen",
-    "check_connection": "Check connection",
-    "hide_zero_stocks": "Ocultar existencias cero"
+    "check_connection": "Check connection"
   }
 }

--- a/src/localization/buttonStrings.json
+++ b/src/localization/buttonStrings.json
@@ -38,7 +38,8 @@
     "customer_data": "Customer Data",
     "factory_reset": "Factory Reset",
     "check_connection": "Check connection",
-    "connection_status": "Connection successful"
+    "connection_status": "Connection successful",
+    "hide_zero_stocks": "Hide zero stocks"
   },
   "fr": {
     "back": "Précédent",
@@ -77,7 +78,8 @@
     "customer_data": "Données Clients",
     "factory_reset": "Réinitialiser",
     "check_connection": "Vérifiez la connexion",
-    "connection_status": "Connexion réussie"
+    "connection_status": "Connexion réussie",
+    "hide_zero_stocks": "Masquer les stocks zéro"
   },
   "gil": {
     "add_master_list_items": "Rinea am list",
@@ -96,7 +98,8 @@
     "new_supplier_invoice": "Bebwan am oota\nman pharmacy",
     "past": "Are I mwaina",
     "use_requested_quantities": "Kabongana maitina\nae kainnanoaki",
-    "use_suggested_quantities": "Kabongana te\nmwaiti are e katauaki"
+    "use_suggested_quantities": "Kabongana te\nmwaiti are e katauaki",
+    "hide_zero_stocks": "Hide zero stocks"
   },
   "tl": {
     "add_master_list_items": "Utiliza Lista Master",
@@ -115,7 +118,8 @@
     "new_supplier_invoice": "Distribuidor nia Invoice Foun",
     "past": "Pasadu",
     "use_suggested_quantities": "Kuantidade Sujere",
-    "use_requested_quantities": "Kuantidade Ezije"
+    "use_requested_quantities": "Kuantidade Ezije",
+    "hide_zero_stocks": "Hide zero stocks"
   },
   "la": {
     "add_batch": "​ໃສ​່​ເລກ​ຊຸດ​ຜະ​ລິດ",
@@ -135,7 +139,8 @@
     "new_supplier_invoice": "ໃບ​ຮັບ​ສິນ​ຄ້າໃໝ່",
     "past": "ໃນທີ່​ຜ່ານ​ມາ",
     "use_suggested_quantities": "ນຳໃຊ້ຈຳ​ນວນທີ່​ຖືກແນະ​ນຳ",
-    "use_requested_quantities": "ນຳໃຊ້ຈຳ​ນວນທີ່​ສະ​ເໜີ​ຂໍ"
+    "use_requested_quantities": "ນຳໃຊ້ຈຳ​ນວນທີ່​ສະ​ເໜີ​ຂໍ",
+    "hide_zero_stocks": "Hide zero stocks"
   },
   "my": {
     "add_fridge": "အအေးပေးစက်အတွင်း သိမ်းဆည်းသည်",
@@ -163,7 +168,8 @@
     "past": "ယခင်",
     "save_changes": "ပြောင်းလဲမှုအားသိမ်းဆည်းသည်",
     "use_requested_quantities": "တောင်းခံထားသော အ‌ရေအတွက်ကို သုံးသည်",
-    "use_suggested_quantities": "အကြံပြုထားသော အရေအတွက်ကို သုံးသည်"
+    "use_suggested_quantities": "အကြံပြုထားသော အရေအတွက်ကို သုံးသည်",
+    "hide_zero_stocks": "Hide zero stocks"
   },
   "pt": {
     "back": "Voltar",
@@ -202,7 +208,8 @@
     "customer_data": "Dados do cliente",
     "factory_reset": "Configuração inicial",
     "check_connection": "Check connection",
-    "connection_status": "Conexão ativa"
+    "connection_status": "Conexão ativa",
+    "hide_zero_stocks": "Hide zero stocks"
   },
   "es": {
     "next": "Siguiente",
@@ -231,6 +238,7 @@
     "use_requested_quantities": "Usar Cantidades Solicitadas",
     "use_suggested_quantities": "Usar Cantidades Sugeridas",
     "view_regimen_data": "Ver Datos del Régimen",
-    "check_connection": "Check connection"
+    "check_connection": "Check connection",
+    "hide_zero_stocks": "Ocultar existencias cero"
   }
 }

--- a/src/localization/dispensingStrings.json
+++ b/src/localization/dispensingStrings.json
@@ -72,7 +72,8 @@
     "edit_supplemental_data": "Edit additional details",
     "refused_vaccine": "Refused vaccine",
     "validation_failed": "Some required fields are not completed.",
-    "patient_deleted": "Patient successfully deleted"
+    "patient_deleted": "Patient successfully deleted",
+    "patient_already_deleted": "'The patient has already been deleted. You cannot sync this patient back."
   },
   "fr": {
     "vaccination_history": "Historique de vaccination pour",

--- a/src/localization/dispensingStrings.json
+++ b/src/localization/dispensingStrings.json
@@ -73,7 +73,8 @@
     "refused_vaccine": "Refused vaccine",
     "validation_failed": "Some required fields are not completed.",
     "patient_deleted": "Patient successfully deleted",
-    "patient_already_deleted": "'The patient has already been deleted. You cannot sync this patient back."
+    "patient_already_exists": "The patient already exists. Can only sync existing patient from tablet to server.",
+    "patient_already_deleted": "The patient has already been deleted. You cannot sync this patient back."
   },
   "fr": {
     "vaccination_history": "Historique de vaccination pour",

--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -99,7 +99,8 @@
     "no_locations": "You don't have any locations to assign! Contact your administrator.",
     "no_options": "No options available. Please contact your administrator!",
     "no_vvm_status": "No vaccine vial monitor statuses available. Please contact your administrator!",
-    "no_reasons": "No requisition line variance reasons available. Please contact your administrator!"
+    "no_reasons": "No requisition line variance reasons available. Please contact your administrator!",
+    "no_records": "No record(s) found."
   },
   "fr": {
     "oh_no": "Oh non!",

--- a/src/pages/StockPage.js
+++ b/src/pages/StockPage.js
@@ -4,22 +4,23 @@
  * Sustainable Solutions (NZ) Ltd. 2019
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { connect } from 'react-redux';
 
-import { getItemLayout, getPageDispatchers } from './dataTableUtilities';
+import { getItemLayout, getPageDispatchers, PageActions } from './dataTableUtilities';
 
 import { DataTable, DataTableHeaderRow, DataTableRow } from '../widgets/DataTable';
-import { DataTablePageView, SearchBar } from '../widgets';
+import { DataTablePageView, SearchBar, ToggleBar } from '../widgets';
 
 import globalStyles from '../globalStyles';
 import { useSyncListener } from '../hooks';
 
-import { generalStrings } from '../localization';
+import { generalStrings, buttonStrings } from '../localization';
 import { SupplierCreditActions } from '../actions/SupplierCreditActions';
 import { RowDetailActions } from '../actions/RowDetailActions';
+import { ROUTES } from '../navigation';
 
 /**
  * Renders a mSupply mobile page with Items and their stock levels.
@@ -49,11 +50,16 @@ export const Stock = ({
   onFilterData,
   onSortColumn,
   refund,
+  showAll,
+  toggleStockOut,
 }) => {
   //  Refresh data on retrieving item or itembatch records from sync.
   useSyncListener(refreshData, ['Item', 'ItemBatch']);
 
   const refundCallback = React.useCallback(() => itemId => refund(itemId), []);
+
+  console.log(data.length);
+  console.log(searchTerm);
 
   const renderRow = useCallback(
     listItem => {
@@ -83,17 +89,33 @@ export const Stock = ({
     />
   );
 
-  const { pageTopSectionContainer } = globalStyles;
+  const toggles = useMemo(
+    () => [{ text: buttonStrings.hide_stockouts, onPress: toggleStockOut, isOn: !showAll }],
+    [showAll]
+  );
+
+  console.log(showAll);
+
+  const {
+    pageTopSectionContainer,
+    pageTopRightSectionContainer,
+    pageTopLeftSectionContainer,
+  } = globalStyles;
   return (
     <DataTablePageView captureUncaughtGestures={false}>
       <View style={pageTopSectionContainer}>
-        <SearchBar
-          onChangeText={onFilterData}
-          value={searchTerm}
-          onFocusOrBlur={selectedRow && onDeselectRow}
-          // eslint-disable-next-line max-len
-          placeholder={`${generalStrings.search_by} ${generalStrings.code} ${generalStrings.or} ${generalStrings.name}`}
-        />
+        <View style={pageTopLeftSectionContainer}>
+          <SearchBar
+            onChangeText={onFilterData}
+            value={searchTerm}
+            onFocusOrBlur={selectedRow && onDeselectRow}
+            // eslint-disable-next-line max-len
+            placeholder={`${generalStrings.search_by} ${generalStrings.code} ${generalStrings.or} ${generalStrings.name}`}
+          />
+        </View>
+        <View style={pageTopRightSectionContainer}>
+          <ToggleBar toggles={toggles} />
+        </View>
       </View>
 
       <DataTable
@@ -113,6 +135,7 @@ const mapDispatchToProps = dispatch => ({
   ...getPageDispatchers(dispatch, '', 'stock'),
   onSelectRow: rowKey => dispatch(RowDetailActions.openItemDetail(rowKey)),
   refund: rowKey => dispatch(SupplierCreditActions.createFromItem(rowKey)),
+  onFilterData: value => dispatch(PageActions.filterDataWithZeroStockToggle(value, ROUTES.STOCK)),
 });
 
 const mapStateToProps = state => {
@@ -126,6 +149,7 @@ export const StockPage = connect(mapStateToProps, mapDispatchToProps)(Stock);
 
 Stock.defaultProps = {
   selectedRow: null,
+  showAll: true,
 };
 
 Stock.propTypes = {
@@ -143,4 +167,6 @@ Stock.propTypes = {
   onFilterData: PropTypes.func.isRequired,
   onSortColumn: PropTypes.func.isRequired,
   refund: PropTypes.func.isRequired,
+  showAll: PropTypes.bool,
+  toggleStockOut: PropTypes.func.isRequired,
 };

--- a/src/pages/StockPage.js
+++ b/src/pages/StockPage.js
@@ -58,9 +58,6 @@ export const Stock = ({
 
   const refundCallback = React.useCallback(() => itemId => refund(itemId), []);
 
-  console.log(data.length);
-  console.log(searchTerm);
-
   const renderRow = useCallback(
     listItem => {
       const { item, index } = listItem;
@@ -90,11 +87,9 @@ export const Stock = ({
   );
 
   const toggles = useMemo(
-    () => [{ text: buttonStrings.hide_stockouts, onPress: toggleStockOut, isOn: !showAll }],
+    () => [{ text: buttonStrings.hide_zero_stocks, onPress: toggleStockOut, isOn: !showAll }],
     [showAll]
   );
-
-  console.log(showAll);
 
   const {
     pageTopSectionContainer,

--- a/src/pages/dataTableUtilities/actions/constants.js
+++ b/src/pages/dataTableUtilities/actions/constants.js
@@ -21,6 +21,7 @@ export const ACTIONS = {
   FILTER_DATA_WITH_FINALISED_TOGGLE: 'filterDataWithFinalisedToggle',
   FILTER_DATA_WITH_OVER_STOCK_TOGGLE: 'filterDataWithOverStockToggle',
   TOGGLE_COLUMN_SET: 'toggleColumnSet',
+  FILTER_DATA_WITH_ZERO_STOCK_TOGGLE: 'filterDataWithZeroStockToggle',
 
   // pageAction constants
   OPEN_MODAL: 'openModal',

--- a/src/pages/dataTableUtilities/actions/tableActions.js
+++ b/src/pages/dataTableUtilities/actions/tableActions.js
@@ -305,6 +305,11 @@ export const filterDataWithOverStockToggle = (searchTerm, route) => ({
   payload: { searchTerm, route },
 });
 
+export const filterDataWithZeroStockToggle = (searchTerm, route) => ({
+  type: ACTIONS.FILTER_DATA_WITH_ZERO_STOCK_TOGGLE,
+  payload: { searchTerm, route },
+});
+
 export const TableActionsLookup = {
   sortData,
   filterData,
@@ -331,4 +336,5 @@ export const TableActionsLookup = {
   filterDataWithFinalisedToggle,
   filterDataWithOverStockToggle,
   toggleColumnSet,
+  filterDataWithZeroStockToggle,
 };

--- a/src/pages/dataTableUtilities/getPageInitialiser.js
+++ b/src/pages/dataTableUtilities/getPageInitialiser.js
@@ -185,6 +185,7 @@ const stockInitialiser = () => {
     filterDataKeys: ['name', 'code'],
     sortKey: 'name',
     isAscending: true,
+    showAll: true,
     selectedRow: null,
     route: ROUTES.STOCK,
     columns: getColumns(ROUTES.STOCK),

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -263,13 +263,11 @@ export const hideOverStocked = state => {
  * Filters by backingData elements `hasStock` field.
  */
 export const toggleStockOut = state => {
-  const { backingData, showAll } = state;
+  const { backingData } = state;
 
-  const newToggleState = !showAll;
+  const newData = backingData.filter(item => item.hasStock);
 
-  const newData = newToggleState ? backingData.slice() : backingData.filter(item => item.hasStock);
-
-  return { ...state, data: newData, showAll: newToggleState, searchTerm: '' };
+  return { ...state, data: newData, showAll: false, searchTerm: '' };
 };
 
 /**

--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -137,6 +137,33 @@ export const filterDataWithOverStockToggle = (state, action) => {
 };
 
 /**
+ * Filters the backingData with REALM - first applying show/hide zero stock filtering
+ * toggle. Sorting is held stable.
+ *
+ */
+export const filterDataWithZeroStockToggle = (state, action) => {
+  const { backingData, filterDataKeys, sortKey, isAscending, showAll } = state;
+  const { payload } = action;
+  const { searchTerm } = payload;
+
+  // Apply query filtering
+  const queryString = filterDataKeys.map(filterTerm => `${filterTerm} CONTAINS[c] $0`).join(' OR ');
+  const queryFilteredData = backingData.filtered(queryString, searchTerm.trim()).slice();
+
+  // Filter by toggle status - showing or not showing zero stocked records.
+  const stockFilteredData = !showAll
+    ? queryFilteredData.slice().filter(item => item.hasStock)
+    : queryFilteredData.slice();
+
+  // Sort the data by the current sorting parameters.
+  const sortedData = sortKey
+    ? sortDataBy(stockFilteredData, sortKey, isAscending)
+    : stockFilteredData;
+
+  return { ...state, data: sortedData, searchTerm };
+};
+
+/**
  * Simply refresh's the data object in state to correctly match the
  * backingData. Used for when side effects such as finalizing manipulate
  * the state of a page from outside the reducer.
@@ -232,7 +259,6 @@ export const hideOverStocked = state => {
 
   return { ...state, data: newData, showAll: false };
 };
-
 /**
  * Filters by backingData elements `hasStock` field.
  */
@@ -285,4 +311,5 @@ export const TableReducerLookup = {
   filterDataWithFinalisedToggle,
   filterDataWithOverStockToggle,
   toggleColumnSet,
+  filterDataWithZeroStockToggle,
 };

--- a/src/reducers/PatientReducer.js
+++ b/src/reducers/PatientReducer.js
@@ -107,7 +107,20 @@ export const PatientReducer = (state = patientInitialState(), action) => {
       return { ...state, currentPatient: null, creatingADR: false };
     }
 
-    case PATIENT_ACTIONS.PATIENT_DELETE:
+    case PATIENT_ACTIONS.PATIENT_DELETE: {
+      const { payload } = action;
+      const { patient } = payload;
+
+      return {
+        ...state,
+        isADRModalOpen: false,
+        currentPatient: patient,
+        creatingADR: false,
+        viewingHistory: false,
+        isEditing: false,
+        isCreating: false,
+      };
+    }
     case PATIENT_ACTIONS.REFRESH: {
       return { ...patientInitialState() };
     }

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -34,6 +34,7 @@ const TYPES = {
   STRING: 'string',
   DATE: 'date',
   NUMBER: 'number',
+  BOOLEAN: 'boolean',
 };
 
 const PARAMETERS = {
@@ -45,6 +46,7 @@ const PARAMETERS = {
   registrationCode: { key: 'code', type: TYPES.STRING },
   limit: { key: 'limit', type: TYPES.NUMBER },
   offset: { key: 'offset', type: TYPES.NUMBER },
+  isDeleted: { key: 'is_deleted', type: TYPES.BOOLEAN },
 };
 
 class BugsnagError extends Error {
@@ -83,12 +85,15 @@ export const createPolicyRecord = policy => {
 const getQueryString = params => {
   const query = params.reduce((queryObject, param) => {
     const [[key, value], [, type]] = Object.entries(param);
-    if (!value) return queryObject;
+
+    // We still want to allow false to pass through
+    if (value === '' || value === null || value === undefined) return queryObject;
 
     const formatter = {
       [TYPES.STRING]: string => `@${string}@`,
       [TYPES.DATE]: date => moment(date).format('DDMMYYYY'),
       [TYPES.NUMBER]: number => Number(number),
+      [TYPES.BOOLEAN]: boolean => Boolean(boolean),
     };
 
     return { ...queryObject, [key]: formatter[type](value) };
@@ -111,6 +116,7 @@ const getPatientQueryString = ({
   barcode = '',
   dateOfBirth = '',
   policyNumber = '',
+  isDeleted = false,
   limit = null,
   offset = null,
 } = {}) => {
@@ -118,11 +124,13 @@ const getPatientQueryString = ({
     { [PARAMETERS.firstName.key]: firstName, type: PARAMETERS.firstName.type },
     { [PARAMETERS.lastName.key]: lastName, type: PARAMETERS.lastName.type },
     { [PARAMETERS.barcode.key]: barcode, type: PARAMETERS.barcode.type },
+    { [PARAMETERS.isDeleted.key]: isDeleted, type: PARAMETERS.isDeleted.type },
     { [PARAMETERS.dateOfBirth.key]: dateOfBirth, type: PARAMETERS.dateOfBirth.type },
     { [PARAMETERS.policyNumber.key]: policyNumber, type: PARAMETERS.policyNumber.type },
     { [PARAMETERS.offset.key]: offset, type: PARAMETERS.offset.type },
     { [PARAMETERS.limit.key]: limit, type: PARAMETERS.limit.type },
   ];
+
   return getQueryString(queryParams);
 };
 

--- a/src/widgets/SimpleTable.js
+++ b/src/widgets/SimpleTable.js
@@ -3,7 +3,7 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import * as Animatable from 'react-native-animatable';
-import { FlatList, TouchableOpacity } from 'react-native';
+import { FlatList, TouchableOpacity, View, Text } from 'react-native';
 import Cell from './DataTable/Cell';
 import { dataTableStyles, GREY } from '../globalStyles/index';
 import { HeaderCell, HeaderRow, TouchableNoFeedback } from './DataTable/index';
@@ -38,8 +38,10 @@ export const SimpleTable = React.memo(
         alternateRow: alternateRowStyle,
         row: basicRowStyle,
         headerRow,
+        emptyRow,
         headerCells,
       } = dataTableStyles;
+
       const renderCells = useCallback(
         rowData => {
           const { id } = rowData;
@@ -91,6 +93,15 @@ export const SimpleTable = React.memo(
         [selectedRows, disabledRows, selectRow, isDisabled]
       );
 
+      const renderEmpty = useCallback(
+        () => (
+          <View style={emptyRow}>
+            <Text style={{ textAlign: 'center' }}>{generalStrings.no_records}</Text>
+          </View>
+        ),
+        []
+      );
+
       const renderHeaderCells = useCallback(
         () =>
           columns.map(({ title, width, alignText }, index) => (
@@ -120,6 +131,7 @@ export const SimpleTable = React.memo(
           renderItem={renderRow}
           stickyHeaderIndices={[0]}
           ListHeaderComponent={renderHeaders}
+          ListEmptyComponent={renderEmpty}
           extraData={selectedRows}
           style={style}
           {...flatListProps}
@@ -135,10 +147,11 @@ SimpleTable.defaultProps = {
   selectRow: null,
   isDisabled: false,
   style: null,
+  data: null,
 };
 
 SimpleTable.propTypes = {
-  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
+  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   columns: PropTypes.array.isRequired,
   selectRow: PropTypes.func,
   selectedRows: PropTypes.object,

--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -118,9 +118,10 @@ const VaccineSelectComponent = ({
     }, 2000);
   }, []);
 
-  const confirmPrescription = React.useCallback(() => runWithLoadingIndicator(onConfirm), [
-    onConfirm,
-  ]);
+  const confirmPrescription = React.useCallback(() => {
+    runWithLoadingIndicator(onConfirm);
+    setOkConfirmButtonEnabled(false);
+  }, [onConfirm]);
 
   const confirmAndRepeatPrescription = React.useCallback(
     () => runWithLoadingIndicator(okAndRepeat),

--- a/src/widgets/modalChildren/MultiSelectList.js
+++ b/src/widgets/modalChildren/MultiSelectList.js
@@ -135,5 +135,5 @@ const localStyles = StyleSheet.create({
   buttonContainer: { alignItems: 'flex-end' },
   resultList: { marginHorizontal: 5, backgroundColor: 'white' },
   confirmButton: { ...globalStyles.button, backgroundColor: SUSSOL_ORANGE, height: 50 },
-  confirmButtonText: { color: 'white', fontSize: 20, fontFamily: APP_FONT_FAMILY },
+  confirmButtonText: { color: 'white', fontSize: 20, fontFamily: APP_FONT_FAMILY, paddingTop: 5 },
 });

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -171,8 +171,12 @@ const mapDispatchToProps = dispatch => ({
   selectPatient: async patient => {
     const localPatient = UIDatabase.get('Name', patient.id);
 
-    if (localPatient.isDeleted) {
-      ToastAndroid.show(dispensingStrings.patient_already_deleted, ToastAndroid.LONG);
+    if (localPatient) {
+      const toastMessage = localPatient.isDeleted
+        ? dispensingStrings.patient_already_deleted
+        : dispensingStrings.patient_already_exists;
+
+      ToastAndroid.show(toastMessage, ToastAndroid.LONG);
       return;
     }
 

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -28,7 +28,7 @@ import { PrescriberActions } from '../../actions/PrescriberActions';
 import { getColumns } from '../../pages/dataTableUtilities';
 import { SimpleTable } from '../SimpleTable';
 
-import { modalStrings, generalStrings } from '../../localization';
+import { modalStrings, generalStrings, dispensingStrings } from '../../localization';
 
 import { APP_FONT_FAMILY, DARK_GREY, ROW_BLUE, WHITE, SUSSOL_ORANGE } from '../../globalStyles';
 
@@ -169,6 +169,13 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => ({
   close: () => dispatch(DispensaryActions.closeLookupModal()),
   selectPatient: async patient => {
+    const localPatient = UIDatabase.get('Name', patient.id);
+
+    if (localPatient.isDeleted) {
+      ToastAndroid.show(dispensingStrings.patient_already_deleted, ToastAndroid.LONG);
+      return;
+    }
+
     const result = await PatientActions.makePatientVisibility(patient);
 
     if (result) {


### PR DESCRIPTION
Fixes #4647 

## Change summary

Added a toggle on `Current stock` having label `Hide zero stocks`

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to `Current stock` menu
- [ ] By defaults it shows all items having some stock and zero stock, also the `Hide zero stocks` toggle button should not be highlighted which means it showing all items with and without(zero) stocks.
- [ ] If we click the `Hide zero stocks` toggle button, it should be highlighted and hide items having zero stock.
- [ ] In another click it should not be highlighted (remains as initial state) and displays all items.
- [ ] Try sorting, searching, filtering, which must comply the state of `Hide zero stocks` toggle button.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
