### PR TITLE
#4871 App hangs/keeps on loading forever when OK button is clicked multiple times while entering a vaccination event 

### DIFF
--- a/src/widgets/Tabs/VaccineSelect.js
+++ b/src/widgets/Tabs/VaccineSelect.js
@@ -118,9 +118,10 @@ const VaccineSelectComponent = ({
     }, 2000);
   }, []);
 
-  const confirmPrescription = React.useCallback(() => runWithLoadingIndicator(onConfirm), [
-    onConfirm,
-  ]);
+  const confirmPrescription = React.useCallback(() => {
+    runWithLoadingIndicator(onConfirm);
+    setOkConfirmButtonEnabled(false);
+  }, [onConfirm]);
 
   const confirmAndRepeatPrescription = React.useCallback(
     () => runWithLoadingIndicator(okAndRepeat),


### PR DESCRIPTION
Fixes #4871

## Change summary

disabled the "Confirm" button after clicking.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Vaccination
- [ ] Select patient and enter details
- [ ] Choose vaccine and prescriber
- [ ] Click `Confirm` button multiple times 
- [ ] See no error
- [ ] Check that vaccination event was saved.

### Related areas to think about

- [ ] If something goes wrong while trying to confirm the vaccination, it might just leave the button disabled. I'm not sure though what can go wrong.