### PR TITLE
#4892 Fix dob field issues

### DIFF
--- a/src/widgets/FormInputs/FormDOBInput.js
+++ b/src/widgets/FormInputs/FormDOBInput.js
@@ -132,6 +132,7 @@ const useDobInput = (initialValue, onChangeDate, onValidate) => {
   const onTypeAge = newAge => {
     const asNumber = Number(newAge);
     const isValid = !Number.isNaN(asNumber) && asNumber < 500;
+    onValidate(newAge);
     typedAge(newAge, isValid);
     onChangeDate(moment().subtract(asNumber, 'years').toDate());
   };

--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -61,7 +61,7 @@ export const DatePicker = ({
         isDisabled={readonly || disabled}
         initialValue={
           moment(selectedTextValue, DATE_FORMAT.DD_MM_YYYY, true).isValid()
-            ? moment(selectedTextValue, DATE_FORMAT.DD_MM_YYYY, true)
+            ? moment(selectedTextValue, DATE_FORMAT.DD_MM_YYYY, true).toDate()
             : moment().toDate()
         }
         minimumDate={options.dateRange === 'future' ? new Date() : null}

--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -22,7 +22,7 @@ export const DatePicker = ({
   const { focusController } = useJSONFormOptions();
   const ref = focusController.useRegisteredRef();
 
-  const [selectedDate, setSelectedDate] = useState('');
+  const [selectedTextValue, setSelectedTextValue] = useState('');
 
   const handleChange = dateString => {
     onChange(dateString);
@@ -35,7 +35,9 @@ export const DatePicker = ({
       ? alternateFormatDate
       : moment(value, DATE_FORMAT.DD_MM_YYYY, true);
 
-    setSelectedDate(expectedFormatDate.isValid() ? expectedFormatDate.toDate() : value);
+    setSelectedTextValue(
+      expectedFormatDate.isValid() ? expectedFormatDate.format(DATE_FORMAT.DD_MM_YYYY) : value
+    );
   }, [value]);
 
   return (
@@ -46,11 +48,7 @@ export const DatePicker = ({
         underlineColorAndroid={DARKER_GREY}
         placeholder={placeholder}
         editable={!(readonly || disabled)}
-        value={
-          moment(selectedDate, DATE_FORMAT.DD_MM_YYYY, true).isValid()
-            ? moment(selectedDate).format(DATE_FORMAT.DD_MM_YYYY)
-            : selectedDate
-        }
+        value={selectedTextValue}
         ref={ref}
         onSubmitEditing={() => focusController.next(ref)}
         onChangeText={handleChange}
@@ -61,7 +59,11 @@ export const DatePicker = ({
       />
       <DatePickerButton
         isDisabled={readonly || disabled}
-        initialValue={selectedDate || moment().toDate()}
+        initialValue={
+          moment(selectedTextValue, DATE_FORMAT.DD_MM_YYYY, true).isValid()
+            ? moment(selectedTextValue, DATE_FORMAT.DD_MM_YYYY, true)
+            : moment().toDate()
+        }
         minimumDate={options.dateRange === 'future' ? new Date() : null}
         maximumDate={options.dateRange === 'past' ? new Date() : null}
         onDateChanged={date => handleChange(moment(date).format(DATE_FORMAT.DD_MM_YYYY))}

--- a/src/widgets/JSONForm/widgets/DatePicker.js
+++ b/src/widgets/JSONForm/widgets/DatePicker.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import React, { useState } from 'react';
 import { TextInput } from 'react-native';
 import moment from 'moment';
@@ -60,7 +61,10 @@ export const DatePicker = ({
       <DatePickerButton
         isDisabled={readonly || disabled}
         initialValue={
-          moment(selectedTextValue, DATE_FORMAT.DD_MM_YYYY, true).isValid()
+          moment(selectedTextValue, DATE_FORMAT.DD_MM_YYYY, true).isValid() ||
+            moment(selectedTextValue, 'D/M/YYYY', true).isValid() ||
+            moment(selectedTextValue, 'D/MM/YYYY', true).isValid() ||
+            moment(selectedTextValue, 'DD/M/YYYY', true).isValid()
             ? moment(selectedTextValue, DATE_FORMAT.DD_MM_YYYY, true).toDate()
             : moment().toDate()
         }


### PR DESCRIPTION
Fixes #4892 #4932

## Change summary

- Datepicker had legacy bugs
  - When you add date with wrong (malformatted) date in text input of datepicker the app would crash
  - Adding date in any other format than MM/DD/YYYY would cause problems. Including M/D/YYYY, MM/D/YYYY format etc.
  - Add M/D/YYYY, MM/D/YYYY format date would validate JSON schema but fail in datepicker open.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] If text input has gibberish date, the validation should fail and show validation failure message. 
- [ ] Opening the datepicker should show default date which is today and not crash.
- [ ] M/D/YYYY or MM/D/YYYY format date should fail validation.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
