### PR TITLE
5099 Stocktake batch sell price crash

### DIFF
--- a/src/pages/dataTableUtilities/actions/cellActions.js
+++ b/src/pages/dataTableUtilities/actions/cellActions.js
@@ -263,7 +263,9 @@ export const editSellPrice = (value, rowKey, route) => (dispatch, getState) => {
   const { value: currencyValue } = valueAsCurrency;
   if (currencyValue !== sellPrice) {
     UIDatabase.write(() => {
-      UIDatabase.update(objectDataType, { id, sellPrice: currencyValue });
+      if (!Number.isNaN(currencyValue)) {
+        UIDatabase.update(objectDataType, { id, sellPrice: currencyValue });
+      }
       dispatch(refreshRow(rowKey, route));
     });
   }

--- a/src/widgets/modals/StocktakeBatchModal.js
+++ b/src/widgets/modals/StocktakeBatchModal.js
@@ -138,7 +138,10 @@ export const StocktakeBatchModalComponent = ({
   const onEditDate = (date, rowKey, columnKey) =>
     dispatch(PageActions.editStocktakeBatchExpiryDate(date, rowKey, columnKey));
   const onEditSellPrice = (newValue, rowKey) =>
-    dispatch(PageActions.editSellPrice(newValue, rowKey));
+    batch(() => {
+      dispatch(PageActions.editSellPrice(newValue, rowKey));
+      reduxDispatch(PageActions.refreshRow(stocktakeItem.id, ROUTES.STOCKTAKE_EDITOR));
+    });
   const onEditBatchDoses = (newValue, rowKey) => {
     dispatch(PageActions.editBatchDoses(newValue, rowKey));
     reduxDispatch(PageActions.refreshRow(stocktakeItem.id, ROUTES.STOCKTAKE_EDITOR));


### PR DESCRIPTION
Fixes #5099

## Change summary

If the user submits wrong format number the system should be wise enough to stop taking input when the format is wrong.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Stocktake, Click on New Stoktake. Click on Batches.
- [ ] In sell price column try adding 2.00., notice the dot at the end. It could be any wrong format.
- [ ] The system should not crash and the price should readjust to a number.

### Related areas to think about

None
