### PR TITLE
5101 Patient survey demographic data does not load

### DIFF
--- a/src/database/utilities/createRecord.js
+++ b/src/database/utilities/createRecord.js
@@ -6,7 +6,6 @@
 import moment from 'moment';
 import { generateUUID } from 'react-native-database';
 
-import UIDatabase from '../UIDatabase';
 import { versionToInteger, formatDateAndTime } from '../../utilities';
 import { parseNumber } from './parsers';
 import { NUMBER_OF_DAYS_IN_A_MONTH, NUMBER_SEQUENCE_KEYS, PATIENT_CODE_LENGTH } from './constants';
@@ -1255,7 +1254,7 @@ const createAdverseDrugReaction = (database, patient, formData, user) => {
 
   if (!formSchema) return null;
 
-  const newADR = UIDatabase.update('AdverseDrugReaction', {
+  const newADR = database.update('AdverseDrugReaction', {
     id: generateUUID(),
     name: patient,
     user,

--- a/src/widgets/PrescriptionInfo.js
+++ b/src/widgets/PrescriptionInfo.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { batch, connect } from 'react-redux';
 
 import { FlexRow } from './FlexRow';
 import { FlexView } from './FlexView';
@@ -28,6 +28,7 @@ import { selectCanEditPatient } from '../selectors/patient';
 import { selectCanEditPrescriber } from '../selectors/prescriber';
 
 import { dispensingStrings } from '../localization';
+import { NameNoteActions } from '../actions';
 
 const PrescriptionInfoComponent = ({
   prescriptionPatient,
@@ -97,7 +98,12 @@ const PrescriptionInfoComponent = ({
 };
 
 const mapDispatchToProps = dispatch => {
-  const editPatient = patient => dispatch(PatientActions.editPatient(patient));
+  const editPatient = patient =>
+    batch(() => {
+      dispatch(NameNoteActions.createSurveyNameNote(patient));
+      dispatch(PatientActions.editPatient(patient));
+    });
+
   const viewHistory = patient => dispatch(PatientActions.viewPatientHistory(patient));
   const editPrescriber = prescriber => dispatch(PrescriberActions.editPrescriber(prescriber));
   return { editPatient, viewHistory, editPrescriber };


### PR DESCRIPTION
Fixes #5101

## Change summary

Survey data needs to be loaded for it to show up in the edit patient window. It is loaded on the edit button click. The button at the front patient select table in dispensing page does load survey data. The button inside does not. Make sure the button inside loads it too.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Load kiribati vax data file
- [ ] Go to the 'Dispensing' page, Select a patient to dispense vaccine to. 
- [ ] This does not happen if you click the patient edit button in the root patient selection table column. Click this button first would load the data for any window coming afterward so to test the bug you have to avoid clicking the button here.
- [ ] In the patient prescriber select window or any other window other then patient select window, click on patient edit button, You can see that the patient demographic data beside the patient detail section load all data loaded. Also save button is not disabled.


### Related areas to think about

None
