### PR TITLE
Fetch all predictions

### DIFF
--- a/src/database/DataTypes/RequisitionItem.js
+++ b/src/database/DataTypes/RequisitionItem.js
@@ -10,6 +10,7 @@ import { UIDatabase } from '..';
 import { SETTINGS_KEYS } from '../../settings';
 import { NUMBER_OF_DAYS_IN_A_MONTH, createRecord } from '../utilities';
 import { customerRequisitionProgramDailyUsage } from '../../utilities/dailyUsage';
+import { logME } from '../../utilities/prediction/macroEyes';
 
 /**
  * A requisition item (i.e. a requisition line).
@@ -87,15 +88,16 @@ export class RequisitionItem extends Realm.Object {
    */
   get suggestedQuantity() {
     /**
-     *
-     * Predicted quantity is received from the ME API
+     * Use predictedQuantity field where we store prediction value from ME API. Since
+     * predictedQuantity can also be equal to 0, include it in the check.
      *
      */
-    if (this.predictedQuantity) {
+    if (this.predictedQuantity >= 0) {
+      logME('USE_ME_PREDICTION: ', this.item?.code);
       const predictedDaily = this.predictedQuantity / NUMBER_OF_DAYS_IN_A_MONTH;
       return Math.ceil(Math.max(predictedDaily * this.daysToSupply - this.stockOnHand, 0));
     }
-
+    logME('FALLBACK_PREDICTION: ', this.item?.code);
     return Math.ceil(Math.max(this.dailyUsage * this.daysToSupply - this.stockOnHand, 0));
   }
 
@@ -311,7 +313,10 @@ RequisitionItem.schema = {
     stockOnHand: { type: 'double', default: 0 },
     dailyUsage: { type: 'double', optional: true },
     imprestQuantity: { type: 'double', optional: true },
-    predictedQuantity: { type: 'double', default: 0 },
+
+    // Default of -1 is used instead of 0 to enable checking for ME predictions = 0
+    predictedQuantity: { type: 'double', default: -1 },
+
     requiredQuantity: { type: 'double', optional: true },
     suppliedQuantity: { type: 'double', default: 0 },
     openingStock: { type: 'double', default: 0 },

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -268,13 +268,15 @@ const SupplierRequisition = ({
 
           updatePredictions(requisition?.id, response);
         } else {
+          logME('ERROR: ', response?.message);
+
           const toastMessage = `${programStrings.ai_predictions_error} - ${response?.message}:${response?.stack}:${API_URL}`;
           ToastAndroid.show(toastMessage, ToastAndroid.LONG);
         }
       })
       .catch(error => {
         ToastAndroid.show(error, ToastAndroid.LONG);
-        logME('ERROR: ', error);
+        logME('EXCEPTION: ', error);
       })
       .finally(() => {
         // Trigger the original suggested values event

--- a/src/utilities/prediction/macroEyes.js
+++ b/src/utilities/prediction/macroEyes.js
@@ -106,17 +106,17 @@ export const getMEPrediction = requestObj => {
   if (!API_URL || !API_KEY) {
     return Promise.resolve({
       error: true,
-      message: 'Provide valid API credentials',
+      message: 'ME API credentials not found',
     });
   }
   ToastAndroid.show(programStrings.ai_predictions_fetching_suggestions, ToastAndroid.SHORT);
 
-  const { supplying_store_id, items } = requestObj;
+  const { supplying_store_id } = requestObj;
 
-  if (supplying_store_id === undefined || items.length === 0) {
+  if (supplying_store_id === undefined) {
     return Promise.resolve({
       error: true,
-      message: 'Provide valid item object',
+      message: 'Supplying store is required',
     });
   }
 

--- a/src/utilities/prediction/macroEyes.js
+++ b/src/utilities/prediction/macroEyes.js
@@ -194,10 +194,20 @@ export const updatePredictions = (requisitionId, items) => {
       selection.forEach(s => {
         const prediction = filterPrediction(s?.item?.code);
 
-        if (prediction.length > 0) {
-          s.predictedQuantity = prediction?.[0]?.suggested_quantity;
-        }
+        /**
+         * If no prediction available for an item, set predictedQuanity to -1, which triggers
+         * fallback to the default calculated based on dailyUsage
+         */
+        s.predictedQuantity = prediction.length > 0 ? prediction?.[0]?.suggested_quantity : -1;
       });
     });
   }
+};
+
+/**
+ * ME Logger
+ *
+ */
+export const logME = (...args) => {
+  console.log('ME_', args);
 };


### PR DESCRIPTION
Fixes #? n/a

## Change summary

Updates the way we fetch predictions from the ME API:
- Update `SupplierRequisitionPage` request object to use default `data` variable to get requisition info
- Remove need for `requestedItems` to be greater than 0 to make API call. Will fetch from the server any time Use Suggested Quanitities button is clicked
- Update `Requisition` item `predictedQuantity` field default to -1
- ME prediction calculation supports suggested quantity = 0
- Added logging function

## Testing

Steps to reproduce or otherwise test the changes of this PR:
- Open any requisition
- Click Use Suggested Quantity button

### Related areas to think about

n/a
