### PR TITLE
#5220 Fixed app crashing after editing patient

### DIFF
--- a/src/actions/PatientActions.js
+++ b/src/actions/PatientActions.js
@@ -156,7 +156,6 @@ const patientUpdate = patientDetails => async (dispatch, getState) => {
     dispatch(closeModal());
     dispatch(DispensaryActions.closeLookupModal());
     dispatch(DispensaryActions.refresh());
-    dispatch(PatientActions.refresh());
   });
 };
 

--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -52,14 +52,19 @@ export const selectAvailableCredit = ({ patient }) =>
 // TODO
 export const selectPatientInsurancePolicies = ({ patient }) => {
   const { currentPatient } = patient;
-  const { policies } = currentPatient;
-  return policies.map(policy => {
-    const { isActive, policyNumber, id, discountRate } = policy;
-    return isActive
-      ? policy
-      : { isActive, id, discountRate, policyNumber: `${policyNumber} (inactive)` };
-  });
+  const { policies } = currentPatient ?? [];
+
+  if (policies) {
+    return policies?.map(policy => {
+      const { isActive, policyNumber, id, discountRate } = policy;
+      return isActive
+        ? policy
+        : { isActive, id, discountRate, policyNumber: `${policyNumber} (inactive)` };
+    });
+  }
+  return [];
 };
+
 export const selectPatientModalOpen = ({ patient }) => {
   const { creatingADR, viewingHistory, isCreating, isEditing } = patient;
   return [isCreating || isEditing, viewingHistory, creatingADR];

--- a/src/widgets/PaymentSummary.js
+++ b/src/widgets/PaymentSummary.js
@@ -119,9 +119,10 @@ const PaymentSummaryComponent = ({
   selectedPrescriptionInsurancePolicy,
   selectedPaymentType,
 }) => {
-  const policyNumbers = React.useMemo(() => insurancePolicies.map(policy => policy.policyNumber), [
-    insurancePolicies,
-  ]);
+  const policyNumbers = React.useMemo(
+    () => insurancePolicies?.map(policy => policy.policyNumber) ?? [],
+    [insurancePolicies]
+  );
 
   const selectedPolicyNumber = React.useMemo(() => {
     let policyNumberFull = '';


### PR DESCRIPTION
#5220 Fixed app crashing after editing patient

Fixes #5220 

## Change summary

Now, app won't crash after editing patient during dispensing process.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Better to test with IC data or enable payment module and insurance policy
- [ ] Go to dispensing, click existing home store patient to dispense
- [ ] On tab 2 and 3 click editable button of patient, with/without updating click `Save` button of patient window.
- [ ] Click Next on dispensing page tab 2 or 2, it should not be crashed.
- [ ] In last payment confirmation tab, try to create new policy with different discount rate.
- [ ] Select any policy and click `Save and Close` button
- [ ] Revisit the same prescription from customer invoice page, follow the above same process.
- [ ] It should be processed without any crash.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
