### PR TITLE
#5086 Reason column should be visible to all items

### DIFF
--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -57,7 +57,6 @@ export const StocktakeBatchModalComponent = ({
   usingVaccines,
   usingHideSnapshotColumn,
   dispatch: reduxDispatch,
-  usingOpenVialWastageReasons,
 }) => {
   const initialState = useMemo(() => {
     const pageObject = stocktakeItem;
@@ -100,21 +99,21 @@ export const StocktakeBatchModalComponent = ({
   const { difference = 0 } = modalValue || {};
 
   const reasonsSelection = (() => {
-    if (usingOpenVialWastageReasons && isVaccine) {
+    if (difference > 0) {
+      return UIDatabase.objects('PositiveAdjustmentReason');
+    }
+
+    if (usingReasons && !isVaccine) {
+      return UIDatabase.objects('NegativeAdjustmentReason');
+    }
+
+    if (isVaccine) {
       return UIDatabase.objects('Options').filtered(
         '(type == $0 || type == $1) && isActive == true',
         'negativeInventoryAdjustment',
         'openVialWastage'
       );
     }
-
-    if (usingReasons && difference !== 0) {
-      if (difference > 0) {
-        return UIDatabase.objects('PositiveAdjustmentReason');
-      }
-      return UIDatabase.objects('NegativeAdjustmentReason');
-    }
-
     return [];
   })();
 
@@ -306,12 +305,10 @@ StocktakeBatchModalComponent.propTypes = {
   usingVaccines: PropTypes.bool.isRequired,
   usingHideSnapshotColumn: PropTypes.bool.isRequired,
   dispatch: PropTypes.func.isRequired,
-  usingOpenVialWastageReasons: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => {
   const usingPayments = selectUsingPayments(state);
-  const usingOpenVialWastageReasons = UIDatabase.objects('OpenVialWastageReason').length > 0;
   const usingReasons =
     UIDatabase.objects('NegativeAdjustmentReason').length > 0 &&
     UIDatabase.objects('PositiveAdjustmentReason').length > 0;
@@ -322,7 +319,6 @@ const mapStateToProps = (state, ownProps) => {
     usingReasons,
     usingVaccines,
     usingHideSnapshotColumn,
-    usingOpenVialWastageReasons,
   };
 };
 

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -61,8 +61,7 @@ export const StocktakeBatchModalComponent = ({
 }) => {
   const initialState = useMemo(() => {
     const pageObject = stocktakeItem;
-
-    if (usingVaccines && usingReasons && usingOpenVialWastageReasons) {
+    if (usingVaccines && usingReasons) {
       return { page: MODALS.STOCKTAKE_BATCH_EDIT_WITH_VACCINES_AND_REASONS, pageObject };
     }
 
@@ -101,20 +100,19 @@ export const StocktakeBatchModalComponent = ({
   const { difference = 0 } = modalValue || {};
 
   const reasonsSelection = (() => {
-    if (difference > 0) {
-      return UIDatabase.objects('PositiveAdjustmentReason');
-    }
-
-    if (usingReasons && !isVaccine) {
-      return UIDatabase.objects('NegativeAdjustmentReason');
-    }
-
     if (usingOpenVialWastageReasons && isVaccine) {
       return UIDatabase.objects('Options').filtered(
         '(type == $0 || type == $1) && isActive == true',
         'negativeInventoryAdjustment',
         'openVialWastage'
       );
+    }
+
+    if (usingReasons && difference !== 0) {
+      if (difference > 0) {
+        return UIDatabase.objects('PositiveAdjustmentReason');
+      }
+      return UIDatabase.objects('NegativeAdjustmentReason');
     }
 
     return [];


### PR DESCRIPTION
If reason is active (if both negative and positive reasons are enabled) then reason column must be visible to all items including vaccines.

Fixes #5086 

## Change summary

Reason column is visible to vaccine items too even `Open vial wastage` reason is disabled

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Take a data having both vaccine and non vaccine items for mobile site, if not then create both
- [ ] Go to mSupply desktop > Preferences > Options > Create some reasons for `Positive`/`Negative` inventory adjustment and `Open vial wastage`.
- [ ] Make a tick to them to enable the respective reason.
- [ ] Setup a mobile and sync must be up to date.
- [ ] Mobile, create a stocktake with vaccine and non vaccine items
- [ ] Click `Batch` column, the `Reason` column must be visible to each batch
- [ ] If difference is greater than zero then positive reason should be visible
- [ ] If difference is less than zero and not vaccine then negative reason should be visible
- [ ] If difference is less than zero and vaccine item then negative and vial reasons should be visible
- [ ] Then finalize stocktake, if at least one batch missed reason then you can't finalize.
- [ ] Repeat same process from point 2, just disable the `Open vial wastage` in desktop
- [ ] Now, all items including vaccines the reason column must visible with either positive or negative reason.
- [ ] You should be able to select one and finalize.
- [ ] Stocktake finalization takes place if reason set to all counted items having quantity difference greater or less than zero

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
