### PR TITLE
#5223 fixed dob issue and dispense vaccine

### DIFF
--- a/src/utilities/formInputConfigs.js
+++ b/src/utilities/formInputConfigs.js
@@ -128,7 +128,7 @@ const FORM_INPUT_CONFIGS = seedObject => ({
     isRequired: true,
     validator: input => {
       let inputDate = moment(input, DATE_FORMAT.DD_MM_YYYY, null, true);
-      if (input instanceof Date && !Number.isNaN(input)) {
+      if (typeof input === 'number') {
         inputDate = moment(input);
       }
 


### PR DESCRIPTION
Fixes #5223 

## Change summary

Able to dispense vaccine to existing patient without playing with dob.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Go to Vaccination module
- [ ] View existing patient and click Next button, should go to next tab without touching date of birth field as it should be accurately set.
- [ ] Dispense a vaccine to them
- [ ] Try to do same to the new patient
- [ ] Also, test in Dispensing module too.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
