### PR TITLE
#5132 check for local duplicity of patient

### DIFF
--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -3,6 +3,7 @@
     "adr_form_for": "ADR Form for:",
     "are_you_sure_delete_sensor": "Are you sure you want to delete this sensor?",
     "are_you_sure_delete_patient": "Are you sure you want to delete this patient?",
+    "are_you_sure_duplicate_patient": "Are you sure you want to duplicate this patient?",
     "patient_cant_delete_with_vaccine_events": "You can only delete records of patients who do not have any active vaccine events. Please make sure that the vaccine events has been deleted if you want to delete this patient.",
     "add_at_least_one_item_before_finalising": "You need to add at least one item before finalising",
     "and": "and",

--- a/src/localization/modalStrings.json
+++ b/src/localization/modalStrings.json
@@ -3,7 +3,7 @@
     "adr_form_for": "ADR Form for:",
     "are_you_sure_delete_sensor": "Are you sure you want to delete this sensor?",
     "are_you_sure_delete_patient": "Are you sure you want to delete this patient?",
-    "are_you_sure_duplicate_patient": "Are you sure you want to duplicate this patient?",
+    "are_you_sure_duplicate_patient": "Are you sure you want to duplicate this patient? A patient with name: {0} and date of birth: {1} already exist.",
     "patient_cant_delete_with_vaccine_events": "You can only delete records of patients who do not have any active vaccine events. Please make sure that the vaccine events has been deleted if you want to delete this patient.",
     "add_at_least_one_item_before_finalising": "You need to add at least one item before finalising",
     "and": "and",

--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -93,11 +93,12 @@ export const selectPatientByNameAndDoB = ({ lastName, firstName, dateOfBirth }) 
   if (dateOfBirth) {
     const dob = moment(dateOfBirth).format('L');
 
-    const query = 'lastName = $0 AND firstName = $1';
+    const query = 'lastName = $0 AND firstName = $1 AND isDeleted = $2';
     const duplicatePatients = UIDatabase.objects('Patient').filtered(
       query,
       lastName.trim(),
-      firstName.trim()
+      firstName.trim(),
+      false
     );
 
     if (duplicatePatients) {

--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -85,6 +85,8 @@ export const selectCanEditPatient = ({ patient }) => {
 /**
  * Query an existing patient by its name(firstName lastName) and DoB,
  * if patient exist then return True
+ * @param { lastName, firstName, dateOfBirth } from completed Form
+ * @returns boolean, True if patient exist with same lastName, firstName, dateOfBirth
  */
 
 export const selectPatientByNameAndDoB = ({ lastName, firstName, dateOfBirth }) => {
@@ -103,7 +105,6 @@ export const selectPatientByNameAndDoB = ({ lastName, firstName, dateOfBirth }) 
         const selectedDoB = selectedPatient.dateOfBirth;
         return moment(selectedDoB).format('L') === dob;
       });
-      console.log('duplicatePatient ', duplicatePatient);
       return duplicatePatient;
     }
   }

--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -2,6 +2,7 @@
  * mSupply Mobile
  * Sustainable Solutions (NZ) Ltd. 2019
  */
+import moment from 'moment';
 
 import currency from '../localization/currency';
 import { UIDatabase } from '../database';
@@ -79,4 +80,32 @@ export const selectCanEditPatient = ({ patient }) => {
   const { isEditable = true } = currentPatient ?? {};
 
   return UIDatabase.getPreference(PREFERENCE_KEYS.CAN_EDIT_PATIENTS_FROM_ANY_STORE) || isEditable;
+};
+
+/**
+ * Query an existing patient by its name(firstName lastName) and DoB,
+ * if patient exist then return True
+ */
+
+export const selectPatientByNameAndDoB = ({ lastName, firstName, dateOfBirth }) => {
+  if (dateOfBirth) {
+    const dob = moment(dateOfBirth).format('L');
+
+    const query = 'lastName = $0 AND firstName = $1';
+    const duplicatePatients = UIDatabase.objects('Patient').filtered(
+      query,
+      lastName.trim(),
+      firstName.trim()
+    );
+
+    if (duplicatePatients) {
+      const duplicatePatient = duplicatePatients.some(selectedPatient => {
+        const selectedDoB = selectedPatient.dateOfBirth;
+        return moment(selectedDoB).format('L') === dob;
+      });
+      console.log('duplicatePatient ', duplicatePatient);
+      return duplicatePatient;
+    }
+  }
+  return false;
 };

--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -128,7 +128,7 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     isRequired: true,
     validator: input => {
       let inputDate = moment(input, DATE_FORMAT.DD_MM_YYYY, null, true);
-      if (typeof input === 'number') {
+      if (input instanceof Date && !Number.isNaN(input)) {
         inputDate = moment(input);
       }
 

--- a/src/widgets/FormInputs/FormDOBInput.js
+++ b/src/widgets/FormInputs/FormDOBInput.js
@@ -125,8 +125,10 @@ const useDobInput = (initialValue, onChangeDate, onValidate) => {
 
   const onTypeDate = newDate => {
     const isValid = onValidate(newDate);
-    typedDate(newDate, isValid);
-    onChangeDate(moment(newDate, DATE_FORMAT.DD_MM_YYYY).toDate());
+    if (isValid) {
+      typedDate(newDate, isValid);
+      onChangeDate(moment(newDate, DATE_FORMAT.DD_MM_YYYY).toDate());
+    }
   };
 
   const onTypeAge = newAge => {

--- a/src/widgets/Tabs/PatientEdit.js
+++ b/src/widgets/Tabs/PatientEdit.js
@@ -9,6 +9,8 @@ import PropTypes from 'prop-types';
 import { ToastAndroid, View } from 'react-native';
 import { connect } from 'react-redux';
 import * as Animatable from 'react-native-animatable';
+import moment from 'moment';
+
 import useButtonEnabled from '../../hooks/useButtonEnabled';
 import { FormControl } from '../FormControl';
 import { PageButton } from '../PageButton';
@@ -70,12 +72,21 @@ const PatientEditComponent = ({
   const { pageTopViewContainer } = globalStyles;
   const [isDeceasedModalOpen, toggleIsDeceasedAlert] = useToggle(false);
   const [canDuplicatePatient, setDuplicatePatient] = useState(false);
-
+  const [alertText, setAlertText] = useState(modalStrings.are_you_sure_duplicate_patient);
   const { enabled: nextButtonEnabled, setEnabled: setNextButtonEnabled } = useButtonEnabled();
 
   useEffect(() => {
     if (isDuplicatePatientLocally && !canSaveForm) {
       setDuplicatePatient(true);
+
+      const dateOfBirth = moment(completedForm.dateOfBirth).format('LL');
+      const name = `${completedForm.firstName} ${completedForm.lastName}`;
+      const alert = modalStrings.formatString(
+        modalStrings.are_you_sure_duplicate_patient,
+        name,
+        dateOfBirth
+      );
+      setAlertText(alert);
     }
   }, [isDuplicatePatientLocally]);
 
@@ -162,7 +173,7 @@ const PatientEditComponent = ({
       </PaperModalContainer>
       <PaperModalContainer isVisible={canDuplicatePatient} onClose={previousTab}>
         <PaperConfirmModal
-          questionText={modalStrings.are_you_sure_duplicate_patient}
+          questionText={alertText}
           confirmText={generalStrings.ok}
           cancelText={buttonStrings.cancel}
           onConfirm={onConfirmDuplicatePatient}

--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -53,7 +53,7 @@ const PatientEditModalComponent = ({
   const isFocused = useIsFocused();
 
   let canSave = canSaveForm && canEditPatient;
-  let canDuplicatePatientEnter = false;
+  let canDuplicatePatient = false;
 
   const hasVaccineEvents = hasVaccineEventsForm;
 
@@ -61,11 +61,7 @@ const PatientEditModalComponent = ({
     canSave = surveySchema && surveyForm && nameNoteIsValid;
   }
 
-  console.log('canSave ', canSave);
-  console.log('isDuplicatePatientLocally ', isDuplicatePatientLocally);
-
-  canDuplicatePatientEnter = canSave && isDuplicatePatientLocally && isCreatePatient;
-  console.log('canDuplicatePatientEnter ', canDuplicatePatientEnter);
+  canDuplicatePatient = canSave && isDuplicatePatientLocally && isCreatePatient;
 
   const canDelete = canEditPatient;
   const showDelete = !isCreatePatient;
@@ -147,10 +143,10 @@ const PatientEditModalComponent = ({
             onCancel={toggleRemoveModal}
           />
         </PaperModalContainer>
-        <PaperModalContainer isVisible={canDuplicatePatientEnter} onClose={cancelPatientEdit}>
+        <PaperModalContainer isVisible={canDuplicatePatient} onClose={cancelPatientEdit}>
           <PaperConfirmModal
-            questionText={modalStrings.are_you_sure_delete_patient}
-            confirmText={generalStrings.remove}
+            questionText={modalStrings.are_you_sure_duplicate_patient}
+            confirmText={generalStrings.save}
             cancelText={buttonStrings.cancel}
             onConfirm={onSaveForm}
             onCancel={cancelPatientEdit}

--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -1,9 +1,11 @@
 /* eslint-disable react/forbid-prop-types */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useIsFocused } from '@react-navigation/core';
+import moment from 'moment';
+
 import { FormControl } from '..';
 import { PageButton } from '../PageButton';
 import { FlexRow } from '../FlexRow';
@@ -49,8 +51,10 @@ const PatientEditModalComponent = ({
   isCreatePatient,
   patientEditModalOpen,
   isDuplicatePatientLocally,
+  completedForm,
 }) => {
   const isFocused = useIsFocused();
+  const [alertText, setAlertText] = useState(modalStrings.are_you_sure_duplicate_patient);
 
   let canSave = canSaveForm && canEditPatient;
   let canDuplicatePatient = false;
@@ -62,6 +66,16 @@ const PatientEditModalComponent = ({
   }
 
   canDuplicatePatient = canSave && isDuplicatePatientLocally && isCreatePatient;
+  useEffect(() => {
+    const dateOfBirth = moment(completedForm.dateOfBirth).format('LL');
+    const name = `${completedForm.firstName} ${completedForm.lastName}`;
+    const alert = modalStrings.formatString(
+      modalStrings.are_you_sure_duplicate_patient,
+      name,
+      dateOfBirth
+    );
+    setAlertText(alert);
+  }, [isDuplicatePatientLocally]);
 
   const canDelete = canEditPatient;
   const showDelete = !isCreatePatient;
@@ -145,7 +159,7 @@ const PatientEditModalComponent = ({
         </PaperModalContainer>
         <PaperModalContainer isVisible={canDuplicatePatient} onClose={cancelPatientEdit}>
           <PaperConfirmModal
-            questionText={modalStrings.are_you_sure_duplicate_patient}
+            questionText={alertText}
             confirmText={generalStrings.save}
             cancelText={buttonStrings.cancel}
             onConfirm={onSaveForm}
@@ -210,6 +224,7 @@ PatientEditModalComponent.propTypes = {
   isCreatePatient: PropTypes.bool,
   patientEditModalOpen: PropTypes.bool.isRequired,
   isDuplicatePatientLocally: PropTypes.bool,
+  completedForm: PropTypes.object.isRequired,
 };
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {

--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -49,17 +49,24 @@ const PatientEditModalComponent = ({
   isCreatePatient,
   patientEditModalOpen,
   isDuplicatePatientLocally,
-  isDuplicatePatientExist,
 }) => {
   const isFocused = useIsFocused();
 
   let canSave = canSaveForm && canEditPatient;
+  let canDuplicatePatientEnter = false;
 
   const hasVaccineEvents = hasVaccineEventsForm;
-  console.log('isDuplicatePatientLocally ', isDuplicatePatientLocally);
 
   if (canSave && !!surveySchema) {
     canSave = surveySchema && surveyForm && nameNoteIsValid;
+  }
+
+  console.log('canSave ', canSave);
+  console.log('isDuplicatePatientLocally ', isDuplicatePatientLocally);
+
+  if (canSave && isDuplicatePatientLocally) {
+    canDuplicatePatientEnter = canSave && isDuplicatePatientLocally;
+    console.log('canDuplicatePatientEnter ', canDuplicatePatientEnter);
   }
 
   const canDelete = canEditPatient;
@@ -67,12 +74,6 @@ const PatientEditModalComponent = ({
 
   const [removeModalOpen, toggleRemoveModal] = useToggle();
   const [cannotDeleteModalOpen, toggleCannotDeleteModal] = useToggle();
-  // const [isDuplicatePatientModalOpen, setDuplicatePatientModal] = useState(false);
-
-  const toggleDuplicatePatientModal = () => !isDuplicatePatientExist;
-  console.log('isDuplicatePatientExist ', isDuplicatePatientExist);
-
-  // const canEnterDuplicatePatient = () => setDuplicatePatient(isDuplicatePatientLocally);
 
   return (
     <ModalContainer
@@ -148,16 +149,13 @@ const PatientEditModalComponent = ({
             onCancel={toggleRemoveModal}
           />
         </PaperModalContainer>
-        <PaperModalContainer
-          isVisible={isDuplicatePatientExist}
-          onClose={toggleDuplicatePatientModal}
-        >
+        <PaperModalContainer isVisible={canDuplicatePatientEnter} onClose={cancelPatientEdit}>
           <PaperConfirmModal
             questionText={modalStrings.are_you_sure_delete_patient}
             confirmText={generalStrings.remove}
             cancelText={buttonStrings.cancel}
-            onConfirm={onDeleteForm}
-            onCancel={toggleDuplicatePatientModal}
+            onConfirm={onSaveForm}
+            onCancel={cancelPatientEdit}
           />
         </PaperModalContainer>
       </FlexRow>
@@ -218,19 +216,14 @@ PatientEditModalComponent.propTypes = {
   isCreatePatient: PropTypes.bool,
   patientEditModalOpen: PropTypes.bool.isRequired,
   isDuplicatePatientLocally: PropTypes.bool,
-  isDuplicatePatientExist: PropTypes.bool.isRequired,
 };
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const { completedForm, isDuplicatePatientLocally } = stateProps;
+  const { completedForm } = stateProps;
   const { onSave, onDelete, onSaveSurvey, ...otherDispatchProps } = dispatchProps;
   // const { surveySchema } = ownProps;
   const surveySchema = selectSurveySchemas()[0];
-  let isDuplicatePatientExist = false;
   const onSaveForm = () => {
-    if (isDuplicatePatientLocally) {
-      isDuplicatePatientExist = isDuplicatePatientLocally;
-    }
     onSave(completedForm);
     if (surveySchema) onSaveSurvey();
   };
@@ -246,7 +239,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     surveySchema,
     onSaveForm,
     onDeleteForm,
-    isDuplicatePatientExist,
   };
 };
 
@@ -268,8 +260,6 @@ const stateToProps = state => {
   const isCreatePatient = selectIsCreatePatient(state);
   const hasVaccineEventsForm = patientHistory.length > 0;
   const [patientEditModalOpen] = selectPatientModalOpen(state);
-  console.log('completedForm ', completedForm);
-
   const isDuplicatePatientLocally = selectPatientByNameAndDoB(completedForm);
 
   return {

--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -64,10 +64,8 @@ const PatientEditModalComponent = ({
   console.log('canSave ', canSave);
   console.log('isDuplicatePatientLocally ', isDuplicatePatientLocally);
 
-  if (canSave && isDuplicatePatientLocally) {
-    canDuplicatePatientEnter = canSave && isDuplicatePatientLocally;
-    console.log('canDuplicatePatientEnter ', canDuplicatePatientEnter);
-  }
+  canDuplicatePatientEnter = canSave && isDuplicatePatientLocally && isCreatePatient;
+  console.log('canDuplicatePatientEnter ', canDuplicatePatientEnter);
 
   const canDelete = canEditPatient;
   const showDelete = !isCreatePatient;


### PR DESCRIPTION
Fixes #5132 

## Change summary

Check for local duplicity of patient when creating new.
If patient already exists with same lastName, firstName, and dateOfBirth then we need a confirmation modal.
Either we can cancel the duplicity or can create duplicate patient.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Dispensary
- [ ] Create a new patient
- [ ] Enter all mandatory fields, the `Save` button will be enable to create new patient.
- [ ] Save above patient.
- [ ] Try to recreate the same patient having same firstName, lastName, and dateOfBirth as above
- [ ] If above fields are matched and mandatory fields are entered then an confirmation alert `Are you sure you want to duplicate this patient? A patient with name: {0} and date of birth: {1} already exist.` will be generated.
- [ ] If you click `Cancel` then nothing will be saved and page return to patient list.
- [ ] If you click `Save` then duplicate patient will be created having same details as above.
- [ ] Repeat above steps for vaccination module, if you try to duplicate a new patient by entering firstName, lastName, and dateOfBirth then above alert will be generated.
- [ ] If you click `Cancel` then page go to previous opening tab.
- [ ] If you click `OK` then page remains in the entry form and keep continue to enter all mandatory fields to create new patient.
- [ ] Make sure that this is applied to new patient only not editing old patient.

### Related areas to think about

@bijaySussol once the above confirmation title `Are you sure you want to duplicate this patient?` approved, we could need its Chinese translation.
