### PR TITLE
5044 not able to create a patients

### DIFF
--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -32,10 +32,11 @@ export const PatientEditModalComponent = ({
   hasVaccineEventsForm,
   isCreatePatient,
 }) => {
-  let canSave = canSaveForm;
+  let canSave = canSaveForm && !isDisabled;
   const hasVaccineEvents = hasVaccineEventsForm;
-  if (canSave) {
-    canSave = !isDisabled && surveySchema && surveyForm && nameNoteIsValid;
+
+  if (canSave && hasVaccineEvents) {
+    canSave = surveySchema && surveyForm && nameNoteIsValid;
   }
 
   const canDelete = !isDisabled;


### PR DESCRIPTION
Fixes #5044

## Change summary

- Only check for surveySchema && surveyForm && nameNoteIsValid if vaccine module is enabled

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Dispensing. 
- [ ] Click on New patients.
- [ ] Fill in all mandatory fields.
- [ ] Previously the Save button remained disabled, now it should be enabled and you should be able to save the patient.

### Regression testing

- [ ] Vaccine module for Kiribati has added surveySchema && surveyForm && nameNoteIsValid checks. So maybe check there to see if the patient creates feature still works.

### Related areas to think about

The vaccine module for Kiribati has added surveySchema && surveyForm && nameNoteIsValid checks. 