### PR TITLE
#5039 Stocktake reasoning resolved

### DIFF
--- a/src/database/DataTypes/StocktakeItem.js
+++ b/src/database/DataTypes/StocktakeItem.js
@@ -151,16 +151,6 @@ export class StocktakeItem extends Realm.Object {
   }
 
   /**
-   * First check whether the batch should have valid a reason,
-   * Return true if at least one batch misses the valid reason
-   *
-   * @return  {boolean}
-   */
-  get hasReasonSet() {
-    return this.batches.some(batch => batch.hasValidReason === false);
-  }
-
-  /**
    * Reset this stocktake item, deleting all batches and recreating them for each corresponding item
    * batch in inventory.
    *


### PR DESCRIPTION
Stocktake reasoning issue fixed

Fixes #5039 

## Change summary

One should set reason to a valid batch if reasoning is activated

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Enable reason (positive and negative) from desktop
- [ ] Sync to mobile well
- [ ] Before testing make sure to test for different type of test case scenario as below then follow from step 4
  - It looks at only counted items, then check all batches of that items.
  - If the batch has counted and there is quantity difference then look at its valid reason.
  - If reason is not set then don't allow to finalize otherwise finalize
- [ ] Create an stocktake and set reason for some of its batch and ignore for some
- [ ] If at least one batch misses the reason then you can't finalize the stocktake
- [ ] When click the finalize button alert `The reason must be set for each item before finalizing stocktake` popped up.
- [ ] Repeat the test by disabling the reason from desktop and clicking finalize button
- [ ] If reason is disabled then one can easily finalize stocktake.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
