### PR TITLE
#4842 Fix Deleted patients again shows up

### DIFF
--- a/src/actions/PatientActions.js
+++ b/src/actions/PatientActions.js
@@ -46,7 +46,7 @@ const patientDelete = () => (dispatch, getState) => {
 
   ToastAndroid.show(dispensingStrings.patient_deleted, ToastAndroid.LONG);
   dispatch(closeModal());
-  return { type: PATIENT_ACTIONS.PATIENT_DELETE };
+  return { type: PATIENT_ACTIONS.PATIENT_DELETE, payload: { patient } };
 };
 
 const patientUpdate = patientDetails => async (dispatch, getState) => {

--- a/src/globalStyles/dataTableStyles.js
+++ b/src/globalStyles/dataTableStyles.js
@@ -188,6 +188,13 @@ export const dataTableStyles = {
     backgroundColor: 'white',
     flexDirection: 'row',
   },
+  emptyRow: {
+    backgroundColor: 'white',
+    height: 250,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   headerCells: {
     left: {
       height: 40,

--- a/src/hooks/useLocalAndRemotePatients.js
+++ b/src/hooks/useLocalAndRemotePatients.js
@@ -151,7 +151,7 @@ export const useLocalAndRemotePatients = (initialValue = []) => {
     if (!response || noMore) return;
 
     dispatch({ type: 'getting_more_patients' });
-    const paramsWithLimits = { ...searchParams, limit, offset };
+    const paramsWithLimits = { ...searchParams, limit, offset, isDeleted: false };
 
     // Use RNFetch as the fetch returned from `useFetch` is coupled with it's state in a specific
     // implementation, which we want to change by appending to the result, rather than replacing.

--- a/src/localization/dispensingStrings.json
+++ b/src/localization/dispensingStrings.json
@@ -72,7 +72,8 @@
     "edit_supplemental_data": "Edit additional details",
     "refused_vaccine": "Refused vaccine",
     "validation_failed": "Some required fields are not completed.",
-    "patient_deleted": "Patient successfully deleted"
+    "patient_deleted": "Patient successfully deleted",
+    "patient_already_deleted": "'The patient has already been deleted. You cannot sync this patient back."
   },
   "fr": {
     "vaccination_history": "Historique de vaccination pour",

--- a/src/localization/generalStrings.json
+++ b/src/localization/generalStrings.json
@@ -99,7 +99,8 @@
     "no_locations": "You don't have any locations to assign! Contact your administrator.",
     "no_options": "No options available. Please contact your administrator!",
     "no_vvm_status": "No vaccine vial monitor statuses available. Please contact your administrator!",
-    "no_reasons": "No requisition line variance reasons available. Please contact your administrator!"
+    "no_reasons": "No requisition line variance reasons available. Please contact your administrator!",
+    "no_records": "No record(s) found."
   },
   "fr": {
     "oh_no": "Oh non!",

--- a/src/reducers/PatientReducer.js
+++ b/src/reducers/PatientReducer.js
@@ -107,7 +107,20 @@ export const PatientReducer = (state = patientInitialState(), action) => {
       return { ...state, currentPatient: null, creatingADR: false };
     }
 
-    case PATIENT_ACTIONS.PATIENT_DELETE:
+    case PATIENT_ACTIONS.PATIENT_DELETE: {
+      const { payload } = action;
+      const { patient } = payload;
+
+      return {
+        ...state,
+        isADRModalOpen: false,
+        currentPatient: patient,
+        creatingADR: false,
+        viewingHistory: false,
+        isEditing: false,
+        isCreating: false,
+      };
+    }
     case PATIENT_ACTIONS.REFRESH: {
       return { ...patientInitialState() };
     }

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -131,8 +131,6 @@ const getPatientQueryString = ({
     { [PARAMETERS.limit.key]: limit, type: PARAMETERS.limit.type },
   ];
 
-  console.log('queryParams', queryParams);
-
   return getQueryString(queryParams);
 };
 

--- a/src/sync/lookupApiUtils.js
+++ b/src/sync/lookupApiUtils.js
@@ -34,6 +34,7 @@ const TYPES = {
   STRING: 'string',
   DATE: 'date',
   NUMBER: 'number',
+  BOOLEAN: 'boolean',
 };
 
 const PARAMETERS = {
@@ -45,6 +46,7 @@ const PARAMETERS = {
   registrationCode: { key: 'code', type: TYPES.STRING },
   limit: { key: 'limit', type: TYPES.NUMBER },
   offset: { key: 'offset', type: TYPES.NUMBER },
+  isDeleted: { key: 'is_deleted', type: TYPES.BOOLEAN },
 };
 
 class BugsnagError extends Error {
@@ -83,12 +85,15 @@ export const createPolicyRecord = policy => {
 const getQueryString = params => {
   const query = params.reduce((queryObject, param) => {
     const [[key, value], [, type]] = Object.entries(param);
-    if (!value) return queryObject;
+
+    // We still want to allow false to pass through
+    if (value === '' || value === null || value === undefined) return queryObject;
 
     const formatter = {
       [TYPES.STRING]: string => `@${string}@`,
       [TYPES.DATE]: date => moment(date).format('DDMMYYYY'),
       [TYPES.NUMBER]: number => Number(number),
+      [TYPES.BOOLEAN]: boolean => Boolean(boolean),
     };
 
     return { ...queryObject, [key]: formatter[type](value) };
@@ -111,6 +116,7 @@ const getPatientQueryString = ({
   barcode = '',
   dateOfBirth = '',
   policyNumber = '',
+  isDeleted = false,
   limit = null,
   offset = null,
 } = {}) => {
@@ -118,11 +124,15 @@ const getPatientQueryString = ({
     { [PARAMETERS.firstName.key]: firstName, type: PARAMETERS.firstName.type },
     { [PARAMETERS.lastName.key]: lastName, type: PARAMETERS.lastName.type },
     { [PARAMETERS.barcode.key]: barcode, type: PARAMETERS.barcode.type },
+    { [PARAMETERS.isDeleted.key]: isDeleted, type: PARAMETERS.isDeleted.type },
     { [PARAMETERS.dateOfBirth.key]: dateOfBirth, type: PARAMETERS.dateOfBirth.type },
     { [PARAMETERS.policyNumber.key]: policyNumber, type: PARAMETERS.policyNumber.type },
     { [PARAMETERS.offset.key]: offset, type: PARAMETERS.offset.type },
     { [PARAMETERS.limit.key]: limit, type: PARAMETERS.limit.type },
   ];
+
+  console.log('queryParams', queryParams);
+
   return getQueryString(queryParams);
 };
 

--- a/src/widgets/SimpleTable.js
+++ b/src/widgets/SimpleTable.js
@@ -3,7 +3,7 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import * as Animatable from 'react-native-animatable';
-import { FlatList, TouchableOpacity } from 'react-native';
+import { FlatList, TouchableOpacity, View, Text } from 'react-native';
 import Cell from './DataTable/Cell';
 import { dataTableStyles, GREY } from '../globalStyles/index';
 import { HeaderCell, HeaderRow, TouchableNoFeedback } from './DataTable/index';
@@ -38,8 +38,10 @@ export const SimpleTable = React.memo(
         alternateRow: alternateRowStyle,
         row: basicRowStyle,
         headerRow,
+        emptyRow,
         headerCells,
       } = dataTableStyles;
+
       const renderCells = useCallback(
         rowData => {
           const { id } = rowData;
@@ -91,6 +93,15 @@ export const SimpleTable = React.memo(
         [selectedRows, disabledRows, selectRow, isDisabled]
       );
 
+      const renderEmpty = useCallback(
+        () => (
+          <View style={emptyRow}>
+            <Text style={{ textAlign: 'center' }}>{generalStrings.no_records}</Text>
+          </View>
+        ),
+        []
+      );
+
       const renderHeaderCells = useCallback(
         () =>
           columns.map(({ title, width, alignText }, index) => (
@@ -120,6 +131,7 @@ export const SimpleTable = React.memo(
           renderItem={renderRow}
           stickyHeaderIndices={[0]}
           ListHeaderComponent={renderHeaders}
+          ListEmptyComponent={renderEmpty}
           extraData={selectedRows}
           style={style}
           {...flatListProps}
@@ -135,10 +147,11 @@ SimpleTable.defaultProps = {
   selectRow: null,
   isDisabled: false,
   style: null,
+  data: null,
 };
 
 SimpleTable.propTypes = {
-  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
+  data: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   columns: PropTypes.array.isRequired,
   selectRow: PropTypes.func,
   selectedRows: PropTypes.object,

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -169,6 +169,16 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => ({
   close: () => dispatch(DispensaryActions.closeLookupModal()),
   selectPatient: async patient => {
+    const localPatient = UIDatabase.get('Name', patient.id);
+
+    if (localPatient.isDeleted) {
+      ToastAndroid.show(
+        'The patient has been deleted. You cannot sync this patient back.',
+        ToastAndroid.LONG
+      );
+      return;
+    }
+
     const result = await PatientActions.makePatientVisibility(patient);
 
     if (result) {

--- a/src/widgets/modals/SearchForm.js
+++ b/src/widgets/modals/SearchForm.js
@@ -28,7 +28,7 @@ import { PrescriberActions } from '../../actions/PrescriberActions';
 import { getColumns } from '../../pages/dataTableUtilities';
 import { SimpleTable } from '../SimpleTable';
 
-import { modalStrings, generalStrings } from '../../localization';
+import { modalStrings, generalStrings, dispensingStrings } from '../../localization';
 
 import { APP_FONT_FAMILY, DARK_GREY, ROW_BLUE, WHITE, SUSSOL_ORANGE } from '../../globalStyles';
 
@@ -172,10 +172,7 @@ const mapDispatchToProps = dispatch => ({
     const localPatient = UIDatabase.get('Name', patient.id);
 
     if (localPatient.isDeleted) {
-      ToastAndroid.show(
-        'The patient has been deleted. You cannot sync this patient back.',
-        ToastAndroid.LONG
-      );
+      ToastAndroid.show(dispensingStrings.patient_already_deleted, ToastAndroid.LONG);
       return;
     }
 


### PR DESCRIPTION
Fixes #4842

## Change summary

Explain and justify your changes

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create or use a patient that has already been synced to server (the patient has to be created in the same tablet's store).
- [ ] Now delete the patient
- [ ] Before it syncs back, do a patient lookup search, see the patient in the list as pre-sync on server the patient is still not deleted yet.
- [ ] Select the patient. Should see an toast message saying "The patient has been deleted. You cannot sync this patient back." or some variant of it. 
- [ ] Go to the patient list, the patient still should not be there.
- [ ] Now sync the patient to the server or wait for it to sync.
- [ ] Now repeat the steps mentioned above again, 
  - [ ] if PR to the issue https://github.com/sussol/msupply/issues/11303 has been merged, you won't see the patient at all as in server it has been soft deleted
  - [ ] If the PR to the issue has not been merged you would see a message saying "The patient has been deleted. You cannot sync this patient back.".
- [ ] Go to the patient list, the patient still should not be there.

### Related areas to think about

Adds two xliffs

- "no_records": "No record(s) found."
- "patient_already_deleted": "'The patient has already been deleted. You cannot sync this patient back."
