### PR TITLE
5059 Sometime when during auto syncing authentication system crashes

### DIFF
--- a/src/authentication/UserAuthenticator.js
+++ b/src/authentication/UserAuthenticator.js
@@ -124,7 +124,7 @@ export class UserAuthenticator {
     if (!this.activeUsername || !this.activePassword) onAuthentication(false);
     try {
       const user = await this.authenticate(this.activeUsername, this.activePassword);
-      onAuthentication(user);
+      onAuthentication(user ?? null);
     } catch (error) {
       onAuthentication(null);
     }


### PR DESCRIPTION
Fixes #5059

## Change summary

- When the system tries to re-authenticate after a scheduled sync call, in UserAuthenticator line 126. The authenticate method sometimes returns a boolean (probably false). The system expects an object or null value so it crashes.
- If the data returned is boolean or non-existential return null.
- The system should gratefully log out and not crash.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] This happens automatically after a schedule so might be difficult to replicate.

### Related areas to think about

All
