### PR TITLE
#4909 Subpage 2 Additional details' changes are overridden by Subpage 3 Vax Event changes

### DIFF
--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -159,10 +159,10 @@ export const VaccinationEventComponent = ({
 
   useEffect(() => {
     if (customDataObject) {
-      setSupplementalData({
+      setSupplementalData(prevState => ({
+        ...prevState,
         updatedSupplementalDataForm: customDataObject,
-        isSupplementalDataValid: true,
-      });
+      }));
       setLoading(false);
     }
   }, [customDataObject]);
@@ -209,7 +209,7 @@ export const VaccinationEventComponent = ({
         transactionBatch,
         vaccine,
         vaccinator,
-        customDataObject,
+        updatedSupplementalDataForm,
         vaccinationEventNameNote
       );
       toggleEditTransaction();
@@ -219,7 +219,14 @@ export const VaccinationEventComponent = ({
       });
       ToastAndroid.show(vaccineStrings.vaccination_not_updated, ToastAndroid.LONG);
     }
-  }, [patient, transactionBatch, vaccine, vaccinator, customDataObject, vaccinationEventNameNote]);
+  }, [
+    patient,
+    transactionBatch,
+    vaccine,
+    vaccinator,
+    updatedSupplementalDataForm,
+    vaccinationEventNameNote,
+  ]);
 
   const tryDelete = useCallback(() => {
     deleteVaccinationEvent(patient, transactionBatch, vaccinationEventNameNote);
@@ -269,7 +276,7 @@ export const VaccinationEventComponent = ({
         </FlexRow>
         <FlexRow flex={1}>
           <View style={localStyles.formContainer}>
-            {!!supplementalDataSchema && !!customDataObject ? (
+            {!!supplementalDataSchema && !!updatedSupplementalDataForm ? (
               <Paper
                 // eslint-disable-next-line prettier/prettier
                 Header={(
@@ -285,7 +292,7 @@ export const VaccinationEventComponent = ({
               >
                 <JSONForm
                   ref={supplementalFormRef}
-                  formData={customDataObject}
+                  formData={updatedSupplementalDataForm}
                   surveySchema={supplementalDataSchema}
                   onChange={(changed, validator) => {
                     setSupplementalData({


### PR DESCRIPTION
Fixes #4909

## Change summary

- Previously a variable customDataObject was being set that never changes with form changes.
- In subpage 3 vax event save, subpage 2 additional details are also saved.
- Now subpage 2's save uses the state object updatedSupplementalDataForm which does change with form change.
- We needed to pass in updatedSupplementalDataForm to the subpage 3 save method instead of customDataObject to have this issue fixed.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Select a vax event that belongs to current store so that it would be editable
- [ ] Edit Page 2: Additonal Details data, save it
- [ ] Edit Page 3: Vaccination event data and save it.
- [ ] Now sync the changes
- [ ] Load the vax event again and check, the Page 2 should not have been overridden it should have the latest changes.
- [ ] Page 3's save would auto save Page 2's change so you actually do not need to click Page 2's save button, page 3's click should save them both.
  - [ ] That is not the case for Extra Informaiton, extra information is independent from the next 2 pages (I don't know why the previous dev chose to do it this way, but it is ok, it does not break anything).


### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
