### PR TITLE
5061 Viewing indicators app crashes

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -679,7 +679,7 @@ const createIndicatorValue = (database, row, column, period) => {
   const { defaultValue: value } = column;
   const indicatorValue = database.create('IndicatorValue', {
     id: generateUUID(),
-    storeId: UIDatabase.getSetting(SETTINGS_KEYS.THIS_STORE_NAME_ID),
+    storeId: database.getSetting(SETTINGS_KEYS.THIS_STORE_NAME_ID),
     row,
     column,
     period,


### PR DESCRIPTION
Fixes #5061

## Change summary

While creating or viewing supplier requisition with program that has indicators.
If you click on indicators button to see the indicator tab the app crashes

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] While creating or viewing supplier requisition with program that has indicators.
- [ ] If you click on the indicators button to see the indicator tab the app should show indicators and not crash

### Related areas to think about

None
