### PR TITLE
#5080 Fix crash when Entering The Details of Insurance Policy in Mobile App

### DIFF
--- a/src/pages/PrescriptionPage.js
+++ b/src/pages/PrescriptionPage.js
@@ -17,6 +17,8 @@ import { useRecordListener } from '../hooks';
 import { WizardActions } from '../actions/WizardActions';
 
 import { dispensingStrings } from '../localization';
+import { InsurancePolicyModel, PrescriberModel } from '../widgets/modals';
+import { PatientEditModal } from '../widgets/modalChildren';
 
 const tabs = [
   {
@@ -30,7 +32,15 @@ const tabs = [
 
 export const Prescription = ({ transaction, completePrescription }) => {
   useRecordListener(completePrescription, transaction, 'Transaction');
-  return <Wizard tabs={tabs} />;
+
+  return (
+    <>
+      <Wizard tabs={tabs} />
+      <InsurancePolicyModel />
+      <PrescriberModel />
+      <PatientEditModal />
+    </>
+  );
 };
 
 const mapDispatchToProps = dispatch => {

--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -1,18 +1,14 @@
 /* eslint-disable no-unused-expressions */
 /* eslint-disable react/forbid-prop-types */
 import React from 'react';
-import { View, ScrollView, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-
+import { View, ScrollView, StyleSheet } from 'react-native';
+import { useIsFocused } from '@react-navigation/native';
 import { PageButton } from './PageButton';
 
 import { FORM_INPUT_TYPES } from '../utilities/formInputConfigs';
-import { FormTextInput } from './FormInputs/FormTextInput';
-import { FormDateInput } from './FormInputs/FormDateInput';
-import { FormToggle } from './FormInputs/FormToggle';
-import { FormDropdown } from './FormInputs/FormDropdown';
-import { FormSlider } from './FormInputs/FormSlider';
+import { FormTextInput, FormDateInput, FormToggle, FormDropdown, FormSlider } from './FormInputs';
 
 import globalStyles, { SUSSOL_ORANGE, WHITE } from '../globalStyles';
 import { modalStrings, generalStrings } from '../localization';
@@ -76,11 +72,15 @@ const FormControlComponent = ({
   shouldAutoFocus,
 }) => {
   const [refs, setRefs] = React.useState([]);
+  const isFocused = useIsFocused();
 
   React.useEffect(() => {
-    onInitialiseForm();
-    setRefs({ length: inputConfig.length });
-  }, []);
+    // Only update state if component comes in focus
+    if (isFocused) {
+      onInitialiseForm();
+      setRefs({ length: inputConfig.length });
+    }
+  }, [isFocused]);
 
   const debouncedUpdateForm = useDebounce(onUpdateForm, 500);
 

--- a/src/widgets/FormControl.js
+++ b/src/widgets/FormControl.js
@@ -2,7 +2,6 @@
 /* eslint-disable react/forbid-prop-types */
 import React from 'react';
 import { View, ScrollView, StyleSheet } from 'react-native';
-import { useIsFocused } from '@react-navigation/native';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -77,15 +76,11 @@ const FormControlComponent = ({
   shouldAutoFocus,
 }) => {
   const [refs, setRefs] = React.useState([]);
-  const isFocused = useIsFocused();
 
   React.useEffect(() => {
-    // Only update state if component comes in focus
-    if (isFocused) {
-      onInitialiseForm();
-      setRefs({ length: inputConfig.length });
-    }
-  }, [isFocused]);
+    onInitialiseForm();
+    setRefs({ length: inputConfig.length });
+  }, []);
 
   const debouncedUpdateForm = useDebounce(onUpdateForm, 500);
 
@@ -410,7 +405,7 @@ const localStyles = StyleSheet.create({
   },
   flexOne: { flex: 1 },
   flexTen: { flex: 10 },
-  flexRow: { flex: 1, flexDirection: 'row' },
+  flexRow: { flex: 1, flexDirection: 'row', paddingVertical: 30 },
   buttonsRow: { marginTop: 10, flexDirection: 'row-reverse' },
   whiteBackground: { backgroundColor: WHITE },
 });

--- a/src/widgets/FormInputs/index.js
+++ b/src/widgets/FormInputs/index.js
@@ -1,0 +1,5 @@
+export { FormTextInput } from './FormTextInput';
+export { FormDateInput } from './FormDateInput';
+export { FormToggle } from './FormToggle';
+export { FormDropdown } from './FormDropdown';
+export { FormSlider } from './FormSlider';

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -56,6 +56,7 @@ export { TextEditor } from './TextEditor';
 export { EditorRow } from './EditorRow';
 export { HotBreachIcon } from './HotBreachIcon';
 export { ColdBreachIcon } from './ColdBreachIcon';
+export { FormControl } from './FormControl';
 
 export * from './StepperInputs';
 export * from './Typography';

--- a/src/widgets/modalChildren/ADRInput.js
+++ b/src/widgets/modalChildren/ADRInput.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import { JSONForm } from '../JSONForm/JSONForm';
-import { UIDatabase } from '../../database/index';
+import { UIDatabase } from '../../database';
 import { FlexRow } from '../FlexRow';
 import { FlexView } from '../FlexView';
 import { PageButton } from '../PageButton';
@@ -23,6 +23,7 @@ const getSchemaItems = jsonSchema => {
   const { items } = causes;
   return items;
 };
+
 const mapHistory = history =>
   history.map((h, index) => {
     const { vaccinator, itemName, confirmDate } = h;
@@ -48,7 +49,7 @@ LoadingIndicator.propTypes = {
   loading: PropTypes.bool.isRequired,
 };
 
-export const ADRInputComponent = ({ onCancel, onSave, patient, vaccineHistory }) => {
+const ADRInputComponent = ({ onCancel, onSave, patient, vaccineHistory }) => {
   const [{ formData, isValid }, setForm] = useState({ formData: null, isValid: false });
   const patientId = patient?.id;
   const [ADRSchema, setADRSchema] = useState(UIDatabase.objects('ADRForm')[0]);

--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -3,26 +3,40 @@ import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { FormControl } from '../FormControl';
+import { FormControl } from '..';
 import { PageButton } from '../PageButton';
 import { FlexRow } from '../FlexRow';
 import { JSONForm } from '../JSONForm/JSONForm';
 import { NameNoteActions } from '../../actions/Entities/NameNoteActions';
 import { selectNameNoteIsValid, selectCreatingNameNote } from '../../selectors/Entities/nameNote';
-import { selectSortedPatientHistory, selectIsCreatePatient } from '../../selectors/patient';
+import {
+  selectSortedPatientHistory,
+  selectIsCreatePatient,
+  selectPatientModalOpen,
+  selectCanEditPatient,
+} from '../../selectors/patient';
 import { selectCompletedForm, selectCanSaveForm } from '../../selectors/form';
 import { PatientActions } from '../../actions/PatientActions';
 import globalStyles, { SUSSOL_ORANGE } from '../../globalStyles';
-import { generalStrings, modalStrings, buttonStrings, navStrings } from '../../localization/index';
+import {
+  generalStrings,
+  modalStrings,
+  buttonStrings,
+  navStrings,
+  dispensingStrings,
+} from '../../localization';
 import { PaperModalContainer } from '../PaperModal/PaperModalContainer';
 import { PaperConfirmModal } from '../PaperModal/PaperConfirmModal';
 import { useToggle } from '../../hooks/index';
+import { ModalContainer } from '../modals';
+import { getFormInputConfig } from '../../utilities/formInputConfigs';
+import { selectSurveySchemas } from '../../selectors/formSchema';
 
-export const PatientEditModalComponent = ({
-  isDisabled,
+const PatientEditModalComponent = ({
+  canEditPatient,
   onSaveForm,
   onDeleteForm,
-  onCancel,
+  cancelPatientEdit,
   inputConfig,
   surveySchema,
   surveyForm,
@@ -31,90 +45,98 @@ export const PatientEditModalComponent = ({
   canSaveForm,
   hasVaccineEventsForm,
   isCreatePatient,
+  patientEditModalOpen,
 }) => {
-  let canSave = canSaveForm && !isDisabled;
+  let canSave = canSaveForm && canEditPatient;
+
   const hasVaccineEvents = hasVaccineEventsForm;
 
-  if (canSave && hasVaccineEvents) {
+  if (canSave && !!surveySchema) {
     canSave = surveySchema && surveyForm && nameNoteIsValid;
   }
 
-  const canDelete = !isDisabled;
+  const canDelete = canEditPatient;
   const showDelete = !isCreatePatient;
 
   const [removeModalOpen, toggleRemoveModal] = useToggle();
   const [cannotDeleteModalOpen, toggleCannotDeleteModal] = useToggle();
 
   return (
-    <FlexRow style={{ flexDirection: 'column' }} flex={1}>
-      <FlexRow flex={1}>
-        <FormControl
-          canSave={surveySchema ? nameNoteIsValid : true}
-          isDisabled={isDisabled}
-          onSave={onSaveForm}
-          onCancel={onCancel}
-          inputConfig={inputConfig}
-          showCancelButton={false}
-          showSaveButton={false}
-        />
-        {!!surveySchema && !!surveyForm && (
-          <View style={styles.formContainer}>
-            <JSONForm
-              surveySchema={surveySchema}
-              formData={surveyForm}
-              onChange={({ formData }, validator) => {
-                onUpdateForm(formData, validator);
-              }}
-            >
-              <></>
-            </JSONForm>
-          </View>
-        )}
-      </FlexRow>
-      <FlexRow flex={0} style={{ justifyContent: 'center' }}>
-        <View style={styles.buttonsRow}>
-          <PageButton
-            onPress={onSaveForm}
-            style={styles.saveButton}
-            isDisabled={!canSave}
-            textStyle={styles.saveButtonTextStyle}
-            text={generalStrings.save}
+    <ModalContainer
+      title={`${dispensingStrings.patient_detail}`}
+      noCancel
+      isVisible={patientEditModalOpen}
+    >
+      <FlexRow style={{ flexDirection: 'column' }} flex={1}>
+        <FlexRow flex={1}>
+          <FormControl
+            canSave={surveySchema ? nameNoteIsValid : true}
+            isDisabled={!canEditPatient}
+            onSave={onSaveForm}
+            onCancel={cancelPatientEdit}
+            inputConfig={inputConfig}
+            showCancelButton={false}
+            showSaveButton={false}
           />
-          {showDelete && (
-            <PageButton
-              onPress={hasVaccineEvents ? toggleCannotDeleteModal : toggleRemoveModal}
-              style={styles.cancelButton}
-              textStyle={styles.saveButtonTextStyle}
-              isDisabled={!canDelete}
-              text={generalStrings.delete}
-            />
+          {!!surveySchema && !!surveyForm && (
+            <View style={styles.formContainer}>
+              <JSONForm
+                surveySchema={surveySchema}
+                formData={surveyForm}
+                onChange={({ formData }, validator) => {
+                  onUpdateForm(formData, validator);
+                }}
+              >
+                <></>
+              </JSONForm>
+            </View>
           )}
-          <PageButton
-            onPress={onCancel}
-            style={styles.cancelButton}
-            textStyle={styles.cancelButtonTextStyle}
-            text={modalStrings.cancel}
+        </FlexRow>
+        <FlexRow flex={0} style={{ justifyContent: 'center' }}>
+          <View style={styles.buttonsRow}>
+            <PageButton
+              onPress={onSaveForm}
+              style={styles.saveButton}
+              isDisabled={!canSave}
+              textStyle={styles.saveButtonTextStyle}
+              text={generalStrings.save}
+            />
+            {showDelete && (
+              <PageButton
+                onPress={hasVaccineEvents ? toggleCannotDeleteModal : toggleRemoveModal}
+                style={styles.cancelButton}
+                textStyle={styles.saveButtonTextStyle}
+                isDisabled={!canDelete}
+                text={generalStrings.delete}
+              />
+            )}
+            <PageButton
+              onPress={cancelPatientEdit}
+              style={styles.cancelButton}
+              textStyle={styles.cancelButtonTextStyle}
+              text={modalStrings.cancel}
+            />
+          </View>
+        </FlexRow>
+        <PaperModalContainer isVisible={cannotDeleteModalOpen} onClose={toggleCannotDeleteModal}>
+          <PaperConfirmModal
+            questionText={modalStrings.patient_cant_delete_with_vaccine_events}
+            confirmText={navStrings.go_back}
+            onConfirm={toggleCannotDeleteModal}
           />
-        </View>
+        </PaperModalContainer>
+        <PaperModalContainer isVisible={removeModalOpen} onClose={toggleRemoveModal}>
+          <PaperConfirmModal
+            questionText={modalStrings.are_you_sure_delete_patient}
+            confirmText={generalStrings.remove}
+            cancelText={buttonStrings.cancel}
+            onConfirm={onDeleteForm}
+            isDisabled={!canDelete}
+            onCancel={toggleRemoveModal}
+          />
+        </PaperModalContainer>
       </FlexRow>
-      <PaperModalContainer isVisible={cannotDeleteModalOpen} onClose={toggleCannotDeleteModal}>
-        <PaperConfirmModal
-          questionText={modalStrings.patient_cant_delete_with_vaccine_events}
-          confirmText={navStrings.go_back}
-          onConfirm={toggleCannotDeleteModal}
-        />
-      </PaperModalContainer>
-      <PaperModalContainer isVisible={removeModalOpen} onClose={toggleRemoveModal}>
-        <PaperConfirmModal
-          questionText={modalStrings.are_you_sure_delete_patient}
-          confirmText={generalStrings.remove}
-          cancelText={buttonStrings.cancel}
-          onConfirm={onDeleteForm}
-          isDisabled={!canDelete}
-          onCancel={toggleRemoveModal}
-        />
-      </PaperModalContainer>
-    </FlexRow>
+    </ModalContainer>
   );
 };
 
@@ -148,7 +170,7 @@ const styles = StyleSheet.create({
 });
 
 PatientEditModalComponent.defaultProps = {
-  isDisabled: false,
+  canEditPatient: false,
   surveyForm: null,
   surveySchema: null,
   nameNoteIsValid: true,
@@ -156,10 +178,10 @@ PatientEditModalComponent.defaultProps = {
 };
 
 PatientEditModalComponent.propTypes = {
-  isDisabled: PropTypes.bool,
+  canEditPatient: PropTypes.bool,
   onSaveForm: PropTypes.func.isRequired,
   onDeleteForm: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
+  cancelPatientEdit: PropTypes.func.isRequired,
   inputConfig: PropTypes.array.isRequired,
   surveyForm: PropTypes.object,
   nameNoteIsValid: PropTypes.bool,
@@ -168,12 +190,14 @@ PatientEditModalComponent.propTypes = {
   canSaveForm: PropTypes.bool.isRequired,
   hasVaccineEventsForm: PropTypes.bool.isRequired,
   isCreatePatient: PropTypes.bool,
+  patientEditModalOpen: PropTypes.bool.isRequired,
 };
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const { completedForm } = stateProps;
   const { onSave, onDelete, onSaveSurvey, ...otherDispatchProps } = dispatchProps;
-  const { surveySchema } = ownProps;
+  // const { surveySchema } = ownProps;
+  const surveySchema = selectSurveySchemas()[0];
 
   const onSaveForm = () => {
     onSave(completedForm);
@@ -188,27 +212,41 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ...ownProps,
     ...otherDispatchProps,
     ...stateProps,
+    surveySchema,
     onSaveForm,
     onDeleteForm,
   };
 };
 
 const stateToProps = state => {
+  const { patient } = state;
+
+  const { currentPatient } = patient;
+  const inputConfig = getFormInputConfig('patient', currentPatient);
+
+  const canEditPatient = selectCanEditPatient(state);
   const nameNoteIsValid = selectNameNoteIsValid(state);
   const nameNote = selectCreatingNameNote(state);
   const completedForm = selectCompletedForm(state);
   const canSaveForm = selectCanSaveForm(state);
-  const patientHistory = selectSortedPatientHistory(state);
+  const patientHistory =
+    patient.currentPatient && patient.currentPatient.transactions
+      ? selectSortedPatientHistory({ patient })
+      : [];
   const isCreatePatient = selectIsCreatePatient(state);
   const hasVaccineEventsForm = patientHistory.length > 0;
+  const [patientEditModalOpen] = selectPatientModalOpen(state);
 
   return {
     canSaveForm,
+    canEditPatient,
     hasVaccineEventsForm,
     completedForm,
     nameNoteIsValid,
     isCreatePatient,
     surveyForm: nameNote?.data ?? null,
+    patientEditModalOpen,
+    inputConfig,
   };
 };
 
@@ -217,6 +255,7 @@ const dispatchToProps = dispatch => ({
   onUpdateForm: (form, validator) => dispatch(NameNoteActions.updateForm(form, validator)),
   onSave: patientDetails => dispatch(PatientActions.patientUpdate(patientDetails)),
   onDelete: () => dispatch(PatientActions.patientDelete()),
+  cancelPatientEdit: () => dispatch(PatientActions.closeModal()),
 });
 
 export const PatientEditModal = connect(

--- a/src/widgets/modalChildren/index.js
+++ b/src/widgets/modalChildren/index.js
@@ -9,3 +9,4 @@ export { ConfirmForm } from './ConfirmForm';
 export { GenericChoiceList } from './GenericChoiceList';
 export { MultiSelectList } from './MultiSelectList';
 export { ToggleSelector } from './ToggleSelector';
+export { PatientEditModal } from './PatientEditModal';

--- a/src/widgets/modals/InsurancePolicyModel.js
+++ b/src/widgets/modals/InsurancePolicyModel.js
@@ -1,0 +1,88 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { selectInsuranceModalOpen, selectCanEditInsurancePolicy } from '../../selectors/insurance';
+import { selectCanEditPatient } from '../../selectors/patient';
+import { ModalContainer } from './ModalContainer';
+import { FormControl } from '..';
+import { InsuranceActions } from '../../actions/InsuranceActions';
+import { dispensingStrings } from '../../localization';
+import { getFormInputConfig } from '../../utilities/formInputConfigs';
+
+const InsurancePolicyModelComponent = ({
+  canEditPatient,
+  // Insurance variables
+  insuranceModalOpen,
+  selectedInsurancePolicy,
+  canEditInsurancePolicy,
+  isCreatingInsurancePolicy,
+  // Insurance callbacks
+  cancelInsuranceEdit,
+  saveInsurancePolicy,
+}) => (
+  <ModalContainer
+    title={`${dispensingStrings.insurance_policy}`}
+    noCancel
+    isVisible={insuranceModalOpen}
+  >
+    <FormControl
+      isDisabled={!canEditInsurancePolicy}
+      confirmOnSave={!canEditPatient}
+      confirmText={dispensingStrings.confirm_new_policy}
+      onSave={saveInsurancePolicy}
+      onCancel={cancelInsuranceEdit}
+      inputConfig={getFormInputConfig(
+        'insurancePolicy',
+        isCreatingInsurancePolicy ? null : selectedInsurancePolicy
+      )}
+    />
+  </ModalContainer>
+);
+
+const mapDispatchToProps = dispatch => ({
+  cancelInsuranceEdit: () => dispatch(InsuranceActions.cancel()),
+  saveInsurancePolicy: policyDetails => dispatch(InsuranceActions.update(policyDetails)),
+});
+
+const mapStateToProps = state => {
+  const { insurance } = state;
+  const { isCreatingInsurancePolicy, selectedInsurancePolicy } = insurance;
+
+  const insuranceModalOpen = selectInsuranceModalOpen(state);
+  const canEditPatient = selectCanEditPatient(state);
+  const canEditInsurancePolicy = selectCanEditInsurancePolicy(state);
+
+  return {
+    insuranceModalOpen,
+    canEditPatient,
+    canEditInsurancePolicy,
+    isCreatingInsurancePolicy,
+    selectedInsurancePolicy,
+  };
+};
+
+export const InsurancePolicyModel = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(InsurancePolicyModelComponent);
+
+InsurancePolicyModelComponent.defaultProps = {
+  selectedInsurancePolicy: null,
+};
+
+InsurancePolicyModelComponent.propTypes = {
+  canEditPatient: PropTypes.bool.isRequired,
+  insuranceModalOpen: PropTypes.bool.isRequired,
+  canEditInsurancePolicy: PropTypes.bool.isRequired,
+  cancelInsuranceEdit: PropTypes.func.isRequired,
+  isCreatingInsurancePolicy: PropTypes.bool.isRequired,
+  saveInsurancePolicy: PropTypes.func.isRequired,
+  selectedInsurancePolicy: PropTypes.object,
+};

--- a/src/widgets/modals/PrescriberModel.js
+++ b/src/widgets/modals/PrescriberModel.js
@@ -1,0 +1,77 @@
+/* eslint-disable react/forbid-prop-types */
+/**
+ * mSupply Mobile
+ * Sustainable Solutions (NZ) Ltd. 2019
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import { selectPrescriberModalOpen, selectCanEditPrescriber } from '../../selectors/prescriber';
+import { ModalContainer } from './ModalContainer';
+import { FormControl } from '..';
+import { dispensingStrings } from '../../localization';
+import { getFormInputConfig } from '../../utilities/formInputConfigs';
+import { PrescriberActions } from '../../actions/PrescriberActions';
+
+const PrescriberModelComponent = ({
+  savePrescriber,
+  cancelPrescriberEdit,
+  // Prescriber variables
+  currentPrescriber,
+  prescriberModalOpen,
+  canEditPrescriber,
+}) => (
+  <ModalContainer
+    title={`${dispensingStrings.prescriber} ${dispensingStrings.details}`}
+    noCancel
+    isVisible={prescriberModalOpen}
+  >
+    <FormControl
+      isDisabled={!canEditPrescriber}
+      onSave={savePrescriber}
+      onCancel={cancelPrescriberEdit}
+      inputConfig={getFormInputConfig('prescriber', currentPrescriber)}
+    />
+  </ModalContainer>
+);
+
+const mapDispatchToProps = dispatch => ({
+  cancelPrescriberEdit: () => dispatch(PrescriberActions.closeModal()),
+  savePrescriber: prescriberDetails =>
+    dispatch(PrescriberActions.updatePrescriber(prescriberDetails)),
+});
+
+const mapStateToProps = state => {
+  const { prescriber } = state;
+  const { currentPrescriber } = prescriber;
+
+  const prescriberModalOpen = selectPrescriberModalOpen(state);
+  const canEditPrescriber = selectCanEditPrescriber(state);
+
+  return {
+    prescriberModalOpen,
+    // Prescriber
+    currentPrescriber,
+    canEditPrescriber,
+  };
+};
+
+export const PrescriberModel = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PrescriberModelComponent);
+
+PrescriberModelComponent.defaultProps = {
+  currentPrescriber: null,
+  canEditPrescriber: false,
+};
+
+PrescriberModelComponent.propTypes = {
+  prescriberModalOpen: PropTypes.bool.isRequired,
+  currentPrescriber: PropTypes.object,
+  canEditPrescriber: PropTypes.bool,
+  savePrescriber: PropTypes.func.isRequired,
+  cancelPrescriberEdit: PropTypes.func.isRequired,
+};

--- a/src/widgets/modals/index.js
+++ b/src/widgets/modals/index.js
@@ -10,3 +10,5 @@ export { DemoUserModal } from './DemoUserModal';
 export { FinaliseModal } from './FinaliseModal';
 export { default as LoginModal } from './LoginModal';
 export { ModalContainer } from './ModalContainer';
+export { InsurancePolicyModel } from './InsurancePolicyModel';
+export { PrescriberModel } from './PrescriberModel';


### PR DESCRIPTION
Fixes #5080

## Change summary

In FormControl, which is shared by all, there is a useIsFocused check that sets isFocused to true when the form control comes in focus. But the problem is in case case of Dispensing > Prescription Page the page are loaded as Wizard pages. The pages take focus but the models are intitialised way below in the hirirarchiy, in Dispensing page iteself and when the models are activated from a button click in any of the Wizard tab page the thus loaded model do not take focus.

This stops initialisation of the FormControl and cause the UI to be unresponsive or submit blank values if saved (since whatever you typed is not stored or tracked).

I did some extensive testing and realised that we do not really need the page be on foucs before initialising the FormFields. In fact we can start loading the fields as soon as the component is loaded. Which is esentially what useEffect with empty devependency fields does. So replacing isFoucsed check with simple useEffect with empty depenedencies. It will run only once when the component mounts which is exactly what we want.

## Testing > 

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Click Dispensing and dispense to any of the patients. Create one if there are no patients.
- [ ] Select a prescriber. Create a new prescriber if there are none.
- [ ] Select one or more items with quantity, and give quantity to this prescription. 
- [ ] Click Next
- [ ] Now in the Payment section click the red circle with + in it to add new insurance policy.
- [ ] Fill the form and update the toggle button dropdown etc. Previously none of these changes were registering and the app was crashing.
- [ ] Make sure the insurance policy would be selected on the Prescription Finalise page.

### Related areas to think about

### Regression checks

- [ ] This change effects all of the FormControl pages. So anything from New patient creation/editing, lookup patient, prescriber create and edit, vaccine survay forms etc. anything that has form loaded in a model needs to retested as this change will affect all of them.
