### PR TITLE
#4894 fixed toggle failure of current stock and stocktake

### DIFF
--- a/src/pages/dataTableUtilities/reducer/tableReducers.js
+++ b/src/pages/dataTableUtilities/reducer/tableReducers.js
@@ -263,11 +263,12 @@ export const hideOverStocked = state => {
  * Filters by backingData elements `hasStock` field.
  */
 export const toggleStockOut = state => {
-  const { backingData } = state;
+  const { backingData, showAll } = state;
+  const newToggleState = !showAll;
 
-  const newData = backingData.filter(item => item.hasStock);
+  const newData = newToggleState ? backingData.slice() : backingData.filter(item => item.hasStock);
 
-  return { ...state, data: newData, showAll: false, searchTerm: '' };
+  return { ...state, data: newData, showAll: newToggleState, searchTerm: '' };
 };
 
 /**


### PR DESCRIPTION
Fixed toggle failure on Current stock and Stocktake by undo the code changes on `toggleStockOut` reducer function

Fixes #4894 

## Change summary

Just undo the refactored code changes on `toggleStockOut` reducer function

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to current stock
- [ ] Click on `Hide zero stock` toggle to hide/show items with zero stocks
- [ ] Similarly, go to Stocktake
- [ ] View/Create new stocktake and click `Hide stockouts` toggle to hide/show items with zero stocks
- [ ] In first click the toggle should be highlighted then hide zero stocks items, and vice-versa.
    
### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
