### PR TITLE
5037 Fix reason would not show on Requisition on Remote desktop

### DIFF
--- a/src/sync/incomingSyncUtils.js
+++ b/src/sync/incomingSyncUtils.js
@@ -762,6 +762,7 @@ export const createOrUpdateRecord = (database, settings, recordType, record) => 
         incomingStock: parseNumber(record.Cust_stock_received),
         outgoingStock: parseNumber(record.Cust_stock_issued),
         daysOutOfStock: parseNumber(record.DOSforAMCadjustment),
+        option: database.getOrCreate('Options', record.optionID),
       };
       const requisitionItem = database.update(recordType, internalRecord);
       // requisitionItem will be an orphan record if it's not unique?

--- a/src/sync/outgoingSyncUtils.js
+++ b/src/sync/outgoingSyncUtils.js
@@ -167,6 +167,7 @@ const generateSyncData = (settings, recordType, record) => {
         DOSforAMCadjustment: String(record.daysOutOfStock),
         stockLosses: String(record.negativeAdjustments),
         stockAdditions: String(record.positiveAdjustments),
+        optionID: record.option?.id ?? '',
       };
     }
     case 'Stocktake': {


### PR DESCRIPTION
Fixes #5037

## Change summary

- Option field from Requistion line (RequisitionItem) was not being synced. I added option id to the sync in and out code and it worked.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create internal order (Supplier Requisition) from a tablet, add reasons to the internal order
- [ ] Check customer requisition on desktop remote system 
- [ ] See the Reason column, the reasons should show properly

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
