### PR TITLE
#4925 Event details subform save buttons are not behaving consistently 

### DIFF
--- a/src/widgets/JSONForm/widgets/Checkboxes.js
+++ b/src/widgets/JSONForm/widgets/Checkboxes.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import CheckBox from '@react-native-community/checkbox';
 
 import { APP_FONT_FAMILY } from '../../../globalStyles/fonts';
-import { SUSSOL_ORANGE } from '../../../globalStyles/colors';
+import { SUSSOL_ORANGE, WEARY_TARMAC } from '../../../globalStyles/colors';
 import { FlexColumn, FlexRow, FlexView } from '../../index';
 
 const selectValue = (value, selected, all) => {
@@ -41,15 +41,16 @@ export const Checkboxes = ({
   const checkboxes = enumOptions.map(option => {
     const itemDisabled = enumDisabled && enumDisabled.indexOf(option.value) !== -1;
     const checked = checkboxesValue.indexOf(option.value) !== -1;
+    const isDisabled = disabled || itemDisabled || readonly;
 
     return (
       <FlexRow key={`checkbox_row_${option.value}`}>
         <FlexColumn>
           <CheckBox
             value={checked}
-            disabled={disabled || itemDisabled || readonly}
+            disabled={isDisabled}
             onValueChange={_onChange(option)}
-            tintColors={{ true: SUSSOL_ORANGE }}
+            tintColors={{ true: isDisabled ? WEARY_TARMAC : SUSSOL_ORANGE }}
           />
         </FlexColumn>
         <FlexColumn>

--- a/src/widgets/JSONForm/widgets/Select.js
+++ b/src/widgets/JSONForm/widgets/Select.js
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Picker } from '@react-native-community/picker';
 
-import { SUSSOL_ORANGE } from '../../../globalStyles/colors';
+import { SUSSOL_ORANGE, LIGHT_GREY } from '../../../globalStyles/colors';
 
 export const Select = ({
   disabled,
@@ -17,11 +17,21 @@ export const Select = ({
   id,
 }) => {
   let pickers = options.enumOptions.map(({ label, value: enumValue }) => (
-    <Picker.Item key={label} label={label} value={enumValue} color={SUSSOL_ORANGE} />
+    <Picker.Item
+      key={label}
+      label={label}
+      value={enumValue}
+      color={disabled ? LIGHT_GREY : SUSSOL_ORANGE}
+    />
   ));
 
   const placeholderItem = (
-    <Picker.Item key={placeholder} label={placeholder} value={placeholder} color={SUSSOL_ORANGE} />
+    <Picker.Item
+      key={placeholder}
+      label={placeholder}
+      value={placeholder}
+      color={disabled ? LIGHT_GREY : SUSSOL_ORANGE}
+    />
   );
 
   pickers = [placeholderItem, ...pickers];

--- a/src/widgets/JSONForm/widgets/Select.js
+++ b/src/widgets/JSONForm/widgets/Select.js
@@ -41,7 +41,7 @@ export const Select = ({
       const { default: defaultValue } = schema;
       onChange(defaultValue);
     }
-  });
+  }, [value, options, schema, onChange]);
 
   return (
     <Picker

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -22,6 +22,7 @@ import globalStyles, {
   GREY,
   SUSSOL_ORANGE,
   DANGER_RED,
+  WARMER_GREY,
 } from '../../globalStyles';
 import { Spinner } from '..';
 import { buttonStrings, generalStrings, modalStrings, vaccineStrings } from '../../localization';
@@ -384,7 +385,12 @@ export const VaccinationEventComponent = ({
           onPress={() =>
             !isCurrentStoreVaccineEvent ? toggleModal() : savePCDForm(surveyForm, updatedPcdForm)
           }
-          style={localStyles.saveButton}
+          style={[
+            localStyles.saveButton,
+            isDeletedVaccinationEvent || !isCurrentStoreVaccineEvent
+              ? localStyles.saveButtonCantEdit
+              : '',
+          ]}
           textStyle={localStyles.saveButtonTextStyle}
           isDisabled={!isPCDValid || isDeletedVaccinationEvent || !(!!surveySchema && !!surveyForm)}
         />
@@ -395,7 +401,12 @@ export const VaccinationEventComponent = ({
               ? toggleModal()
               : saveSupplementalData(vaccinationEventNameNote, updatedSupplementalDataForm)
           }
-          style={localStyles.saveButton}
+          style={[
+            localStyles.saveButton,
+            isDeletedVaccinationEvent || !isCurrentStoreVaccineEvent
+              ? localStyles.saveButtonCantEdit
+              : '',
+          ]}
           textStyle={localStyles.saveButtonTextStyle}
           isDisabled={
             !isSupplementalDataValid ||
@@ -405,7 +416,12 @@ export const VaccinationEventComponent = ({
         />
         <PageButton
           text={isEditingTransaction ? buttonStrings.save_changes : buttonStrings.edit}
-          style={localStyles.saveButton}
+          style={[
+            localStyles.saveButton,
+            isDeletedVaccinationEvent || !isCurrentStoreVaccineEvent
+              ? localStyles.saveButtonCantEdit
+              : '',
+          ]}
           textStyle={localStyles.saveButtonTextStyle}
           onPress={isEditingTransaction ? trySave : tryEdit}
           isDisabled={isDeletedVaccinationEvent}
@@ -514,6 +530,9 @@ const localStyles = StyleSheet.create({
     flex: 1,
     backgroundColor: SUSSOL_ORANGE,
     alignSelf: 'center',
+  },
+  saveButtonCantEdit: {
+    backgroundColor: WARMER_GREY,
   },
   saveButtonTextStyle: {
     ...globalStyles.buttonText,

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -388,7 +388,7 @@ export const VaccinationEventComponent = ({
           style={[
             localStyles.saveButton,
             isDeletedVaccinationEvent || !isCurrentStoreVaccineEvent
-              ? localStyles.saveButtonCantEdit
+              ? localStyles.saveButtonCannotEdit
               : '',
           ]}
           textStyle={localStyles.saveButtonTextStyle}
@@ -404,7 +404,7 @@ export const VaccinationEventComponent = ({
           style={[
             localStyles.saveButton,
             isDeletedVaccinationEvent || !isCurrentStoreVaccineEvent
-              ? localStyles.saveButtonCantEdit
+              ? localStyles.saveButtonCannotEdit
               : '',
           ]}
           textStyle={localStyles.saveButtonTextStyle}
@@ -419,7 +419,7 @@ export const VaccinationEventComponent = ({
           style={[
             localStyles.saveButton,
             isDeletedVaccinationEvent || !isCurrentStoreVaccineEvent
-              ? localStyles.saveButtonCantEdit
+              ? localStyles.saveButtonCannotEdit
               : '',
           ]}
           textStyle={localStyles.saveButtonTextStyle}
@@ -531,7 +531,7 @@ const localStyles = StyleSheet.create({
     backgroundColor: SUSSOL_ORANGE,
     alignSelf: 'center',
   },
-  saveButtonCantEdit: {
+  saveButtonCannotEdit: {
     backgroundColor: WARMER_GREY,
   },
   saveButtonTextStyle: {

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-curly-newline */
 /* eslint-disable react/forbid-prop-types */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { View, StyleSheet, Text, ToastAndroid } from 'react-native';
+import { View, Text, ToastAndroid } from 'react-native';
 import PropTypes from 'prop-types';
 import { batch, connect } from 'react-redux';
 import { FlexRow } from '../FlexRow';
@@ -246,14 +246,18 @@ export const VaccinationEventComponent = ({
     );
   }
 
+  const isDisabled = isDeletedVaccinationEvent || !isCurrentStoreVaccineEvent;
+
+  const styles = getStyles({ isDisabled });
+
   return (
     <FlexView>
-      <FlexRow flex={1} style={localStyles.formContainer}>
+      <FlexRow flex={1} style={styles.formContainer}>
         <FlexRow flex={1}>
-          <View style={localStyles.formContainer}>
+          <View style={styles.formContainer}>
             {!!surveySchema && !!surveyForm ? (
               <FlexRow flex={1}>
-                <View style={localStyles.formContainer}>
+                <View style={styles.formContainer}>
                   <JSONForm
                     ref={pcdFormRef}
                     formData={surveyForm.data ?? null}
@@ -264,7 +268,7 @@ export const VaccinationEventComponent = ({
                         isPCDValid: validator(changed.formData),
                       });
                     }}
-                    disabled={isDeletedVaccinationEvent || !isCurrentStoreVaccineEvent}
+                    disabled={isDisabled}
                   >
                     <></>
                   </JSONForm>
@@ -276,7 +280,7 @@ export const VaccinationEventComponent = ({
           </View>
         </FlexRow>
         <FlexRow flex={1}>
-          <View style={localStyles.formContainer}>
+          <View style={styles.formContainer}>
             {!!supplementalDataSchema && !!updatedSupplementalDataForm ? (
               <Paper
                 // eslint-disable-next-line prettier/prettier
@@ -289,7 +293,7 @@ export const VaccinationEventComponent = ({
                 )}
                 contentContainerStyle={{ flex: 1 }}
                 style={{ flex: 1 }}
-                headerContainerStyle={localStyles.title}
+                headerContainerStyle={styles.title}
               >
                 <JSONForm
                   ref={supplementalFormRef}
@@ -301,7 +305,7 @@ export const VaccinationEventComponent = ({
                       isSupplementalDataValid: validator(changed.formData),
                     });
                   }}
-                  disabled={isDeletedVaccinationEvent || !isCurrentStoreVaccineEvent}
+                  disabled={isDisabled}
                 >
                   <></>
                 </JSONForm>
@@ -313,14 +317,14 @@ export const VaccinationEventComponent = ({
         </FlexRow>
         {!!vaccinationEventSchema && !!vaccinationEvent && !!parsedVaccinationEvent && (
           <FlexRow flex={1}>
-            <View style={localStyles.formContainer}>
+            <View style={styles.formContainer}>
               <Paper
                 Header={
                   <Title title={vaccineStrings.vaccine_event_transact_data_title} size="large" />
                 }
                 contentContainerStyle={{ flex: 1 }}
                 style={{ flex: 1 }}
-                headerContainerStyle={localStyles.title}
+                headerContainerStyle={styles.title}
               >
                 {!isEditingTransaction ? (
                   <JSONForm
@@ -346,7 +350,7 @@ export const VaccinationEventComponent = ({
                       <Title title={vaccineStrings.vaccines} size="medium" />
                       <DropDown
                         isDisabled={vaccineDropDownValues.length === 0}
-                        style={(localStyles.dropdown, { width: null, flex: 1 })}
+                        style={(styles.dropdown, { width: null, flex: 1 })}
                         values={vaccineDropDownValues.map(item => item.name)}
                         onValueChange={(_, i) => {
                           const selectedVaccine = vaccines.find(
@@ -361,8 +365,8 @@ export const VaccinationEventComponent = ({
                       <PageButton
                         text={buttonStrings.delete_vaccination_event}
                         onPress={toggleDeleteModal}
-                        style={localStyles.deleteButton}
-                        textStyle={localStyles.saveButtonTextStyle}
+                        style={styles.deleteButton}
+                        textStyle={styles.saveButtonTextStyle}
                       />
                     </FlexRow>
                     <FlexRow flex={1} style={{ marginBottom: 10 }}>
@@ -385,13 +389,8 @@ export const VaccinationEventComponent = ({
           onPress={() =>
             !isCurrentStoreVaccineEvent ? toggleModal() : savePCDForm(surveyForm, updatedPcdForm)
           }
-          style={[
-            localStyles.saveButton,
-            isDeletedVaccinationEvent || !isCurrentStoreVaccineEvent
-              ? localStyles.saveButtonCannotEdit
-              : '',
-          ]}
-          textStyle={localStyles.saveButtonTextStyle}
+          style={styles.saveButton}
+          textStyle={styles.saveButtonTextStyle}
           isDisabled={!isPCDValid || isDeletedVaccinationEvent || !(!!surveySchema && !!surveyForm)}
         />
         <PageButton
@@ -401,13 +400,8 @@ export const VaccinationEventComponent = ({
               ? toggleModal()
               : saveSupplementalData(vaccinationEventNameNote, updatedSupplementalDataForm)
           }
-          style={[
-            localStyles.saveButton,
-            isDeletedVaccinationEvent || !isCurrentStoreVaccineEvent
-              ? localStyles.saveButtonCannotEdit
-              : '',
-          ]}
-          textStyle={localStyles.saveButtonTextStyle}
+          style={styles.saveButton}
+          textStyle={styles.saveButtonTextStyle}
           isDisabled={
             !isSupplementalDataValid ||
             isDeletedVaccinationEvent ||
@@ -416,13 +410,8 @@ export const VaccinationEventComponent = ({
         />
         <PageButton
           text={isEditingTransaction ? buttonStrings.save_changes : buttonStrings.edit}
-          style={[
-            localStyles.saveButton,
-            isDeletedVaccinationEvent || !isCurrentStoreVaccineEvent
-              ? localStyles.saveButtonCannotEdit
-              : '',
-          ]}
-          textStyle={localStyles.saveButtonTextStyle}
+          style={styles.saveButton}
+          textStyle={styles.saveButtonTextStyle}
           onPress={isEditingTransaction ? trySave : tryEdit}
           isDisabled={isDeletedVaccinationEvent}
         />
@@ -517,27 +506,13 @@ const mapDispatchToProps = dispatch => {
   return { editTransaction, savePCDForm, saveSupplementalData, deleteVaccinationEvent };
 };
 
-const localStyles = StyleSheet.create({
+const getStyles = context => ({
   dropdown: { height: 35, marginTop: 0, marginBottom: 0, marginLeft: 0 },
   formContainer: {
     flex: 1,
     flexDirection: 'row',
     backgroundColor: 'white',
     alignItems: 'stretch',
-  },
-  saveButton: {
-    ...globalStyles.button,
-    flex: 1,
-    backgroundColor: SUSSOL_ORANGE,
-    alignSelf: 'center',
-  },
-  saveButtonCannotEdit: {
-    backgroundColor: WARMER_GREY,
-  },
-  saveButtonTextStyle: {
-    ...globalStyles.buttonText,
-    color: 'white',
-    fontSize: 14,
   },
   title: {
     textAlignVertical: 'center',
@@ -551,6 +526,20 @@ const localStyles = StyleSheet.create({
     flex: 1,
     backgroundColor: DANGER_RED,
     alignSelf: 'center',
+  },
+  saveButton: [
+    {
+      ...globalStyles.button,
+      flex: 1,
+      backgroundColor: SUSSOL_ORANGE,
+      alignSelf: 'center',
+    },
+    context.isDisabled && { backgroundColor: WARMER_GREY },
+  ],
+  saveButtonTextStyle: {
+    ...globalStyles.buttonText,
+    color: 'white',
+    fontSize: 14,
   },
 });
 


### PR DESCRIPTION
Fixes #4925

## Change summary

Gray out form control and buttons of Vaccination Events detail edit page when the page is not editable.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to vaccination 
- [ ] Select a Patient who has vaccination event you know does not originate for the current store
- [ ] Select the patient and then the vaccination event
- [ ] See the fields are grayed out, including checkbox and dropdowns
- [ ] See the buttons are grayed out too
- [ ] Select a Patient who has vaccination event you know originate for the current store
- [ ] Select the patient and then the vaccination event
- [ ] See the fields are not grayed out and are editable
- [ ] See the buttons are not grayed out and function as they supposed to

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
