### PR TITLE
#5215 fixed alert issue for name duplicity check

### DIFF
--- a/src/selectors/Entities/name.js
+++ b/src/selectors/Entities/name.js
@@ -138,6 +138,8 @@ export const selectIsNewName = state => {
   const { editing } = nameState;
   const { id } = editing ?? '';
 
-  const isNewName = UIDatabase.objects('Name').filtered('id = $0', id).length === 0;
-  return isNewName;
+  if (id) {
+    return UIDatabase.objects('Name').filtered('id = $0', id).length === 0;
+  }
+  return false;
 };

--- a/src/selectors/Entities/name.js
+++ b/src/selectors/Entities/name.js
@@ -132,3 +132,12 @@ export const selectWasPatientVaccinatedWithinOneDay = state => {
 
   return !!history.filter(historyRecord => historyRecord.confirmDate.getTime() > oneDayAgo).length;
 };
+
+export const selectIsNewName = state => {
+  const nameState = selectSpecificEntityState(state, 'name');
+  const { editing } = nameState;
+  const { id } = editing ?? '';
+
+  const isNewName = UIDatabase.objects('Name').filtered('id = $0', id).length === 0;
+  return isNewName;
+};

--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -71,7 +71,6 @@ export const selectPatientModalOpen = ({ patient }) => {
  * @returns boolean
  */
 export const selectIsCreatePatient = ({ patient }) => {
-  console.log('patient ', patient);
   const { isCreating } = patient;
   return isCreating;
 };
@@ -100,7 +99,6 @@ export const selectPatientByNameAndDoB = ({ lastName, firstName, dateOfBirth }) 
       firstName.trim(),
       false
     );
-    console.log('duplicatePatients ', duplicatePatients);
     if (duplicatePatients) {
       const duplicatePatient = duplicatePatients.some(selectedPatient => {
         const selectedDoB = selectedPatient.dateOfBirth;

--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -71,6 +71,7 @@ export const selectPatientModalOpen = ({ patient }) => {
  * @returns boolean
  */
 export const selectIsCreatePatient = ({ patient }) => {
+  console.log('patient ', patient);
   const { isCreating } = patient;
   return isCreating;
 };
@@ -92,7 +93,6 @@ export const selectCanEditPatient = ({ patient }) => {
 export const selectPatientByNameAndDoB = ({ lastName, firstName, dateOfBirth }) => {
   if (dateOfBirth) {
     const dob = moment(dateOfBirth).format('L');
-
     const query = 'lastName = $0 AND firstName = $1 AND isDeleted = $2';
     const duplicatePatients = UIDatabase.objects('Patient').filtered(
       query,
@@ -100,7 +100,7 @@ export const selectPatientByNameAndDoB = ({ lastName, firstName, dateOfBirth }) 
       firstName.trim(),
       false
     );
-
+    console.log('duplicatePatients ', duplicatePatients);
     if (duplicatePatients) {
       const duplicatePatient = duplicatePatients.some(selectedPatient => {
         const selectedDoB = selectedPatient.dateOfBirth;

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -63,7 +63,6 @@ import { DataTable, DataTableRow, DataTableHeaderRow } from '../DataTable';
 import { selectVaccinePatientHistory } from '../../selectors/Entities/name';
 import { PatientHistoryModal } from '../modals/PatientHistory';
 import { VaccinationEvent } from '../modals/VaccinationEvent';
-import { PatientActions } from '../../actions/PatientActions';
 
 const getMessage = (noResults, error) => {
   if (noResults) return generalStrings.could_not_find_patient;
@@ -372,12 +371,7 @@ const PatientSelectComponent = ({
 };
 
 const mapDispatchToProps = dispatch => {
-  const onCancelPrescription = () =>
-    batch(() => {
-      dispatch(VaccinePrescriptionActions.cancel());
-      dispatch(PatientActions.refresh());
-      dispatch(NameActions.reset());
-    });
+  const onCancelPrescription = () => dispatch(VaccinePrescriptionActions.cancel());
 
   const selectPatient = patient =>
     batch(async () => {
@@ -393,7 +387,7 @@ const mapDispatchToProps = dispatch => {
   const createPatient = () =>
     batch(() => {
       const patient = createDefaultName('patient', generateUUID());
-      dispatch(PatientActions.createPatient(patient));
+      dispatch(NameActions.create(patient));
       dispatch(NameNoteActions.createSurveyNameNote(patient));
       dispatch(WizardActions.switchTab(1));
     });
@@ -410,7 +404,6 @@ const mapDispatchToProps = dispatch => {
 const mapStateToProps = state => {
   const patientState = selectSpecificEntityState(state, 'name');
   const { searchTerm, sortKey, isAscending } = patientState;
-
   const completedForm = selectCompletedForm(state);
   const formConfig = selectPatientSearchFormConfig();
 

--- a/src/widgets/Tabs/PatientSelect.js
+++ b/src/widgets/Tabs/PatientSelect.js
@@ -63,6 +63,7 @@ import { DataTable, DataTableRow, DataTableHeaderRow } from '../DataTable';
 import { selectVaccinePatientHistory } from '../../selectors/Entities/name';
 import { PatientHistoryModal } from '../modals/PatientHistory';
 import { VaccinationEvent } from '../modals/VaccinationEvent';
+import { PatientActions } from '../../actions/PatientActions';
 
 const getMessage = (noResults, error) => {
   if (noResults) return generalStrings.could_not_find_patient;
@@ -371,7 +372,12 @@ const PatientSelectComponent = ({
 };
 
 const mapDispatchToProps = dispatch => {
-  const onCancelPrescription = () => dispatch(VaccinePrescriptionActions.cancel());
+  const onCancelPrescription = () =>
+    batch(() => {
+      dispatch(VaccinePrescriptionActions.cancel());
+      dispatch(PatientActions.refresh());
+      dispatch(NameActions.reset());
+    });
 
   const selectPatient = patient =>
     batch(async () => {
@@ -386,9 +392,8 @@ const mapDispatchToProps = dispatch => {
 
   const createPatient = () =>
     batch(() => {
-      const id = generateUUID();
-      const patient = createDefaultName('patient', id);
-      dispatch(NameActions.create(patient));
+      const patient = createDefaultName('patient', generateUUID());
+      dispatch(PatientActions.createPatient(patient));
       dispatch(NameNoteActions.createSurveyNameNote(patient));
       dispatch(WizardActions.switchTab(1));
     });

--- a/src/widgets/modalChildren/PatientEditModal.js
+++ b/src/widgets/modalChildren/PatientEditModal.js
@@ -253,7 +253,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
 
 const stateToProps = state => {
   const { patient } = state;
-
   const { currentPatient } = patient;
   const inputConfig = getFormInputConfig('patient', currentPatient);
 


### PR DESCRIPTION
Fixes #5215 

## Change summary

Mobile > In the vaccination module > Name duplicity check alert should be generated for new patient.
Check for local duplicity of patient when creating new.
If patient already exists with same lastName, firstName, and dateOfBirth then we need a confirmation modal.
Either we can cancel the duplicity or can create duplicate patient.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Vaccination, if not activated then active from desktop
- [ ] Create a new patient
- [ ] Enter all mandatory fields, the `Save` button will be enable to create new patient.
- [ ] Save above patient.
- [ ] Try to recreate the same patient having same firstName, lastName, and dateOfBirth as above
- [ ] If above fields are matched then an confirmation alert `Are you sure you want to duplicate this patient? A patient with name: {0} and date of birth: {1} already exist.` will be generated.
- [ ] If you click `Cancel` then nothing will be saved and page return to first tab of vaccination page.
- [ ] If you click `OK` then you are allowed to create a duplicate patient having same details as above.
- [ ] After clicking `OK`, and entering all mandatory fields click `Next` button and process all step to create a patient and its related vaccination event.
- [ ] In vaccination module a patient will be created successfully after vaccination.
- [ ] After this test same process from `Dispensing` module too.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
