### PR TITLE
#4908 Alert improved while vaccination event edited

### DIFF
--- a/src/actions/Entities/NameNoteActions.js
+++ b/src/actions/Entities/NameNoteActions.js
@@ -74,7 +74,7 @@ const saveEditing = () => (dispatch, getState) => {
 };
 
 const updateNameNote = (originalNote, updatedData) => () => {
-  const { id, patientEvent, name, entryDate, _data, isDeleted } = originalNote;
+  const { id, patientEvent, name, entryDate, _data, isDeleted, storeID } = originalNote;
 
   // Quick & dirty check if the object was updated, trims out some un-needed updates
   const isDirty = _data !== JSON.stringify(updatedData);
@@ -87,6 +87,7 @@ const updateNameNote = (originalNote, updatedData) => () => {
       entryDate: new Date(entryDate),
       _data: JSON.stringify(updatedData),
       isDeleted,
+      storeID,
     };
 
     UIDatabase.write(() => {
@@ -145,6 +146,7 @@ const createNotes = (nameNotes = []) => {
           _data: JSON.stringify(nameNote?.data),
           entryDate: new Date(nameNote?.entryDate),
           isDeleted: nameNote.isDeleted,
+          storeID: nameNote.storeID,
         };
 
         UIDatabase.update('NameNote', toSave);

--- a/src/actions/Entities/VaccinePrescriptionActions.js
+++ b/src/actions/Entities/VaccinePrescriptionActions.js
@@ -220,6 +220,7 @@ const createVaccinationNameNote = (
     entryDate: new Date(),
     _data: JSON.stringify(data),
     isDeleted: false,
+    storeID: storeId,
   };
   UIDatabase.write(() => UIDatabase.create('NameNote', newNameNote));
 };

--- a/src/database/DataTypes/NameNote.js
+++ b/src/database/DataTypes/NameNote.js
@@ -28,6 +28,7 @@ export class NameNote extends Realm.Object {
       nameID: this.name?.id,
       note: this.note,
       patientEventID: this.patientEvent?.id,
+      storeID: this.storeID,
     };
   }
 }
@@ -43,6 +44,7 @@ NameNote.schema = {
     name: 'Name',
     note: { type: 'string', optional: true },
     patientEvent: 'PatientEvent',
+    storeID: { type: 'string', optional: true },
   },
 };
 

--- a/src/database/DataTypes/NameNote.js
+++ b/src/database/DataTypes/NameNote.js
@@ -44,7 +44,7 @@ NameNote.schema = {
     name: 'Name',
     note: { type: 'string', optional: true },
     patientEvent: 'PatientEvent',
-    storeID: { type: 'string', optional: true },
+    storeID: { type: 'string', default: '' },
   },
 };
 

--- a/src/database/schema.js
+++ b/src/database/schema.js
@@ -257,7 +257,7 @@ export const schema = {
     VaccineVialMonitorStatus,
     VaccineVialMonitorStatusLog,
   ],
-  schemaVersion: 29,
+  schemaVersion: 30,
 };
 
 export default schema;

--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -222,7 +222,7 @@ const getPatientUniqueCode = database => {
 
 const createNameNote = (
   database,
-  { id, data, patientEventID, nameID, entryDate = new Date(), isDeleted = false }
+  { id, data, patientEventID, nameID, entryDate = new Date(), isDeleted = false, storeID }
 ) => {
   const patientEvent = database.get('PatientEvent', patientEventID);
   const name = database.get('Name', nameID);
@@ -234,6 +234,7 @@ const createNameNote = (
       patientEvent,
       entryDate: new Date(entryDate),
       isDeleted,
+      storeID,
     });
     newNameNote.data = data;
   }

--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -1159,6 +1159,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         isDeleted: parseBoolean(record.is_deleted),
         name: database.getOrCreate('Name', record.name_ID),
         note: record.note,
+        storeID: record.store_ID,
       });
       break;
     }

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -422,7 +422,7 @@ const generateSyncData = (settings, recordType, record) => {
         name_ID: record.name?.id ?? '',
         entry_date: getDateString(record.entryDate),
         data: record.data,
-        store_ID: settings.get(THIS_STORE_ID),
+        store_ID: record.storeID,
         note: record.note,
         is_deleted: String(record.isDeleted),
         // The NameNote table is in the middle of a migration away from the current impl

--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -84,6 +84,7 @@ export const VaccinationEventComponent = ({
   const [vaccineDropDownValues, setVaccineDropDownValues] = useState([]);
   const [vaccinator, setVaccinator] = useState();
   const [vaccine, setVaccine] = useState();
+  const [nameNoteStoreID, setNameNoteStoreID] = useState();
 
   const [isEditingTransaction, toggleEditTransaction] = useToggle(false);
   const [isModalOpen, toggleModal] = useToggle(false);
@@ -122,6 +123,10 @@ export const VaccinationEventComponent = ({
         isDeletedVaccinationEvent: !!vaccinationEventNameNote?.isDeleted,
       });
     }
+
+    if (vaccinationEventNameNote?.storeID) {
+      setNameNoteStoreID(vaccinationEventNameNote?.storeID);
+    }
   }, [vaccinationEventNameNote]);
 
   useEffect(() => {
@@ -150,10 +155,9 @@ export const VaccinationEventComponent = ({
       const nameNoteStoreName = vaccinationEvent?.storeName;
 
       const localString = modalStrings.vaccine_event_not_editable_store;
-
       const alert = nameNoteStoreName
         ? modalStrings.formatString(localString, nameNoteStoreName)
-        : modalStrings.vaccine_event_not_editable;
+        : modalStrings.formatString(localString, nameNoteStoreID);
       setAlertText(alert);
     }
   }, [vaccinationEvent]);


### PR DESCRIPTION
While editing another store vaccination event, the name note records neither show the created store name nor store id.

So, if store name is available(mostly in new records), then show the store name as it is. But for older records which doesn't have store_id or storeName related then show at least store_id of name_note which should be similar to prescription's store_id

Fixes #4908 

## Change summary

Updated `NameNote` schema with `storeID` field which hold the real store_id to display on alert.
Added above `storeID` field all over where NameNote is created/update and during incoming/outgoing sync records etc.

Data migration is not required as most of the existing data of mobile has wrong store_id. The store_id of prescription(transaction) is different to name_note.store_id.

So, as schema is updated we need to re-sync whole data to get records for store_id

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] First, don't use existing mobile data. Just delete that and recreate new one with fresh setup
- [ ] Look at the `Vaccinations > Select a patient > Click History button`
- [ ] There should be at least one vaccination history, click on either one.
- [ ] Better to select vaccination history created from another store which should be non-editable in home store.
- [ ] In vaccination event details window, click on `Save changes` and `Edit` button
- [ ] If this is new data and storeName is available then alert should have store name.
- [ ] If storeName is not available then it will be populated with store_id having same alert message.
- [ ] Similar to attached snapshot.
<img width="568" alt="Screen Shot 2022-09-28 at 14 48 11" src="https://user-images.githubusercontent.com/13060254/192738121-3dbb704e-b05f-419d-8dc0-2d806599d8d0.png">


### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
