### PR TITLE
#4887 New patient button should only go to tab 2 in Vaccine dispensing

### DIFF
--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -384,7 +384,7 @@ const mapDispatchToProps = dispatch => {
       const patient = createDefaultName('patient', id);
       dispatch(NameActions.create(patient));
       dispatch(NameNoteActions.createSurveyNameNote(patient));
-      dispatch(WizardActions.nextTab());
+      dispatch(WizardActions.switchTab(1));
     });
   const updateForm = (key, value) => dispatch(FormActions.updateForm(key, value));
 


### PR DESCRIPTION
Fixes #4887

## Change summary

Explain and justify your changes

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Vaccination.
- [ ] Tap New Patient` button multiple times. It should only go to Tab 2 and should not let you go further without validation.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
