### PR TITLE
#4913 Vax event creation and editing should not trigger patient update if the current store is not patient's home store

### DIFF
--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -11,7 +11,7 @@ import {
   selectSelectedSupplementalData,
   selectSelectedVaccinator,
 } from '../../selectors/Entities/vaccinePrescription';
-import { selectEditingNameId } from '../../selectors/Entities/name';
+import { selectEditingNameId, selectEditingName } from '../../selectors/Entities/name';
 import { NameActions } from './NameActions';
 import { NameNoteActions } from './NameNoteActions';
 import { goBack, gotoVaccineDispensingPage } from '../../navigation/actions';
@@ -230,6 +230,7 @@ const getPcdNameNoteID = patientId => {
     .sorted('entryDate', true);
   return patientNameNotes.length > 0 ? patientNameNotes[0].id : '';
 };
+
 const createSupplementaryData = () => (dispatch, getState) => {
   // Create a supplementaryData object which is seeded with the data that was last
   // entered against a prescription
@@ -281,7 +282,14 @@ const confirm = () => (dispatch, getState) => {
     });
   }
   batch(() => {
-    dispatch(NameActions.saveEditing());
+    const { isEditable = true } = selectEditingName(getState());
+
+    // We are already not allowing patient update for patient that do not belong
+    // to the current store. This check will stop unnecessary updates.
+    if (isEditable) {
+      dispatch(NameActions.saveEditing());
+    }
+
     dispatch(NameNoteActions.saveEditing());
     dispatch(reset());
   });


### PR DESCRIPTION
Fixes #4913

## Change summary

Steps to reproduce the behaviour:

1. This may not be reproducible easily as our code is stopping the editing of patient detail section of vaccination event through UI restriction. But we know the unnecessary sync queue happens.
3. So to test this condition do this:
    1. Use two tablets
    2. In tablet 1 create a patient and its vaccine event. Sync it.
    3. In tablet 2 pull the changes.
    4. In tablet 1 again edit the patient details, dob or something and sync it too.
    5. In tablet 2 without syncing in the step `iv` updates, create a vaccine event. Since the patient is from Tablet 1 you would not be allowed to edit the patient so you have made no changes to the patient details but since you have not synced tablet 1 changes from step `iv` you would still see the old dob which is ok.
    6. Now sync your changes.
    7. Go to tablet 1 pull the latest sync changes.
    8. Go to the patient's detail, the changes you had made in step `iv` are gone. The changes in step `v` have overridden your step `iv` changes, which should not happen because 
        a. the patient does not belong to tablet 2 and hence should be editable from tablet 2
        b. You have not made any changes to patient detail so no patient update sync should have happened. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Use two tablets
- [ ] In tablet 1 create a patient and its vaccine event. Sync it.
- [ ] In tablet 2 pull the changes.
- [ ] Step X: In tablet 1 again edit the patient details, dob or something and sync it too.
- [ ] Step Y: In tablet 2 without syncing in the step X updates, create a vaccine event. Since the patient is from Tablet 1 you would not be allowed to edit the patient so you have made no changes to the patient details but since you have not synced tablet 1 changes from step X you would still see the old dob which is ok.
- [ ] Now sync your changes.
- [ ] Go to tablet 1 pull the latest sync changes.
- [ ] Go to the patient's detail, the changes you had made in step X should not be gone. They should still show. 
- [ ] The changes in step Y should not override step X changes.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
