### PR TITLE
5097 Fix Instances of same model in different nested routes opens multiple  models in background

### DIFF
--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { useIsFocused } from '@react-navigation/core';
 import { FormControl } from '..';
 import { PageButton } from '../PageButton';
 import { FlexRow } from '../FlexRow';
@@ -47,6 +48,8 @@ const PatientEditModalComponent = ({
   isCreatePatient,
   patientEditModalOpen,
 }) => {
+  const isFocused = useIsFocused();
+
   let canSave = canSaveForm && canEditPatient;
 
   const hasVaccineEvents = hasVaccineEventsForm;
@@ -65,7 +68,7 @@ const PatientEditModalComponent = ({
     <ModalContainer
       title={`${dispensingStrings.patient_detail}`}
       noCancel
-      isVisible={patientEditModalOpen}
+      isVisible={isFocused && patientEditModalOpen}
     >
       <FlexRow style={{ flexDirection: 'column' }} flex={1}>
         <FlexRow flex={1}>

--- a/src/widgets/modals/InsurancePolicyModel.js
+++ b/src/widgets/modals/InsurancePolicyModel.js
@@ -8,6 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
+import { useIsFocused } from '@react-navigation/core';
 import { selectInsuranceModalOpen, selectCanEditInsurancePolicy } from '../../selectors/insurance';
 import { selectCanEditPatient } from '../../selectors/patient';
 import { ModalContainer } from './ModalContainer';
@@ -26,25 +27,29 @@ const InsurancePolicyModelComponent = ({
   // Insurance callbacks
   cancelInsuranceEdit,
   saveInsurancePolicy,
-}) => (
-  <ModalContainer
-    title={`${dispensingStrings.insurance_policy}`}
-    noCancel
-    isVisible={insuranceModalOpen}
-  >
-    <FormControl
-      isDisabled={!canEditInsurancePolicy}
-      confirmOnSave={!canEditPatient}
-      confirmText={dispensingStrings.confirm_new_policy}
-      onSave={saveInsurancePolicy}
-      onCancel={cancelInsuranceEdit}
-      inputConfig={getFormInputConfig(
-        'insurancePolicy',
-        isCreatingInsurancePolicy ? null : selectedInsurancePolicy
-      )}
-    />
-  </ModalContainer>
-);
+}) => {
+  const isFocused = useIsFocused();
+
+  return (
+    <ModalContainer
+      title={`${dispensingStrings.insurance_policy}`}
+      noCancel
+      isVisible={isFocused && insuranceModalOpen}
+    >
+      <FormControl
+        isDisabled={!canEditInsurancePolicy}
+        confirmOnSave={!canEditPatient}
+        confirmText={dispensingStrings.confirm_new_policy}
+        onSave={saveInsurancePolicy}
+        onCancel={cancelInsuranceEdit}
+        inputConfig={getFormInputConfig(
+          'insurancePolicy',
+          isCreatingInsurancePolicy ? null : selectedInsurancePolicy
+        )}
+      />
+    </ModalContainer>
+  );
+};
 
 const mapDispatchToProps = dispatch => ({
   cancelInsuranceEdit: () => dispatch(InsuranceActions.cancel()),

--- a/src/widgets/modals/PrescriberModel.js
+++ b/src/widgets/modals/PrescriberModel.js
@@ -8,6 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
+import { useIsFocused } from '@react-navigation/core';
 import { selectPrescriberModalOpen, selectCanEditPrescriber } from '../../selectors/prescriber';
 import { ModalContainer } from './ModalContainer';
 import { FormControl } from '..';
@@ -22,20 +23,24 @@ const PrescriberModelComponent = ({
   currentPrescriber,
   prescriberModalOpen,
   canEditPrescriber,
-}) => (
-  <ModalContainer
-    title={`${dispensingStrings.prescriber} ${dispensingStrings.details}`}
-    noCancel
-    isVisible={prescriberModalOpen}
-  >
-    <FormControl
-      isDisabled={!canEditPrescriber}
-      onSave={savePrescriber}
-      onCancel={cancelPrescriberEdit}
-      inputConfig={getFormInputConfig('prescriber', currentPrescriber)}
-    />
-  </ModalContainer>
-);
+}) => {
+  const isFocused = useIsFocused();
+
+  return (
+    <ModalContainer
+      title={`${dispensingStrings.prescriber} ${dispensingStrings.details}`}
+      noCancel
+      isVisible={isFocused && prescriberModalOpen}
+    >
+      <FormControl
+        isDisabled={!canEditPrescriber}
+        onSave={savePrescriber}
+        onCancel={cancelPrescriberEdit}
+        inputConfig={getFormInputConfig('prescriber', currentPrescriber)}
+      />
+    </ModalContainer>
+  );
+};
 
 const mapDispatchToProps = dispatch => ({
   cancelPrescriberEdit: () => dispatch(PrescriberActions.closeModal()),


### PR DESCRIPTION
Fixes #5097

## Change summary

Use useIsFocused to check if the model is in focus. The background one would have this value returned to false and foreground one has it to true. Add this isFocused check in model visible prop of the model.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Patient edit/create or prescriber edit/create. Could you open it from the prescriber select window?
- [ ] You would see the patient edit or prescriber edit model open. It would work properly and will let you edit data properly.
- [ ] Previously If you have a slow system and you give good attention you can see 2 models open, one at the background and one at the foreground. Most of the time this is unnoticeable. Also has not bearing on functionality but it is a problem. This multiple model opening should not happen.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
