### PR TITLE
#5237 Case sensitive should be ignored to check name duplicity

### DIFF
--- a/src/selectors/patient.js
+++ b/src/selectors/patient.js
@@ -92,7 +92,7 @@ export const selectCanEditPatient = ({ patient }) => {
 export const selectPatientByNameAndDoB = ({ lastName, firstName, dateOfBirth }) => {
   if (dateOfBirth) {
     const dob = moment(dateOfBirth).format('L');
-    const query = 'lastName = $0 AND firstName = $1 AND isDeleted = $2';
+    const query = 'lastName BEGINSWITH[c] $0 AND firstName BEGINSWITH[c] $1 AND isDeleted = $2';
     const duplicatePatients = UIDatabase.objects('Patient').filtered(
       query,
       lastName.trim(),


### PR DESCRIPTION
Case sensitive should be ignored to check name duplicity

Fixes #5237 

## Change summary

Creating duplicate name will be checked and alert generated by ignoring the case sensitive of name.

## Testing

Steps to reproduce or otherwise test the changes of this PR:

- [ ] Create a new name e.g. `arjun sah` and enter dob and other mandatory fields.
- [ ] Again try to create same name with Caps On e.g. `ARJUN SAH`, enter dob as above and mandatory fields in the dispensing form and just first, last, and dob in the vaccination form.
- [ ] There should be an alert `Are you sure you want to duplicate this patient? A patient with name: ARJUN SAH and date of birth: {1} already exist.`
- [ ] Click either Cancel or Save/Next to create duplicate patient.

### Related areas to think about

If there are any general areas of the codebase your changes might have side affects on, mention them here
