### PR TITLE
5068 Fix New Stock take crashes

### DIFF
--- a/src/pages/StocktakeManagePage.js
+++ b/src/pages/StocktakeManagePage.js
@@ -21,6 +21,7 @@ import globalStyles from '../globalStyles';
 
 import { ROUTES } from '../navigation/constants';
 import { useLoadingIndicator } from '../hooks/useLoadingIndicator';
+import { checkIsObjectValuesEmpty } from '../utilities';
 
 export const StocktakeManage = ({
   dispatch,
@@ -49,8 +50,10 @@ export const StocktakeManage = ({
   // On navigating to this screen, if a stocktake is passed through, update the selection with
   // the items already in the stocktake.
   useEffect(() => {
-    if (pageObject) dispatch(PageActions.selectItems(pageObject.itemsInStocktake, route));
-  }, []);
+    if (pageObject?.itemsInStocktake) {
+      dispatch(PageActions.selectItems(pageObject.itemsInStocktake, route));
+    }
+  }, [pageObject]);
 
   const getCallback = (colKey, propName) => {
     switch (colKey) {
@@ -65,7 +68,9 @@ export const StocktakeManage = ({
   const onConfirmStocktake = () => {
     runWithLoadingIndicator(() => {
       const itemIds = Array.from(dataState.keys()).filter(id => dataState.get(id).isSelected && id);
-      if (pageObject) return dispatch(updateStocktake(pageObject, itemIds, name));
+      if (!checkIsObjectValuesEmpty(pageObject)) {
+        return dispatch(updateStocktake(pageObject, itemIds, name));
+      }
       return dispatch(createStocktake({ stocktakeName: name, itemIds }));
     });
   };
@@ -140,7 +145,9 @@ export const StocktakeManage = ({
 
       <BottomTextEditor
         isOpen
-        buttonText={pageObject ? modalStrings.confirm : modalStrings.create}
+        buttonText={
+          !checkIsObjectValuesEmpty(pageObject) ? modalStrings.confirm : modalStrings.create
+        }
         value={name}
         placeholder={modalStrings.give_your_stocktake_a_name}
         onConfirm={onConfirmStocktake}

--- a/src/utilities/checkIsObject.js
+++ b/src/utilities/checkIsObject.js
@@ -11,3 +11,8 @@ export const checkIsObject = object =>
 
 export const checkIsObjectEmpty = object =>
   checkIsObject(object) && Object.keys(object).length === 0;
+
+// We need this method because immutable objects such as state would return
+// Object.values(object).length === 0
+export const checkIsObjectValuesEmpty = object =>
+  Object.values(object).length === 0 && checkIsObject(object);

--- a/src/utilities/checkIsObject.js
+++ b/src/utilities/checkIsObject.js
@@ -12,7 +12,8 @@ export const checkIsObject = object =>
 export const checkIsObjectEmpty = object =>
   checkIsObject(object) && Object.keys(object).length === 0;
 
-// We need this method because immutable objects such as state would return
-// Object.values(object).length === 0
+// We need this method because objects such as state would return
+// Object.keys(object).length === 0 even if they have properties as they are
+// immutable properties
 export const checkIsObjectValuesEmpty = object =>
   Object.values(object).length === 0 && checkIsObject(object);

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -17,7 +17,7 @@ export { requestPermission } from './requestPermission';
 export { backupValidation, selectDocument } from './fileSystem';
 export { debounce } from './underscoreMethods';
 export { getModalTitle, MODAL_KEYS } from './getModalTitle';
-export { checkIsObject, checkIsObjectEmpty } from './checkIsObject';
+export { checkIsObject, checkIsObjectEmpty, checkIsObjectValuesEmpty } from './checkIsObject';
 export { validateReport } from './validateReport';
 export { chunk } from './chunk';
 export { parsePositiveIntegerInterfaceInput } from './parsers';


### PR DESCRIPTION
Fixes #5068

## Change summary

This issue was introduced by code here https://github.com/openmsupply/mobile/commit/f5f3b612728adec9ccd2ec9c31ed81397933ad94.

Previously StocktaakeManagerPage was expecting an object as prop but was getting undefined and that gave this warning:

![SCR-20230117-jx9](https://user-images.githubusercontent.com/683452/212849131-3cb27faa-4922-4d86-ad4d-84be5992c16c.png)

I made the changes in the commit f5f3b612728adec9ccd2ec9c31ed81397933ad94 to fix this warning and it spawned this error because now that the default value is empty object it is no longer undefined and the methods that had undefined checks were getting called.

I fixed with by adding an checkIsObjectValuesEmpty check method instead of object cheack.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Log into mobile store
- [ ] Go into stocktakes
- [ ] Create new stocktake
- [ ] You should be able to create, edit or delete stocktake without any errors or warning

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
