### PR TITLE
#4987 Fix React-native failed to build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,18 +21,16 @@ buildscript {
     }
 }
 
+def REACT_NATIVE_VERSION = new File(['node', '--print',"JSON.parse(require('fs').readFileSync(require.resolve('react-native/package.json'), 'utf-8')).version"].execute(null, rootDir).text.trim())
+
 allprojects {
-    repositories {
-        exclusiveContent {
-           filter {
-               includeGroup "com.facebook.react"
-           }
-           forRepository {
-               maven {
-                   url "$rootDir/../node_modules/react-native/android"
-               }
-           }
+    configurations.all {
+        resolutionStrategy {
+            // Remove this override in 0.65+, as a proper fix is included in react-native itself.
+            force "com.facebook.react:react-native:" + REACT_NATIVE_VERSION
         }
+    }
+    repositories {
         mavenLocal()
         google()
         jcenter()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,16 @@ buildscript {
 
 allprojects {
     repositories {
+        exclusiveContent {
+           filter {
+               includeGroup "com.facebook.react"
+           }
+           forRepository {
+               maven {
+                   url "$rootDir/../node_modules/react-native/android"
+               }
+           }
+        }
         mavenLocal()
         google()
         jcenter()


### PR DESCRIPTION


Fixes #4987

## Change summary

What [this fix](https://stackoverflow.com/a/74334163) will do is apply an exclusiveContent resolution rule that will force the resolution of React Native Android library, to use the one inside node_modules. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Open a terminal and do `yarn start`
- [ ] Open another terminal and do `yarn android`
- [ ] The application should build without problems

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
