### PR TITLE
Remove JSON.stringify so that createCustomerInvoice method's JSON.str…

### DIFF
--- a/src/widgets/modals/VaccinationEvent.js
+++ b/src/widgets/modals/VaccinationEvent.js
@@ -470,7 +470,7 @@ const mapDispatchToProps = dispatch => {
         ...vaccinationEvent.extra,
         prescription: {
           ...vaccinationEvent.extra.prescription,
-          customData: JSON.stringify(updatedSupplementalData),
+          customData: updatedSupplementalData,
         },
       },
     };


### PR DESCRIPTION
Fixes #5017 

## Change summary

- You get a JSON-malformed warning log when a new vaccine event is created.
- This happens because the vaccine custom data, which is actually JSON data, is being double encoded being stored as string in customData field of Transaction.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a new vaccine event from mobile and sync it
- [ ] Technically you are fine if you do not see JSON malformed log but that won't show up on normal installation according to @bijaySussol . Bijay has been intercpting the data coming in during sync and validating the transaction json, which would malform because double encoded data would try to show up as string when data would be like this: `customData: "{"name":"value"}"`, we know this will break the json format. 
- [ ] After this fix, the above case would not happen.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
