### PR TITLE
Fix undefined in fetching requisition

### DIFF
--- a/src/database/DataTypes/RequisitionItem.js
+++ b/src/database/DataTypes/RequisitionItem.js
@@ -10,7 +10,7 @@ import { UIDatabase } from '..';
 import { SETTINGS_KEYS } from '../../settings';
 import { NUMBER_OF_DAYS_IN_A_MONTH, createRecord } from '../utilities';
 import { customerRequisitionProgramDailyUsage } from '../../utilities/dailyUsage';
-import { logME } from '../../utilities/prediction/macroEyes';
+import { PREDICTION_NOT_AVAILABLE, logME } from '../../utilities/prediction/macroEyes';
 
 /**
  * A requisition item (i.e. a requisition line).
@@ -93,7 +93,7 @@ export class RequisitionItem extends Realm.Object {
      *
      */
     if (this.predictedQuantity >= 0) {
-      logME('USE_ME_PREDICTION: ', this.item?.code);
+      logME('USE_ME_PREDICTION: ', this.predictedQuantity, this.item?.code);
       const predictedDaily = this.predictedQuantity / NUMBER_OF_DAYS_IN_A_MONTH;
       return Math.ceil(Math.max(predictedDaily * this.daysToSupply - this.stockOnHand, 0));
     }
@@ -313,10 +313,7 @@ RequisitionItem.schema = {
     stockOnHand: { type: 'double', default: 0 },
     dailyUsage: { type: 'double', optional: true },
     imprestQuantity: { type: 'double', optional: true },
-
-    // Default of -1 is used instead of 0 to enable checking for ME predictions = 0
-    predictedQuantity: { type: 'double', default: -1 },
-
+    predictedQuantity: { type: 'double', default: PREDICTION_NOT_AVAILABLE },
     requiredQuantity: { type: 'double', optional: true },
     suppliedQuantity: { type: 'double', default: 0 },
     openingStock: { type: 'double', default: 0 },

--- a/src/pages/SupplierRequisitionPage.js
+++ b/src/pages/SupplierRequisitionPage.js
@@ -241,11 +241,14 @@ const SupplierRequisition = ({
           };
         }) || [];
 
-    const { requisition } = data[0];
+    const { requisition } = data?.[0] || {};
 
     const requestObject = {
       // Requisition metadata
+
+      // TODO: Rename to `store_id`
       supplying_store_id: storeId,
+
       program: program?.id,
       order_type: requisition?.orderType,
       period: requisition?.period?.id,
@@ -254,6 +257,8 @@ const SupplierRequisition = ({
       // Items requesting prediction
       items: requestedItems,
     };
+
+    logME('REQUISITION: ', requisition);
 
     logME('REQUEST: ', requestObject);
 

--- a/src/utilities/prediction/macroEyes.js
+++ b/src/utilities/prediction/macroEyes.js
@@ -18,6 +18,14 @@ const TIMEOUT_MS = 10 * 1000;
 
 /**
  *
+ * Default value for the predictedQuantity in a RequisitionItem. This ensures
+ * predictions from the ME API = 0 will not default to the mSupply calculation
+ *
+ */
+export const PREDICTION_NOT_AVAILABLE = -1;
+
+/**
+ *
  * Fetches suggested quantities using React hooks
  *
  */
@@ -100,9 +108,9 @@ export const useMEPrediction = ({ item, retryCount = 3, timeout = TIMEOUT_MS }) 
 export const getMEPrediction = requestObj => {
   const API_URL =
     UIDatabase.getSetting(SETTINGS_KEYS.ME_PREDICTION_API_URL) ||
-    'http://civapi.dev.macro-eyes.com';
-
+    'https://civapi.dev.macro-eyes.com';
   const API_KEY = UIDatabase.getSetting(SETTINGS_KEYS.ME_PREDICTION_API_KEY);
+
   if (!API_URL || !API_KEY) {
     return Promise.resolve({
       error: true,
@@ -209,5 +217,5 @@ export const updatePredictions = (requisitionId, items) => {
  *
  */
 export const logME = (...args) => {
-  console.log('ME_', args);
+  console.debug('ME_', args);
 };


### PR DESCRIPTION
Fixes #5212 

## Change summary

Fixes error that causes crashing when `Use Suggested Quantities` button is clicked

## Testing

- Go to Requisition page
- Click `Use Suggested Quantities`

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
