### PR TITLE
#4974 stocktake reason should be mandatory

### DIFF
--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -205,7 +205,7 @@ export class Stocktake extends Realm.Object {
    * @return {boolean}
    */
   get hasReasonNotSet() {
-    return this.items.some(item => !item.hasReasonSet === false);
+    return this.items.some(item => item.hasReasonSet === true);
   }
 
   /**

--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -279,9 +279,11 @@ export class Stocktake extends Realm.Object {
       finaliseStatus.message = modalStrings.stocktake_no_counted_items;
     }
 
-    if (this.hasReasonNotSet && this.isReasonActive && finaliseStatus.success) {
-      finaliseStatus.success = false;
-      finaliseStatus.message = modalStrings.reason_must_set_before_finalizing_stocktake;
+    if (this.isReasonActive && finaliseStatus.success) {
+      if (this.hasReasonNotSet) {
+        finaliseStatus.success = false;
+        finaliseStatus.message = modalStrings.reason_must_set_before_finalizing_stocktake;
+      }
     }
 
     return finaliseStatus;

--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -8,6 +8,7 @@ import { complement } from 'set-manipulator';
 
 import { addBatchToParent, createRecord, getTotal } from '../utilities';
 import { generalStrings, modalStrings } from '../../localization';
+import { UIDatabase } from '..';
 
 /**
  * A stocktake.
@@ -204,7 +205,21 @@ export class Stocktake extends Realm.Object {
    * @return {boolean}
    */
   get hasReasonNotSet() {
-    return this.items.some(item => item.hasReasonSet === true);
+    return this.items.some(item => !item.hasReasonSet === false);
+  }
+
+  /**
+   * Check wether Reason i.e. Option is activated in mSupply desktop
+   * Return True if all positive and negative reasons are activated
+   *
+   * @return {boolean}
+   */
+  // eslint-disable-next-line class-methods-use-this
+  get isReasonActive() {
+    return (
+      UIDatabase.objects('NegativeAdjustmentReason').length > 0 &&
+      UIDatabase.objects('PositiveAdjustmentReason').length > 0
+    );
   }
 
   /**
@@ -259,13 +274,12 @@ export class Stocktake extends Realm.Object {
 
   get canFinalise() {
     const finaliseStatus = { success: true, message: modalStrings.finalise_stocktake };
-
     if (!this.hasSomeCountedItems) {
       finaliseStatus.success = false;
       finaliseStatus.message = modalStrings.stocktake_no_counted_items;
     }
 
-    if (this.hasReasonNotSet) {
+    if (this.hasReasonNotSet && this.isReasonActive && finaliseStatus.success) {
       finaliseStatus.success = false;
       finaliseStatus.message = modalStrings.reason_must_set_before_finalizing_stocktake;
     }

--- a/src/database/DataTypes/Stocktake.js
+++ b/src/database/DataTypes/Stocktake.js
@@ -199,6 +199,15 @@ export class Stocktake extends Realm.Object {
   }
 
   /**
+   * Get if stocktake has any item without reason set
+   *
+   * @return {boolean}
+   */
+  get hasReasonNotSet() {
+    return this.items.some(item => item.hasReasonSet === true);
+  }
+
+  /**
    * Resets a list of stocktake items.
    *
    * @param  {Realm}                  database
@@ -254,6 +263,11 @@ export class Stocktake extends Realm.Object {
     if (!this.hasSomeCountedItems) {
       finaliseStatus.success = false;
       finaliseStatus.message = modalStrings.stocktake_no_counted_items;
+    }
+
+    if (this.hasReasonNotSet) {
+      finaliseStatus.success = false;
+      finaliseStatus.message = modalStrings.reason_must_set_before_finalizing_stocktake;
     }
 
     return finaliseStatus;

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -157,7 +157,7 @@ export class StocktakeItem extends Realm.Object {
    * @return  {boolean}
    */
   get hasReasonSet() {
-    return this.batches.some(batch => !batch.hasValidReason === true);
+    return this.batches.some(batch => batch.hasValidReason === false);
   }
 
   /**

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -157,7 +157,7 @@ export class StocktakeItem extends Realm.Object {
    * @return  {boolean}
    */
   get hasReasonSet() {
-    return this.batches.some(batch => batch.hasValidReason === false);
+    return this.batches.some(batch => !batch.hasValidReason === true);
   }
 
   /**

--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -151,6 +151,16 @@ export class StocktakeItem extends Realm.Object {
   }
 
   /**
+   * First check whether the batch should have valid a reason,
+   * Return true if at least one batch misses the valid reason
+   *
+   * @return  {boolean}
+   */
+  get hasReasonSet() {
+    return this.batches.some(batch => batch.hasValidReason === false);
+  }
+
+  /**
    * Reset this stocktake item, deleting all batches and recreating them for each corresponding item
    * batch in inventory.
    *

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -40,6 +40,7 @@
     "record_stock_to_issue_before_finalising": "You need to record how much stock to issue before finalising",
     "remove_these_items": "Are you sure you want to remove these items?",
     "remove": "Remove",
+    "reason_must_set_before_finalizing_stocktake": "The reason must be set for each item before finalizing stocktake.",
     "search_for_an_item_to_add": "Search for an item to add",
     "search_for_the_customer": "Search for the customer",
     "search_for_the_supplier": "Search for the supplier",


### PR DESCRIPTION
Fixes #4974 

## Change summary

Check if reason is activated in desktop and not set to at least one stock take batch then gives alert when finalizing. 

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Enable reason (positive and negative) from desktop
- [ ] Sync to mobile well
- [ ] Create an stocktake and set reason for some of its batch and ignore for some
- [ ] If at least one batch misses the reason then you can't finalize the stocktake
- [ ] When click the finalize button alert `The reason must be set for each item before finalizing stocktake` popped up.
- [ ] Repeat the test by disabling the reason from desktop and clicking finalize button
- [ ] If reason is disabled then one can easily finalize stocktake.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
