### PR TITLE
App crashes while creating policy in prescription dispensing

### DIFF
--- a/src/widgets/FormInputs/FormSlider.js
+++ b/src/widgets/FormInputs/FormSlider.js
@@ -63,5 +63,5 @@ FormSlider.propTypes = {
   step: PropTypes.number.isRequired,
   value: PropTypes.number.isRequired,
   onValueChange: PropTypes.func.isRequired,
-  isDisabled: PropTypes.isDisabled,
+  isDisabled: PropTypes.bool,
 };


### PR DESCRIPTION
Fixes #5043 

## Change summary

- In `src/widget/FormInputs/FormSlider.js`, the proptype for isDisabled was set to PropTypes.isDisabled which not an available prop-type so React native thought it was a function and when it got boolean it freaked out and crashed.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] In dispensing click on dispense, select a prescriber, select an item, give quantity and click next. 
- [ ] In the payment section click the plus button to add an insurance ploicy
- [ ] Previously it was crashing now it should not.

### Related areas to think about

None
