### PR TITLE
#4847 Fixed chopping of label Done

### DIFF
--- a/src/widgets/modalChildren/MultiSelectList.js
+++ b/src/widgets/modalChildren/MultiSelectList.js
@@ -135,5 +135,5 @@ const localStyles = StyleSheet.create({
   buttonContainer: { alignItems: 'flex-end' },
   resultList: { marginHorizontal: 5, backgroundColor: 'white' },
   confirmButton: { ...globalStyles.button, backgroundColor: SUSSOL_ORANGE, height: 50 },
-  confirmButtonText: { color: 'white', fontSize: 20, fontFamily: APP_FONT_FAMILY },
+  confirmButtonText: { color: 'white', fontSize: 20, fontFamily: APP_FONT_FAMILY, paddingTop: 5 },
 });


### PR DESCRIPTION
 Fixed chopping of label `Done` in model window

Fixes #4847 

## Change summary

On modal window, the confirm button is `Done` which should be visible accurately without any chopping of text.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Customer invoice > Add master list items > Done button should be visible without chopping.
- [ ] Go to Supplier requisition > Add master list items > Done button should be visible without chopping.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
